### PR TITLE
Add rule-level memoization (packrat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,44 @@ These need no new VM or compiler machinery.
 
 Each item is a self-contained feature that unlocks further work.
 
-- **Memoization (packrat parsing).** Caches rule results per input
-  position. Primary payoff: *incremental parsing* — O(Δ) per input
-  change instead of O(n). Covers both the easy case (append-only
-  streaming — an LLM response arriving character-by-character in a TUI)
-  and the general case (arbitrary-position edits — a cursor insertion
-  or deletion anywhere in the input), because both reduce to
-  "invalidate the memo entries whose spans cross the edit point and
-  re-parse from there" per Yedidia's thesis, Ch. 4. Also a prerequisite
-  for left-recursion support.
+- **Threshold-based memoization.** Runtime filter on `MemoClose`: skip
+  inserting an entry whose matched span is shorter than some byte
+  threshold. Tiny leaf rules pay the lookup cost without the storage
+  win, and empirically that is where most of the memo-table memory is
+  wasted (Yedidia thesis §5.2.4 — gains flatten around 4096 bytes;
+  GPeg defaults to 512 and benchmarks at 128). No grammar changes, one
+  configurable constant. Needs a benchmark harness first to pick a
+  sensible default. Listed before incremental parsing because it is
+  what makes a persistent memo table memory-feasible — GPeg's
+  rationale for having this filter at all.
+- **Incremental parsing.** O(Δ) per input change instead of O(n), by
+  invalidating only the memo entries whose spans cross the edit point
+  (Yedidia's thesis, Ch. 4). Covers both append-only streaming (an LLM
+  response arriving character-by-character in a TUI) and arbitrary-
+  position edits (a cursor insertion or deletion anywhere in the input).
+  Builds on the memoization layer — the memo table is the substrate;
+  this task adds the public edit/diff API and the invalidation protocol.
+  Depends on threshold-based memoization above for memory feasibility:
+  without the threshold, every rule call at every position accumulates
+  an entry in a table that must survive across edits.
 - **Left recursion support.** Not needed for JSON, but natural for some
-  grammar idioms (especially arithmetic-expression grammars). Most modern
-  PEG implementations support it via Warth et al.'s algorithm; most of
-  those require memoization.
+  grammar idioms (especially arithmetic-expression grammars). The
+  intended reference is Medeiros, Mascarenhas & Ierusalimschy 2014 —
+  §5 gives a parsing-machine extension matching ours, and its
+  bounded-recursion L table is stack-structured and separate from the
+  packrat memo, so it composes cleanly with threshold-based memoization
+  above. Warth/Douglass/Millstein 2008 is the seminal paper and the
+  most widely cited approach, but it couples seed-and-grow to the memo
+  table itself — which would fight the threshold filter — and inherits
+  the nullable-LR bugs Medeiros 2014 §6 documents.
+- **Explicit memoization opt-out.** Maybe. Per-rule or per-expression
+  annotation (e.g. `Rule <-! body` or `{{! expr }}`) disabling caching
+  on named hot spots. Grammar authors should not have to reason about
+  cache strategy — that is the library's job — so this is reserved as
+  an escape hatch, not a default. Add it only if, after threshold-based
+  memoization, profiling still points at specific rules where rematch
+  beats lookup. Inverts GPeg's `{{ p }}` opt-in at this level, which
+  maps cleanly if the need arises.
 - **Bytecode serialization.** Pre-compile grammars once and ship the
   `Vec<Instruction>` plus capture-name table as data. Useful for embedded
   distributions and startup-time-sensitive consumers.
@@ -134,7 +159,10 @@ Each item is a self-contained feature that unlocks further work.
   streaming responses, in-progress code). The ability to recover past
   a syntax error and continue highlighting the rest of the input is
   important; this is a real extension to the VM and a known research
-  area in PEG implementations.
+  area in PEG implementations. If left recursion lands first, the
+  recovery protocol must unwind Medeiros' L table consistently
+  alongside the VM stack — analogous to how `fail()` already handles
+  `Memo` frames.
 
 ### Self-hosting — parsing PEG grammars using pegvm itself
 
@@ -147,7 +175,10 @@ syntax itself, executed by the VM. Prerequisites, in order:
    parse, captures must be able to produce user values (e.g. a `Pattern`
    node) rather than spans. LPEG calls these *function captures*;
    Yedidia's thesis discusses them. This is a real VM feature, not a
-   refactor.
+   refactor. Interacts with memoization: a memo entry's `captures`
+   field today stores `Vec<Capture>` (plain spans); with typed captures
+   it becomes a vector of user values, which will need to be
+   clone-able or reference-counted to replay from cache.
 2. **Write `peg.peg`.** A PEG grammar that describes PEG grammar syntax.
    A few dozen rules; the language is small.
 3. **Hand-compile `peg.peg` to bytecode.** The bootstrap artifact: a

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -80,6 +80,7 @@ Each `Pattern` variant maps to a small fixed sequence of `Instruction`s. The ins
 | Matching | `Char`, `Set`, `Any`, `TestChar`, `TestSet` | Consume input bytes, or fall through to a label if the current byte doesn't match. |
 | Control flow | `Jump`, `Choice`, `Commit`, `PartialCommit`, `BackCommit`, `FailTwice`, `Fail` | Express ordered choice, repetition, and predicates in terms of pushing and popping backtrack records. |
 | Calls | `Call`, `Return` | Invoke a named rule and return from it — the `NonTerminal` variant compiles to `Call(address)`. |
