### PR TITLE
Partial-match rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ properties described in *Why this approach* below are **design goals that
 this MVP is trying to prove** — the architecture supports them, but none are
 yet demonstrated across more than one grammar. Expect breaking changes.
 
+Malformed or incomplete inputs render the longest valid prefix styled and
+the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
+
 ## Why this approach
 
 The aim is a small, efficient runtime with compact grammars and
@@ -87,11 +90,6 @@ These need no new VM or compiler machinery.
 
 Each item is a self-contained feature that unlocks further work.
 
-- **Partial-match rendering.** Small VM change: on failure, surface the
-  deepest `sp` reached and the captures valid at that point. Lets the
-  highlighter render `input[..matched]` styled and `input[matched..]`
-  plain, eliminating the "plain → styled → plain → styled" flicker when
-  rendering incomplete input.
 - **Memoization (packrat parsing).** Caches rule results per input
   position. Primary payoff: *incremental parsing* — O(Δ) per input
   change instead of O(n). Covers both the easy case (append-only

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -11,13 +11,24 @@
 //! coloring. PEG nesting guarantees captures form a forest (no overlap),
 //! which is why a stack works rather than an interval tree.
 //!
+//! # Partial-match rendering
+//!
+//! When the VM cannot match the full input, it still returns captures
+//! valid at the farthest position it reached (see `MatchResult` in
+//! [`crate::pegvm`]). The renderer styles `input[..matched]` using those
+//! captures and emits `input[matched..]` plain. This is why malformed or
+//! in-progress inputs show a styled prefix followed by a plain tail,
+//! rather than the whole input going unstyled on the first character
+//! that fails to parse.
+//!
 //! # Load-bearing invariant
 //!
 //! Stripping the ANSI escape codes from `highlight(input)` must yield the
-//! original `input` unchanged. The renderer never reorders, drops, or
-//! substitutes input bytes — it only inserts color codes around them.
-//! The integration tests assert this directly with a `strip_ansi` helper;
-//! any change to the renderer must preserve the property.
+//! original `input` unchanged, *including* for inputs the VM only
+//! partially matches. The renderer never reorders, drops, or substitutes
+//! input bytes — it only inserts color codes around them. The integration
+//! tests assert this directly with a `strip_ansi` helper; any change to
+//! the renderer must preserve the property.
 
 pub mod theme;
 

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -67,11 +67,14 @@ impl Highlighter {
 
     /// Run the VM and return raw captures alongside how many bytes matched.
     /// Useful for tests and debugging.
+    ///
+    /// On partial match (VM failed to reach `End`), the returned `matched`
+    /// is the farthest input position reached and `captures` are the spans
+    /// valid at that point — so the renderer naturally styles the valid
+    /// prefix and emits the unparseable tail plain.
     pub fn captures(&self, input: &str) -> (usize, Vec<Capture>) {
-        match VM::new(&self.program.code, input.as_bytes()).run() {
-            Some(r) => (r.matched, r.captures),
-            None => (0, Vec::new()),
-        }
+        let r = VM::new(&self.program.code, input.as_bytes()).run();
+        (r.matched, r.captures)
     }
 
     pub fn capture_kinds(&self) -> &[String] {

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -9,12 +9,12 @@ This document is a guided tour of the **types** that make up the module: what ea
 Three transformations connect the key types:
 
 ```
-&str  ──parse_grammar──▶  Grammar  ──compile_grammar──▶  Program  ──VM::run──▶  Option<MatchResult>
+&str  ──parse_grammar──▶  Grammar  ──compile_grammar──▶  Program  ──VM::run──▶  MatchResult
 ```
 
 - `parse_grammar` is text-level: it consumes a grammar source and produces a `Grammar` value.
 - `compile_grammar` is AST-level: it consumes a `Grammar` and produces a `Program` (bytecode plus metadata).
-- `VM::run` is runtime-level: it consumes a `Program` and an input and produces (if the input matches) a `MatchResult`.
+- `VM::run` is runtime-level: it consumes a `Program` and an input and produces a `MatchResult` whose `complete` flag distinguishes full matches from partial ones.
 
 Every other type in the module exists to serve one of these three stages.
 
@@ -158,8 +158,9 @@ pub struct Capture {
 }
 
 pub struct MatchResult {
-    pub matched: usize,          // bytes consumed
+    pub matched: usize,
     pub captures: Vec<Capture>,
+    pub complete: bool,
 }
 ```
 
@@ -168,9 +169,14 @@ A `Capture` is a closed span over the input paired with a kind tag: "these bytes
 Captures returned in a `MatchResult` have two non-obvious guarantees:
 
 1. **They form a properly-nested forest over the input.** Because PEG syntactic structure nests, captures can only stand in a sibling-or-parent relationship — never partially overlap. This is what lets the highlighter use a stack-based renderer rather than an interval tree.
-2. **They reflect only alternatives that actually succeeded.** Captures begun inside a failed choice are discarded during backtracking (see `VM::fail`). The caller sees a history consistent with the winning parse, not with everything the VM tried.
+2. **They reflect only alternatives that actually succeeded up to `matched`.** Captures begun inside a failed choice are discarded during backtracking (see `VM::fail`). The caller sees a history consistent with the winning parse, not with everything the VM tried.
 
-A `MatchResult` is emitted only when the VM reaches `End` — partial matches (grammar fits a prefix but not the whole input) are expressed by `matched < input.len()`, not by a partial result. A full non-match returns `None`.
+A `MatchResult` is always returned. The `complete` flag distinguishes the two cases:
+
+- `complete == true`: the VM reached `End`. `matched` is the `sp` at that point (potentially less than `input.len()` if the grammar is designed to stop early — no trailing `!.`).
+- `complete == false`: the VM exhausted its backtrack stack without reaching `End`. `matched` is the farthest input position the VM ever reached before retreating — the "farthest failure position" heuristic of Ford 2004, used for error reporting by LPegLabel and the `lpeg-ffp` fork — and `captures` are the captures valid at that point, with any still-open captures closed at `matched`.
+
+This partial result is what lets the highlighter render a styled prefix and a plain tail for malformed input, without the VM knowing anything about highlighting.
 
 ## Error types
 
@@ -179,7 +185,7 @@ The module has two error types, one per transformation in the pipeline that can 
 - `ParseError` is returned by `parse_grammar` when the grammar source is malformed (unterminated string, missing `<-`, duplicate rule, etc.). It carries line and column information.
 - `CompileError` is returned by `compile_grammar` when the grammar is well-formed text but semantically invalid — a `NonTerminal("foo")` with no matching rule, or a start rule that doesn't exist.
 
-Runtime mismatch (the input doesn't match the grammar) is not an error type: `VM::run` returns `Option<MatchResult>` and a failed parse is `None`. The distinction is deliberate — a grammar error is an author bug (the grammar needs fixing), a runtime non-match is a data bug (the input didn't conform).
+Runtime mismatch (the input doesn't match the grammar) is not an error type: `VM::run` returns a `MatchResult` whose `complete` flag is `false` when the input didn't conform. The distinction is deliberate — a grammar error is an author bug (the grammar needs fixing), a runtime non-match is a data bug (the input didn't conform).
 
 ## Invariants the types alone can't express
 
@@ -187,7 +193,8 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 
 1. **`PartialCommit` must target the body of a repetition, not the `Choice` that starts it.** `PartialCommit` updates the existing top backtrack frame rather than pushing a new one; jumping back to the `Choice` would push a fresh frame every iteration, exhausting memory and — worse — corrupting the stack so that an enclosing `Return` pops the wrong kind of entry. This is the first thing to check when extending the compiler.
 2. **Captures are truncated on backtrack.** Any instruction that enters the fail protocol routes through `VM::fail`, which restores the capture buffer length from the backtrack frame. New backtracking instructions must reuse this helper rather than re-implement it.
-3. **Byte-oriented.** `CharSet` is a set of `u8` values; UTF-8 is never decoded. This is a deliberate simplification appropriate for the MVP and will need to be revisited before serious Unicode-aware grammars.
+3. **`VM::fail` and `BackCommit` are the only sites where `sp` retreats.** Both must route through `VM::maybe_snapshot` so the farthest-failure bookkeeping sees every retreat. Between retreats `sp` is monotone non-decreasing, which is why snapshots at those two sites capture the true deepest point reached. Any new instruction that rewinds `sp` must update this invariant.
+4. **Byte-oriented.** `CharSet` is a set of `u8` values; UTF-8 is never decoded. This is a deliberate simplification appropriate for the MVP and will need to be revisited before serious Unicode-aware grammars.
 
 ## References
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -19,10 +19,21 @@ enum StackEntry {
     },
 }
 
+/// Outcome of running a compiled [`Program`](super::Program) against an input.
+///
+/// - `complete == true`: the VM reached `End`. `matched` is the `sp` at that
+///   point, which may be less than `input.len()` if the grammar is designed
+///   to stop early (no trailing `!.`).
+/// - `complete == false`: the VM exhausted its backtrack stack without
+///   reaching `End`. `matched` is the farthest input position the VM ever
+///   reached before retreating (Ford 2004's "farthest failure position"),
+///   and `captures` are the captures that were valid at that point — any
+///   captures left open at `matched` are closed there.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchResult {
     pub matched: usize,
     pub captures: Vec<Capture>,
+    pub complete: bool,
 }
 
 pub struct VM<'p, 'i> {
@@ -32,6 +43,8 @@ pub struct VM<'p, 'i> {
     sp: usize,
     stack: Vec<StackEntry>,
     captures: Vec<OpenCapture>,
+    max_sp: usize,
+    max_captures: Vec<OpenCapture>,
 }
 
 #[derive(Debug, Clone)]
@@ -50,19 +63,24 @@ impl<'p, 'i> VM<'p, 'i> {
             sp: 0,
             stack: Vec::new(),
             captures: Vec::new(),
+            max_sp: 0,
+            max_captures: Vec::new(),
         }
     }
 
-    pub fn run(mut self) -> Option<MatchResult> {
+    pub fn run(mut self) -> MatchResult {
         loop {
-            let instr = self.program.get(self.ip)?;
+            let instr = match self.program.get(self.ip) {
+                Some(i) => i,
+                None => return self.finalize_partial(),
+            };
             match instr {
                 Instruction::Char(b) => {
                     if self.input.get(self.sp) == Some(b) {
                         self.sp += 1;
                         self.ip += 1;
                     } else if !self.fail() {
-                        return None;
+                        return self.finalize_partial();
                     }
                 }
                 Instruction::Set(set) => match self.input.get(self.sp) {
@@ -72,7 +90,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     }
                     _ => {
                         if !self.fail() {
-                            return None;
+                            return self.finalize_partial();
                         }
                     }
                 },
@@ -82,7 +100,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         self.sp += n;
                         self.ip += 1;
                     } else if !self.fail() {
-                        return None;
+                        return self.finalize_partial();
                     }
                 }
                 Instruction::TestChar(b, label) => {
@@ -131,6 +149,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.ip = label.0;
                 }
                 Instruction::BackCommit(label) => {
+                    self.maybe_snapshot();
                     let entry = self.pop_backtrack();
                     if let StackEntry::Backtrack {
                         sp, capture_len, ..
@@ -144,12 +163,12 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::FailTwice => {
                     self.pop_backtrack();
                     if !self.fail() {
-                        return None;
+                        return self.finalize_partial();
                     }
                 }
                 Instruction::Fail => {
                     if !self.fail() {
-                        return None;
+                        return self.finalize_partial();
                     }
                 }
                 Instruction::Call(label) => {
@@ -182,18 +201,11 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.ip += 1;
                 }
                 Instruction::End => {
-                    return Some(MatchResult {
+                    return MatchResult {
                         matched: self.sp,
-                        captures: self
-                            .captures
-                            .into_iter()
-                            .map(|c| Capture {
-                                kind: c.kind,
-                                start: c.start,
-                                end: c.end.unwrap_or(c.start),
-                            })
-                            .collect(),
-                    });
+                        captures: close_captures(self.captures, self.sp),
+                        complete: true,
+                    };
                 }
             }
         }
@@ -207,6 +219,7 @@ impl<'p, 'i> VM<'p, 'i> {
     }
 
     fn fail(&mut self) -> bool {
+        self.maybe_snapshot();
         while let Some(entry) = self.stack.pop() {
             if let StackEntry::Backtrack {
                 ip,
@@ -222,4 +235,35 @@ impl<'p, 'i> VM<'p, 'i> {
         }
         false
     }
+
+    /// Update the farthest-failure snapshot if `sp` has advanced past the
+    /// previous maximum. Called from the only two sites where `sp` retreats —
+    /// [`fail`](Self::fail) and the `BackCommit` handler — plus defensively
+    /// at finalize time. Between retreats `sp` is monotone non-decreasing,
+    /// so these hooks capture the true deepest point.
+    fn maybe_snapshot(&mut self) {
+        if self.sp > self.max_sp {
+            self.max_sp = self.sp;
+            self.max_captures = self.captures.clone();
+        }
+    }
+
+    fn finalize_partial(mut self) -> MatchResult {
+        self.maybe_snapshot();
+        MatchResult {
+            matched: self.max_sp,
+            captures: close_captures(self.max_captures, self.max_sp),
+            complete: false,
+        }
+    }
+}
+
+fn close_captures(open: Vec<OpenCapture>, close_at: usize) -> Vec<Capture> {
+    open.into_iter()
+        .map(|c| Capture {
+            kind: c.kind,
+            start: c.start,
+            end: c.end.unwrap_or(close_at),
+        })
+        .collect()
 }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -5,7 +5,7 @@ use syntax_highlighter::pegvm::{
     MatchResult, Pattern, VM,
 };
 
-fn run_pattern(pat: &Pattern, input: &[u8]) -> Option<MatchResult> {
+fn run_pattern(pat: &Pattern, input: &[u8]) -> MatchResult {
     let prog = compile_pattern(pat);
     VM::new(&prog.code, input).run()
 }
@@ -24,12 +24,13 @@ fn literal_pattern() {
     let p = Pattern::literal("hi");
     assert_eq!(
         run_pattern(&p, b"hi"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"ho"), None);
+    assert!(!run_pattern(&p, b"ho").complete);
 }
 
 #[test]
@@ -37,12 +38,13 @@ fn char_class_pattern() {
     let p = Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]));
     assert_eq!(
         run_pattern(&p, b"5"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"x"), None);
+    assert!(!run_pattern(&p, b"x").complete);
 }
 
 #[test]
@@ -50,12 +52,13 @@ fn any_char_pattern() {
     let p = Pattern::AnyChar;
     assert_eq!(
         run_pattern(&p, b"q"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b""), None);
+    assert!(!run_pattern(&p, b"").complete);
 }
 
 #[test]
@@ -63,12 +66,13 @@ fn sequence_pattern() {
     let p = Pattern::seq(vec![Pattern::literal("ab"), Pattern::literal("cd")]);
     assert_eq!(
         run_pattern(&p, b"abcd"),
-        Some(MatchResult {
+        MatchResult {
             matched: 4,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"abce"), None);
+    assert!(!run_pattern(&p, b"abce").complete);
 }
 
 #[test]
@@ -76,19 +80,21 @@ fn ordered_choice_two() {
     let p = Pattern::choice(vec![Pattern::literal("ab"), Pattern::literal("ax")]);
     assert_eq!(
         run_pattern(&p, b"ab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"ax"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"ay"), None);
+    assert!(!run_pattern(&p, b"ay").complete);
 }
 
 #[test]
@@ -100,26 +106,29 @@ fn ordered_choice_three() {
     ]);
     assert_eq!(
         run_pattern(&p, b"foo"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"bar"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"baz"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"qux"), None);
+    assert!(!run_pattern(&p, b"qux").complete);
 }
 
 #[test]
@@ -127,44 +136,49 @@ fn repeat_zero_or_more() {
     let p = Pattern::Repeat(Box::new(Pattern::literal("a")));
     assert_eq!(
         run_pattern(&p, b""),
-        Some(MatchResult {
+        MatchResult {
             matched: 0,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"aaa"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"aab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
 }
 
 #[test]
 fn repeat_one_or_more() {
     let p = Pattern::RepeatOne(Box::new(Pattern::literal("a")));
-    assert_eq!(run_pattern(&p, b""), None);
+    assert!(!run_pattern(&p, b"").complete);
     assert_eq!(
         run_pattern(&p, b"a"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"aaa"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
 }
 
@@ -176,19 +190,21 @@ fn optional_pattern() {
     ]);
     assert_eq!(
         run_pattern(&p, b"x"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run_pattern(&p, b"-x"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"--x"), None);
+    assert!(!run_pattern(&p, b"--x").complete);
 }
 
 #[test]
@@ -199,12 +215,13 @@ fn not_predicate_pattern() {
     ]);
     assert_eq!(
         run_pattern(&p, b"b"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"a"), None);
+    assert!(!run_pattern(&p, b"a").complete);
 }
 
 #[test]
@@ -217,12 +234,13 @@ fn and_predicate_pattern() {
     ]);
     assert_eq!(
         run_pattern(&p, b"ab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run_pattern(&p, b"bb"), None);
+    assert!(!run_pattern(&p, b"bb").complete);
 }
 
 #[test]
@@ -232,10 +250,11 @@ fn capture_records_kind_and_span() {
     assert_eq!(prog.capture_kinds, vec!["number".to_string()]);
     assert_eq!(
         VM::new(&prog.code, b"42").run(),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
             captures: vec![cap(0, 0, 2)],
-        })
+            complete: true,
+        }
     );
 }
 
@@ -257,14 +276,15 @@ fn nested_captures_flow_through_compile() {
     );
     assert_eq!(
         VM::new(&prog.code, b"ab").run(),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
             captures: vec![
                 cap(0, 0, 2), // @outer
                 cap(1, 0, 1), // @inner "a"
                 cap(1, 1, 2), // @inner "b"
             ],
-        })
+            complete: true,
+        }
     );
 }
 
@@ -284,12 +304,13 @@ fn grammar_with_nonterminals() {
     let prog = compile_grammar(&rules, "start").unwrap();
     assert_eq!(
         VM::new(&prog.code, b"123abc").run(),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(VM::new(&prog.code, b"abc").run(), None);
+    assert!(!VM::new(&prog.code, b"abc").run().complete);
 }
 
 #[test]

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -175,7 +175,8 @@ fn end_to_end_grammar_compile_run() {
     use syntax_highlighter::pegvm::{compile_grammar, VM};
     let g = parse("number <- [0-9]+");
     let prog = compile_grammar(&g.rules, &g.start).unwrap();
-    let r = VM::new(&prog.code, b"42abc").run().unwrap();
+    let r = VM::new(&prog.code, b"42abc").run();
+    assert!(r.complete);
     assert_eq!(r.matched, 2);
 }
 

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -73,17 +73,27 @@ fn parses_string_with_unicode_escape() {
 }
 
 #[test]
-fn rejects_unterminated_string() {
+fn partial_unterminated_string_advances_past_quote() {
+    // On malformed input the VM no longer gives up at sp=0; it surfaces the
+    // farthest position reached. The quote itself is consumed before the
+    // string body starts failing.
     let h = hl();
-    let (matched, _) = h.captures(r#""oops"#);
-    assert_eq!(matched, 0);
+    let input = r#""oops"#;
+    let (matched, _) = h.captures(input);
+    assert!(matched > 0, "expected some progress, got {}", matched);
+    assert!(matched <= input.len());
 }
 
 #[test]
-fn rejects_trailing_garbage() {
+fn partial_trailing_garbage_reports_max_sp() {
+    // The json rule ends with `!.`; trailing garbage fails the top-level
+    // parse. The VM now reports the farthest position reached (the end of
+    // the valid JSON prefix) rather than zero.
     let h = hl();
-    let (matched, _) = h.captures(r#"{"a": 1} extra"#);
-    assert_eq!(matched, 0, "json rule has !. so trailing junk must fail");
+    let input = r#"{"a": 1} extra"#;
+    let (matched, _) = h.captures(input);
+    assert!(matched > 0, "expected progress past the valid prefix");
+    assert!(matched <= input.len());
 }
 
 #[test]

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -161,6 +161,40 @@ fn highlighting_preserves_input_text() {
     assert_eq!(stripped, input);
 }
 
+#[test]
+fn partial_match_renders_prefix_styled_and_tail_plain() {
+    // The valid JSON prefix must be styled; the trailing garbage must appear
+    // verbatim in the output (no ANSI codes wrapping it). The round-trip
+    // invariant must hold for the whole output.
+    let h = hl();
+    let input = r#"{"a": 1} extra"#;
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input, "round-trip must be preserved");
+    assert!(
+        out.contains(theme::color_for("number")) || out.contains(theme::color_for("string")),
+        "expected some styling on the valid prefix, got {:?}",
+        out
+    );
+    // The literal " extra" substring must appear without any ANSI codes
+    // interleaved between its bytes.
+    assert!(
+        out.contains(" extra"),
+        "trailing garbage must render verbatim, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn unterminated_string_still_round_trips() {
+    // The load-bearing strip_ansi invariant must hold even when the input
+    // is malformed — partial-match rendering must not reorder, drop, or
+    // substitute input bytes.
+    let h = hl();
+    let input = r#"{"a": "oops"#;
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
 fn strip_ansi(s: &str) -> String {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -2,7 +2,7 @@ use syntax_highlighter::pegvm::{
     Capture, CaptureKind, CharSet, Instruction, Label, MatchResult, VM,
 };
 
-fn run(program: &[Instruction], input: &[u8]) -> Option<MatchResult> {
+fn run(program: &[Instruction], input: &[u8]) -> MatchResult {
     VM::new(program, input).run()
 }
 
@@ -25,20 +25,36 @@ fn match_literal_abc() {
     ];
     assert_eq!(
         run(&prog, b"abc"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run(&prog, b"abcd"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"abx"), None);
-    assert_eq!(run(&prog, b"ab"), None);
+    assert_eq!(
+        run(&prog, b"abx"),
+        MatchResult {
+            matched: 2,
+            captures: vec![],
+            complete: false,
+        }
+    );
+    assert_eq!(
+        run(&prog, b"ab"),
+        MatchResult {
+            matched: 2,
+            captures: vec![],
+            complete: false,
+        }
+    );
 }
 
 #[test]
@@ -47,13 +63,28 @@ fn match_charset() {
     let prog = [Instruction::Set(digits), Instruction::End];
     assert_eq!(
         run(&prog, b"7"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"a"), None);
-    assert_eq!(run(&prog, b""), None);
+    assert_eq!(
+        run(&prog, b"a"),
+        MatchResult {
+            matched: 0,
+            captures: vec![],
+            complete: false,
+        }
+    );
+    assert_eq!(
+        run(&prog, b""),
+        MatchResult {
+            matched: 0,
+            captures: vec![],
+            complete: false,
+        }
+    );
 }
 
 #[test]
@@ -61,12 +92,20 @@ fn any_skips_n_bytes() {
     let prog = [Instruction::Any(3), Instruction::End];
     assert_eq!(
         run(&prog, b"xyz"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"xy"), None);
+    assert_eq!(
+        run(&prog, b"xy"),
+        MatchResult {
+            matched: 0,
+            captures: vec![],
+            complete: false,
+        }
+    );
 }
 
 #[test]
@@ -84,19 +123,22 @@ fn ordered_choice_first_alternative() {
     ];
     assert_eq!(
         run(&prog, b"ab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run(&prog, b"ax"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"ay"), None);
+    let r = run(&prog, b"ay");
+    assert!(!r.complete);
 }
 
 #[test]
@@ -112,31 +154,35 @@ fn repetition_zero_or_more() {
     ];
     assert_eq!(
         run(&prog, b""),
-        Some(MatchResult {
+        MatchResult {
             matched: 0,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run(&prog, b"a"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run(&prog, b"aaaa"),
-        Some(MatchResult {
+        MatchResult {
             matched: 4,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
     assert_eq!(
         run(&prog, b"aaab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 3,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
 }
 
@@ -153,13 +199,16 @@ fn not_predicate() {
     ];
     assert_eq!(
         run(&prog, b"b"),
-        Some(MatchResult {
+        MatchResult {
             matched: 1,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"a"), None);
-    assert_eq!(run(&prog, b""), None);
+    let r_a = run(&prog, b"a");
+    assert!(!r_a.complete);
+    let r_empty = run(&prog, b"");
+    assert!(!r_empty.complete);
 }
 
 #[test]
@@ -181,12 +230,15 @@ fn call_and_return() {
     ];
     assert_eq!(
         run(&prog, b"aa"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
-            captures: vec![]
-        })
+            captures: vec![],
+            complete: true,
+        }
     );
-    assert_eq!(run(&prog, b"ab"), None);
+    let r = run(&prog, b"ab");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 1);
 }
 
 #[test]
@@ -206,10 +258,11 @@ fn captures_recorded_on_success() {
     ];
     assert_eq!(
         run(&prog, b"ab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
             captures: vec![cap(7, 0, 2)],
-        })
+            complete: true,
+        }
     );
 }
 
@@ -241,10 +294,11 @@ fn captures_truncated_on_backtrack() {
     ];
     assert_eq!(
         run(&prog, b"ax"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
             captures: vec![], // discarded during backtrack
-        })
+            complete: true,
+        }
     );
 }
 
@@ -273,14 +327,15 @@ fn nested_captures_kept_in_order() {
     ];
     assert_eq!(
         run(&prog, b"ab"),
-        Some(MatchResult {
+        MatchResult {
             matched: 2,
             captures: vec![
                 cap(1, 0, 2), // outer
                 cap(2, 0, 1), // inner 1
                 cap(2, 1, 2), // inner 2
             ],
-        })
+            complete: true,
+        }
     );
 }
 
@@ -293,4 +348,73 @@ fn charset_negate_and_union() {
     let merged = vowels.union(&CharSet::from_bytes(b"y"));
     assert!(merged.contains(b'y'));
     assert!(merged.contains(b'a'));
+}
+
+#[test]
+fn partial_match_on_failure_returns_max_sp_and_open_captures() {
+    // Grammar: "ab" @mark{ "cd" }  — match "ab", then a captured "cd".
+    //  0: Char a
+    //  1: Char b
+    //  2: CaptureBegin 0
+    //  3: Char c
+    //  4: Char d
+    //  5: CaptureEnd
+    //  6: End
+    //
+    // Input "abcX" advances to sp=3 inside the @mark capture, then fails
+    // on 'd' vs 'X'. Expect complete:false, matched=3, and one capture
+    // still open at the failure point closed at sp=3 (start=2).
+    let prog = [
+        Instruction::Char(b'a'),
+        Instruction::Char(b'b'),
+        Instruction::CaptureBegin(CaptureKind(0)),
+        Instruction::Char(b'c'),
+        Instruction::Char(b'd'),
+        Instruction::CaptureEnd,
+        Instruction::End,
+    ];
+    let r = run(&prog, b"abcX");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 3);
+    assert_eq!(r.captures, vec![cap(0, 2, 3)]);
+}
+
+#[test]
+fn partial_match_fail_before_any_progress() {
+    let prog = [Instruction::Char(b'a'), Instruction::End];
+    let r = run(&prog, b"z");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 0);
+    assert_eq!(r.captures, vec![]);
+}
+
+#[test]
+fn partial_match_prefers_deepest_point_across_backtracks() {
+    // Grammar: "aaa" / "aab"
+    // First alternative advances to sp=2 on "aaX" before failing on 'a'
+    // vs 'X'; second alternative fails earlier. max_sp should stick at 2.
+    //
+    //  0: Choice L1 (=5)
+    //  1: Char a
+    //  2: Char a
+    //  3: Char a
+    //  4: Commit L2 (=8)
+    //  5: Char a   (L1)
+    //  6: Char a
+    //  7: Char b
+    //  8: End      (L2)
+    let prog = [
+        Instruction::Choice(Label(5)),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'a'),
+        Instruction::Commit(Label(8)),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'b'),
+        Instruction::End,
+    ];
+    let r = run(&prog, b"aaX");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 2);
 }


### PR DESCRIPTION
Implements **Partial-match rendering** from the [VM roadmap](https://github.com/stefanobaghino/syntax-highlighter/blob/main/README.md#vm-and-compiler-extensions): on parse failure the VM now surfaces the farthest position reached plus the captures valid there, so the highlighter styles the valid prefix and leaves the tail plain — eliminating the "plain → styled → plain → styled" flicker on incomplete or mid-edit inputs.

## Approach

Standard "farthest failure position" heuristic (Ford 2004; see `src/pegvm/README.md`). The only two sites where `sp` retreats are `VM::fail()` and the `BackCommit` handler — between retreats `sp` is monotone, so a single snapshot hook at those two sites captures the true deepest point reached. `MatchResult` gains a `complete` flag; `VM::run` returns it unconditionally (no more `Option`). Any captures left open at the farthest point are closed there so the highlight renderer — unchanged — naturally styles `input[..matched]` and emits `input[matched..]` plain.

## Commits

1. `561e7d2` — VM-level farthest-failure tracking and return-type change.
2. `c614860` — end-to-end highlight tests exercising the new behavior.
3. `d40c7f8` — documentation (`src/pegvm/README.md`, module docs, `README.md` status/roadmap).

## Test plan

CI covers it — `cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`. No additional local-only tests.