### PR TITLE
Add SQLite SELECT grammar (backtracking-stress validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ that can scale to many languages without binary bloat.
 
 ## Status
 
-Early MVP. Ships JSON and TOML grammars and an ANSI-coloring CLI. The
-properties described in *Why this approach* below are **design goals that
-this MVP is trying to prove** — the architecture supports them, and the
-first cross-language validation (JSON + TOML) is in. Expect breaking
-changes.
+Early MVP. Ships JSON, TOML, and SQLite-SELECT grammars and an
+ANSI-coloring CLI. The properties described in *Why this approach*
+below are **design goals that this MVP is trying to prove** — the
+architecture supports them, and cross-language validation spans three
+grammar shapes (JSON, TOML, and a backtracking-heavy SQL SELECT
+subset). Expect breaking changes.
 
-The CLI picks a grammar by file extension (`.json`, `.toml`) or an
-explicit `-l json|toml` flag; stdin without a flag defaults to JSON.
+The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`)
+or an explicit `-l json|toml|sql` flag; stdin without a flag defaults
+to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
@@ -65,6 +67,7 @@ For stdin with a non-default language, pass `-l`:
 
 ```bash
 printf '[package]\nname = "demo"\n' | cargo run -- -l toml
+printf 'SELECT id FROM users WHERE active;\n' | cargo run -- -l sql
 ```
 
 ## Grammar format
@@ -84,12 +87,16 @@ largest piece of work.
 
 These need no new VM or compiler machinery.
 
-- **More language grammars.** JSON and TOML ship today. Adding a language
-  means writing a grammar file. Remaining candidates: Python, Rust, CSS
-  or a SQL dialect (both have the shared-prefix alternatives that would
-  stress a future packrat cache). YAML is deferred — its context-sensitive
-  indentation semantics make it a poor fit for PEG without additional
-  machinery.
+- **More language grammars.** JSON, TOML, and a SQLite SELECT subset
+  ship today. Adding a language means writing a grammar file.
+  Expanding the SQLite grammar to the full dialect (INSERT/UPDATE/
+  DELETE/DDL/triggers) is the intended vehicle for two roadmap
+  deliverables it is uniquely positioned to support: a large-grammar
+  bytecode-size datapoint (JSON and TOML are both compact formats) and
+  a multi-statement error-recovery use case (single-SELECT does not
+  exercise it). Remaining candidates beyond SQLite: Python, Rust, CSS.
+  YAML is deferred — its context-sensitive indentation semantics make
+  it a poor fit for PEG without additional machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is
   orthogonal to the VM.

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -1,0 +1,334 @@
+# SQLite SELECT grammar with highlight annotations.
+# The first rule is the start rule.
+#
+# Scope: SQLite SELECT statements sufficient to highlight realistic
+# read-only queries. Covers expressions, JOINs, simple (non-recursive)
+# CTEs, compound SELECT (UNION / INTERSECT / EXCEPT), CASE, CAST, EXISTS,
+# scalar subqueries, function calls, bind parameters, string / BLOB /
+# numeric / NULL / boolean literals, and line / block comments.
+#
+# Deferred: INSERT / UPDATE / DELETE / DDL / triggers / PRAGMA /
+# transactions; WITH RECURSIVE; window functions (`OVER(...)`).
+# Expanding to the full SQLite dialect is intended future work with two
+# specific payoffs (see README.md roadmap):
+#   - a large-grammar bytecode-size datapoint (vs. JSON and TOML)
+#   - a multi-statement error-recovery use case, which single-SELECT
+#     does not exercise
+#
+# Capture kinds (all present in src/highlight/theme.rs):
+#   keyword, string, number, comment, operator, punctuation,
+#   type, function, constant, variable.
+#
+# Capture-kind notes:
+#   - Table names in FROM / JOIN / CTE heads are @type; column
+#     references are @variable. The same lexeme gets a different kind
+#     depending on syntactic position — a genuine win of grammar-driven
+#     highlighting over scope-based matchers.
+#   - BLOB literals X'...' are @string (byte strings; no @bytes kind).
+#   - Bind parameters (?, ?N, :name, @name, $name) are @variable.
+#   - Quoted identifiers ("...", `...`, [...]) are @variable.
+#
+# This grammar deliberately exercises shared-prefix backtracking in the
+# expression rules (function_call vs qualified_column_ref vs bare
+# column_ref; paren_expr vs scalar subquery). These patterns motivate
+# the memoization work in the README roadmap.
+
+# --- Top level --------------------------------------------------------
+
+sql_file   <- ws (statement (stmt_sep statement)*)? stmt_sep? ws !.
+stmt_sep   <- ws @punctuation{';'} ws
+statement  <- select_stmt
+
+# --- SELECT statement -------------------------------------------------
+
+select_stmt    <- with_clause? select_core compound_tail* order_clause? limit_clause?
+
+with_clause    <- kw_with ws cte_defn (ws @punctuation{','} ws cte_defn)* ws
+cte_defn       <- @type{bare_ident} ws kw_as ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
+
+select_core    <- kw_select (ws (kw_distinct / kw_all))? ws result_list
+                  (ws from_clause)? (ws where_clause)? (ws group_clause)? (ws having_clause)?
+
+result_list    <- result_column (ws @punctuation{','} ws result_column)*
+result_column  <- table_star / @operator{'*'} / aliased_expr
+table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
+aliased_expr   <- expr (ws kw_as ws @variable{bare_ident_nonkw}
+                      / ws @variable{bare_ident_nonkw})?
+
+compound_tail  <- ws (kw_union (ws kw_all)? / kw_intersect / kw_except) ws select_core
+
+from_clause    <- kw_from ws table_or_subquery (ws join_clause)*
+table_or_subquery <- @punctuation{'('} ws select_stmt ws @punctuation{')'} (ws table_alias)?
+                   / qualified_table_name (ws table_alias)?
+qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
+table_alias    <- kw_as ws @variable{bare_ident_nonkw}
+                / @variable{bare_ident_nonkw}
+
+join_clause    <- join_op ws table_or_subquery (ws join_constraint)?
+join_op        <- @punctuation{','}
+                / kw_natural (ws join_type)? ws kw_join
+                / join_type ws kw_join
+                / kw_join
+join_type      <- kw_left (ws kw_outer)?
+                / kw_right (ws kw_outer)?
+                / kw_full (ws kw_outer)?
+                / kw_inner
+                / kw_cross
+join_constraint<- kw_on ws expr
+                / kw_using ws @punctuation{'('} ws ident_list ws @punctuation{')'}
+ident_list     <- @variable{bare_ident_nonkw} (ws @punctuation{','} ws @variable{bare_ident_nonkw})*
+
+where_clause   <- kw_where ws expr
+group_clause   <- kw_group ws kw_by ws expr (ws @punctuation{','} ws expr)*
+having_clause  <- kw_having ws expr
+
+order_clause   <- ws kw_order ws kw_by ws order_item (ws @punctuation{','} ws order_item)*
+order_item     <- expr (ws (kw_asc / kw_desc))?
+
+limit_clause   <- ws kw_limit ws expr (ws kw_offset ws expr
+                                     / ws @punctuation{','} ws expr)?
+
+# --- Expressions (low → high precedence) -------------------------------
+# Classic precedence-climbing without left recursion. Each level either
+# matches the next-higher level or chains several of them with an
+# operator. No shared-prefix issues between levels.
+
+expr        <- or_expr
+or_expr     <- and_expr (ws kw_or ws and_expr)*
+and_expr    <- not_expr (ws kw_and ws not_expr)*
+not_expr    <- kw_not ws not_expr / cmp_expr
+cmp_expr    <- bit_expr cmp_tail*
+cmp_tail    <- ws kw_is ws (kw_not ws)? bit_expr
+             / ws (kw_not ws)? kw_between ws bit_expr ws kw_and ws bit_expr
+             / ws (kw_not ws)? kw_in ws @punctuation{'('} ws in_args? ws @punctuation{')'}
+             / ws (kw_not ws)? kw_like ws bit_expr (ws kw_escape ws bit_expr)?
+             / ws (kw_not ws)? kw_glob ws bit_expr
+             / ws (kw_not ws)? kw_match ws bit_expr
+             / ws (kw_not ws)? kw_regexp ws bit_expr
+             / ws cmp_op ws bit_expr
+in_args     <- select_stmt / expr (ws @punctuation{','} ws expr)*
+cmp_op      <- @operator{'=='} / @operator{'<='} / @operator{'>='}
+             / @operator{'!='} / @operator{'<>'} / @operator{'='}
+             / @operator{'<'} / @operator{'>'}
+bit_expr    <- add_expr (ws bit_op ws add_expr)*
+bit_op      <- @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
+add_expr    <- mul_expr (ws add_op ws mul_expr)*
+add_op      <- @operator{'+'} / @operator{'-'}
+mul_expr    <- concat_expr (ws mul_op ws concat_expr)*
+mul_op      <- @operator{'*'} / @operator{'/'} / @operator{'%'}
+concat_expr <- unary_expr (ws @operator{'||'} ws unary_expr)*
+unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) ws unary_expr
+             / primary
+
+# Shared-prefix hotspots: function_call / qualified_column_ref /
+# column_ref_bare all start with an identifier — the classic packrat
+# motivator.
+primary     <- literal
+             / case_expr
+             / cast_expr
+             / exists_expr
+             / paren_primary
+             / function_call
+             / qualified_column_ref
+             / column_ref_bare
+             / bind_param
+
+paren_primary <- @punctuation{'('} ws (select_stmt / expr) ws @punctuation{')'}
+
+function_call <- @function{bare_ident_nonkw} ws @punctuation{'('} ws func_args? ws @punctuation{')'}
+func_args   <- @operator{'*'}
+             / (kw_distinct ws)? expr (ws @punctuation{','} ws expr)*
+
+qualified_column_ref <- @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
+column_ref_bare      <- @variable{bare_ident_nonkw}
+
+case_expr   <- kw_case (ws expr)? (ws when_clause)+ (ws kw_else ws expr)? ws kw_end
+when_clause <- kw_when ws expr ws kw_then ws expr
+
+cast_expr   <- kw_cast ws @punctuation{'('} ws expr ws kw_as ws @type{bare_ident} ws @punctuation{')'}
+
+exists_expr <- kw_exists ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
+
+# --- Literals ---------------------------------------------------------
+# Order matters: blob before string (X' prefix consumed first); number
+# tries hex / float / int in that order inside number_body.
+
+literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
+
+null_lit    <- @constant{null_body !ident_char}
+bool_lit    <- @constant{bool_body !ident_char}
+null_body   <- [nN][uU][lL][lL]
+bool_body   <- [tT][rR][uU][eE] / [fF][aA][lL][sS][eE]
+
+blob_lit    <- @string{blob_body}
+blob_body   <- [xX] "'" [0-9a-fA-F]* "'"
+string_lit  <- @string{string_body}
+string_body <- "'" ("''" / !"'" .)* "'"
+
+number_body <- '0x' [0-9a-fA-F]+ !ident_char
+             / float_body
+             / int_body
+float_body  <- [0-9]+ '.' [0-9]+ ([eE] [+\-]? [0-9]+)?
+             / [0-9]+ [eE] [+\-]? [0-9]+
+int_body    <- [0-9]+
+
+# Bind parameters are placeholders bound at execute time — lexically
+# variables, not named constants.
+bind_param  <- @variable{bind_body}
+bind_body   <- '?' [0-9]*
+             / [:@$] ident_start ident_cont*
+
+# --- Identifiers ------------------------------------------------------
+# Four syntactic forms — bare, double-quoted, backtick, bracketed.
+# `bare_ident_nonkw` excludes SQL keywords via a big negative lookahead
+# (the expected-slow path that memoization is meant to accelerate).
+# `bare_ident` allows keyword-named identifiers (used inside CAST type
+# names and CTE heads where a keyword like INTEGER is actually the
+# content we want to capture as @type).
+
+bare_ident_nonkw  <- quoted_ident / !keyword_word bare_raw
+bare_ident        <- quoted_ident / bare_raw
+quoted_ident      <- double_quoted_id / backtick_id / bracket_id
+
+bare_raw          <- ident_start ident_cont*
+ident_start       <- [a-zA-Z_]
+ident_cont        <- [a-zA-Z0-9_]
+ident_char        <- [a-zA-Z0-9_]
+
+double_quoted_id  <- '"' ('""' / !'"' !linebreak .)* '"'
+backtick_id       <- '`' ('``' / !'`' !linebreak .)* '`'
+bracket_id        <- '[' (!']' !linebreak .)* ']'
+
+# --- Keywords (case-insensitive) --------------------------------------
+# Per-letter character classes give case-insensitive matching without
+# VM support. Every kw_* wraps its body in @keyword{...} and appends
+# the `!ident_char` boundary so `SELECT` doesn't match the prefix of
+# `SELECTED`. `keyword_word` reuses the same boundary for the
+# identifier-exclusion negative lookahead.
+
+kw_select    <- @keyword{sel_body !ident_char}
+kw_from      <- @keyword{from_body !ident_char}
+kw_where     <- @keyword{where_body !ident_char}
+kw_group     <- @keyword{group_body !ident_char}
+kw_by        <- @keyword{by_body !ident_char}
+kw_having    <- @keyword{having_body !ident_char}
+kw_order     <- @keyword{order_body !ident_char}
+kw_asc       <- @keyword{asc_body !ident_char}
+kw_desc      <- @keyword{desc_body !ident_char}
+kw_limit     <- @keyword{limit_body !ident_char}
+kw_offset    <- @keyword{offset_body !ident_char}
+kw_join      <- @keyword{join_body !ident_char}
+kw_inner     <- @keyword{inner_body !ident_char}
+kw_left      <- @keyword{left_body !ident_char}
+kw_right     <- @keyword{right_body !ident_char}
+kw_full      <- @keyword{full_body !ident_char}
+kw_outer     <- @keyword{outer_body !ident_char}
+kw_cross     <- @keyword{cross_body !ident_char}
+kw_natural   <- @keyword{natural_body !ident_char}
+kw_on        <- @keyword{on_body !ident_char}
+kw_using     <- @keyword{using_body !ident_char}
+kw_as        <- @keyword{as_body !ident_char}
+kw_distinct  <- @keyword{distinct_body !ident_char}
+kw_all       <- @keyword{all_body !ident_char}
+kw_union     <- @keyword{union_body !ident_char}
+kw_intersect <- @keyword{intersect_body !ident_char}
+kw_except    <- @keyword{except_body !ident_char}
+kw_with      <- @keyword{with_body !ident_char}
+kw_and       <- @keyword{and_body !ident_char}
+kw_or        <- @keyword{or_body !ident_char}
+kw_not       <- @keyword{not_body !ident_char}
+kw_is        <- @keyword{is_body !ident_char}
+kw_in        <- @keyword{in_body !ident_char}
+kw_like      <- @keyword{like_body !ident_char}
+kw_glob      <- @keyword{glob_body !ident_char}
+kw_match     <- @keyword{match_body !ident_char}
+kw_regexp    <- @keyword{regexp_body !ident_char}
+kw_between   <- @keyword{between_body !ident_char}
+kw_escape    <- @keyword{escape_body !ident_char}
+kw_case      <- @keyword{case_body !ident_char}
+kw_when      <- @keyword{when_body !ident_char}
+kw_then      <- @keyword{then_body !ident_char}
+kw_else      <- @keyword{else_body !ident_char}
+kw_end       <- @keyword{end_body !ident_char}
+kw_cast      <- @keyword{cast_body !ident_char}
+kw_exists    <- @keyword{exists_body !ident_char}
+kw_collate   <- @keyword{collate_body !ident_char}
+
+# Keyword bodies — raw letter matchers, no boundary check.
+
+sel_body       <- [sS][eE][lL][eE][cC][tT]
+from_body      <- [fF][rR][oO][mM]
+where_body     <- [wW][hH][eE][rR][eE]
+group_body     <- [gG][rR][oO][uU][pP]
+by_body        <- [bB][yY]
+having_body    <- [hH][aA][vV][iI][nN][gG]
+order_body     <- [oO][rR][dD][eE][rR]
+asc_body       <- [aA][sS][cC]
+desc_body      <- [dD][eE][sS][cC]
+limit_body     <- [lL][iI][mM][iI][tT]
+offset_body    <- [oO][fF][fF][sS][eE][tT]
+join_body      <- [jJ][oO][iI][nN]
+inner_body     <- [iI][nN][nN][eE][rR]
+left_body      <- [lL][eE][fF][tT]
+right_body     <- [rR][iI][gG][hH][tT]
+full_body      <- [fF][uU][lL][lL]
+outer_body     <- [oO][uU][tT][eE][rR]
+cross_body     <- [cC][rR][oO][sS][sS]
+natural_body   <- [nN][aA][tT][uU][rR][aA][lL]
+on_body        <- [oO][nN]
+using_body     <- [uU][sS][iI][nN][gG]
+as_body        <- [aA][sS]
+distinct_body  <- [dD][iI][sS][tT][iI][nN][cC][tT]
+all_body       <- [aA][lL][lL]
+union_body     <- [uU][nN][iI][oO][nN]
+intersect_body <- [iI][nN][tT][eE][rR][sS][eE][cC][tT]
+except_body    <- [eE][xX][cC][eE][pP][tT]
+with_body      <- [wW][iI][tT][hH]
+and_body       <- [aA][nN][dD]
+or_body        <- [oO][rR]
+not_body       <- [nN][oO][tT]
+is_body        <- [iI][sS]
+in_body        <- [iI][nN]
+like_body      <- [lL][iI][kK][eE]
+glob_body      <- [gG][lL][oO][bB]
+match_body     <- [mM][aA][tT][cC][hH]
+regexp_body    <- [rR][eE][gG][eE][xX][pP]
+between_body   <- [bB][eE][tT][wW][eE][eE][nN]
+escape_body    <- [eE][sS][cC][aA][pP][eE]
+case_body      <- [cC][aA][sS][eE]
+when_body      <- [wW][hH][eE][nN]
+then_body      <- [tT][hH][eE][nN]
+else_body      <- [eE][lL][sS][eE]
+end_body       <- [eE][nN][dD]
+cast_body      <- [cC][aA][sS][tT]
+exists_body    <- [eE][xX][iI][sS][tT][sS]
+collate_body   <- [cC][oO][lL][lL][aA][tT][eE]
+
+# Keyword negative-lookahead for the identifier rule. Ordering: among
+# alternatives that share a prefix, put the longer body first so PEG
+# first-match doesn't accept a shorter keyword when a longer one would
+# match (e.g. INTERSECT before IN, NATURAL before NOT, DISTINCT before
+# DESC, OUTER before OR). `!ident_char` is applied once at the outside
+# so each body stays boundary-free.
+keyword_word <-
+    ( intersect_body / between_body / distinct_body / collate_body
+    / natural_body / regexp_body / outer_body / offset_body
+    / having_body / except_body / exists_body / escape_body
+    / sel_body / union_body / inner_body / right_body
+    / group_body / order_body / where_body / match_body / cross_body
+    / limit_body / from_body / join_body / left_body
+    / full_body / glob_body / desc_body / with_body / cast_body
+    / case_body / when_body / then_body / else_body / like_body
+    / null_body / bool_body / using_body / asc_body / all_body
+    / end_body / and_body / not_body
+    / in_body / is_body / on_body / or_body / as_body / by_body
+    ) !ident_char
+
+# --- Whitespace & comments -------------------------------------------
+
+ws            <- (comment / [ \t\n\r])*
+comment       <- line_comment / block_comment
+line_comment  <- @comment{'--' (!linebreak .)*}
+block_comment <- @comment{'/*' block_body '*/'}
+block_body    <- (!'*/' .)*
+linebreak     <- '\r'? '\n'

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,13 @@ use syntax_highlighter::highlight::Highlighter;
 
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 
 #[derive(Clone, Copy)]
 enum Lang {
     Json,
     Toml,
+    Sql,
 }
 
 impl Lang {
@@ -18,6 +20,7 @@ impl Lang {
         match self {
             Lang::Json => JSON_GRAMMAR,
             Lang::Toml => TOML_GRAMMAR,
+            Lang::Sql => SQLITE_GRAMMAR,
         }
     }
 
@@ -25,6 +28,7 @@ impl Lang {
         match name {
             "json" => Some(Lang::Json),
             "toml" => Some(Lang::Toml),
+            "sql" | "sqlite" => Some(Lang::Sql),
             _ => None,
         }
     }
@@ -50,18 +54,16 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
             "-l" | "--lang" => {
                 let name = it
                     .next()
-                    .ok_or_else(|| format!("{} requires a value (json|toml)", arg))?;
-                lang =
-                    Some(Lang::from_name(&name).ok_or_else(|| {
-                        format!("unknown language {:?} (expected json|toml)", name)
-                    })?);
+                    .ok_or_else(|| format!("{} requires a value (json|toml|sql)", arg))?;
+                lang = Some(Lang::from_name(&name).ok_or_else(|| {
+                    format!("unknown language {:?} (expected json|toml|sql)", name)
+                })?);
             }
             other if other.starts_with("--lang=") => {
                 let name = &other["--lang=".len()..];
-                lang =
-                    Some(Lang::from_name(name).ok_or_else(|| {
-                        format!("unknown language {:?} (expected json|toml)", name)
-                    })?);
+                lang = Some(Lang::from_name(name).ok_or_else(|| {
+                    format!("unknown language {:?} (expected json|toml|sql)", name)
+                })?);
             }
             _ => {
                 if path.is_some() {
@@ -81,7 +83,7 @@ fn pick_lang(cli: &Cli) -> Result<Lang, String> {
     match &cli.path {
         Some(p) => Lang::from_extension(Path::new(p)).ok_or_else(|| {
             format!(
-                "cannot infer language from path {:?}; pass --lang json|toml",
+                "cannot infer language from path {:?}; pass --lang json|toml|sql",
                 p
             )
         }),

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -1,0 +1,407 @@
+use std::collections::HashSet;
+
+use syntax_highlighter::pegvm::{compile_grammar, parse_grammar, Capture, Program, VM};
+
+const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+
+fn compile() -> Program {
+    let g = parse_grammar(SQLITE_GRAMMAR).expect("SQLite grammar should parse");
+    compile_grammar(&g.rules, &g.start).expect("SQLite grammar should compile")
+}
+
+fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
+    let prog = compile();
+    let r = VM::new(&prog.code, input.as_bytes()).run();
+    (
+        r.matched,
+        r.captures,
+        prog.capture_kinds.clone(),
+        r.complete,
+    )
+}
+
+fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+        .collect()
+}
+
+fn spans_for<'a>(
+    captures: &[Capture],
+    kinds: &[String],
+    kind: &str,
+    input: &'a str,
+) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == kind)
+        .map(|c| &input[c.start..c.end])
+        .collect()
+}
+
+fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(
+        complete,
+        "expected complete match for {:?}, got matched={} kinds={:?}",
+        input,
+        matched,
+        kinds_for(&caps, &kinds)
+    );
+    assert_eq!(
+        matched,
+        input.len(),
+        "expected full-input match for {:?}",
+        input
+    );
+    (caps, kinds)
+}
+
+#[test]
+fn grammar_parses_and_compiles() {
+    let prog = compile();
+    assert!(!prog.code.is_empty());
+    assert!(!prog.capture_kinds.is_empty());
+    eprintln!(
+        "SQLite bytecode: {} rules, {} kinds, {} instr",
+        parse_grammar(SQLITE_GRAMMAR).unwrap().rules.len(),
+        prog.capture_kinds.len(),
+        prog.code.len()
+    );
+}
+
+#[test]
+fn capture_kinds_are_only_theme_kinds() {
+    let prog = compile();
+    let expected: HashSet<&str> = [
+        "keyword",
+        "string",
+        "number",
+        "comment",
+        "operator",
+        "punctuation",
+        "type",
+        "function",
+        "constant",
+        "variable",
+    ]
+    .into_iter()
+    .collect();
+    let actual: HashSet<&str> = prog.capture_kinds.iter().map(String::as_str).collect();
+    assert!(
+        actual.is_subset(&expected),
+        "SQLite grammar must stay within the hardcoded-theme vocabulary; got extras: {:?}",
+        actual.difference(&expected).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn simple_select_literal() {
+    let (caps, kinds) = assert_complete_full("SELECT 1;");
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["keyword", "number", "punctuation"]
+    );
+}
+
+#[test]
+fn select_column_from_table() {
+    let input = "SELECT col FROM tbl";
+    let (caps, kinds) = assert_complete_full(input);
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["keyword", "variable", "keyword", "type"]
+    );
+}
+
+#[test]
+fn select_star() {
+    let input = "SELECT * FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    assert_eq!(
+        kinds_for(&caps, &kinds),
+        vec!["keyword", "operator", "keyword", "type"]
+    );
+}
+
+#[test]
+fn table_dot_star() {
+    let input = "SELECT t.* FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    assert!(
+        ks.contains(&"operator"),
+        "expected * as operator, got {:?}",
+        ks
+    );
+    // Both `t`s should be @type.
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert_eq!(
+        types.len(),
+        2,
+        "expected two @type captures for `t`, got {:?}",
+        types
+    );
+}
+
+#[test]
+fn qualified_column_is_variable() {
+    let input = "SELECT t.col FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let vars = spans_for(&caps, &kinds, "variable", input);
+    assert_eq!(vars, vec!["t", "col"]);
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert_eq!(types, vec!["t"]);
+}
+
+#[test]
+fn function_call_emits_function_capture() {
+    let input = "SELECT COUNT(*) FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let funcs = spans_for(&caps, &kinds, "function", input);
+    assert_eq!(funcs, vec!["COUNT"]);
+}
+
+#[test]
+fn where_clause_with_eq_and_and_is_null() {
+    let input = "SELECT a FROM t WHERE a = 1 AND b IS NULL";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    assert!(ks.contains(&"operator"), "missing operator in {:?}", ks);
+    assert!(
+        ks.contains(&"constant"),
+        "missing constant (NULL) in {:?}",
+        ks
+    );
+    // Keywords: SELECT, FROM, WHERE, AND, IS.
+    let kw_count = ks.iter().filter(|k| **k == "keyword").count();
+    assert!(
+        kw_count >= 5,
+        "expected >= 5 keywords, got {}: {:?}",
+        kw_count,
+        ks
+    );
+}
+
+#[test]
+fn case_expression() {
+    let input = "SELECT CASE WHEN a THEN 1 ELSE 2 END FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    // Four CASE-related keywords: CASE WHEN THEN ELSE END (5).
+    let kw_count = ks.iter().filter(|k| **k == "keyword").count();
+    assert!(
+        kw_count >= 7,
+        "expected many keywords, got {}: {:?}",
+        kw_count,
+        ks
+    );
+}
+
+#[test]
+fn cast_emits_type_on_target() {
+    let input = "SELECT CAST(x AS INTEGER) FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert!(
+        types.contains(&"INTEGER"),
+        "expected INTEGER as @type, got {:?}",
+        types
+    );
+    assert!(types.contains(&"t"), "expected t as @type, got {:?}", types);
+}
+
+#[test]
+fn string_literal_with_doubled_quote() {
+    let input = "SELECT 'it''s' FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let strings = spans_for(&caps, &kinds, "string", input);
+    assert_eq!(strings, vec!["'it''s'"]);
+}
+
+#[test]
+fn blob_literal_is_string() {
+    let input = "SELECT X'DEAD' FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let strings = spans_for(&caps, &kinds, "string", input);
+    assert_eq!(strings, vec!["X'DEAD'"]);
+}
+
+#[test]
+fn integer_variants() {
+    for input in ["SELECT 0", "SELECT 42", "SELECT 0xDEAD"] {
+        let (caps, kinds) = assert_complete_full(input);
+        let nums = spans_for(&caps, &kinds, "number", input);
+        assert_eq!(nums.len(), 1, "input: {:?}", input);
+    }
+}
+
+#[test]
+fn float_variants() {
+    for input in ["SELECT 3.14", "SELECT 1e10", "SELECT 6.022e23"] {
+        let (caps, kinds) = assert_complete_full(input);
+        let nums = spans_for(&caps, &kinds, "number", input);
+        assert_eq!(nums.len(), 1, "input: {:?}", input);
+    }
+}
+
+#[test]
+fn null_true_false_are_constants() {
+    for (input, expected) in [
+        ("SELECT NULL", "NULL"),
+        ("SELECT TRUE", "TRUE"),
+        ("SELECT FALSE", "FALSE"),
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        let consts = spans_for(&caps, &kinds, "constant", input);
+        assert_eq!(consts, vec![expected]);
+    }
+}
+
+#[test]
+fn line_and_block_comments_are_captured() {
+    let input = "-- a line\nSELECT /* inline */ 1";
+    let (caps, kinds) = assert_complete_full(input);
+    let comments = spans_for(&caps, &kinds, "comment", input);
+    assert_eq!(comments.len(), 2);
+    assert!(comments[0].starts_with("--"));
+    assert!(comments[1].starts_with("/*"));
+}
+
+#[test]
+fn bind_parameters_are_variables() {
+    for input in [
+        "SELECT ? FROM t",
+        "SELECT ?1 FROM t",
+        "SELECT :name FROM t",
+        "SELECT @name FROM t",
+        "SELECT $name FROM t",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        let ks = kinds_for(&caps, &kinds);
+        // Bind param must surface as @variable.
+        assert!(
+            ks.contains(&"variable"),
+            "expected @variable for bind param in {:?}, kinds={:?}",
+            input,
+            ks
+        );
+    }
+}
+
+#[test]
+fn compound_select_union_all() {
+    let input = "SELECT 1 UNION ALL SELECT 2";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    let kw_count = ks.iter().filter(|k| **k == "keyword").count();
+    assert!(
+        kw_count >= 4,
+        "expected 4 keywords (SELECT UNION ALL SELECT), got {:?}",
+        ks
+    );
+}
+
+#[test]
+fn simple_cte() {
+    let input = "WITH t AS (SELECT 1) SELECT 2 FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert!(
+        types.iter().filter(|s| **s == "t").count() >= 2,
+        "expected `t` captured as @type (CTE head + FROM), got {:?}",
+        types
+    );
+}
+
+#[test]
+fn case_insensitive_keywords() {
+    // Same query in lowercase and uppercase should both parse.
+    assert_complete_full("SELECT 1");
+    assert_complete_full("select 1");
+    assert_complete_full("SeLeCt 1");
+}
+
+#[test]
+fn join_on_clause() {
+    let input = "SELECT * FROM u JOIN o ON u.id = o.uid";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    assert!(ks.contains(&"operator"));
+    // u, o at table positions; also u, o, id, uid at column positions.
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert!(
+        types.contains(&"u"),
+        "expected `u` as @type, got {:?}",
+        types
+    );
+    assert!(
+        types.contains(&"o"),
+        "expected `o` as @type, got {:?}",
+        types
+    );
+}
+
+#[test]
+fn left_outer_join() {
+    let input = "SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id";
+    let (caps, _) = assert_complete_full(input);
+    assert!(!caps.is_empty());
+}
+
+#[test]
+fn realistic_multiclause_query() {
+    let input = "\
+SELECT u.id, COUNT(*) AS n
+FROM users u
+JOIN orders o ON u.id = o.user_id
+WHERE u.active AND o.total > 100.0
+GROUP BY u.id
+ORDER BY n DESC
+LIMIT 10;
+";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks: HashSet<&str> = kinds_for(&caps, &kinds).into_iter().collect();
+    for expected in [
+        "keyword",
+        "number",
+        "punctuation",
+        "operator",
+        "type",
+        "variable",
+        "function",
+    ] {
+        assert!(
+            ks.contains(expected),
+            "missing kind {} in {:?}",
+            expected,
+            ks
+        );
+    }
+}
+
+#[test]
+fn in_list_and_in_subquery() {
+    assert_complete_full("SELECT 1 FROM t WHERE a IN (1, 2, 3)");
+    assert_complete_full("SELECT 1 FROM t WHERE a IN (SELECT x FROM s)");
+}
+
+#[test]
+fn between_and_like() {
+    assert_complete_full("SELECT 1 FROM t WHERE a BETWEEN 1 AND 10");
+    assert_complete_full("SELECT 1 FROM t WHERE a LIKE 'x%'");
+    assert_complete_full("SELECT 1 FROM t WHERE a NOT LIKE 'x%' ESCAPE '\\'");
+}
+
+#[test]
+fn exists_subquery() {
+    assert_complete_full("SELECT 1 WHERE EXISTS (SELECT 1)");
+}
+
+#[test]
+fn quoted_identifiers() {
+    assert_complete_full("SELECT \"a\".\"b\" FROM \"a\"");
+    assert_complete_full("SELECT `a`.`b` FROM `a`");
+    assert_complete_full("SELECT [a].[b] FROM [a]");
+}