+| Memoization | `MemoOpen`, `MemoClose` | Rule-level packrat cache. The compiler wraps every rule body with a pair; on a hit `MemoOpen` replays cached captures and jumps to the rule's `Return`; on a miss it pushes a `Memo` frame that `MemoClose` commits as a success entry or `fail()` commits as a failure entry. |
 | Captures | `CaptureBegin`, `CaptureEnd` | Bracket a matched span with a kind tag so the VM can record it. |
 | Termination | `End` | Mark the end of a successful match. |
 
@@ -195,6 +196,9 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 2. **Captures are truncated on backtrack.** Any instruction that enters the fail protocol routes through `VM::fail`, which restores the capture buffer length from the backtrack frame. New backtracking instructions must reuse this helper rather than re-implement it.
 3. **`VM::fail` and `BackCommit` are the only sites where `sp` retreats.** Both must route through `VM::maybe_snapshot` so the farthest-failure bookkeeping sees every retreat. Between retreats `sp` is monotone non-decreasing, which is why snapshots at those two sites capture the true deepest point reached. Any new instruction that rewinds `sp` must update this invariant.
 4. **Byte-oriented.** `CharSet` is a set of `u8` values; UTF-8 is never decoded. This is a deliberate simplification appropriate for the MVP and will need to be revisited before serious Unicode-aware grammars.
+5. **Memo replay is absolute-sp.** Cached captures carry the original `start`/`end` byte offsets; a `MemoOpen` hit only fires when `sp == start_sp`, so the stored values are replayed verbatim. Entries are inserted as already-closed `OpenCapture`s so the enclosing `CaptureEnd`'s innermost-still-open search (`rposition(c.end.is_none())`) binds to the caller's open capture rather than a replayed one.
+6. **`VM::fail` records every `Memo` frame it traverses.** When unwinding to find a `Backtrack`, each `Memo` frame encountered is committed as a failure entry before being discarded. Silently dropping a frame would leak re-executions on future calls at the same sp. The loop is an exhaustive `match` over `StackEntry` specifically to make omissions a compiler error.
+7. **`MemoOpen` calls `maybe_snapshot` after applying a success hit.** The hit advances `sp` past code that didn't execute; without the snapshot call the farthest-failure bookkeeping would miss the advance and `MatchResult.complete == false` would report a stale deepest point.
 
 ## References
 
