### PR TITLE
Add TOML grammar as second language (validation milestone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ that can scale to many languages without binary bloat.
 
 ## Status
 
-Early MVP. Ships a single JSON grammar and an ANSI-coloring CLI. The
+Early MVP. Ships JSON and TOML grammars and an ANSI-coloring CLI. The
 properties described in *Why this approach* below are **design goals that
-this MVP is trying to prove** — the architecture supports them, but none are
-yet demonstrated across more than one grammar. Expect breaking changes.
+this MVP is trying to prove** — the architecture supports them, and the
+first cross-language validation (JSON + TOML) is in. Expect breaking
+changes.
+
+The CLI picks a grammar by file extension (`.json`, `.toml`) or an
+explicit `-l json|toml` flag; stdin without a flag defaults to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
@@ -50,10 +54,17 @@ quantifying the resulting binary footprint — is the work ahead.
 echo '{"key": [1, true, "hello"], "nested": {"a": null}}' | cargo run
 ```
 
-Or point it at a file:
+Or point it at a file (grammar picked by extension):
 
 ```bash
 cargo run -- path/to/file.json
+cargo run -- Cargo.toml
+```
+
+For stdin with a non-default language, pass `-l`:
+
+```bash
+printf '[package]\nname = "demo"\n' | cargo run -- -l toml
 ```
 
 ## Grammar format
@@ -73,8 +84,12 @@ largest piece of work.
 
 These need no new VM or compiler machinery.
 
-- **More language grammars.** Adding a language means writing a grammar
-  file. Candidates: Python, Rust, TOML, YAML, a SQL dialect or two.
+- **More language grammars.** JSON and TOML ship today. Adding a language
+  means writing a grammar file. Remaining candidates: Python, Rust, CSS
+  or a SQL dialect (both have the shared-prefix alternatives that would
+  stress a future packrat cache). YAML is deferred — its context-sensitive
+  indentation semantics make it a poor fit for PEG without additional
+  machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is
   orthogonal to the VM.

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -1,0 +1,123 @@
+# TOML v1.0 grammar with highlight annotations.
+# The first rule is the start rule.
+#
+# Capture kinds used (all present in src/highlight/theme.rs):
+#   comment, property, type, string, number, constant, punctuation.
+#
+# Scope: the complete TOML v1.0 surface. The only deferred item is
+# semantic duplicate-key detection, which is a parser concern and not
+# expressible in PEG.
+#
+# Capture-kind notes:
+#   - Dotted key segments on the LHS of '=' are @property (cyan).
+#   - Section-header path segments inside [ ] and [[ ]] are @type (yellow).
+#   - Datetime literals are @number — the hardcoded theme has no @date
+#     kind; revisit when a theme-file is introduced.
+#   - inf / nan are @constant (like true/false), not @number.
+
+toml          <- ws (entry (entry_sep entry)*)? ws !.
+
+entry         <- array_of_tables_header / table_header / pair
+entry_sep     <- inline_space comment? linebreak ws
+
+# Key-value pair: LHS key as @property, RHS value.
+pair          <- key inline_space @punctuation{'='} inline_space value
+
+# Section headers: path segments as @type.
+table_header              <- @punctuation{'['} inline_space key_path inline_space @punctuation{']'}
+array_of_tables_header    <- @punctuation{'[['} inline_space key_path inline_space @punctuation{']]'}
+
+# Keys. Dotted keys are several segments joined by '.'. The two rules
+# differ only in the capture kind applied to each segment.
+key           <- key_seg_prop (inline_space @punctuation{'.'} inline_space key_seg_prop)*
+key_path      <- key_seg_type (inline_space @punctuation{'.'} inline_space key_seg_type)*
+
+key_seg_prop  <- @property{key_seg_body}
+key_seg_type  <- @type{key_seg_body}
+key_seg_body  <- bare_key / basic_string / literal_string
+bare_key      <- [A-Za-z0-9_\-]+
+
+# Values. Order matters: try longer-prefixed / more-specific alternatives
+# first so PEG's first-match semantics pick the right one.
+#   - datetime before number (both start with digits)
+#   - inf_nan before number (share the optional sign)
+#   - float before integer (both start with digits; float distinguished
+#     by the frac/exp tail)
+value         <- string_val
+               / @constant{inf_nan}
+               / datetime
+               / float
+               / integer
+               / @constant{bool_lit}
+               / array
+               / inline_table
+
+# --- Strings -----------------------------------------------------------
+# Multi-line forms come first because their opening/closing delimiters
+# are longer than the single-line forms.
+string_val    <- @string{string_body}
+string_body   <- basic_multiline / literal_multiline / basic_string / literal_string
+
+basic_string  <- '"' (basic_char / escape)* '"'
+basic_char    <- !["\\\n\r] .
+escape        <- '\\' (["\\bfnrt] / 'u' hex hex hex hex / 'U' hex hex hex hex hex hex hex hex)
+
+basic_multiline <- '"""' multiline_basic_body '"""'
+multiline_basic_body <- (!'"""' .)*
+
+literal_string  <- "'" literal_char* "'"
+literal_char    <- !['\n\r] .
+
+literal_multiline <- "'''" multiline_literal_body "'''"
+multiline_literal_body <- (!"'''" .)*
+
+# --- Numbers -----------------------------------------------------------
+integer       <- @number{int_body}
+int_body      <- hex_int / oct_int / bin_int / dec_int
+dec_int       <- [+\-]? unsigned_dec
+unsigned_dec  <- '0' / [1-9] ('_'? [0-9])*
+hex_int       <- '0x' hex ('_'? hex)*
+oct_int       <- '0o' [0-7] ('_'? [0-7])*
+bin_int       <- '0b' [01] ('_'? [01])*
+
+float         <- @number{float_body}
+float_body    <- [+\-]? unsigned_dec (frac exp? / exp)
+frac          <- '.' [0-9] ('_'? [0-9])*
+exp           <- [eE] [+\-]? [0-9] ('_'? [0-9])*
+
+inf_nan       <- [+\-]? ('inf' / 'nan')
+bool_lit      <- 'true' / 'false'
+
+# --- Datetime (RFC 3339 subset) ---------------------------------------
+datetime      <- @number{datetime_body}
+datetime_body <- full_datetime / local_datetime / local_date / local_time
+full_datetime <- date date_time_sep time time_offset
+local_datetime <- date date_time_sep time
+local_date    <- date
+local_time    <- time
+date_time_sep <- 'T' / 't' / ' '
+date          <- [0-9] [0-9] [0-9] [0-9] '-' [0-9] [0-9] '-' [0-9] [0-9]
+time          <- [0-9] [0-9] ':' [0-9] [0-9] ':' [0-9] [0-9] time_frac?
+time_frac     <- '.' [0-9]+
+time_offset   <- 'Z' / 'z' / [+\-] [0-9] [0-9] ':' [0-9] [0-9]
+
+# --- Arrays (multiline, trailing comma, interior comments allowed) -----
+array         <- @punctuation{'['} array_ws array_body? array_ws @punctuation{']'}
+array_body    <- value (array_ws @punctuation{','} array_ws value)* (array_ws @punctuation{','})?
+
+# --- Inline tables (no newlines, no trailing comma per v1.0) ----------
+inline_table  <- @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
+inline_table_body <- inline_pair (inline_space @punctuation{','} inline_space inline_pair)*
+inline_pair   <- key inline_space @punctuation{'='} inline_space value
+
+# --- Whitespace & comments --------------------------------------------
+inline_space  <- [ \t]*
+linebreak     <- '\r'? '\n'
+comment       <- @comment{'#' (!linebreak .)*}
+
+# Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
+# consumes at least one byte, so the enclosing '*' cannot infinite-loop.
+ws            <- (comment / [ \t\r\n])*
+array_ws      <- ws
+
+hex           <- [0-9a-fA-F]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,113 @@
 use std::io::{self, Read, Write};
+use std::path::Path;
 use std::process::ExitCode;
 
 use syntax_highlighter::highlight::Highlighter;
 
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+
+#[derive(Clone, Copy)]
+enum Lang {
+    Json,
+    Toml,
+}
+
+impl Lang {
+    fn grammar(self) -> &'static str {
+        match self {
+            Lang::Json => JSON_GRAMMAR,
+            Lang::Toml => TOML_GRAMMAR,
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "json" => Some(Lang::Json),
+            "toml" => Some(Lang::Toml),
+            _ => None,
+        }
+    }
+
+    fn from_extension(path: &Path) -> Option<Self> {
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .and_then(Self::from_name)
+    }
+}
+
+struct Cli {
+    lang: Option<Lang>,
+    path: Option<String>,
+}
+
+fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
+    let mut lang = None;
+    let mut path = None;
+    let mut it = args.peekable();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "-l" | "--lang" => {
+                let name = it
+                    .next()
+                    .ok_or_else(|| format!("{} requires a value (json|toml)", arg))?;
+                lang =
+                    Some(Lang::from_name(&name).ok_or_else(|| {
+                        format!("unknown language {:?} (expected json|toml)", name)
+                    })?);
+            }
+            other if other.starts_with("--lang=") => {
+                let name = &other["--lang=".len()..];
+                lang =
+                    Some(Lang::from_name(name).ok_or_else(|| {
+                        format!("unknown language {:?} (expected json|toml)", name)
+                    })?);
+            }
+            _ => {
+                if path.is_some() {
+                    return Err(format!("unexpected extra argument {:?}", arg));
+                }
+                path = Some(arg);
+            }
+        }
+    }
+    Ok(Cli { lang, path })
+}
+
+fn pick_lang(cli: &Cli) -> Result<Lang, String> {
+    if let Some(l) = cli.lang {
+        return Ok(l);
+    }
+    match &cli.path {
+        Some(p) => Lang::from_extension(Path::new(p)).ok_or_else(|| {
+            format!(
+                "cannot infer language from path {:?}; pass --lang json|toml",
+                p
+            )
+        }),
+        None => Ok(Lang::Json),
+    }
+}
 
 fn main() -> ExitCode {
-    let mut args = std::env::args().skip(1);
-    let input = match args.next() {
-        Some(path) => match std::fs::read_to_string(&path) {
+    let cli = match parse_args(std::env::args().skip(1)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("syntax-highlighter: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let lang = match pick_lang(&cli) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("syntax-highlighter: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let input = match &cli.path {
+        Some(path) => match std::fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("syntax-highlighter: {}: {}", path, e);
@@ -25,7 +124,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let highlighter = match Highlighter::new(JSON_GRAMMAR) {
+    let highlighter = match Highlighter::new(lang.grammar()) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("syntax-highlighter: grammar error: {}", e);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,23 @@
+/// Strip ANSI CSI escape sequences from `s`, returning the visible text.
+/// Used by the highlight integration tests to assert the round-trip
+/// invariant: `strip_ansi(highlight(x)) == x`.
+pub fn strip_ansi(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2;
+            while i < bytes.len() && !bytes[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap()
+}

--- a/tests/grammar_toml_tests.rs
+++ b/tests/grammar_toml_tests.rs
@@ -1,0 +1,381 @@
+use std::collections::HashSet;
+
+use syntax_highlighter::pegvm::{compile_grammar, parse_grammar, Capture, Program, VM};
+
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+
+fn compile() -> Program {
+    let g = parse_grammar(TOML_GRAMMAR).expect("TOML grammar should parse");
+    compile_grammar(&g.rules, &g.start).expect("TOML grammar should compile")
+}
+
+fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
+    let prog = compile();
+    let r = VM::new(&prog.code, input.as_bytes()).run();
+    (
+        r.matched,
+        r.captures,
+        prog.capture_kinds.clone(),
+        r.complete,
+    )
+}
+
+fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+        .collect()
+}
+
+fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == kind)
+        .map(|c| format!("{}..{}", c.start, c.end))
+        .collect()
+}
+
+fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(
+        complete,
+        "expected complete match, got matched={} kinds={:?}",
+        matched, caps
+    );
+    assert_eq!(matched, input.len(), "expected full-input match");
+    (caps, kinds)
+}
+
+#[test]
+fn grammar_parses_and_compiles() {
+    let prog = compile();
+    assert!(!prog.code.is_empty());
+    assert!(!prog.capture_kinds.is_empty());
+}
+
+#[test]
+fn capture_kinds_are_only_theme_kinds() {
+    let prog = compile();
+    let expected: HashSet<&str> = [
+        "comment",
+        "property",
+        "type",
+        "string",
+        "number",
+        "constant",
+        "punctuation",
+    ]
+    .into_iter()
+    .collect();
+    let actual: HashSet<&str> = prog.capture_kinds.iter().map(String::as_str).collect();
+    assert_eq!(
+        actual, expected,
+        "TOML grammar must stay within the hardcoded-theme vocabulary"
+    );
+}
+
+#[test]
+fn empty_document_matches() {
+    let (caps, _) = assert_complete_full("");
+    assert!(caps.is_empty());
+}
+
+#[test]
+fn whitespace_only_document_matches() {
+    assert_complete_full("\n\n   \n");
+}
+
+#[test]
+fn single_line_comment_is_captured() {
+    let (caps, kinds) = assert_complete_full("# hi\n");
+    assert_eq!(kinds_for(&caps, &kinds), vec!["comment"]);
+}
+
+#[test]
+fn simple_pair_captures_property_punctuation_value() {
+    let (caps, kinds) = assert_complete_full("key = 1\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "number"]
+    );
+}
+
+#[test]
+fn dotted_key_emits_property_segments_and_dot_punctuation() {
+    let (caps, kinds) = assert_complete_full("a.b.c = true\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec![
+            "property",
+            "punctuation", // .
+            "property",
+            "punctuation", // .
+            "property",
+            "punctuation", // =
+            "constant"
+        ]
+    );
+}
+
+#[test]
+fn quoted_keys_are_still_property() {
+    let (caps, kinds) = assert_complete_full("\"a.b\".c = 1\n");
+    let ks = kinds_for(&caps, &kinds);
+    assert_eq!(
+        ks,
+        vec![
+            "property",
+            "punctuation",
+            "property",
+            "punctuation",
+            "number"
+        ]
+    );
+}
+
+#[test]
+fn table_header_path_is_type() {
+    let (caps, kinds) = assert_complete_full("[foo.bar]\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["punctuation", "type", "punctuation", "type", "punctuation"]
+    );
+}
+
+#[test]
+fn array_of_tables_header_is_type() {
+    let (caps, kinds) = assert_complete_full("[[servers]]\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["punctuation", "type", "punctuation"]
+    );
+}
+
+#[test]
+fn string_value_basic() {
+    let (caps, kinds) = assert_complete_full("s = \"hi\"\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "string"]
+    );
+}
+
+#[test]
+fn string_value_literal() {
+    let (caps, kinds) = assert_complete_full("s = 'hi'\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "string"]
+    );
+}
+
+#[test]
+fn string_multiline_basic() {
+    let input = "s = \"\"\"line1\nline2\"\"\"\n";
+    let (caps, kinds) = assert_complete_full(input);
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "string"]
+    );
+}
+
+#[test]
+fn string_multiline_literal() {
+    let input = "s = '''line1\nline2'''\n";
+    let (caps, kinds) = assert_complete_full(input);
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "string"]
+    );
+}
+
+#[test]
+fn integer_variants_all_parse() {
+    for input in [
+        "n = 0\n",
+        "n = 42\n",
+        "n = -17\n",
+        "n = +99\n",
+        "n = 1_000_000\n",
+        "n = 0xDEAD_beef\n",
+        "n = 0o755\n",
+        "n = 0b1010_1010\n",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        assert_eq!(
+            kinds_for(&caps, &kinds),
+            vec!["property", "punctuation", "number"],
+            "input: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn float_variants_all_parse() {
+    for input in [
+        "f = 3.14\n",
+        "f = -0.5\n",
+        "f = 1e10\n",
+        "f = 6.626e-34\n",
+        "f = 9_224_617.445_991_228\n",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        assert_eq!(
+            kinds_for(&caps, &kinds),
+            vec!["property", "punctuation", "number"],
+            "input: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn inf_nan_are_constants() {
+    for input in ["f = inf\n", "f = -inf\n", "f = +inf\n", "f = nan\n"] {
+        let (caps, kinds) = assert_complete_full(input);
+        assert_eq!(
+            kinds_for(&caps, &kinds),
+            vec!["property", "punctuation", "constant"],
+            "input: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn booleans_are_constants() {
+    for input in ["b = true\n", "b = false\n"] {
+        let (caps, kinds) = assert_complete_full(input);
+        assert_eq!(
+            kinds_for(&caps, &kinds),
+            vec!["property", "punctuation", "constant"],
+            "input: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn datetime_variants_are_numbers() {
+    for input in [
+        "d = 1979-05-27T07:32:00Z\n",
+        "d = 1979-05-27T07:32:00-07:00\n",
+        "d = 1979-05-27T07:32:00.999999\n",
+        "d = 1979-05-27T07:32:00\n",
+        "d = 1979-05-27 07:32:00\n",
+        "d = 1979-05-27\n",
+        "d = 07:32:00\n",
+        "d = 07:32:00.999999\n",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        assert_eq!(
+            kinds_for(&caps, &kinds),
+            vec!["property", "punctuation", "number"],
+            "input: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn empty_array_matches() {
+    let (caps, kinds) = assert_complete_full("a = []\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["property", "punctuation", "punctuation", "punctuation"]
+    );
+}
+
+#[test]
+fn array_with_mixed_primitive_values() {
+    let (caps, kinds) = assert_complete_full("a = [1, \"two\", true]\n");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec![
+            "property",
+            "punctuation", // =
+            "punctuation", // [
+            "number",
+            "punctuation", // ,
+            "string",
+            "punctuation", // ,
+            "constant",
+            "punctuation", // ]
+        ]
+    );
+}
+
+#[test]
+fn multiline_array_with_trailing_comma_and_interior_comment() {
+    let input = "a = [\n  1,\n  # inside\n  2,\n]\n";
+    let (caps, kinds) = assert_complete_full(input);
+    // Order of captures follows start position. Before-`[` we have key and =
+    // punctuation; after that the capture interleaving matters less than the
+    // fact that each expected kind appears.
+    let ks = kinds_for(&caps, &kinds);
+    assert!(
+        ks.contains(&"comment"),
+        "expected interior comment, got {:?}",
+        ks
+    );
+    assert_eq!(ks.iter().filter(|k| **k == "number").count(), 2);
+}
+
+#[test]
+fn inline_table_value() {
+    let input = "t = { a = 1, b = \"x\" }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    assert!(ks.contains(&"string"));
+    assert!(ks.contains(&"number"));
+    // The outer key "t" and the inner keys "a", "b" are all @property.
+    assert_eq!(ks.iter().filter(|k| **k == "property").count(), 3);
+}
+
+#[test]
+fn trailing_comment_after_value() {
+    let (caps, kinds) = assert_complete_full("k = 1 # trailing\n");
+    let ks = kinds_for(&caps, &kinds);
+    assert!(ks.contains(&"comment"));
+}
+
+#[test]
+fn realistic_cargo_toml_excerpt() {
+    let input = r#"# A realistic snippet.
+[package]
+name = "demo"
+version = "0.1.0"
+edition = 2021
+authors = ["alice", "bob"]
+publish = false
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[[bin]]
+name = "demo"
+path = "src/main.rs"
+"#;
+    let (caps, kinds) = assert_complete_full(input);
+    let ks: HashSet<&str> = kinds_for(&caps, &kinds).into_iter().collect();
+    for expected in [
+        "property",
+        "type",
+        "string",
+        "number",
+        "constant",
+        "punctuation",
+        "comment",
+    ] {
+        assert!(ks.contains(expected), "missing kind {}", expected);
+    }
+    // Section headers for [package], [dependencies], [[bin]] produce `type`
+    // captures; verify we have at least 3.
+    let type_spans = kind_spans(&caps, &kinds, "type");
+    assert!(
+        type_spans.len() >= 3,
+        "expected >= 3 type captures for section headers, got {:?}",
+        type_spans
+    );
+}

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -1,5 +1,9 @@
 use syntax_highlighter::highlight::{theme, Highlighter};
 
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 
 fn hl() -> Highlighter {
@@ -193,25 +197,4 @@ fn unterminated_string_still_round_trips() {
     let input = r#"{"a": "oops"#;
     let out = h.highlight(input);
     assert_eq!(strip_ansi(&out), input);
-}
-
-fn strip_ansi(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
-            i += 2;
-            while i < bytes.len() && !bytes[i].is_ascii_alphabetic() {
-                i += 1;
-            }
-            if i < bytes.len() {
-                i += 1;
-            }
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(out).unwrap()
 }

--- a/tests/highlight_toml_tests.rs
+++ b/tests/highlight_toml_tests.rs
@@ -1,0 +1,207 @@
+use syntax_highlighter::highlight::{theme, Highlighter};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+
+fn hl() -> Highlighter {
+    Highlighter::new(TOML_GRAMMAR).expect("TOML grammar should compile")
+}
+
+#[test]
+fn parses_simple_pair() {
+    let h = hl();
+    let input = "key = 1\n";
+    let (matched, caps) = h.captures(input);
+    assert_eq!(matched, input.len());
+    assert!(!caps.is_empty());
+}
+
+#[test]
+fn highlight_string_uses_green() {
+    let h = hl();
+    let out = h.highlight("s = \"hello\"\n");
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color, got {:?}",
+        out
+    );
+    assert!(out.contains("hello"));
+}
+
+#[test]
+fn highlight_number_uses_yellow() {
+    let h = hl();
+    let out = h.highlight("n = 42\n");
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected number color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_boolean_uses_constant() {
+    let h = hl();
+    let out = h.highlight("b = true\n");
+    assert!(
+        out.contains(theme::color_for("constant")),
+        "expected constant color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_inf_uses_constant_not_number() {
+    // inf / nan are @constant in this grammar, grouped with true/false
+    // rather than with 42 / 3.14. Verify the color lands as constant.
+    let h = hl();
+    let out = h.highlight("f = inf\n");
+    // Locate where "inf" appears and check the preceding ANSI escape.
+    let idx = out.find("inf").expect("inf must appear in output");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("constant")),
+        "expected constant color before inf, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_comment_uses_comment_color() {
+    let h = hl();
+    let out = h.highlight("# a comment\n");
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_key_uses_property_not_string() {
+    // A bare key on the LHS of = should render as @property (cyan), not
+    // as @string (green). This is the JSON-equivalent of the "property vs
+    // string" distinction, adapted to TOML bare keys.
+    let h = hl();
+    let out = h.highlight("name = \"alice\"\n");
+    let prop = theme::color_for("property");
+    let str_color = theme::color_for("string");
+
+    let idx_name = out.find("name").expect("key text not present");
+    let preceding_key = &out[..idx_name];
+    assert!(
+        preceding_key.ends_with(prop),
+        "expected property color before key, got tail {:?}",
+        preceding_key
+    );
+
+    let idx_val = out.find("\"alice\"").expect("value text not present");
+    let preceding_val = &out[..idx_val];
+    assert!(
+        preceding_val.ends_with(str_color),
+        "expected string color before value, got tail {:?}",
+        preceding_val
+    );
+}
+
+#[test]
+fn highlight_section_header_uses_type_color() {
+    let h = hl();
+    let out = h.highlight("[package]\n");
+    let ty = theme::color_for("type");
+    let idx = out.find("package").expect("section path must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(ty),
+        "expected type color before section path, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_array_of_tables_header_uses_type_color() {
+    let h = hl();
+    let out = h.highlight("[[bin]]\n");
+    let ty = theme::color_for("type");
+    let idx = out.find("bin").expect("section path must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(ty),
+        "expected type color before section path, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlighting_preserves_input_text() {
+    // Stripping ANSI codes must yield the original input byte-for-byte.
+    let h = hl();
+    let input = r#"# A realistic snippet.
+[package]
+name = "demo"
+version = "0.1.0"
+edition = 2021
+authors = ["alice", "bob"]
+publish = false
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[[bin]]
+name = "demo"
+path = "src/main.rs"
+"#;
+    let out = h.highlight(input);
+    let stripped = strip_ansi(&out);
+    assert_eq!(stripped, input);
+}
+
+#[test]
+fn blank_lines_and_trailing_comments_are_preserved() {
+    // Blank lines between entries and trailing end-of-line comments must
+    // survive the round trip verbatim.
+    let h = hl();
+    let input = "\n\n# leading\n\nkey = 1 # trailing\n\n\n";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
+#[test]
+fn partial_match_unterminated_string_still_round_trips() {
+    // The load-bearing strip_ansi invariant must hold on malformed input.
+    let h = hl();
+    let input = "key = \"oops\n";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
+#[test]
+fn partial_match_unclosed_table_header_still_round_trips() {
+    let h = hl();
+    let input = "[package\nname = \"x\"";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
+#[test]
+fn partial_match_renders_prefix_styled_and_tail_plain() {
+    // The valid prefix should carry some ANSI styling; the trailing
+    // garbage should render verbatim in the output.
+    let h = hl();
+    let input = "key = 1\n!!garbage";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input, "round-trip must hold");
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected styled prefix, got {:?}",
+        out
+    );
+    assert!(
+        out.contains("!!garbage"),
+        "trailing garbage must render verbatim, got {:?}",
+        out
+    );
+}


### PR DESCRIPTION
## Summary

Lands **TOML** as the second language grammar, validating that the
PEG/VM/capture machinery generalizes beyond JSON. This is the first real
test of the "grammars are data, languages are small" claim with n=2.

Three commits:

1. **Grammar + tests** (`d10b4af`). Complete TOML v1.0 surface
   (`grammars/toml.peg`), 25 structural tests, 14 end-to-end highlight
   tests, `strip_ansi` helper extracted to `tests/common/mod.rs` and
   shared across both highlight suites. Only semantic duplicate-key
   detection is out of scope (parser concern, not PEG-expressible).
2. **CLI dispatch** (`c8dd652`). File extension picks the grammar
   (`.json`, `.toml`); stdin uses `-l json|toml`, defaulting to JSON
   to preserve prior behavior.
3. **Docs** (`4b91d75`). README Status, Quick demo, and Roadmap.

## Validation signal

- **Capture-kind vocabulary.** TOML maps cleanly onto the seven kinds
  already in `src/highlight/theme.rs` (`comment`, `property`, `type`,
  `string`, `number`, `constant`, `punctuation`). No new kinds were
  needed — evidence that the hardcoded theme is adequate for at least
  two grammars and the theme-file work can wait. Calls worth noting:
  section-header paths are `@type` (yellow, distinct from cyan keys);
  `inf`/`nan` are `@constant` (shape-kin to `true`/`false`); datetimes
  are `@number` (the hardcoded theme has no `date` kind).
- **Bytecode footprint.** First n=2 datapoint for the
  compact-bytecode claim:
  - `json.peg` → 16 rules, 5 kinds, **165 instructions**
  - `toml.peg` → 59 rules, 7 kinds, **511 instructions**

  TOML is ~3× JSON, consistent with a grammar that adds comments,
  line-oriented structure, multi-line strings, four integer bases with
  separators, RFC 3339 datetimes, inline/array-of-tables, and
  `inf`/`nan`. Well inside the "kilobyte range" ambition.
- **Partial-match rendering on a different shape.** Malformed TOML
  (unterminated strings, unclosed headers) round-trips byte-for-byte;
  the valid prefix renders styled and the rest plain. Exercises the
  farthest-failure machinery on a line-oriented grammar.
- **No changes needed in `src/highlight/*`, `src/pegvm/*`, or
  `src/lib.rs`.** The only library-level file touched is `src/main.rs`
  (CLI dispatch). The rest of the infrastructure generalized as
  designed.

## Test plan

Nothing beyond CI — all coverage is in `tests/grammar_toml_tests.rs`
(25 cases) and `tests/highlight_toml_tests.rs` (14 cases), both run
by `cargo test`. Manually verified `cargo run -- Cargo.toml` round-trips
byte-for-byte against the real `Cargo.toml`.