--- a/tests/highlight_sql_tests.rs
+++ b/tests/highlight_sql_tests.rs
@@ -1,0 +1,207 @@
+use syntax_highlighter::highlight::{theme, Highlighter};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
+const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+
+fn hl() -> Highlighter {
+    Highlighter::new(SQLITE_GRAMMAR).expect("SQLite grammar should compile")
+}
+
+#[test]
+fn parses_minimal_select() {
+    let h = hl();
+    let input = "SELECT 1;";
+    let (matched, caps) = h.captures(input);
+    assert_eq!(matched, input.len());
+    assert!(!caps.is_empty());
+}
+
+#[test]
+fn highlight_keyword_uses_keyword_color() {
+    let h = hl();
+    let out = h.highlight("SELECT 1");
+    let kw = theme::color_for("keyword");
+    let idx = out.find("SELECT").expect("SELECT must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(kw),
+        "expected keyword color before SELECT, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_string_uses_string_color() {
+    let h = hl();
+    let out = h.highlight("SELECT 'hi' FROM t");
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_number_uses_number_color() {
+    let h = hl();
+    let out = h.highlight("SELECT 42 FROM t");
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected number color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_null_uses_constant_color() {
+    let h = hl();
+    let out = h.highlight("SELECT NULL");
+    let c = theme::color_for("constant");
+    let idx = out.find("NULL").expect("NULL must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(c),
+        "expected constant color before NULL, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_comment_uses_comment_color() {
+    let h = hl();
+    let out = h.highlight("-- note\nSELECT 1");
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_function_uses_function_color() {
+    let h = hl();
+    let out = h.highlight("SELECT COUNT(*) FROM t");
+    let f = theme::color_for("function");
+    let idx = out.find("COUNT").expect("COUNT must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(f),
+        "expected function color before COUNT, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_table_in_from_uses_type_color() {
+    let h = hl();
+    let out = h.highlight("SELECT c FROM users");
+    let t = theme::color_for("type");
+    let idx = out.find("users").expect("table name must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(t),
+        "expected type color before table name, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_cast_target_uses_type_color() {
+    let h = hl();
+    let out = h.highlight("SELECT CAST(x AS INTEGER) FROM t");
+    let t = theme::color_for("type");
+    let idx = out.find("INTEGER").expect("INTEGER must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(t),
+        "expected type color before CAST target, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlight_operator_uses_operator_color() {
+    let h = hl();
+    let out = h.highlight("SELECT a FROM t WHERE a = 1");
+    assert!(
+        out.contains(theme::color_for("operator")),
+        "expected operator color, got {:?}",
+        out
+    );
+}
+
+#[test]
+fn highlight_bind_param_uses_variable_color() {
+    let h = hl();
+    let out = h.highlight("SELECT :name FROM t");
+    let v = theme::color_for("variable");
+    let idx = out.find(":name").expect(":name must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(v),
+        "expected variable color before :name, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn highlighting_preserves_input_text() {
+    // Stripping ANSI codes must yield the original input byte-for-byte.
+    let h = hl();
+    let input = "\
+-- A representative query.
+WITH recent AS (SELECT id FROM orders)
+SELECT u.id, COUNT(*) AS n
+FROM users u
+LEFT JOIN recent r ON u.id = r.id
+WHERE u.active AND u.score > 0.5
+GROUP BY u.id
+HAVING n > 0
+ORDER BY n DESC
+LIMIT 10;
+
+SELECT 1 UNION ALL SELECT 2;
+";
+    let out = h.highlight(input);
+    let stripped = strip_ansi(&out);
+    assert_eq!(stripped, input);
+}
+
+#[test]
+fn partial_match_unterminated_string_still_round_trips() {
+    let h = hl();
+    let input = "SELECT 'oops\nFROM t";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
+#[test]
+fn partial_match_unclosed_paren_still_round_trips() {
+    let h = hl();
+    let input = "SELECT COUNT( FROM t";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input);
+}
+
+#[test]
+fn partial_match_renders_prefix_styled_and_tail_plain() {
+    // The valid SELECT prefix should carry styling; trailing garbage renders
+    // verbatim. This mirrors the TOML partial-match test.
+    let h = hl();
+    let input = "SELECT 1; !!garbage";
+    let out = h.highlight(input);
+    assert_eq!(strip_ansi(&out), input, "round-trip must hold");
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected styled prefix, got {:?}",
+        out
+    );
+    assert!(
+        out.contains("!!garbage"),
+        "trailing garbage must render verbatim, got {:?}",
+        out
+    );
+}


### PR DESCRIPTION
## Summary

Third language grammar — SQLite SELECT-only. Scope, capture mapping,
deferrals, and why this subset matters for future memoization work:
`grammars/sqlite.peg` header. Full-dialect leverage for future
bytecode-size and error-recovery deliverables: the "More language
grammars" bullet in `README.md`.

## Bytecode datapoint

| Grammar         | Instructions |
|---|---:|
| JSON            |  165 |
| TOML            |  511 |
| SQLite SELECT   | 1791 |

First grammar at this scale; running baseline for future sizing
measurements. Not committed (would be brittle to grammar tweaks).

## Test plan

CI covers grammar parsing, highlight colors, and round-trip /
partial-match rendering via the new `tests/grammar_sql_tests.rs` and
`tests/highlight_sql_tests.rs`. Additional manual checks, since no
CLI integration harness exists:

- [x] Extension dispatch: `cargo run -- /tmp/demo.sql`
- [x] `--lang=sqlite` alias: `printf '...' | cargo run -- --lang=sqlite`

Candidates for promotion if a CLI harness lands.