@@ -204,6 +208,12 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 - Sérgio Medeiros and Roberto Ierusalimschy, [*A Parsing Machine for PEGs*](https://www.inf.puc-rio.br/~roberto/docs/ry08-4.pdf). DLS 2008.
 - Roberto Ierusalimschy, [*A Text Pattern-Matching Tool based on Parsing Expression Grammars*](https://www.inf.puc-rio.br/~roberto/docs/peg.pdf). Software: Practice and Experience, 39(3):221–258, 2009.
 - Zachary Yedidia, [*Incremental PEG Parsing*](https://zyedidia.github.io/notes/yedidia_thesis.pdf). Ph.D. thesis, 2021. Chapter 3 ("A PEG Parsing Machine") is the clearest modern presentation of the instruction set used here and the reference to read first.
+
+Left recursion (roadmap-adjacent; not implemented):
+
+- Alessandro Warth, James R. Douglass, and Todd Millstein, [*Packrat Parsers Can Support Left Recursion*](https://web.cs.ucla.edu/~todd/research/pepm08.pdf). PEPM 2008. Seminal seed-and-grow algorithm; couples left-recursion handling to the packrat memo table.
+- Laurence Tratt, [*Direct Left-Recursive Parsing Expression Grammars*](http://tratt.net/laurie/research/pubs/papers/tratt__direct_left_recursive_parsing_expression_grammars.pdf). Middlesex University Technical Report EIS-10-01, 2010. Adapts Warth's idea to PEGs without packrat memoization; direct left recursion only.
+- Sérgio Medeiros, Fabio Mascarenhas, and Roberto Ierusalimschy, [*Left recursion in parsing expression grammars*](https://arxiv.org/pdf/1207.0443.pdf). Science of Computer Programming 96:177–190, 2014. "Bounded left recursion" semantics with §5 giving a parsing-machine extension matching ours; L table is stack-structured and separate from the packrat memo. Fixes nullable-LR bugs that Warth's algorithm has.
 
 ### Reference implementations
 

--- a/src/pegvm/compiler.rs
+++ b/src/pegvm/compiler.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 
-use super::instruction::{CaptureKind, Instruction, Label};
+use super::instruction::{CaptureKind, Instruction, Label, MemoId};
 use super::pattern::Pattern;
 
 #[derive(Debug, Clone)]
 pub struct Program {
     pub code: Vec<Instruction>,
     pub capture_kinds: Vec<String>,
+    /// Number of memoized rules. Each rule gets a distinct `MemoId` in the
+    /// range `0..memo_count`, assigned in compilation order, so the VM can
+    /// size its memo table once up front.
+    pub memo_count: usize,
 }
 
 #[derive(Debug)]
@@ -76,6 +80,7 @@ impl Compiler {
             Instruction::TestChar(b, _) => Instruction::TestChar(*b, target),
             Instruction::TestSet(s, _) => Instruction::TestSet(*s, target),
             Instruction::Call(_) => Instruction::Call(target),
+            Instruction::MemoOpen(id, _) => Instruction::MemoOpen(*id, target),
             other => panic!("patch_jump: not a jump instruction: {:?}", other),
         };
         self.code[idx] = new;
@@ -203,6 +208,7 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
     Program {
         code: c.code,
         capture_kinds: c.capture_names,
+        memo_count: 0,
     }
 }
 
@@ -235,10 +241,19 @@ pub fn compile_grammar(
     }
 
     let mut rule_addrs: HashMap<String, usize> = HashMap::new();
+    let mut memo_count: u32 = 0;
     for name in ordered {
         rule_addrs.insert(name.clone(), c.pos());
+        let memo_id = MemoId(memo_count);
+        memo_count += 1;
+        // MemoOpen's Label is patched to the Return address below so a cache
+        // hit can skip straight past the body to the rule's Return.
+        let memo_open = c.emit(Instruction::MemoOpen(memo_id, Label(0)));
         c.compile_pat(&rules[name]);
+        c.emit(Instruction::MemoClose(memo_id));
+        let return_addr = c.pos();
         c.emit(Instruction::Return);
+        c.patch_jump(memo_open, return_addr);
     }
 
     // Patch the bootstrap Call.
@@ -257,5 +272,6 @@ pub fn compile_grammar(
     Ok(Program {
         code: c.code,
         capture_kinds: c.capture_names,
+        memo_count: memo_count as usize,
     })
 }

--- a/src/pegvm/instruction.rs
+++ b/src/pegvm/instruction.rs
@@ -23,6 +23,12 @@ impl std::fmt::Debug for Label {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct CaptureKind(pub u16);
 
+/// Opaque tag identifying a memoized rule. Assigned 1:1 with rule addresses
+/// by `compile_grammar`. The VM uses it as an index into its memo table.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
+pub struct MemoId(pub u32);
+
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct CharSet([u8; 32]);
@@ -150,6 +156,16 @@ pub enum Instruction {
 
     Call(Label),
     Return,
+
+    /// Rule-level memoization prologue. On a cache hit the VM advances `sp`
+    /// to the cached end and jumps to the `Label` (the rule's `Return`
+    /// address); on a miss it pushes a `StackEntry::Memo` frame and falls
+    /// through to the rule body.
+    MemoOpen(MemoId, Label),
+    /// Rule-level memoization epilogue. Pops the matching `StackEntry::Memo`
+    /// frame and records a success entry for this rule at the frame's
+    /// `start_sp`.
+    MemoClose(MemoId),
 
     CaptureBegin(CaptureKind),
     CaptureEnd,

--- a/src/pegvm/mod.rs
+++ b/src/pegvm/mod.rs
@@ -8,4 +8,4 @@ pub use compiler::{compile_grammar, compile_pattern, CompileError, Program};
 pub use grammar::{parse as parse_grammar, Grammar, ParseError};
 pub use instruction::{CaptureKind, CharSet, Instruction, Label, MemoId};
 pub use pattern::Pattern;
-pub use vm::{Capture, MatchResult, VM};
+pub use vm::{Capture, MatchResult, MemoStats, VM};

--- a/src/pegvm/mod.rs
+++ b/src/pegvm/mod.rs
@@ -6,6 +6,6 @@ pub mod vm;
 
 pub use compiler::{compile_grammar, compile_pattern, CompileError, Program};
 pub use grammar::{parse as parse_grammar, Grammar, ParseError};
-pub use instruction::{CaptureKind, CharSet, Instruction, Label};
+pub use instruction::{CaptureKind, CharSet, Instruction, Label, MemoId};
 pub use pattern::Pattern;
 pub use vm::{Capture, MatchResult, VM};

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1,4 +1,4 @@
-use super::instruction::{CaptureKind, Instruction};
+use super::instruction::{CaptureKind, Instruction, MemoId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Capture {
@@ -16,6 +16,17 @@ enum StackEntry {
     },
     Return {
         ip: usize,
+    },
+    /// Frame for an in-flight memoized rule call. Pushed by `MemoOpen` on a
+    /// cache miss, popped by `MemoClose` on success (which records the entry)
+    /// or by `fail()` when the rule escapes via failure (which records a
+    /// failure entry). Holds enough state to locate the cache slot
+    /// (`memo_id`, `start_sp`) and to slice the captures produced inside the
+    /// rule (`capture_start_len`).
+    Memo {
+        memo_id: MemoId,
+        start_sp: usize,
+        capture_start_len: usize,
     },
 }
 
@@ -178,10 +189,51 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::Return => {
                     let ret_ip = match self.stack.pop() {
                         Some(StackEntry::Return { ip }) => ip,
-                        Some(_) => panic!("Return found Backtrack on stack"),
+                        Some(other) => {
+                            panic!("Return expected Return on stack top, got {:?}", other)
+                        }
                         None => panic!("Return on empty stack"),
                     };
                     self.ip = ret_ip;
+                }
+                Instruction::MemoOpen(memo_id, _return_label) => {
+                    self.stack.push(StackEntry::Memo {
+                        memo_id: *memo_id,
+                        start_sp: self.sp,
+                        capture_start_len: self.captures.len(),
+                    });
+                    self.ip += 1;
+                }
+                Instruction::MemoClose(memo_id) => {
+                    match self.stack.pop() {
+                        Some(StackEntry::Memo {
+                            memo_id: top_id,
+                            start_sp,
+                            capture_start_len,
+                        }) => {
+                            debug_assert_eq!(
+                                top_id, *memo_id,
+                                "MemoClose id mismatch: expected {:?}, found {:?}",
+                                memo_id, top_id,
+                            );
+                            debug_assert!(
+                                start_sp <= self.sp,
+                                "MemoClose: rule body retreated past start_sp ({} > {})",
+                                start_sp,
+                                self.sp,
+                            );
+                            debug_assert!(
+                                capture_start_len <= self.captures.len(),
+                                "MemoClose: capture buffer shrank below entry baseline ({} > {})",
+                                capture_start_len,
+                                self.captures.len(),
+                            );
+                        }
+                        other => {
+                            panic!("MemoClose expected Memo on stack top, got {:?}", other)
+                        }
+                    }
+                    self.ip += 1;
                 }
                 Instruction::CaptureBegin(kind) => {
                     self.captures.push(OpenCapture {

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::instruction::{CaptureKind, Instruction, MemoId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +49,20 @@ pub struct MatchResult {
     pub complete: bool,
 }
 
+/// Diagnostic counters for the memoization cache, exposed via
+/// [`VM::run_with_memo_stats`]. Primarily used by tests and benchmarks to
+/// prove the cache is doing its job.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MemoStats {
+    /// Number of distinct `(memo_id, start_sp)` pairs in the table at the
+    /// end of the run. Each entry represents one cached rule outcome
+    /// (success or failure).
+    pub entries: usize,
+    /// Number of times `MemoOpen` resolved via a cached entry instead of
+    /// re-executing the rule body.
+    pub hits: usize,
+}
+
 pub struct VM<'p, 'i> {
     program: &'p [Instruction],
     input: &'i [u8],
@@ -56,6 +72,24 @@ pub struct VM<'p, 'i> {
     captures: Vec<OpenCapture>,
     max_sp: usize,
     max_captures: Vec<OpenCapture>,
+    /// Packrat memo table, keyed by `(memo_id, start_sp)`. Populated by
+    /// `MemoClose` on success and by `fail()` on failure escape (Commit 5).
+    memo: HashMap<(MemoId, usize), MemoEntry>,
+    /// Running count of resolved cache hits, exposed via `MemoStats`.
+    memo_hits: usize,
+}
+
+/// A memo-table entry for a rule invocation at a specific input position.
+///
+/// `end_sp.is_some()` encodes success and carries the sp at which the rule
+/// finished matching, plus the captures it produced (already closed).
+/// `end_sp.is_none()` encodes a cached failure — future hits at the same
+/// `(memo_id, start_sp)` enter `fail()` directly without re-running the
+/// rule body.
+#[derive(Debug, Clone)]
+struct MemoEntry {
+    end_sp: Option<usize>,
+    captures: Vec<Capture>,
 }
 
 #[derive(Debug, Clone)]
@@ -76,10 +110,16 @@ impl<'p, 'i> VM<'p, 'i> {
             captures: Vec::new(),
             max_sp: 0,
             max_captures: Vec::new(),
+            memo: HashMap::new(),
+            memo_hits: 0,
         }
     }
 
-    pub fn run(mut self) -> MatchResult {
+    pub fn run(self) -> MatchResult {
+        self.run_with_memo_stats().0
+    }
+
+    pub fn run_with_memo_stats(mut self) -> (MatchResult, MemoStats) {
         loop {
             let instr = match self.program.get(self.ip) {
                 Some(i) => i,
@@ -196,43 +236,105 @@ impl<'p, 'i> VM<'p, 'i> {
                     };
                     self.ip = ret_ip;
                 }
-                Instruction::MemoOpen(memo_id, _return_label) => {
-                    self.stack.push(StackEntry::Memo {
-                        memo_id: *memo_id,
-                        start_sp: self.sp,
-                        capture_start_len: self.captures.len(),
-                    });
-                    self.ip += 1;
+                Instruction::MemoOpen(memo_id, return_label) => {
+                    if let Some(entry) = self.memo.get(&(*memo_id, self.sp)) {
+                        self.memo_hits += 1;
+                        match entry.end_sp {
+                            Some(end_sp) => {
+                                // Success hit: replay captures into the live
+                                // buffer. They are keyed by absolute offsets
+                                // and valid iff this hit fires at the same
+                                // start_sp — which is exactly the key we just
+                                // matched on. Insert as already-closed so the
+                                // enclosing `CaptureEnd`'s `rposition` search
+                                // (which binds to the innermost still-open
+                                // capture) skips over them.
+                                for c in &entry.captures {
+                                    self.captures.push(OpenCapture {
+                                        kind: c.kind,
+                                        start: c.start,
+                                        end: Some(c.end),
+                                    });
+                                }
+                                self.sp = end_sp;
+                                self.ip = return_label.0;
+                                // Applying a hit advances `sp` past code that
+                                // did not execute; the farthest-failure
+                                // bookkeeping must see the advance.
+                                self.maybe_snapshot();
+                            }
+                            None => {
+                                // Cached failure: enter fail() immediately
+                                // without re-executing the rule body. Do not
+                                // push a Memo frame.
+                                if !self.fail() {
+                                    return self.finalize_partial();
+                                }
+                            }
+                        }
+                    } else {
+                        self.stack.push(StackEntry::Memo {
+                            memo_id: *memo_id,
+                            start_sp: self.sp,
+                            capture_start_len: self.captures.len(),
+                        });
+                        self.ip += 1;
+                    }
                 }
                 Instruction::MemoClose(memo_id) => {
-                    match self.stack.pop() {
+                    let (top_id, start_sp, capture_start_len) = match self.stack.pop() {
                         Some(StackEntry::Memo {
-                            memo_id: top_id,
+                            memo_id,
                             start_sp,
                             capture_start_len,
-                        }) => {
-                            debug_assert_eq!(
-                                top_id, *memo_id,
-                                "MemoClose id mismatch: expected {:?}, found {:?}",
-                                memo_id, top_id,
-                            );
-                            debug_assert!(
-                                start_sp <= self.sp,
-                                "MemoClose: rule body retreated past start_sp ({} > {})",
-                                start_sp,
-                                self.sp,
-                            );
-                            debug_assert!(
-                                capture_start_len <= self.captures.len(),
-                                "MemoClose: capture buffer shrank below entry baseline ({} > {})",
-                                capture_start_len,
-                                self.captures.len(),
-                            );
-                        }
+                        }) => (memo_id, start_sp, capture_start_len),
                         other => {
                             panic!("MemoClose expected Memo on stack top, got {:?}", other)
                         }
-                    }
+                    };
+                    debug_assert_eq!(
+                        top_id, *memo_id,
+                        "MemoClose id mismatch: expected {:?}, found {:?}",
+                        memo_id, top_id,
+                    );
+                    debug_assert!(
+                        start_sp <= self.sp,
+                        "MemoClose: rule body retreated past start_sp ({} > {})",
+                        start_sp,
+                        self.sp,
+                    );
+                    debug_assert!(
+                        capture_start_len <= self.captures.len(),
+                        "MemoClose: capture buffer shrank below entry baseline ({} > {})",
+                        capture_start_len,
+                        self.captures.len(),
+                    );
+                    // Snapshot the captures produced inside the rule. All of
+                    // them must be closed at this point — PEG captures are
+                    // lexically scoped to `@name{...}` and cannot straddle a
+                    // rule boundary, so any `OpenCapture` with `end.is_none()`
+                    // would be a compiler bug.
+                    let rule_captures: Vec<Capture> = self.captures[capture_start_len..]
+                        .iter()
+                        .map(|c| {
+                            debug_assert!(
+                                c.end.is_some(),
+                                "MemoClose: open capture straddles rule boundary"
+                            );
+                            Capture {
+                                kind: c.kind,
+                                start: c.start,
+                                end: c.end.unwrap_or(self.sp),
+                            }
+                        })
+                        .collect();
+                    self.memo.insert(
+                        (*memo_id, start_sp),
+                        MemoEntry {
+                            end_sp: Some(self.sp),
+                            captures: rule_captures,
+                        },
+                    );
                     self.ip += 1;
                 }
                 Instruction::CaptureBegin(kind) => {
@@ -253,11 +355,18 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.ip += 1;
                 }
                 Instruction::End => {
-                    return MatchResult {
-                        matched: self.sp,
-                        captures: close_captures(self.captures, self.sp),
-                        complete: true,
+                    let stats = MemoStats {
+                        entries: self.memo.len(),
+                        hits: self.memo_hits,
                     };
+                    return (
+                        MatchResult {
+                            matched: self.sp,
+                            captures: close_captures(self.captures, self.sp),
+                            complete: true,
+                        },
+                        stats,
+                    );
                 }
             }
         }
@@ -300,13 +409,18 @@ impl<'p, 'i> VM<'p, 'i> {
         }
     }
 
-    fn finalize_partial(mut self) -> MatchResult {
+    fn finalize_partial(mut self) -> (MatchResult, MemoStats) {
         self.maybe_snapshot();
-        MatchResult {
+        let stats = MemoStats {
+            entries: self.memo.len(),
+            hits: self.memo_hits,
+        };
+        let result = MatchResult {
             matched: self.max_sp,
             captures: close_captures(self.max_captures, self.max_sp),
             complete: false,
-        }
+        };
+        (result, stats)
     }
 }
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -382,16 +382,44 @@ impl<'p, 'i> VM<'p, 'i> {
     fn fail(&mut self) -> bool {
         self.maybe_snapshot();
         while let Some(entry) = self.stack.pop() {
-            if let StackEntry::Backtrack {
-                ip,
-                sp,
-                capture_len,
-            } = entry
-            {
-                self.ip = ip;
-                self.sp = sp;
-                self.captures.truncate(capture_len);
-                return true;
+            // Explicit match on all three variants — silently dropping a
+            // `Memo` frame would skip caching its failure and leak
+            // re-executions on future hits at the same sp.
+            match entry {
+                StackEntry::Backtrack {
+                    ip,
+                    sp,
+                    capture_len,
+                } => {
+                    self.ip = ip;
+                    self.sp = sp;
+                    self.captures.truncate(capture_len);
+                    return true;
+                }
+                StackEntry::Memo {
+                    memo_id,
+                    start_sp,
+                    capture_start_len: _,
+                } => {
+                    // Cache the failure so a future call at the same sp
+                    // short-circuits into `fail()` without re-executing the
+                    // body. Captures produced inside the rule will be
+                    // truncated by whichever `Backtrack` ultimately catches
+                    // this unwind (its `capture_len` was snapshotted *before*
+                    // MemoOpen pushed this frame).
+                    self.memo.insert(
+                        (memo_id, start_sp),
+                        MemoEntry {
+                            end_sp: None,
+                            captures: Vec::new(),
+                        },
+                    );
+                }
+                StackEntry::Return { .. } => {
+                    // Rule-call frame unwinding past its caller. The caller's
+                    // Backtrack (if any) is deeper on the stack and will be
+                    // found by continued popping.
+                }
             }
         }
         false

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use syntax_highlighter::pegvm::{
     compile_grammar, compile_pattern, Capture, CaptureKind, CharSet, Instruction, Label,
-    MatchResult, Pattern, VM,
+    MatchResult, MemoId, Pattern, VM,
 };
 
 fn run_pattern(pat: &Pattern, input: &[u8]) -> MatchResult {
@@ -357,6 +357,43 @@ fn repeat_emits_partial_commit() {
             Instruction::Char(b'a'),
             Instruction::PartialCommit(Label(1)),
             Instruction::End,
+        ]
+    );
+}
+
+#[test]
+fn grammar_rules_are_wrapped_in_memo_open_close() {
+    // start <- "a"
+    // other <- "b"
+    // Layout:
+    //   0: Call(start)
+    //   1: End
+    //   2: MemoOpen(0, L5)   ; start's Return is at 5
+    //   3: Char 'a'
+    //   4: MemoClose(0)
+    //   5: Return
+    //   6: MemoOpen(1, L9)   ; other's Return is at 9
+    //   7: Char 'b'
+    //   8: MemoClose(1)
+    //   9: Return
+    let mut rules = HashMap::new();
+    rules.insert("start".into(), Pattern::literal("a"));
+    rules.insert("other".into(), Pattern::literal("b"));
+    let prog = compile_grammar(&rules, "start").unwrap();
+    assert_eq!(prog.memo_count, 2);
+    assert_eq!(
+        prog.code,
+        vec![
+            Instruction::Call(Label(2)),
+            Instruction::End,
+            Instruction::MemoOpen(MemoId(0), Label(5)),
+            Instruction::Char(b'a'),
+            Instruction::MemoClose(MemoId(0)),
+            Instruction::Return,
+            Instruction::MemoOpen(MemoId(1), Label(9)),
+            Instruction::Char(b'b'),
+            Instruction::MemoClose(MemoId(1)),
+            Instruction::Return,
         ]
     );
 }

--- a/tests/highlight_memo_tests.rs
+++ b/tests/highlight_memo_tests.rs
@@ -1,0 +1,54 @@
+//! End-to-end demonstration that memoization fires on one of the shipping
+//! grammars and that it does not change the observable match result.
+//!
+//! This is the proof-of-life for packrat-by-default: a real grammar, a real
+//! input, and a non-zero hit count means the cache is doing work on the
+//! actual workloads the highlighter serves.
+
+use syntax_highlighter::pegvm::{compile_grammar, parse_grammar, VM};
+
+const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
+
+#[test]
+fn sqlite_select_registers_memo_hits() {
+    // The SQL grammar has a lot of ordered alternatives that share prefixes
+    // (keywords, identifiers, expressions) — exactly the shape where
+    // memoization earns its keep.
+    let g = parse_grammar(SQLITE_GRAMMAR).unwrap();
+    let prog = compile_grammar(&g.rules, &g.start).unwrap();
+
+    let input = "SELECT id, name FROM users WHERE active AND id > 10;";
+    let (result, stats) = VM::new(&prog.code, input.as_bytes()).run_with_memo_stats();
+
+    assert!(
+        result.complete,
+        "SQL grammar should accept the sample input"
+    );
+    assert!(
+        stats.hits > 0,
+        "expected memoization to fire on the SQL grammar, got {} hits / {} entries",
+        stats.hits,
+        stats.entries,
+    );
+}
+
+#[test]
+fn json_run_records_memo_entries() {
+    // JSON is a small grammar and highly structured, so hits may not occur
+    // on simple inputs — but every rule call still lands an entry in the
+    // table. This test just confirms the cache is wired end-to-end on a
+    // shipping grammar.
+    let g = parse_grammar(JSON_GRAMMAR).unwrap();
+    let prog = compile_grammar(&g.rules, &g.start).unwrap();
+
+    let input = br#"{"a": 1, "b": [true, null, "x"]}"#;
+    let (result, stats) = VM::new(&prog.code, input).run_with_memo_stats();
+
+    assert!(result.complete);
+    assert!(
+        stats.entries > 0,
+        "expected memo table to populate on JSON, got {} entries",
+        stats.entries,
+    );
+}

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -1,0 +1,191 @@
+//! Memoization behavior tests: the cache populates, hits replay correctly,
+//! and captures survive replay — even when the memoized rule is nested
+//! inside an outer capture (the capture-replay bug most likely to bite a
+//! naive first implementation).
+
+use std::collections::HashMap;
+
+use syntax_highlighter::pegvm::{
+    compile_grammar, Capture, CaptureKind, CharSet, MatchResult, Pattern, VM,
+};
+
+fn cap(kind: u16, start: usize, end: usize) -> Capture {
+    Capture {
+        kind: CaptureKind(kind),
+        start,
+        end,
+    }
+}
+
+/// `start <- (X "aa") / (X "bb")`, `X <- [a-z]`.
+///
+/// On input "ab" the first alternative fails after X matches at sp=0, the VM
+/// backtracks to sp=0, and the second alternative re-calls X at the same
+/// position. The second call must hit the cache.
+#[test]
+fn second_alternative_reuses_memoized_x() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("X".into()),
+                Pattern::literal("aa"),
+            ]),
+            Pattern::seq(vec![
+                Pattern::NonTerminal("X".into()),
+                Pattern::literal("bb"),
+            ]),
+        ]),
+    );
+    rules.insert(
+        "X".into(),
+        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let (result, stats) = VM::new(&prog.code, b"abb").run_with_memo_stats();
+    assert_eq!(
+        result,
+        MatchResult {
+            matched: 3,
+            captures: vec![],
+            complete: true,
+        }
+    );
+    assert!(stats.hits >= 1, "expected ≥1 memo hit, got {}", stats.hits);
+}
+
+/// Same shape as above but verifies the memo table holds entries (not just
+/// hits). One entry per distinct `(rule, sp)` pair actually executed.
+#[test]
+fn memo_table_populates_on_success() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::seq(vec![
+            Pattern::NonTerminal("X".into()),
+            Pattern::NonTerminal("X".into()),
+        ]),
+    );
+    rules.insert(
+        "X".into(),
+        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let (_, stats) = VM::new(&prog.code, b"ab").run_with_memo_stats();
+    // start at sp=0, X at sp=0, X at sp=1 — three distinct entries.
+    assert_eq!(stats.entries, 3);
+    // No alternatives are tried twice at the same sp, so no hits.
+    assert_eq!(stats.hits, 0);
+}
+
+/// Bug A regression: a memoized rule is called from inside an enclosing
+/// `@outer{ ... }` capture. On the second call (a memo hit) the replay
+/// inserts cached captures as *closed* entries; the enclosing `CaptureEnd`
+/// must still bind to the outer capture (the only one with `end.is_none()`)
+/// rather than mis-closing a replayed entry.
+///
+/// Grammar:
+///   start <- outer
+///   outer <- @outer{ Inner Inner }   # two calls to Inner inside a capture
+///   Inner <- @inner{ [a-z] }
+///
+/// On "aa": first Inner call at sp=0 produces `@inner{"a"}`. Second Inner
+/// call at sp=1 is a distinct entry (different sp) — but the structure
+/// exercises the replay machinery: both @inner captures must nest under
+/// @outer correctly.
+///
+/// To force a true replay at the same sp, we instead use:
+///   start <- outer
+///   outer <- @outer{ (Inner "x") / (Inner "y") }
+///   Inner <- @inner{ [a-z] }
+/// On "ay": first alternative fails ("ay" doesn't have trailing "x"),
+/// Inner's cached result is reused in the second alternative. The critical
+/// assertion is that the outer capture closes at sp=2 (not at sp=1 — which
+/// is where the inner capture closes), i.e. CaptureEnd bound to the right
+/// slot during the replay.
+#[test]
+fn memo_hit_inside_outer_capture_preserves_nesting() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::Capture(
+            "outer".into(),
+            Box::new(Pattern::choice(vec![
+                Pattern::seq(vec![
+                    Pattern::NonTerminal("Inner".into()),
+                    Pattern::literal("x"),
+                ]),
+                Pattern::seq(vec![
+                    Pattern::NonTerminal("Inner".into()),
+                    Pattern::literal("y"),
+                ]),
+            ])),
+        ),
+    );
+    rules.insert(
+        "Inner".into(),
+        Pattern::Capture(
+            "inner".into(),
+            Box::new(Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')]))),
+        ),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    // Capture kind ids are assigned in first-seen order: "outer" = 0, "inner" = 1.
+    let outer_kind = prog
+        .capture_kinds
+        .iter()
+        .position(|n| n == "outer")
+        .unwrap() as u16;
+    let inner_kind = prog
+        .capture_kinds
+        .iter()
+        .position(|n| n == "inner")
+        .unwrap() as u16;
+
+    let (result, stats) = VM::new(&prog.code, b"ay").run_with_memo_stats();
+    assert!(result.complete);
+    assert_eq!(result.matched, 2);
+    // Outer capture spans the full input [0,2); inner captures the 'a' at [0,1).
+    // The inner capture appears twice because the memoized Inner is first
+    // executed (emitting @inner{[0,1)}) and then *replayed* from cache on the
+    // second alternative (emitting another @inner{[0,1)}). Both must nest
+    // under @outer, which must close at 2.
+    assert!(
+        result.captures.contains(&cap(outer_kind, 0, 2)),
+        "outer capture missing or mis-closed: {:?}",
+        result.captures
+    );
+    assert!(
+        result.captures.contains(&cap(inner_kind, 0, 1)),
+        "inner capture missing: {:?}",
+        result.captures
+    );
+    assert!(stats.hits >= 1, "expected a cache hit, got {}", stats.hits);
+}
+
+/// A grammar that's memoized-by-default produces byte-identical results on
+/// a "happy path" input with no backtracking — the cache has no effect on
+/// correctness, only on work done.
+#[test]
+fn memoization_does_not_change_results_on_linear_parse() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::RepeatOne(Box::new(Pattern::NonTerminal("digit".into()))),
+    );
+    rules.insert(
+        "digit".into(),
+        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')])),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let result = VM::new(&prog.code, b"12345").run();
+    assert_eq!(
+        result,
+        MatchResult {
+            matched: 5,
+            captures: vec![],
+            complete: true,
+        }
+    );
+}

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -164,6 +164,110 @@ fn memo_hit_inside_outer_capture_preserves_nesting() {
     assert!(stats.hits >= 1, "expected a cache hit, got {}", stats.hits);
 }
 
+/// `start <- (!A "b") / (!A "c")`, `A <- "a"`.
+///
+/// On input "cx" the first alternative's `!A` succeeds because A fails at
+/// sp=0, but "b" fails at sp=0, forcing backtrack. The second alternative's
+/// `!A` at sp=0 must hit the cached A-failure rather than re-executing A's
+/// body.
+#[test]
+fn cached_failure_short_circuits_not_predicate() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NotPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::literal("b"),
+            ]),
+            Pattern::seq(vec![
+                Pattern::NotPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::literal("c"),
+            ]),
+        ]),
+    );
+    rules.insert("A".into(), Pattern::literal("a"));
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let (result, stats) = VM::new(&prog.code, b"c").run_with_memo_stats();
+    assert!(result.complete);
+    assert_eq!(result.matched, 1);
+    assert!(
+        stats.hits >= 1,
+        "expected a cached-failure hit, got {}",
+        stats.hits
+    );
+}
+
+/// Nested memoized rules both failing must both land failure entries in the
+/// table — not just the innermost one. `outer <- inner "b"`, `inner <- "a"`.
+/// On input "x": inner fails, outer has no backtrack machinery so it also
+/// fails. Both failures must be cached.
+#[test]
+fn nested_memoized_rule_failures_both_cached() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::NonTerminal("outer".into()),
+            Pattern::NonTerminal("fallback".into()),
+        ]),
+    );
+    rules.insert(
+        "outer".into(),
+        Pattern::seq(vec![
+            Pattern::NonTerminal("inner".into()),
+            Pattern::literal("b"),
+        ]),
+    );
+    rules.insert("inner".into(), Pattern::literal("a"));
+    rules.insert(
+        "fallback".into(),
+        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let (result, stats) = VM::new(&prog.code, b"x").run_with_memo_stats();
+    assert!(result.complete);
+    assert_eq!(result.matched, 1);
+    // Entries expected: start(success at 0), outer(failure at 0),
+    // inner(failure at 0), fallback(success at 0). Four distinct slots.
+    assert_eq!(stats.entries, 4, "got entries: {}", stats.entries);
+}
+
+/// `&A` succeeds in both alternatives; the second alternative's `&A` call
+/// must hit the cache AND BackCommit must still find a `Backtrack` on top
+/// (not the `Memo` frame from the successful rule call, which `MemoClose`
+/// has already popped).
+///
+/// `start <- (&A "z") / (&A "y")`, `A <- [a-z]`. On input "y": &A peeks and
+/// succeeds at sp=0, "z" fails at sp=0, backtrack to the second alternative,
+/// &A peeks again at sp=0 (memo hit), "y" matches.
+#[test]
+fn and_predicate_with_memoized_rule() {
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::AndPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::literal("z"),
+            ]),
+            Pattern::seq(vec![
+                Pattern::AndPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::literal("y"),
+            ]),
+        ]),
+    );
+    rules.insert(
+        "A".into(),
+        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+    );
+    let prog = compile_grammar(&rules, "start").unwrap();
+    let (result, stats) = VM::new(&prog.code, b"y").run_with_memo_stats();
+    assert!(result.complete);
+    assert_eq!(result.matched, 1);
+    assert!(stats.hits >= 1, "expected a hit, got {}", stats.hits);
+}
+
 /// A grammar that's memoized-by-default produces byte-identical results on
 /// a "happy path" input with no backtracking — the cache has no effect on
 /// correctness, only on work done.


### PR DESCRIPTION
## Summary

Rule-level packrat memoization, on by default. Four commits land independently:

- `464f490` — `MemoOpen`/`MemoClose` opcodes + per-rule wrapping; inert runtime.
- `25175e5` — Memo table, commit-on-success, success-hit replay.
- `e7aa315` — Failure caching in `VM::fail`, short-circuit on cached failure.
- `754be39` — Docs refresh; see `src/pegvm/README.md` §Invariants items 5–7 for the three new invariants the memoization layer introduces, and the top-level `README.md` roadmap for the updated follow-on list (incremental parsing, left recursion).

Diagnostic surface: `VM::run_with_memo_stats` returns `MemoStats { entries, hits }`.

Two deviations from the plan, called out in the relevant commit messages:

- Table is `HashMap<(MemoId, usize), MemoEntry>`, not `Vec<HashMap>` (see `25175e5`'s commit body for the rationale).
- Plan's Commits 3 and 4 are squashed into `25175e5` — `MemoEntry` fields are written by `MemoClose` and only read by `MemoOpen`'s hit branch, which fights `RUSTFLAGS=-D warnings` if split.