### PR TITLE
Incremental parsing (stateful Highlighter + MemoCache + A/B bench)

### DIFF
--- a/.claude/skills/memo-bench/SKILL.md
+++ b/.claude/skills/memo-bench/SKILL.md
@@ -109,5 +109,14 @@ need their live captures preserved — see the comment on the gate in
   interval. The threshold knee is an order-of-magnitude decision; if
   two adjacent thresholds look within a few percent of each other,
   treat them as tied.
-- **Regression across commits.** The harness prints absolute numbers,
-  not diffs. To compare two branches, run on both and diff by eye.
+
+## Comparing two commits
+
+The harness also writes a JSONL stream to
+`target/bench-results/memo.jsonl` (one row per cell, same fields as
+the human table). Use the sibling `./compare.sh <ref-a> <ref-b> memo`
+to spin up git worktrees for each ref, run the bench in each, and
+print a join-by-cell delta table (the script does `cd $(git
+rev-parse --show-toplevel)` internally, so cwd doesn't matter).
+Requires `jq` on PATH. The same script also handles the companion
+`incremental` bench — drop the argument to run both.

--- a/.claude/skills/memo-bench/compare.sh
+++ b/.claude/skills/memo-bench/compare.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Compare the bench harness output between two git refs.
+#
+# Usage:
+#   ./compare.sh <ref-before> <ref-after> [bench-name...]
+#
+# Default bench list: memo, incremental. Pass a subset to scope the run.
+# Example: ./compare.sh main HEAD incremental
+#
+# Strategy:
+#   - Create temporary git worktrees for each ref.
+#   - Run `cargo bench --bench <name>` in each, collecting the JSONL
+#     artifacts at target/bench-results/<name>.jsonl.
+#   - Join rows by their identifying key fields (grammar/fixture/edit_kind
+#     for incremental, grammar/fixture/threshold for memo) and print a
+#     delta table.
+#
+# Depends on: git, cargo, jq.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    cat >&2 <<'USAGE'
+usage: compare.sh <ref-before> <ref-after> [bench-name...]
+  benches: memo (default), incremental (default)
+USAGE
+    exit 2
+fi
+
+REF_A="$1"
+REF_B="$2"
+shift 2
+if [ $# -eq 0 ]; then
+    BENCHES=("memo" "incremental")
+else
+    BENCHES=("$@")
+fi
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+command -v git >/dev/null || { echo "git is required" >&2; exit 1; }
+command -v cargo >/dev/null || { echo "cargo is required" >&2; exit 1; }
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+TMP=$(mktemp -d)
+trap 'git worktree remove --force "$TMP/a" 2>/dev/null; git worktree remove --force "$TMP/b" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+echo "[1/4] preparing worktrees: a=$REF_A, b=$REF_B"
+git worktree add --detach "$TMP/a" "$REF_A" >/dev/null
+git worktree add --detach "$TMP/b" "$REF_B" >/dev/null
+
+for bench in "${BENCHES[@]}"; do
+    echo
+    echo "[2/4] running bench '$bench' on $REF_A"
+    (cd "$TMP/a" && cargo bench --bench "$bench" --quiet) >/dev/null
+    echo "[3/4] running bench '$bench' on $REF_B"
+    (cd "$TMP/b" && cargo bench --bench "$bench" --quiet) >/dev/null
+
+    out_a="$TMP/a/target/bench-results/$bench.jsonl"
+    out_b="$TMP/b/target/bench-results/$bench.jsonl"
+    if [ ! -s "$out_a" ] || [ ! -s "$out_b" ]; then
+        echo "  missing jsonl output for '$bench', skipping" >&2
+        continue
+    fi
+
+    # Pick the identifying key fields and the primary timing column
+    # per bench. The key set must be stable across commits so the join
+    # finds matching rows.
+    case "$bench" in
+        memo)
+            key='[.grammar, .fixture, (.threshold|tostring)] | join("/")'
+            metric='.time_us'
+            metric_label='time_us'
+            ;;
+        incremental)
+            key='[.grammar, .fixture, .edit_kind] | join("/")'
+            metric='.warm_us'
+            metric_label='warm_us'
+            ;;
+        *)
+            echo "  unknown bench '$bench', skipping" >&2
+            continue
+            ;;
+    esac
+
+    echo
+    echo "[4/4] delta for '$bench' ($metric_label, $REF_A → $REF_B):"
+    echo
+    printf "  %-40s %10s %10s %10s\n" "key" "$REF_A" "$REF_B" "Δ%"
+    printf "  %-40s %10s %10s %10s\n" "----------------------------------------" "----------" "----------" "----------"
+
+    # Emit (key, metric) rows per file, then join on key.
+    jq -r "\"\($key)\t\($metric)\"" "$out_a" | sort > "$TMP/a.tsv"
+    jq -r "\"\($key)\t\($metric)\"" "$out_b" | sort > "$TMP/b.tsv"
+    join -t $'\t' -a 1 -a 2 -e 'N/A' -o '0,1.2,2.2' "$TMP/a.tsv" "$TMP/b.tsv" |
+        awk -F'\t' '{
+            a=$2; b=$3;
+            delta = (a == "N/A" || b == "N/A") ? "N/A" \
+                : (a == 0 ? "inf" : sprintf("%+.1f%%", (b - a) / a * 100));
+            printf "  %-40s %10s %10s %10s\n", $1, a, b, delta
+        }'
+done
+
+echo
+echo "done."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ path = "src/main.rs"
 name = "memo"
 path = "benches/memo.rs"
 harness = false
+
+[[bench]]
+name = "incremental"
+path = "benches/incremental.rs"
+harness = false

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,75 @@
+//! Shared helpers for the custom bench harnesses under `benches/`.
+//!
+//! Included from each bench file via `#[path = "common.rs"]` — Cargo
+//! treats each bench as its own crate root, so this is the lightest
+//! way to share code without promoting it to the library.
+//!
+//! The JSONL emitter is the mechanism that makes commit-by-commit
+//! performance tracking possible (the `memo-bench` skill's compare
+//! script reads these files). Every row is one self-contained JSON
+//! object on a line; keys identify the cell, numeric fields carry
+//! the measurement.
+
+use std::fs::{create_dir_all, File};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+pub const BENCH_RESULTS_DIR: &str = "target/bench-results";
+
+/// Open (truncating) a JSONL file under [`BENCH_RESULTS_DIR`] for the
+/// named bench. Caller writes one row per `writeln!` using
+/// [`format_row`]. Returns `None` if the output directory can't be
+/// created — benches still complete, but skip machine output.
+pub fn open_jsonl(bench_name: &str) -> Option<BufWriter<File>> {
+    let mut path = PathBuf::from(BENCH_RESULTS_DIR);
+    if create_dir_all(&path).is_err() {
+        return None;
+    }
+    path.push(format!("{bench_name}.jsonl"));
+    File::create(&path).ok().map(BufWriter::new)
+}
+
+/// Serialize an iterator of `(key, value)` pairs as a one-line JSON
+/// object. Values are already-formatted JSON scalars (strings must be
+/// double-quoted by the caller). Keeps the dependency surface at zero.
+///
+/// This is deliberately minimal — no escaping of string values beyond
+/// what the caller provides. All bench cells use ASCII-only string
+/// fields (grammar/fixture/edit-kind labels are chosen that way) so
+/// no escaping is needed.
+pub fn write_jsonl_row(
+    out: &mut BufWriter<File>,
+    fields: &[(&str, String)],
+) -> std::io::Result<()> {
+    let mut line = String::from("{");
+    for (i, (k, v)) in fields.iter().enumerate() {
+        if i > 0 {
+            line.push(',');
+        }
+        line.push('"');
+        line.push_str(k);
+        line.push_str("\":");
+        line.push_str(v);
+    }
+    line.push('}');
+    writeln!(out, "{line}")
+}
+
+pub fn json_str(s: &str) -> String {
+    format!("\"{s}\"")
+}
+
+pub fn json_num<T: std::fmt::Display>(n: T) -> String {
+    format!("{n}")
+}
+
+pub fn json_f64(n: f64) -> String {
+    // Bench cells produce microsecond numbers; 3 decimals is enough
+    // and keeps the files grep-able / human-readable.
+    format!("{n:.3}")
+}
+
+pub fn median(mut xs: Vec<u128>) -> u128 {
+    xs.sort_unstable();
+    xs[xs.len() / 2]
+}

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,0 +1,298 @@
+//! Incremental-reparse sweep: measures the warm reparse time after a
+//! small edit against the cold full-parse baseline, across every
+//! shipped grammar and fixture size × a fixed set of edit shapes.
+//!
+//! Invoke with `cargo bench --bench incremental`.
+//!
+//! Like `benches/memo.rs`, this is a custom harness: median-of-N wall
+//! clock, no criterion, `pegvm` stays dependency-free. Output is a
+//! human-readable table on stdout and a JSONL machine-readable stream
+//! at `target/bench-results/incremental.jsonl` (read by the
+//! `memo-bench` skill's compare script).
+//!
+//! Per-cell correctness guard: the warm-reparse captures must match
+//! a fresh full-parse on the post-edit input exactly. A divergence
+//! aborts the bench before any timing is recorded.
+
+use std::time::Instant;
+
+use syntax_highlighter::highlight::Highlighter;
+
+#[path = "common.rs"]
+mod common;
+
+use common::{json_f64, json_num, json_str, median, open_jsonl, write_jsonl_row};
+
+const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+
+const JSON_SMALL: &str = include_str!("fixtures/small.json");
+const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
+const JSON_LARGE: &str = include_str!("fixtures/large.json");
+
+const TOML_SMALL: &str = include_str!("fixtures/small.toml");
+const TOML_MEDIUM: &str = include_str!("fixtures/medium.toml");
+const TOML_LARGE: &str = include_str!("fixtures/large.toml");
+
+const SQL_SMALL: &str = include_str!("fixtures/small.sql");
+const SQL_MEDIUM: &str = include_str!("fixtures/medium.sql");
+const SQL_LARGE: &str = include_str!("fixtures/large.sql");
+
+const RUNS_PER_CELL: usize = 11;
+
+#[derive(Clone, Copy)]
+enum EditKind {
+    /// Append a single character at the end. Simulates streaming
+    /// input arriving one char at a time.
+    AppendOneChar,
+    /// Insert 10 bytes near the middle. Simulates typing in the
+    /// middle of a document.
+    InsertMid10,
+    /// Delete 10 bytes near the middle. Simulates selecting-and-
+    /// deleting a small span.
+    DeleteMid10,
+}
+
+impl EditKind {
+    fn label(&self) -> &'static str {
+        match self {
+            EditKind::AppendOneChar => "append_1c",
+            EditKind::InsertMid10 => "insert_10",
+            EditKind::DeleteMid10 => "delete_10",
+        }
+    }
+
+    /// Apply this edit to `inc`. Each bench iteration must call this on
+    /// a freshly primed highlighter so the cache reflects exactly one
+    /// edit's worth of invalidation.
+    fn apply(&self, inc: &mut Highlighter) {
+        match self {
+            EditKind::AppendOneChar => inc.append(" "),
+            EditKind::InsertMid10 => {
+                let at = pick_boundary(inc.input(), inc.input().len() / 2);
+                inc.edit(at, at, "          ");
+            }
+            EditKind::DeleteMid10 => {
+                let a = pick_boundary(inc.input(), inc.input().len() / 2);
+                let mut b = a + 10;
+                while b < inc.input().len() && !inc.input().is_char_boundary(b) {
+                    b += 1;
+                }
+                if b > inc.input().len() {
+                    b = inc.input().len();
+                }
+                inc.edit(a, b, "");
+            }
+        }
+    }
+}
+
+/// Walk `pos` forward to the next char boundary if it isn't on one.
+/// Fixtures are ASCII-only today, but keep the helper robust.
+fn pick_boundary(s: &str, mut pos: usize) -> usize {
+    while pos < s.len() && !s.is_char_boundary(pos) {
+        pos += 1;
+    }
+    pos
+}
+
+struct Cell {
+    grammar: &'static str,
+    fixture_label: &'static str,
+    edit_kind: EditKind,
+    cold_ns: u128,
+    warm_ns: u128,
+    speedup: f64,
+    warm_hits: usize,
+    warm_misses: usize,
+    warm_hit_rate: f64,
+}
+
+fn run_cell(
+    grammar_src: &str,
+    grammar_label: &'static str,
+    fixture_label: &'static str,
+    fixture: &str,
+    edit_kind: EditKind,
+) -> Cell {
+    // Correctness guard: one warm iteration and one fresh full parse
+    // must agree bit-for-bit on captures before we trust any timings.
+    {
+        let mut inc = Highlighter::new(grammar_src).unwrap();
+        inc.set_input(fixture.to_string());
+        edit_kind.apply(&mut inc);
+        let mut fresh = Highlighter::new(grammar_src).unwrap();
+        fresh.set_input(inc.input().to_string());
+        assert_eq!(
+            inc.captures(),
+            fresh.captures(),
+            "warm-reparse captures diverged from fresh parse: {}/{}/{}",
+            grammar_label,
+            fixture_label,
+            edit_kind.label(),
+        );
+    }
+
+    // Build the post-edit input once outside the timed regions.
+    let post_edit = {
+        let mut inc = Highlighter::new(grammar_src).unwrap();
+        inc.set_input(fixture.to_string());
+        edit_kind.apply(&mut inc);
+        inc.input().to_string()
+    };
+
+    // Cold: each iteration drops the cache and full-parses the
+    // post-edit input from scratch. `set_input` performs a cold
+    // parse by construction (new MemoCache, every rule invocation
+    // is a miss).
+    let mut cold_times = Vec::with_capacity(RUNS_PER_CELL);
+    let mut fresh = Highlighter::new(grammar_src).unwrap();
+    for _ in 0..RUNS_PER_CELL {
+        let t0 = Instant::now();
+        fresh.set_input(post_edit.clone());
+        cold_times.push(t0.elapsed().as_nanos());
+    }
+
+    // Warm: reset to post-initial-parse state, apply edit, time just
+    // the edit (which does the incremental reparse).
+    let mut warm_times = Vec::with_capacity(RUNS_PER_CELL);
+    let mut last_stats = syntax_highlighter::pegvm::MemoStats::default();
+    for _ in 0..RUNS_PER_CELL {
+        let mut inc = Highlighter::new(grammar_src).unwrap();
+        inc.set_input(fixture.to_string());
+        let t0 = Instant::now();
+        edit_kind.apply(&mut inc);
+        warm_times.push(t0.elapsed().as_nanos());
+        last_stats = inc.last_stats();
+    }
+
+    let cold_ns = median(cold_times);
+    let warm_ns = median(warm_times);
+    let speedup = cold_ns as f64 / warm_ns as f64;
+    let lookups = last_stats.hits + last_stats.misses;
+    let warm_hit_rate = if lookups == 0 {
+        0.0
+    } else {
+        last_stats.hits as f64 / lookups as f64
+    };
+
+    Cell {
+        grammar: grammar_label,
+        fixture_label,
+        edit_kind,
+        cold_ns,
+        warm_ns,
+        speedup,
+        warm_hits: last_stats.hits,
+        warm_misses: last_stats.misses,
+        warm_hit_rate,
+    }
+}
+
+fn print_header() {
+    println!(
+        "{:<6} {:<7} {:<10} {:>10} {:>10} {:>8} {:>8} {:>8} {:>9}",
+        "gram", "fixture", "edit", "cold(us)", "warm(us)", "speedup", "hits", "misses", "hit_rate"
+    );
+}
+
+fn print_cell(c: &Cell) {
+    println!(
+        "{:<6} {:<7} {:<10} {:>10.1} {:>10.1} {:>8.2} {:>8} {:>8} {:>8.1}%",
+        c.grammar,
+        c.fixture_label,
+        c.edit_kind.label(),
+        c.cold_ns as f64 / 1000.0,
+        c.warm_ns as f64 / 1000.0,
+        c.speedup,
+        c.warm_hits,
+        c.warm_misses,
+        c.warm_hit_rate * 100.0,
+    );
+}
+
+fn emit_jsonl(out: &mut Option<std::io::BufWriter<std::fs::File>>, c: &Cell) {
+    let Some(w) = out else { return };
+    let row = &[
+        ("bench", json_str("incremental")),
+        ("grammar", json_str(c.grammar)),
+        ("fixture", json_str(c.fixture_label)),
+        ("edit_kind", json_str(c.edit_kind.label())),
+        ("cold_us", json_f64(c.cold_ns as f64 / 1000.0)),
+        ("warm_us", json_f64(c.warm_ns as f64 / 1000.0)),
+        ("speedup", json_f64(c.speedup)),
+        ("warm_hits", json_num(c.warm_hits)),
+        ("warm_misses", json_num(c.warm_misses)),
+        ("warm_hit_rate", json_f64(c.warm_hit_rate)),
+        ("runs", json_num(RUNS_PER_CELL)),
+    ];
+    let _ = write_jsonl_row(w, row);
+}
+
+struct GrammarCase {
+    label: &'static str,
+    source: &'static str,
+    fixtures: &'static [(&'static str, &'static str)],
+}
+
+fn main() {
+    let cases: &[GrammarCase] = &[
+        GrammarCase {
+            label: "json",
+            source: JSON_GRAMMAR,
+            fixtures: &[
+                ("small", JSON_SMALL),
+                ("medium", JSON_MEDIUM),
+                ("large", JSON_LARGE),
+            ],
+        },
+        GrammarCase {
+            label: "toml",
+            source: TOML_GRAMMAR,
+            fixtures: &[
+                ("small", TOML_SMALL),
+                ("medium", TOML_MEDIUM),
+                ("large", TOML_LARGE),
+            ],
+        },
+        GrammarCase {
+            label: "sql",
+            source: SQL_GRAMMAR,
+            fixtures: &[
+                ("small", SQL_SMALL),
+                ("medium", SQL_MEDIUM),
+                ("large", SQL_LARGE),
+            ],
+        },
+    ];
+    let kinds = [
+        EditKind::AppendOneChar,
+        EditKind::InsertMid10,
+        EditKind::DeleteMid10,
+    ];
+
+    println!(
+        "incremental reparse sweep — {} runs/cell; cold = fresh Highlighter parse of post-edit input",
+        RUNS_PER_CELL
+    );
+    println!();
+    print_header();
+
+    let mut jsonl = open_jsonl("incremental");
+    for case in cases {
+        for (fixture_label, fixture) in case.fixtures {
+            for kind in &kinds {
+                // Edits require at least ~20 bytes to find a middle.
+                // Skip the small fixtures for mid-range edits so we
+                // don't panic on empty ranges.
+                if fixture.len() < 20 && !matches!(kind, EditKind::AppendOneChar) {
+                    continue;
+                }
+                let cell = run_cell(case.source, case.label, fixture_label, fixture, *kind);
+                print_cell(&cell);
+                emit_jsonl(&mut jsonl, &cell);
+            }
+        }
+    }
+}

--- a/benches/memo.rs
+++ b/benches/memo.rs
@@ -17,6 +17,11 @@ use std::time::Instant;
 
 use syntax_highlighter::pegvm::{compile_grammar, parse_grammar, Program, VM};
 
+#[path = "common.rs"]
+mod common;
+
+use common::{json_f64, json_num, json_str, median, open_jsonl, write_jsonl_row};
+
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
@@ -48,11 +53,6 @@ fn compile(name: &str, src: &str) -> Program {
         .unwrap_or_else(|e| panic!("compile {name}: {e:?}"))
 }
 
-fn median(mut xs: Vec<u128>) -> u128 {
-    xs.sort_unstable();
-    xs[xs.len() / 2]
-}
-
 /// Run one cell: `runs` executions of the VM at a fixed threshold. Returns
 /// the median wall time (nanoseconds), plus a single `(matched, complete,
 /// stats)` tuple — all runs are deterministic, so one sample suffices.
@@ -80,7 +80,7 @@ fn sweep_cell(
     (median(times), matched, complete, stats)
 }
 
-fn print_grammar_table(case: &GrammarCase) {
+fn print_grammar_table(case: &GrammarCase, jsonl: &mut Option<std::io::BufWriter<std::fs::File>>) {
     println!("=== {} ===", case.name);
     println!(
         "{:<8} {:>6} {:>10} {:>8} {:>8} {:>8} {:>9}",
@@ -129,6 +129,21 @@ fn print_grammar_table(case: &GrammarCase) {
                 misses,
                 hit_rate * 100.0
             );
+            if let Some(w) = jsonl.as_mut() {
+                let row = &[
+                    ("bench", json_str("memo")),
+                    ("grammar", json_str(case.name)),
+                    ("fixture", json_str(label)),
+                    ("threshold", json_num(thr)),
+                    ("time_us", json_f64(median_ns as f64 / 1000.0)),
+                    ("entries", json_num(entries)),
+                    ("hits", json_num(hits)),
+                    ("misses", json_num(misses)),
+                    ("hit_rate", json_f64(hit_rate)),
+                    ("runs", json_num(RUNS_PER_CELL)),
+                ];
+                let _ = write_jsonl_row(w, row);
+            }
         }
         println!();
     }
@@ -171,7 +186,8 @@ fn main() {
     );
     println!();
 
+    let mut jsonl = open_jsonl("memo");
     for case in &cases {
-        print_grammar_table(case);
+        print_grammar_table(case, &mut jsonl);
     }
 }

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -1,8 +1,31 @@
 //! ANSI-colored syntax highlighting on top of [`crate::pegvm`].
 //!
-//! [`Highlighter`] compiles a PEG grammar once, then renders highlighted
-//! output for any input by running the VM and translating its captures
-//! into ANSI escape codes.
+//! [`Highlighter`] compiles a PEG grammar once, owns the current input,
+//! and carries a [`MemoCache`](crate::pegvm::MemoCache) across edits so
+//! re-highlighting after a small change touches only the memo entries
+//! whose spans cross the edit point (see
+//! [`crate::pegvm::incremental`] for the invalidation protocol). The
+//! first [`set_input`](Highlighter::set_input) is a cold full parse;
+//! each [`edit`](Highlighter::edit) / [`append`](Highlighter::append)
+//! is a warm incremental reparse.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! # use syntax_highlighter::highlight::Highlighter;
+//! let mut h = Highlighter::new(include_str!("../../grammars/json.peg")).unwrap();
+//! h.set_input(r#"{"a":1}"#.into());
+//! h.edit(4, 5, "42");          // replace `1` with `42`
+//! h.append(", \"b\": true");   // streaming append
+//! println!("{}", h.highlight());
+//! ```
+//!
+//! Equivalence guarantee: for any input `I` and any sequence of edits
+//! transforming it into `I'`, calling [`highlight`](Highlighter::highlight)
+//! after the edits must produce the same bytes as constructing a fresh
+//! [`Highlighter`] and calling `set_input(I')` then `highlight()`. The
+//! integration tests in `tests/incremental_tests.rs` cover this across
+//! shipped grammars and edit sequences.
 //!
 //! # Rendering strategy
 //!
@@ -23,17 +46,19 @@
 //!
 //! # Load-bearing invariant
 //!
-//! Stripping the ANSI escape codes from `highlight(input)` must yield the
-//! original `input` unchanged, *including* for inputs the VM only
-//! partially matches. The renderer never reorders, drops, or substitutes
-//! input bytes — it only inserts color codes around them. The integration
-//! tests assert this directly with a `strip_ansi` helper; any change to
-//! the renderer must preserve the property.
+//! Stripping the ANSI escape codes from [`highlight`](Highlighter::highlight)
+//! must yield the current [`input`](Highlighter::input) unchanged,
+//! *including* for inputs the VM only partially matches. The renderer
+//! never reorders, drops, or substitutes input bytes — it only inserts
+//! color codes around them. The integration tests assert this directly
+//! with a `strip_ansi` helper; any change to the renderer must preserve
+//! the property.
 
 pub mod theme;
 
 use crate::pegvm::{
-    compile_grammar, parse_grammar, Capture, CompileError, ParseError, Program, VM,
+    compile_grammar, incremental::Edit, parse_grammar, Capture, CompileError, MemoCache, MemoStats,
+    ParseError, Program, VM,
 };
 
 #[derive(Debug)]
@@ -65,36 +90,112 @@ impl From<CompileError> for HighlightError {
     }
 }
 
+/// Stateful, always-incremental highlighter. Holds the compiled program,
+/// the current input, the carry-across memo cache, and the most recent
+/// parse result. Every mutating method (`set_input`, `edit`, `append`)
+/// re-parses synchronously and refreshes the cached captures; read
+/// methods (`highlight`, `captures`, `input`) never parse.
 pub struct Highlighter {
     program: Program,
+    input: String,
+    cache: MemoCache,
+    matched: usize,
+    captures: Vec<Capture>,
+    last_stats: MemoStats,
 }
 
 impl Highlighter {
     pub fn new(grammar_source: &str) -> Result<Self, HighlightError> {
         let g = parse_grammar(grammar_source)?;
         let program = compile_grammar(&g.rules, &g.start)?;
-        Ok(Highlighter { program })
+        Ok(Self {
+            program,
+            input: String::new(),
+            cache: MemoCache::new(),
+            matched: 0,
+            captures: Vec::new(),
+            last_stats: MemoStats::default(),
+        })
     }
 
-    /// Run the VM and return raw captures alongside how many bytes matched.
-    /// Useful for tests and debugging.
+    /// Replace the entire input and perform a cold parse. Discards any
+    /// prior cache — use this when the new input is unrelated to the
+    /// old one (e.g. loading a different file). For small edits to the
+    /// current input, prefer [`edit`](Self::edit) or
+    /// [`append`](Self::append) instead.
+    pub fn set_input(&mut self, input: String) {
+        self.input = input;
+        self.cache = MemoCache::new();
+        self.reparse();
+    }
+
+    /// Replace `input[start..old_end]` with `replacement` and re-parse
+    /// incrementally. Entries in the carry-across cache whose examined
+    /// span crosses `start` are dropped; the rest are shifted to
+    /// reflect the new byte offsets and served as hits on the warm
+    /// parse.
     ///
-    /// On partial match (VM failed to reach `End`), the returned `matched`
-    /// is the farthest input position reached and `captures` are the spans
+    /// Panics if `start > old_end` or `old_end > self.input.len()`.
+    pub fn edit(&mut self, start: usize, old_end: usize, replacement: &str) {
+        assert!(start <= old_end, "edit: start must be <= old_end");
+        assert!(
+            old_end <= self.input.len(),
+            "edit: old_end ({}) past input.len() ({})",
+            old_end,
+            self.input.len()
+        );
+        let edit = Edit::replacement(start, old_end, replacement.len());
+        self.input.replace_range(start..old_end, replacement);
+        self.cache.apply_edit(edit);
+        self.reparse();
+    }
+
+    /// Streaming append: convenience for edits at `self.input.len()`.
+    /// Optimized for the char-by-char case an LLM-streaming UI hits.
+    pub fn append(&mut self, text: &str) {
+        let at = self.input.len();
+        self.edit(at, at, text);
+    }
+
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Raw captures from the most recent parse, alongside how many
+    /// bytes matched. Useful for tests and debugging.
+    ///
+    /// On partial match (VM failed to reach `End`), `matched` is the
+    /// farthest input position reached and the captures are the spans
     /// valid at that point — so the renderer naturally styles the valid
     /// prefix and emits the unparseable tail plain.
-    pub fn captures(&self, input: &str) -> (usize, Vec<Capture>) {
-        let r = VM::new(&self.program.code, input.as_bytes()).run();
-        (r.matched, r.captures)
+    pub fn captures(&self) -> (usize, &[Capture]) {
+        (self.matched, &self.captures)
     }
 
     pub fn capture_kinds(&self) -> &[String] {
         &self.program.capture_kinds
     }
 
-    pub fn highlight(&self, input: &str) -> String {
-        let (_, captures) = self.captures(input);
-        render(input, &captures, &self.program.capture_kinds)
+    pub fn highlight(&self) -> String {
+        render(&self.input, &self.captures, &self.program.capture_kinds)
+    }
+
+    /// Memo cache diagnostics from the most recent parse. `hits` /
+    /// `misses` reflect the warm re-parse's consumption of the seeded
+    /// cache; `entries` is the post-parse cache size. Primarily useful
+    /// for benchmarks measuring incremental speedup.
+    pub fn last_stats(&self) -> MemoStats {
+        self.last_stats
+    }
+
+    fn reparse(&mut self) {
+        let seeded = std::mem::take(&mut self.cache);
+        let (result, stats, cache_after) =
+            VM::new_with_cache(&self.program.code, self.input.as_bytes(), seeded).run_with_cache();
+        self.cache = cache_after;
+        self.matched = result.matched;
+        self.captures = result.captures;
+        self.last_stats = stats;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let highlighter = match Highlighter::new(lang.grammar()) {
+    let mut highlighter = match Highlighter::new(lang.grammar()) {
         Ok(h) => h,
         Err(e) => {
             eprintln!("syntax-highlighter: grammar error: {}", e);
@@ -134,8 +134,8 @@ fn main() -> ExitCode {
         }
     };
 
-    let out = highlighter.highlight(&input);
-    if let Err(e) = io::stdout().write_all(out.as_bytes()) {
+    highlighter.set_input(input);
+    if let Err(e) = io::stdout().write_all(highlighter.highlight().as_bytes()) {
         eprintln!("syntax-highlighter: writing output: {}", e);
         return ExitCode::from(2);
     }

--- a/src/pegvm/incremental.rs
+++ b/src/pegvm/incremental.rs
@@ -1,0 +1,390 @@
+//! Persistent memoization cache for incremental reparsing.
+//!
+//! The [`VM`] in this crate already memoizes every rule invocation during
+//! a single run. Incremental parsing reuses that memo across edits: after
+//! the user changes the input, most cached entries are still valid and
+//! only the ones whose examined-span crosses the edit point need to be
+//! recomputed. [`MemoCache`] is the ownership wrapper around that memo
+//! between runs; [`MemoCache::apply_edit`] is the invalidation protocol.
+//!
+//! # Correctness
+//!
+//! Each memo entry carries its `examined_max` — the farthest input
+//! position the rule's execution ever looked at (see
+//! [`crate::pegvm::vm`]'s `MemoEntry` doc). For an edit that replaces
+//! bytes `[edit.start, edit.old_end)` with content that produces the new
+//! range `[edit.start, edit.new_end)`:
+//!
+//! - An entry at `(memo_id, start_sp)` is **invalidated** iff
+//!   `start_sp < edit.old_end && examined_max > edit.start`. This covers
+//!   both entries that started inside the edit region (their starting
+//!   byte has changed) and entries that started before but peeked into
+//!   it (their outcome might have depended on the changed bytes).
+//! - An entry with `start_sp >= edit.old_end` is **shifted** by
+//!   `delta = new_end - old_end` so its key, `end_sp`, `examined_max`,
+//!   and capture offsets land on the equivalent position in the new
+//!   input.
+//! - An entry with `start_sp < edit.old_end && examined_max <= edit.start`
+//!   lives entirely before the edit region — it is kept unshifted.
+//!
+//! Rebuilding the HashMap on every edit is `O(|cache|)`. Fine on the
+//! working set sizes we care about; a position-indexed structure (e.g.
+//! `BTreeMap<usize, ...>`) is a future optimization if cache size grows.
+//!
+//! Note for future work: when left-recursion support lands, its L-table
+//! will need its own invalidation pass in parallel with this one.
+
+use std::collections::HashMap;
+
+use super::instruction::MemoId;
+use super::vm::MemoEntry;
+
+/// A description of a single edit to the parser's input. The replacement
+/// content itself is not stored — the cache only needs the byte offsets.
+///
+/// - **Insertion** of `k` bytes at position `p`: `start = old_end = p`,
+///   `new_end = p + k`. Use [`Edit::insertion`].
+/// - **Deletion** of `[a, b)`: `start = a`, `old_end = b`, `new_end = a`.
+///   Use [`Edit::deletion`].
+/// - **Replacement** of `[a, b)` with `k` bytes: `start = a`,
+///   `old_end = b`, `new_end = a + k`. Use [`Edit::replacement`].
+///
+/// Invariant: `start <= old_end` and `start <= new_end`. An edit where
+/// `start == old_end == new_end` is a no-op and
+/// [`MemoCache::apply_edit`] returns without touching the table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Edit {
+    pub start: usize,
+    pub old_end: usize,
+    pub new_end: usize,
+}
+
+impl Edit {
+    pub fn insertion(at: usize, inserted_len: usize) -> Self {
+        Edit {
+            start: at,
+            old_end: at,
+            new_end: at + inserted_len,
+        }
+    }
+
+    pub fn deletion(start: usize, old_end: usize) -> Self {
+        debug_assert!(start <= old_end, "Edit::deletion: start must be <= old_end");
+        Edit {
+            start,
+            old_end,
+            new_end: start,
+        }
+    }
+
+    pub fn replacement(start: usize, old_end: usize, new_len: usize) -> Self {
+        debug_assert!(
+            start <= old_end,
+            "Edit::replacement: start must be <= old_end"
+        );
+        Edit {
+            start,
+            old_end,
+            new_end: start + new_len,
+        }
+    }
+
+    fn delta(self) -> isize {
+        self.new_end as isize - self.old_end as isize
+    }
+
+    fn is_noop(self) -> bool {
+        self.start == self.old_end && self.start == self.new_end
+    }
+}
+
+/// Memoization table carried across incremental reparses. Opaque wrapper
+/// around the same `HashMap<(MemoId, usize), MemoEntry>` the VM uses
+/// internally. Construct via [`MemoCache::new`]; hand to
+/// `VM::new_with_cache` (arriving in a follow-up commit) to seed the
+/// next run, and reclaim the post-run table via `VM::into_cache`.
+#[derive(Debug, Default, Clone)]
+pub struct MemoCache {
+    table: HashMap<(MemoId, usize), MemoEntry>,
+}
+
+impl MemoCache {
+    pub fn new() -> Self {
+        MemoCache::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.table.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    /// Apply `edit` to every cached entry: drop the ones whose examined
+    /// span crosses the edit point, shift the ones that follow it, and
+    /// leave untouched the ones that finished before it. See the
+    /// module-level docs for the full correctness argument.
+    pub fn apply_edit(&mut self, edit: Edit) {
+        if edit.is_noop() {
+            return;
+        }
+        let delta = edit.delta();
+        let mut next = HashMap::with_capacity(self.table.len());
+        for ((memo_id, start_sp), mut entry) in self.table.drain() {
+            if invalidates(edit, start_sp, &entry) {
+                continue;
+            }
+            if start_sp >= edit.old_end {
+                let new_start_sp = start_sp.wrapping_add_signed(delta);
+                shift_entry(&mut entry, delta);
+                next.insert((memo_id, new_start_sp), entry);
+            } else {
+                // Entry lives entirely before the edit; keep unshifted.
+                next.insert((memo_id, start_sp), entry);
+            }
+        }
+        self.table = next;
+    }
+
+    /// Drain the underlying table; leaves `self` empty. Package-internal
+    /// hook for `VM::new_with_cache` (next commit) to seed its memo
+    /// directly without an extra copy.
+    #[allow(dead_code)] // consumed by the VM wiring in the next commit
+    pub(crate) fn take(&mut self) -> HashMap<(MemoId, usize), MemoEntry> {
+        std::mem::take(&mut self.table)
+    }
+
+    /// Replace the underlying table. Package-internal hook for
+    /// `VM::into_cache` (next commit) to return a populated cache after
+    /// a run.
+    #[allow(dead_code)] // consumed by the VM wiring in the next commit
+    pub(crate) fn install(&mut self, table: HashMap<(MemoId, usize), MemoEntry>) {
+        self.table = table;
+    }
+
+    /// Package-internal read access for tests to assert on per-entry
+    /// structure without leaking `MemoEntry`.
+    #[cfg(test)]
+    pub(crate) fn get(&self, memo_id: MemoId, start_sp: usize) -> Option<&MemoEntry> {
+        self.table.get(&(memo_id, start_sp))
+    }
+}
+
+fn invalidates(edit: Edit, start_sp: usize, entry: &MemoEntry) -> bool {
+    start_sp < edit.old_end && entry.examined_max > edit.start
+}
+
+fn shift_entry(entry: &mut MemoEntry, delta: isize) {
+    if let Some(ref mut end_sp) = entry.end_sp {
+        *end_sp = end_sp.wrapping_add_signed(delta);
+    }
+    entry.examined_max = entry.examined_max.wrapping_add_signed(delta);
+    for c in &mut entry.captures {
+        c.start = c.start.wrapping_add_signed(delta);
+        c.end = c.end.wrapping_add_signed(delta);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the invalidation predicate and shift math. End-to-end
+    //! parse-edit-reparse equivalence tests arrive once the VM can be
+    //! seeded from a `MemoCache` (next commit).
+    use super::*;
+    use crate::pegvm::vm::{Capture, MemoEntry};
+    use crate::pegvm::CaptureKind;
+
+    fn cap(start: usize, end: usize) -> Capture {
+        Capture {
+            kind: CaptureKind(0),
+            start,
+            end,
+        }
+    }
+
+    fn success(end_sp: usize, examined_max: usize, caps: Vec<Capture>) -> MemoEntry {
+        MemoEntry {
+            end_sp: Some(end_sp),
+            examined_max,
+            captures: caps,
+        }
+    }
+
+    fn failure(examined_max: usize) -> MemoEntry {
+        MemoEntry {
+            end_sp: None,
+            examined_max,
+            captures: Vec::new(),
+        }
+    }
+
+    fn populate(pairs: Vec<((MemoId, usize), MemoEntry)>) -> MemoCache {
+        let mut cache = MemoCache::new();
+        let mut table = HashMap::new();
+        for (k, v) in pairs {
+            table.insert(k, v);
+        }
+        cache.install(table);
+        cache
+    }
+
+    #[test]
+    fn noop_edit_leaves_everything_intact() {
+        let mut cache = populate(vec![
+            ((MemoId(0), 0), success(10, 12, vec![cap(0, 10)])),
+            ((MemoId(1), 5), success(8, 8, vec![])),
+        ]);
+        cache.apply_edit(Edit {
+            start: 7,
+            old_end: 7,
+            new_end: 7,
+        });
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(MemoId(0), 0).unwrap().examined_max, 12);
+        assert_eq!(cache.get(MemoId(1), 5).unwrap().end_sp, Some(8));
+    }
+
+    #[test]
+    fn entry_fully_before_edit_is_kept_unshifted() {
+        // entry at 0..5, examined_max=5. Edit at 10..10 inserting 3 bytes.
+        let mut cache = populate(vec![((MemoId(0), 0), success(5, 5, vec![cap(1, 4)]))]);
+        cache.apply_edit(Edit::insertion(10, 3));
+        let e = cache.get(MemoId(0), 0).expect("must survive");
+        assert_eq!(e.end_sp, Some(5));
+        assert_eq!(e.examined_max, 5);
+        assert_eq!(e.captures, vec![cap(1, 4)]);
+    }
+
+    #[test]
+    fn entry_starting_after_edit_is_shifted() {
+        // entry starts at sp=20, examined_max=30. Edit inserts 5 bytes at sp=5.
+        let mut cache = populate(vec![((MemoId(2), 20), success(25, 30, vec![cap(22, 24)]))]);
+        cache.apply_edit(Edit::insertion(5, 5));
+        assert!(cache.get(MemoId(2), 20).is_none(), "old key gone");
+        let e = cache
+            .get(MemoId(2), 25)
+            .expect("entry present under shifted key");
+        assert_eq!(e.end_sp, Some(30));
+        assert_eq!(e.examined_max, 35);
+        assert_eq!(e.captures, vec![cap(27, 29)]);
+    }
+
+    #[test]
+    fn deletion_shifts_entries_left() {
+        // entry at sp=20, examined_max=30. Delete bytes 5..10 (5 bytes removed).
+        let mut cache = populate(vec![((MemoId(0), 20), success(25, 30, vec![cap(20, 25)]))]);
+        cache.apply_edit(Edit::deletion(5, 10));
+        let e = cache
+            .get(MemoId(0), 15)
+            .expect("entry present under shifted key");
+        assert_eq!(e.end_sp, Some(20));
+        assert_eq!(e.examined_max, 25);
+        assert_eq!(e.captures, vec![cap(15, 20)]);
+    }
+
+    #[test]
+    fn entry_spanning_edit_is_invalidated() {
+        // entry starts at 0, examined up to 20. Edit at 10..12.
+        // examined_max (20) > edit.start (10) AND start_sp (0) < old_end (12).
+        let mut cache = populate(vec![((MemoId(0), 0), success(18, 20, vec![cap(0, 18)]))]);
+        cache.apply_edit(Edit::replacement(10, 12, 2));
+        assert_eq!(cache.len(), 0, "entry must be dropped");
+    }
+
+    #[test]
+    fn entry_starting_inside_edit_is_invalidated() {
+        // Even if examined_max never reaches past start, an entry whose
+        // starting byte sits inside the edit region is stale — the byte
+        // at start_sp may have changed. The predicate catches this
+        // because examined_max >= start_sp > edit.start.
+        let mut cache = populate(vec![((MemoId(0), 8), success(10, 10, vec![]))]);
+        cache.apply_edit(Edit::replacement(5, 12, 7));
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn entry_ending_at_edit_boundary_is_kept() {
+        // Entry examined up to exactly edit.start (exclusive: examined_max == 10,
+        // reads go through position 9). The read at position 9 doesn't overlap
+        // with bytes 10.., so the entry is valid.
+        let mut cache = populate(vec![((MemoId(0), 0), success(10, 10, vec![]))]);
+        cache.apply_edit(Edit::replacement(10, 12, 5));
+        let e = cache.get(MemoId(0), 0).expect("entry must survive");
+        assert_eq!(e.examined_max, 10);
+    }
+
+    #[test]
+    fn failure_entry_with_eof_read_is_invalidated_on_append() {
+        // Append scenario: old input had length 5. The failing rule
+        // probed position 5 (EOF), which bumped its watermark to 6 —
+        // `track_read` fires *before* the bounds check, so a read at
+        // `sp = 5` registers the intent to examine position 5 even
+        // when `input.get(5)` returns None. Appending bytes at
+        // position 5 changes what lives there, so the cached failure
+        // is stale. Predicate: `0 < 5 && 6 > 5` → drop.
+        let mut cache = populate(vec![((MemoId(0), 0), failure(6))]);
+        cache.apply_edit(Edit::insertion(5, 3));
+        assert_eq!(cache.len(), 0, "EOF-sensitive failure must be dropped");
+    }
+
+    #[test]
+    fn failure_entry_with_bounded_read_survives_append() {
+        // Failure entry examined only up to position 3 (< old_input_len).
+        // Appending bytes past the examined range doesn't affect it.
+        let mut cache = populate(vec![((MemoId(0), 0), failure(3))]);
+        cache.apply_edit(Edit::insertion(5, 3));
+        let e = cache.get(MemoId(0), 0).expect("failure must survive");
+        assert_eq!(e.end_sp, None);
+        assert_eq!(e.examined_max, 3);
+    }
+
+    #[test]
+    fn insert_at_zero_shifts_everything() {
+        // Edit::insertion(0, k) shifts every entry by k and invalidates
+        // nothing (examined_max >= start_sp >= 0; start_sp < 0 is
+        // impossible, so the `start_sp < edit.old_end == 0` leg of the
+        // predicate is always false).
+        let mut cache = populate(vec![
+            ((MemoId(0), 0), success(5, 5, vec![cap(0, 5)])),
+            ((MemoId(1), 10), success(15, 18, vec![cap(11, 14)])),
+        ]);
+        cache.apply_edit(Edit::insertion(0, 4));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(MemoId(0), 4).unwrap().end_sp, Some(9));
+        assert_eq!(cache.get(MemoId(0), 4).unwrap().captures, vec![cap(4, 9)]);
+        assert_eq!(cache.get(MemoId(1), 14).unwrap().examined_max, 22);
+    }
+
+    #[test]
+    fn replacement_of_equal_length_does_not_shift_but_invalidates() {
+        // delta = 0, but entries whose examined_max > edit.start must
+        // still be invalidated — the byte content within [start, end)
+        // has changed.
+        let mut cache = populate(vec![
+            ((MemoId(0), 0), success(20, 20, vec![cap(0, 20)])), // spans edit
+            ((MemoId(1), 25), success(30, 30, vec![cap(25, 30)])), // after edit
+        ]);
+        cache.apply_edit(Edit::replacement(10, 15, 5));
+        assert!(cache.get(MemoId(0), 0).is_none(), "spanning entry dropped");
+        // After-edit entry unshifted (delta=0) and intact.
+        let e = cache.get(MemoId(1), 25).expect("after-edit entry survives");
+        assert_eq!(e.end_sp, Some(30));
+        assert_eq!(e.captures, vec![cap(25, 30)]);
+    }
+
+    #[test]
+    fn same_start_sp_multiple_memo_ids_shift_together() {
+        // Two rules memoized at the same position get independent keys;
+        // shift them both.
+        let mut cache = populate(vec![
+            ((MemoId(0), 10), success(15, 15, vec![])),
+            ((MemoId(1), 10), success(12, 12, vec![])),
+        ]);
+        cache.apply_edit(Edit::insertion(5, 2));
+        assert!(cache.get(MemoId(0), 10).is_none());
+        assert!(cache.get(MemoId(1), 10).is_none());
+        assert_eq!(cache.get(MemoId(0), 12).unwrap().end_sp, Some(17));
+        assert_eq!(cache.get(MemoId(1), 12).unwrap().end_sp, Some(14));
+    }
+}

--- a/src/pegvm/incremental.rs
+++ b/src/pegvm/incremental.rs
@@ -15,16 +15,26 @@
 //! bytes `[edit.start, edit.old_end)` with content that produces the new
 //! range `[edit.start, edit.new_end)`:
 //!
-//! - An entry at `(memo_id, start_sp)` is **invalidated** iff
+//! - A **success** entry at `(memo_id, start_sp)` is **invalidated** iff
 //!   `start_sp < edit.old_end && examined_max > edit.start`. This covers
 //!   both entries that started inside the edit region (their starting
 //!   byte has changed) and entries that started before but peeked into
 //!   it (their outcome might have depended on the changed bytes).
+//! - Any **failure** entry is dropped unconditionally on every edit.
+//!   Failure entries short-circuit `MemoOpen` to `fail()` on re-entry
+//!   without carrying the farthest-sp capture snapshot that a real
+//!   `fail()` along the slow path would write to `max_captures`; if a
+//!   warm parse hits such an entry and the overall parse then fails,
+//!   the rendered prefix would be empty regardless of how far the VM
+//!   actually progressed. Rather than teach the VM to reconstruct the
+//!   missing snapshot on a memo hit, we forfeit cross-edit failure
+//!   persistence. Intra-parse memoization still short-circuits within a
+//!   single run.
 //! - An entry with `start_sp >= edit.old_end` is **shifted** by
 //!   `delta = new_end - old_end` so its key, `end_sp`, `examined_max`,
 //!   and capture offsets land on the equivalent position in the new
 //!   input.
-//! - An entry with `start_sp < edit.old_end && examined_max <= edit.start`
+//! - A success entry with `start_sp < edit.old_end && examined_max <= edit.start`
 //!   lives entirely before the edit region — it is kept unshifted.
 //!
 //! Rebuilding the HashMap on every edit is `O(|cache|)`. Fine on the
@@ -172,6 +182,9 @@ impl MemoCache {
 }
 
 fn invalidates(edit: Edit, start_sp: usize, entry: &MemoEntry) -> bool {
+    if entry.end_sp.is_none() {
+        return true;
+    }
     start_sp < edit.old_end && entry.examined_max > edit.start
 }
 
@@ -315,28 +328,19 @@ mod tests {
     }
 
     #[test]
-    fn failure_entry_with_eof_read_is_invalidated_on_append() {
-        // Append scenario: old input had length 5. The failing rule
-        // probed position 5 (EOF), which bumped its watermark to 6 —
-        // `track_read` fires *before* the bounds check, so a read at
-        // `sp = 5` registers the intent to examine position 5 even
-        // when `input.get(5)` returns None. Appending bytes at
-        // position 5 changes what lives there, so the cached failure
-        // is stale. Predicate: `0 < 5 && 6 > 5` → drop.
-        let mut cache = populate(vec![((MemoId(0), 0), failure(6))]);
+    fn failure_entries_are_dropped_on_any_edit() {
+        // Failure entries carry no capture snapshot, so a warm `MemoOpen`
+        // hit that goes to `fail()` cannot update `max_sp`/`max_captures`
+        // the way a slow-path fail would. Rather than teach the VM to
+        // reconstruct that snapshot, we drop every failure entry on every
+        // edit — regardless of where its examined range sits relative to
+        // the edit point.
+        let mut cache = populate(vec![
+            ((MemoId(0), 0), failure(6)), // EOF-sensitive failure
+            ((MemoId(1), 0), failure(3)), // bounded failure, well before edit
+        ]);
         cache.apply_edit(Edit::insertion(5, 3));
-        assert_eq!(cache.len(), 0, "EOF-sensitive failure must be dropped");
-    }
-
-    #[test]
-    fn failure_entry_with_bounded_read_survives_append() {
-        // Failure entry examined only up to position 3 (< old_input_len).
-        // Appending bytes past the examined range doesn't affect it.
-        let mut cache = populate(vec![((MemoId(0), 0), failure(3))]);
-        cache.apply_edit(Edit::insertion(5, 3));
-        let e = cache.get(MemoId(0), 0).expect("failure must survive");
-        assert_eq!(e.end_sp, None);
-        assert_eq!(e.examined_max, 3);
+        assert_eq!(cache.len(), 0, "all failure entries must be dropped");
     }
 
     #[test]

--- a/src/pegvm/mod.rs
+++ b/src/pegvm/mod.rs
@@ -1,11 +1,13 @@
 pub mod compiler;
 pub mod grammar;
+pub mod incremental;
 pub mod instruction;
 pub mod pattern;
 pub mod vm;
 
 pub use compiler::{compile_grammar, compile_pattern, CompileError, Program};
 pub use grammar::{parse as parse_grammar, Grammar, ParseError};
+pub use incremental::{Edit, MemoCache};
 pub use instruction::{CaptureKind, CharSet, Instruction, Label, MemoId};
 pub use pattern::Pattern;
 pub use vm::{Capture, MatchResult, MemoStats, VM};

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -174,6 +174,23 @@ impl<'p, 'i> VM<'p, 'i> {
         self
     }
 
+    /// Construct a VM whose memo table is pre-populated with `cache`.
+    /// Entries the seeded cache agrees with the program on (same rule +
+    /// position) will be served as hits without re-executing the rule
+    /// body — that is the entire point of incremental parsing. The
+    /// caller is responsible for ensuring the cache was built against
+    /// either this same input or a prior input plus a correctly applied
+    /// [`MemoCache::apply_edit`](super::incremental::MemoCache::apply_edit).
+    pub fn new_with_cache(
+        program: &'p [Instruction],
+        input: &'i [u8],
+        mut cache: super::incremental::MemoCache,
+    ) -> Self {
+        let mut vm = Self::new(program, input);
+        vm.memo = cache.take();
+        vm
+    }
+
     pub fn run(self) -> MatchResult {
         self.run_with_memo_stats().0
     }
@@ -183,11 +200,24 @@ impl<'p, 'i> VM<'p, 'i> {
         (result, stats)
     }
 
+    /// Run the VM to completion and return the populated memo as a
+    /// [`MemoCache`](super::incremental::MemoCache) so the caller can
+    /// carry it across an edit. Equivalent to `run_with_memo_stats`
+    /// plus a rewrap; the cache retains every entry recorded during
+    /// this run, including entries seeded in via [`new_with_cache`]
+    /// that survived the parse.
+    pub fn run_with_cache(self) -> (MatchResult, MemoStats, super::incremental::MemoCache) {
+        let (result, stats, memo) = self.run_core();
+        let mut cache = super::incremental::MemoCache::new();
+        cache.install(memo);
+        (result, stats, cache)
+    }
+
     /// Core execution loop. Returns the result, stats, and the final memo
     /// table. Package-internal wrapper for tests that need to inspect
-    /// per-entry details (notably `examined_max`) and the eventual
-    /// incremental-parsing hook that harvests the memo for later reuse
-    /// across edits.
+    /// per-entry details (notably `examined_max`) and for the public
+    /// `run_with_cache` variant that rewraps the table into a
+    /// [`MemoCache`](super::incremental::MemoCache).
     fn run_core(mut self) -> (MatchResult, MemoStats, HashMap<(MemoId, usize), MemoEntry>) {
         loop {
             let instr = match self.program.get(self.ip) {

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -121,11 +121,15 @@ pub struct VM<'p, 'i> {
 /// and for successful entries `>= end_sp`. Incremental parsing uses it as
 /// the invalidation bound: an edit touching any byte before
 /// `examined_max` may change the rule's outcome, so the entry is stale.
+///
+/// Fields are `pub(crate)` so the `incremental` module (which holds the
+/// `MemoCache` that reuses entries across edits) can read and shift them.
+/// Outside the crate the type is opaque.
 #[derive(Debug, Clone)]
-struct MemoEntry {
-    end_sp: Option<usize>,
-    examined_max: usize,
-    captures: Vec<Capture>,
+pub(crate) struct MemoEntry {
+    pub(crate) end_sp: Option<usize>,
+    pub(crate) examined_max: usize,
+    pub(crate) captures: Vec<Capture>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -94,6 +94,17 @@ pub struct VM<'p, 'i> {
     /// GPeg (default 512) and Yedidia §5.2.4 (knee near 4096). Failure
     /// entries in `fail()` are not filtered; their value is short-circuiting.
     memo_threshold: usize,
+    /// Per-rule-invocation watermark of the farthest input position examined
+    /// since the enclosing `StackEntry::Memo` frame was pushed. One entry
+    /// per live `Memo` frame, pushed/popped in lockstep with them. The
+    /// topmost value is bumped by every read site via `track_read`; at
+    /// `MemoClose` or the `Memo` arm of `fail()` the popped value becomes
+    /// the outgoing entry's `examined_max` and is then merged into the new
+    /// top (the parent rule's watermark). Needed for incremental parsing:
+    /// an edit at position `p` invalidates a cached entry iff
+    /// `p < entry.examined_max`, so the bound must reflect lookahead reads
+    /// past `end_sp` as well as the consumed span.
+    memo_examined: Vec<usize>,
 }
 
 /// A memo-table entry for a rule invocation at a specific input position.
@@ -103,9 +114,17 @@ pub struct VM<'p, 'i> {
 /// `end_sp.is_none()` encodes a cached failure — future hits at the same
 /// `(memo_id, start_sp)` enter `fail()` directly without re-running the
 /// rule body.
+///
+/// `examined_max` is the farthest input position the rule's execution ever
+/// looked at, including lookahead past `end_sp` (`&expr` / `!expr`) and
+/// failed reads. It is always `>= start_sp` (the key's second component),
+/// and for successful entries `>= end_sp`. Incremental parsing uses it as
+/// the invalidation bound: an edit touching any byte before
+/// `examined_max` may change the rule's outcome, so the entry is stale.
 #[derive(Debug, Clone)]
 struct MemoEntry {
     end_sp: Option<usize>,
+    examined_max: usize,
     captures: Vec<Capture>,
 }
 
@@ -138,6 +157,7 @@ impl<'p, 'i> VM<'p, 'i> {
             memo_hits: 0,
             memo_misses: 0,
             memo_threshold: Self::DEFAULT_MEMO_THRESHOLD,
+            memo_examined: Vec::new(),
         }
     }
 
@@ -154,7 +174,17 @@ impl<'p, 'i> VM<'p, 'i> {
         self.run_with_memo_stats().0
     }
 
-    pub fn run_with_memo_stats(mut self) -> (MatchResult, MemoStats) {
+    pub fn run_with_memo_stats(self) -> (MatchResult, MemoStats) {
+        let (result, stats, _memo) = self.run_core();
+        (result, stats)
+    }
+
+    /// Core execution loop. Returns the result, stats, and the final memo
+    /// table. Package-internal wrapper for tests that need to inspect
+    /// per-entry details (notably `examined_max`) and the eventual
+    /// incremental-parsing hook that harvests the memo for later reuse
+    /// across edits.
+    fn run_core(mut self) -> (MatchResult, MemoStats, HashMap<(MemoId, usize), MemoEntry>) {
         loop {
             let instr = match self.program.get(self.ip) {
                 Some(i) => i,
@@ -162,6 +192,7 @@ impl<'p, 'i> VM<'p, 'i> {
             };
             match instr {
                 Instruction::Char(b) => {
+                    self.track_read(1);
                     if self.input.get(self.sp) == Some(b) {
                         self.sp += 1;
                         self.ip += 1;
@@ -169,19 +200,23 @@ impl<'p, 'i> VM<'p, 'i> {
                         return self.finalize_partial();
                     }
                 }
-                Instruction::Set(set) => match self.input.get(self.sp) {
-                    Some(b) if set.contains(*b) => {
-                        self.sp += 1;
-                        self.ip += 1;
-                    }
-                    _ => {
-                        if !self.fail() {
-                            return self.finalize_partial();
+                Instruction::Set(set) => {
+                    self.track_read(1);
+                    match self.input.get(self.sp) {
+                        Some(b) if set.contains(*b) => {
+                            self.sp += 1;
+                            self.ip += 1;
+                        }
+                        _ => {
+                            if !self.fail() {
+                                return self.finalize_partial();
+                            }
                         }
                     }
-                },
+                }
                 Instruction::Any(n) => {
                     let n = *n as usize;
+                    self.track_read(n);
                     if self.sp + n <= self.input.len() {
                         self.sp += n;
                         self.ip += 1;
@@ -190,6 +225,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     }
                 }
                 Instruction::TestChar(b, label) => {
+                    self.track_read(1);
                     if self.input.get(self.sp) == Some(b) {
                         self.sp += 1;
                         self.ip += 1;
@@ -197,15 +233,18 @@ impl<'p, 'i> VM<'p, 'i> {
                         self.ip = label.0;
                     }
                 }
-                Instruction::TestSet(set, label) => match self.input.get(self.sp) {
-                    Some(b) if set.contains(*b) => {
-                        self.sp += 1;
-                        self.ip += 1;
+                Instruction::TestSet(set, label) => {
+                    self.track_read(1);
+                    match self.input.get(self.sp) {
+                        Some(b) if set.contains(*b) => {
+                            self.sp += 1;
+                            self.ip += 1;
+                        }
+                        _ => {
+                            self.ip = label.0;
+                        }
                     }
-                    _ => {
-                        self.ip = label.0;
-                    }
-                },
+                }
                 Instruction::Jump(label) => {
                     self.ip = label.0;
                 }
@@ -274,6 +313,14 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::MemoOpen(memo_id, return_label) => {
                     if let Some(entry) = self.memo.get(&(*memo_id, self.sp)) {
                         self.memo_hits += 1;
+                        // Cache hit substitutes for executing the rule body;
+                        // propagate its examined watermark to the enclosing
+                        // rule (if any) so an outer rule's `examined_max`
+                        // subsumes everything this call would have looked at.
+                        // The bump is deferred past the `entry` borrow
+                        // below (`self.bump_top_memo_examined` is `&mut
+                        // self` and would conflict with it).
+                        let hit_examined = entry.examined_max;
                         match entry.end_sp {
                             Some(end_sp) => {
                                 // Success hit: replay captures into the live
@@ -291,6 +338,11 @@ impl<'p, 'i> VM<'p, 'i> {
                                         end: Some(c.end),
                                     });
                                 }
+                                // `entry` is no longer used past this point;
+                                // the immutable borrow of `self.memo` ends
+                                // by NLL, releasing `&mut self` for the
+                                // bump and maybe_snapshot below.
+                                self.bump_top_memo_examined(hit_examined);
                                 self.sp = end_sp;
                                 self.ip = return_label.0;
                                 // Applying a hit advances `sp` past code that
@@ -302,6 +354,7 @@ impl<'p, 'i> VM<'p, 'i> {
                                 // Cached failure: enter fail() immediately
                                 // without re-executing the rule body. Do not
                                 // push a Memo frame.
+                                self.bump_top_memo_examined(hit_examined);
                                 if !self.fail() {
                                     return self.finalize_partial();
                                 }
@@ -314,6 +367,11 @@ impl<'p, 'i> VM<'p, 'i> {
                             start_sp: self.sp,
                             capture_start_len: self.captures.len(),
                         });
+                        // Parallel watermark for this frame. Starts at the
+                        // rule's entry sp; read sites bump it as the body
+                        // executes. Popped together with the `Memo` frame
+                        // at `MemoClose` or in `fail()`'s `Memo` arm.
+                        self.memo_examined.push(self.sp);
                         self.ip += 1;
                     }
                 }
@@ -345,6 +403,23 @@ impl<'p, 'i> VM<'p, 'i> {
                         capture_start_len,
                         self.captures.len(),
                     );
+                    // Pop this frame's examined watermark. Every `Memo`
+                    // frame push (in `MemoOpen` miss) is paired with a
+                    // `memo_examined` push, and this is the only
+                    // non-failure pop site, so the stacks must align.
+                    let examined_max = self
+                        .memo_examined
+                        .pop()
+                        .expect("MemoClose: memo_examined underflow");
+                    debug_assert!(
+                        examined_max >= self.sp,
+                        "MemoClose: examined_max ({}) fell behind end_sp ({})",
+                        examined_max,
+                        self.sp,
+                    );
+                    // Propagate up so the parent rule's watermark covers
+                    // everything this one examined.
+                    self.bump_top_memo_examined(examined_max);
                     // Threshold filter: skip caching if the matched span is
                     // smaller than `memo_threshold`. Tiny leaf rules pay the
                     // lookup cost without a meaningful storage win — see
@@ -377,6 +452,7 @@ impl<'p, 'i> VM<'p, 'i> {
                             (*memo_id, start_sp),
                             MemoEntry {
                                 end_sp: Some(self.sp),
+                                examined_max,
                                 captures: rule_captures,
                             },
                         );
@@ -413,6 +489,7 @@ impl<'p, 'i> VM<'p, 'i> {
                             complete: true,
                         },
                         stats,
+                        self.memo,
                     );
                 }
             }
@@ -448,6 +525,13 @@ impl<'p, 'i> VM<'p, 'i> {
                     start_sp,
                     capture_start_len: _,
                 } => {
+                    // Pop the paired examined watermark. See `MemoOpen`
+                    // miss path — every `StackEntry::Memo` push is twinned
+                    // with a `memo_examined` push.
+                    let examined_max = self
+                        .memo_examined
+                        .pop()
+                        .expect("fail(): memo_examined underflow on Memo frame");
                     // Cache the failure so a future call at the same sp
                     // short-circuits into `fail()` without re-executing the
                     // body. Captures produced inside the rule will be
@@ -458,9 +542,15 @@ impl<'p, 'i> VM<'p, 'i> {
                         (memo_id, start_sp),
                         MemoEntry {
                             end_sp: None,
+                            examined_max,
                             captures: Vec::new(),
                         },
                     );
+                    // Propagate to the parent rule: a failure here depended
+                    // on input through `examined_max`, and any caller that
+                    // ultimately retries a different path still saw those
+                    // bytes.
+                    self.bump_top_memo_examined(examined_max);
                 }
                 StackEntry::Return { .. } => {
                     // Rule-call frame unwinding past its caller. The caller's
@@ -470,6 +560,29 @@ impl<'p, 'i> VM<'p, 'i> {
             }
         }
         false
+    }
+
+    /// Bump the in-flight rule's examined watermark to at least `pos`.
+    /// Invoked from every read site (Char/Set/Any/TestChar/TestSet) and
+    /// from memo-hit propagation, so a rule's `MemoEntry.examined_max`
+    /// reflects lookahead and failed reads past `end_sp`. A no-op when no
+    /// `Memo` frame is live (top-level program reads don't feed any
+    /// cached entry).
+    fn bump_top_memo_examined(&mut self, pos: usize) {
+        if let Some(top) = self.memo_examined.last_mut() {
+            if pos > *top {
+                *top = pos;
+            }
+        }
+    }
+
+    /// Record that the current instruction examines `n` bytes starting at
+    /// `self.sp`. The probe happens at the current `sp` whether the read
+    /// succeeds (consume) or fails (EOF or mismatch) — in both cases the
+    /// outcome depends on bytes up to `sp + n`, so the watermark must
+    /// advance there. `n = 1` for Char/Set/TestChar/TestSet; `n` for Any.
+    fn track_read(&mut self, n: usize) {
+        self.bump_top_memo_examined(self.sp + n);
     }
 
     /// Update the farthest-failure snapshot if `sp` has advanced past the
@@ -484,7 +597,7 @@ impl<'p, 'i> VM<'p, 'i> {
         }
     }
 
-    fn finalize_partial(mut self) -> (MatchResult, MemoStats) {
+    fn finalize_partial(mut self) -> (MatchResult, MemoStats, HashMap<(MemoId, usize), MemoEntry>) {
         self.maybe_snapshot();
         let stats = MemoStats {
             entries: self.memo.len(),
@@ -496,7 +609,7 @@ impl<'p, 'i> VM<'p, 'i> {
             captures: close_captures(self.max_captures, self.max_sp),
             complete: false,
         };
-        (result, stats)
+        (result, stats, self.memo)
     }
 }
 
@@ -508,4 +621,160 @@ fn close_captures(open: Vec<OpenCapture>, close_at: usize) -> Vec<Capture> {
             end: c.end.unwrap_or(close_at),
         })
         .collect()
+}
+
+#[cfg(test)]
+mod examined_max_tests {
+    //! Verify that every memo entry records the farthest input position
+    //! its rule invocation ever examined, including lookahead past
+    //! `end_sp` and failed reads. Incremental parsing's invalidation
+    //! predicate (`edit.start <= entry.examined_max`) depends on this
+    //! bound being tight-enough to be useful and safe-at-minimum to be
+    //! correct.
+    //!
+    //! Tests access `VM::run_core` directly to inspect the private
+    //! memo map — post-run the public `run_with_memo_stats` has already
+    //! discarded it.
+    use super::*;
+    use crate::pegvm::{compile_grammar, Pattern};
+    use std::collections::HashMap;
+
+    fn rule(rules: &mut HashMap<String, Pattern>, name: &str, pat: Pattern) {
+        rules.insert(name.into(), pat);
+    }
+
+    #[test]
+    fn and_predicate_success_records_examined_past_end_sp() {
+        // start <- "x" &"y"   against "xy"
+        // Consumed span is "x" (end_sp = 1) but the &"y" lookahead
+        // read position 1, so examined_max must be 2.
+        let mut rules = HashMap::new();
+        rule(
+            &mut rules,
+            "start",
+            Pattern::seq(vec![
+                Pattern::literal("x"),
+                Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+            ]),
+        );
+        let prog = compile_grammar(&rules, "start").unwrap();
+        let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
+        assert!(result.complete);
+        assert_eq!(result.matched, 1, "only 'x' is consumed");
+        let entry = memo
+            .get(&(MemoId(0), 0))
+            .expect("start's memo entry missing");
+        assert_eq!(entry.end_sp, Some(1));
+        assert_eq!(
+            entry.examined_max, 2,
+            "&\"y\" read past end_sp; examined_max must reflect it"
+        );
+    }
+
+    #[test]
+    fn and_predicate_failure_records_examined_up_to_failed_read() {
+        // start <- "x" &"z"   against "xy"
+        // "x" succeeds (sp=1), then &"z" reads 'y' at sp=1 and fails.
+        // The failure entry for start at sp=0 must remember that
+        // position 1 was examined, so an edit there can invalidate it.
+        let mut rules = HashMap::new();
+        rule(
+            &mut rules,
+            "start",
+            Pattern::seq(vec![
+                Pattern::literal("x"),
+                Pattern::AndPredicate(Box::new(Pattern::literal("z"))),
+            ]),
+        );
+        let prog = compile_grammar(&rules, "start").unwrap();
+        let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
+        assert!(!result.complete, "overall parse must fail");
+        let entry = memo
+            .get(&(MemoId(0), 0))
+            .expect("start's failure entry missing");
+        assert_eq!(entry.end_sp, None);
+        assert_eq!(
+            entry.examined_max, 2,
+            "failed read of 'z' at position 1 examined position 1+1"
+        );
+    }
+
+    #[test]
+    fn nested_rule_examined_max_propagates_to_caller() {
+        // outer <- inner "y"
+        // inner <- "x"
+        // against "xy".  inner's entry: end_sp=1, examined_max=1.
+        // outer's entry: end_sp=2, examined_max=2 (reads 'y' at sp=1).
+        // The propagation test: inner's examined_max (1) must flow into
+        // outer's watermark when inner's MemoClose pops.
+        let mut rules = HashMap::new();
+        rule(
+            &mut rules,
+            "outer",
+            Pattern::seq(vec![
+                Pattern::NonTerminal("inner".into()),
+                Pattern::literal("y"),
+            ]),
+        );
+        rule(&mut rules, "inner", Pattern::literal("x"));
+        let prog = compile_grammar(&rules, "outer").unwrap();
+        let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
+        assert!(result.complete);
+        assert_eq!(result.matched, 2);
+        // outer is start → MemoId(0); inner is the other → MemoId(1).
+        let outer = memo.get(&(MemoId(0), 0)).expect("outer entry missing");
+        assert_eq!(outer.end_sp, Some(2));
+        assert_eq!(outer.examined_max, 2);
+        let inner = memo.get(&(MemoId(1), 0)).expect("inner entry missing");
+        assert_eq!(inner.end_sp, Some(1));
+        assert_eq!(inner.examined_max, 1);
+    }
+
+    #[test]
+    fn memo_hit_propagates_examined_max_to_caller() {
+        // Two alternatives both start with the memoized rule X.
+        // The first alternative's success call to X populates the
+        // cache with examined_max = 1; the second alternative's call
+        // is a hit. The hit must still contribute X's examined_max to
+        // whichever rule encloses the call.
+        //
+        // Grammar:
+        //   start <- (X "aa") / (X "bb")
+        //   X <- "a"
+        // Input: "abb" — first alt fails after X matches "a" and "aa"
+        // fails on "bb"; backtrack to second alt, which hits X's cache
+        // and then matches "bb".
+        let mut rules = HashMap::new();
+        rule(
+            &mut rules,
+            "start",
+            Pattern::choice(vec![
+                Pattern::seq(vec![
+                    Pattern::NonTerminal("X".into()),
+                    Pattern::literal("aa"),
+                ]),
+                Pattern::seq(vec![
+                    Pattern::NonTerminal("X".into()),
+                    Pattern::literal("bb"),
+                ]),
+            ]),
+        );
+        rule(&mut rules, "X", Pattern::literal("a"));
+        let prog = compile_grammar(&rules, "start").unwrap();
+        let (result, stats, memo) = VM::new(&prog.code, b"abb")
+            .with_memo_threshold(0)
+            .run_core();
+        assert!(result.complete);
+        assert_eq!(result.matched, 3);
+        assert!(stats.hits >= 1, "second alternative must hit X's cache");
+        // start's examined_max must include every byte start's execution
+        // ever looked at: position 2 was examined when the first
+        // alternative tried "aa" at sp=1 and "bb" at sp=1 needed byte 2.
+        let start = memo.get(&(MemoId(0), 0)).expect("start entry missing");
+        assert_eq!(start.end_sp, Some(3));
+        assert_eq!(
+            start.examined_max, 3,
+            "start's execution examined up to position 3"
+        );
+    }
 }

--- a/tests/highlight_sql_tests.rs
+++ b/tests/highlight_sql_tests.rs
@@ -6,23 +6,24 @@ use common::strip_ansi;
 
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 
-fn hl() -> Highlighter {
-    Highlighter::new(SQLITE_GRAMMAR).expect("SQLite grammar should compile")
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(SQLITE_GRAMMAR).expect("SQLite grammar should compile");
+    h.set_input(input.to_string());
+    h
 }
 
 #[test]
 fn parses_minimal_select() {
-    let h = hl();
     let input = "SELECT 1;";
-    let (matched, caps) = h.captures(input);
+    let h = hl(input);
+    let (matched, caps) = h.captures();
     assert_eq!(matched, input.len());
     assert!(!caps.is_empty());
 }
 
 #[test]
 fn highlight_keyword_uses_keyword_color() {
-    let h = hl();
-    let out = h.highlight("SELECT 1");
+    let out = hl("SELECT 1").highlight();
     let kw = theme::color_for("keyword");
     let idx = out.find("SELECT").expect("SELECT must appear");
     let preceding = &out[..idx];
@@ -35,8 +36,7 @@ fn highlight_keyword_uses_keyword_color() {
 
 #[test]
 fn highlight_string_uses_string_color() {
-    let h = hl();
-    let out = h.highlight("SELECT 'hi' FROM t");
+    let out = hl("SELECT 'hi' FROM t").highlight();
     assert!(
         out.contains(theme::color_for("string")),
         "expected string color, got {:?}",
@@ -46,8 +46,7 @@ fn highlight_string_uses_string_color() {
 
 #[test]
 fn highlight_number_uses_number_color() {
-    let h = hl();
-    let out = h.highlight("SELECT 42 FROM t");
+    let out = hl("SELECT 42 FROM t").highlight();
     assert!(
         out.contains(theme::color_for("number")),
         "expected number color, got {:?}",
@@ -57,8 +56,7 @@ fn highlight_number_uses_number_color() {
 
 #[test]
 fn highlight_null_uses_constant_color() {
-    let h = hl();
-    let out = h.highlight("SELECT NULL");
+    let out = hl("SELECT NULL").highlight();
     let c = theme::color_for("constant");
     let idx = out.find("NULL").expect("NULL must appear");
     let preceding = &out[..idx];
@@ -71,8 +69,7 @@ fn highlight_null_uses_constant_color() {
 
 #[test]
 fn highlight_comment_uses_comment_color() {
-    let h = hl();
-    let out = h.highlight("-- note\nSELECT 1");
+    let out = hl("-- note\nSELECT 1").highlight();
     assert!(
         out.contains(theme::color_for("comment")),
         "expected comment color, got {:?}",
@@ -82,8 +79,7 @@ fn highlight_comment_uses_comment_color() {
 
 #[test]
 fn highlight_function_uses_function_color() {
-    let h = hl();
-    let out = h.highlight("SELECT COUNT(*) FROM t");
+    let out = hl("SELECT COUNT(*) FROM t").highlight();
     let f = theme::color_for("function");
     let idx = out.find("COUNT").expect("COUNT must appear");
     let preceding = &out[..idx];
@@ -96,8 +92,7 @@ fn highlight_function_uses_function_color() {
 
 #[test]
 fn highlight_table_in_from_uses_type_color() {
-    let h = hl();
-    let out = h.highlight("SELECT c FROM users");
+    let out = hl("SELECT c FROM users").highlight();
     let t = theme::color_for("type");
     let idx = out.find("users").expect("table name must appear");
     let preceding = &out[..idx];
@@ -110,8 +105,7 @@ fn highlight_table_in_from_uses_type_color() {
 
 #[test]
 fn highlight_cast_target_uses_type_color() {
-    let h = hl();
-    let out = h.highlight("SELECT CAST(x AS INTEGER) FROM t");
+    let out = hl("SELECT CAST(x AS INTEGER) FROM t").highlight();
     let t = theme::color_for("type");
     let idx = out.find("INTEGER").expect("INTEGER must appear");
     let preceding = &out[..idx];
@@ -124,8 +118,7 @@ fn highlight_cast_target_uses_type_color() {
 
 #[test]
 fn highlight_operator_uses_operator_color() {
-    let h = hl();
-    let out = h.highlight("SELECT a FROM t WHERE a = 1");
+    let out = hl("SELECT a FROM t WHERE a = 1").highlight();
     assert!(
         out.contains(theme::color_for("operator")),
         "expected operator color, got {:?}",
@@ -135,8 +128,7 @@ fn highlight_operator_uses_operator_color() {
 
 #[test]
 fn highlight_bind_param_uses_variable_color() {
-    let h = hl();
-    let out = h.highlight("SELECT :name FROM t");
+    let out = hl("SELECT :name FROM t").highlight();
     let v = theme::color_for("variable");
     let idx = out.find(":name").expect(":name must appear");
     let preceding = &out[..idx];
@@ -150,7 +142,6 @@ fn highlight_bind_param_uses_variable_color() {
 #[test]
 fn highlighting_preserves_input_text() {
     // Stripping ANSI codes must yield the original input byte-for-byte.
-    let h = hl();
     let input = "\
 -- A representative query.
 WITH recent AS (SELECT id FROM orders)
@@ -165,24 +156,22 @@ LIMIT 10;
 
 SELECT 1 UNION ALL SELECT 2;
 ";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     let stripped = strip_ansi(&out);
     assert_eq!(stripped, input);
 }
 
 #[test]
 fn partial_match_unterminated_string_still_round_trips() {
-    let h = hl();
     let input = "SELECT 'oops\nFROM t";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }
 
 #[test]
 fn partial_match_unclosed_paren_still_round_trips() {
-    let h = hl();
     let input = "SELECT COUNT( FROM t";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }
 
@@ -190,9 +179,8 @@ fn partial_match_unclosed_paren_still_round_trips() {
 fn partial_match_renders_prefix_styled_and_tail_plain() {
     // The valid SELECT prefix should carry styling; trailing garbage renders
     // verbatim. This mirrors the TOML partial-match test.
-    let h = hl();
     let input = "SELECT 1; !!garbage";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input, "round-trip must hold");
     assert!(
         out.contains(theme::color_for("number")),

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -6,14 +6,16 @@ use common::strip_ansi;
 
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 
-fn hl() -> Highlighter {
-    Highlighter::new(JSON_GRAMMAR).expect("JSON grammar should compile")
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(JSON_GRAMMAR).expect("JSON grammar should compile");
+    h.set_input(input.to_string());
+    h
 }
 
 #[test]
 fn parses_minimal_object() {
-    let h = hl();
-    let (matched, caps) = h.captures("{}");
+    let h = hl("{}");
+    let (matched, caps) = h.captures();
     assert_eq!(matched, 2);
     assert!(
         !caps.is_empty(),
@@ -23,57 +25,54 @@ fn parses_minimal_object() {
 
 #[test]
 fn parses_minimal_array() {
-    let h = hl();
-    let (matched, _) = h.captures("[]");
+    let h = hl("[]");
+    let (matched, _) = h.captures();
     assert_eq!(matched, 2);
 }
 
 #[test]
 fn parses_string_value() {
-    let h = hl();
-    let (matched, _) = h.captures(r#""hello""#);
+    let h = hl(r#""hello""#);
+    let (matched, _) = h.captures();
     assert_eq!(matched, 7);
 }
 
 #[test]
 fn parses_number_value() {
-    let h = hl();
-    assert_eq!(h.captures("42").0, 2);
-    assert_eq!(h.captures("-3.14").0, 5);
-    assert_eq!(h.captures("1e10").0, 4);
-    assert_eq!(h.captures("-0.5e-3").0, 7);
+    assert_eq!(hl("42").captures().0, 2);
+    assert_eq!(hl("-3.14").captures().0, 5);
+    assert_eq!(hl("1e10").captures().0, 4);
+    assert_eq!(hl("-0.5e-3").captures().0, 7);
 }
 
 #[test]
 fn parses_constants() {
-    let h = hl();
-    assert_eq!(h.captures("true").0, 4);
-    assert_eq!(h.captures("false").0, 5);
-    assert_eq!(h.captures("null").0, 4);
+    assert_eq!(hl("true").captures().0, 4);
+    assert_eq!(hl("false").captures().0, 5);
+    assert_eq!(hl("null").captures().0, 4);
 }
 
 #[test]
 fn parses_nested_object() {
-    let h = hl();
     let input = r#"{"a": {"b": [1, 2, true]}}"#;
-    let (matched, caps) = h.captures(input);
+    let h = hl(input);
+    let (matched, caps) = h.captures();
     assert_eq!(matched, input.len());
     assert!(caps.len() > 5);
 }
 
 #[test]
 fn parses_string_with_escapes() {
-    let h = hl();
     let input = r#""he said \"hi\"""#;
-    let (matched, _) = h.captures(input);
+    let h = hl(input);
+    let (matched, _) = h.captures();
     assert_eq!(matched, input.len());
 }
 
 #[test]
 fn parses_string_with_unicode_escape() {
-    let h = hl();
     let input = r#""\u00e9""#;
-    assert_eq!(h.captures(input).0, input.len());
+    assert_eq!(hl(input).captures().0, input.len());
 }
 
 #[test]
@@ -81,9 +80,9 @@ fn partial_unterminated_string_advances_past_quote() {
     // On malformed input the VM no longer gives up at sp=0; it surfaces the
     // farthest position reached. The quote itself is consumed before the
     // string body starts failing.
-    let h = hl();
     let input = r#""oops"#;
-    let (matched, _) = h.captures(input);
+    let h = hl(input);
+    let (matched, _) = h.captures();
     assert!(matched > 0, "expected some progress, got {}", matched);
     assert!(matched <= input.len());
 }
@@ -93,17 +92,16 @@ fn partial_trailing_garbage_reports_max_sp() {
     // The json rule ends with `!.`; trailing garbage fails the top-level
     // parse. The VM now reports the farthest position reached (the end of
     // the valid JSON prefix) rather than zero.
-    let h = hl();
     let input = r#"{"a": 1} extra"#;
-    let (matched, _) = h.captures(input);
+    let h = hl(input);
+    let (matched, _) = h.captures();
     assert!(matched > 0, "expected progress past the valid prefix");
     assert!(matched <= input.len());
 }
 
 #[test]
 fn highlight_string_uses_green() {
-    let h = hl();
-    let out = h.highlight(r#""hi""#);
+    let out = hl(r#""hi""#).highlight();
     assert!(
         out.contains(theme::color_for("string")),
         "expected string color in {:?}",
@@ -115,16 +113,14 @@ fn highlight_string_uses_green() {
 
 #[test]
 fn highlight_number_uses_yellow() {
-    let h = hl();
-    let out = h.highlight("42");
+    let out = hl("42").highlight();
     assert!(out.contains(theme::color_for("number")), "got {:?}", out);
     assert!(out.contains("42"));
 }
 
 #[test]
 fn highlight_constant_uses_magenta() {
-    let h = hl();
-    let out = h.highlight("true");
+    let out = hl("true").highlight();
     assert!(out.contains(theme::color_for("constant")), "got {:?}", out);
     assert!(out.contains("true"));
 }
@@ -133,8 +129,7 @@ fn highlight_constant_uses_magenta() {
 fn highlight_property_uses_cyan_not_string_green() {
     // In `pair`, the key is wrapped in @property{string} — it should render as a
     // property (cyan), not as a string (green).
-    let h = hl();
-    let out = h.highlight(r#"{"name": "value"}"#);
+    let out = hl(r#"{"name": "value"}"#).highlight();
     let prop = theme::color_for("property");
     let str_color = theme::color_for("string");
     // The key "name" should appear under property color
@@ -158,9 +153,8 @@ fn highlight_property_uses_cyan_not_string_green() {
 #[test]
 fn highlighting_preserves_input_text() {
     // Stripping ANSI codes should yield the original input.
-    let h = hl();
     let input = r#"{"key": [1, true, "hello"], "nested": {"a": null}}"#;
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     let stripped = strip_ansi(&out);
     assert_eq!(stripped, input);
 }
@@ -170,9 +164,8 @@ fn partial_match_renders_prefix_styled_and_tail_plain() {
     // The valid JSON prefix must be styled; the trailing garbage must appear
     // verbatim in the output (no ANSI codes wrapping it). The round-trip
     // invariant must hold for the whole output.
-    let h = hl();
     let input = r#"{"a": 1} extra"#;
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input, "round-trip must be preserved");
     assert!(
         out.contains(theme::color_for("number")) || out.contains(theme::color_for("string")),
@@ -193,8 +186,7 @@ fn unterminated_string_still_round_trips() {
     // The load-bearing strip_ansi invariant must hold even when the input
     // is malformed — partial-match rendering must not reorder, drop, or
     // substitute input bytes.
-    let h = hl();
     let input = r#"{"a": "oops"#;
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }

--- a/tests/highlight_toml_tests.rs
+++ b/tests/highlight_toml_tests.rs
@@ -6,23 +6,24 @@ use common::strip_ansi;
 
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 
-fn hl() -> Highlighter {
-    Highlighter::new(TOML_GRAMMAR).expect("TOML grammar should compile")
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(TOML_GRAMMAR).expect("TOML grammar should compile");
+    h.set_input(input.to_string());
+    h
 }
 
 #[test]
 fn parses_simple_pair() {
-    let h = hl();
     let input = "key = 1\n";
-    let (matched, caps) = h.captures(input);
+    let h = hl(input);
+    let (matched, caps) = h.captures();
     assert_eq!(matched, input.len());
     assert!(!caps.is_empty());
 }
 
 #[test]
 fn highlight_string_uses_green() {
-    let h = hl();
-    let out = h.highlight("s = \"hello\"\n");
+    let out = hl("s = \"hello\"\n").highlight();
     assert!(
         out.contains(theme::color_for("string")),
         "expected string color, got {:?}",
@@ -33,8 +34,7 @@ fn highlight_string_uses_green() {
 
 #[test]
 fn highlight_number_uses_yellow() {
-    let h = hl();
-    let out = h.highlight("n = 42\n");
+    let out = hl("n = 42\n").highlight();
     assert!(
         out.contains(theme::color_for("number")),
         "expected number color, got {:?}",
@@ -44,8 +44,7 @@ fn highlight_number_uses_yellow() {
 
 #[test]
 fn highlight_boolean_uses_constant() {
-    let h = hl();
-    let out = h.highlight("b = true\n");
+    let out = hl("b = true\n").highlight();
     assert!(
         out.contains(theme::color_for("constant")),
         "expected constant color, got {:?}",
@@ -57,8 +56,7 @@ fn highlight_boolean_uses_constant() {
 fn highlight_inf_uses_constant_not_number() {
     // inf / nan are @constant in this grammar, grouped with true/false
     // rather than with 42 / 3.14. Verify the color lands as constant.
-    let h = hl();
-    let out = h.highlight("f = inf\n");
+    let out = hl("f = inf\n").highlight();
     // Locate where "inf" appears and check the preceding ANSI escape.
     let idx = out.find("inf").expect("inf must appear in output");
     let preceding = &out[..idx];
@@ -71,8 +69,7 @@ fn highlight_inf_uses_constant_not_number() {
 
 #[test]
 fn highlight_comment_uses_comment_color() {
-    let h = hl();
-    let out = h.highlight("# a comment\n");
+    let out = hl("# a comment\n").highlight();
     assert!(
         out.contains(theme::color_for("comment")),
         "expected comment color, got {:?}",
@@ -85,8 +82,7 @@ fn highlight_key_uses_property_not_string() {
     // A bare key on the LHS of = should render as @property (cyan), not
     // as @string (green). This is the JSON-equivalent of the "property vs
     // string" distinction, adapted to TOML bare keys.
-    let h = hl();
-    let out = h.highlight("name = \"alice\"\n");
+    let out = hl("name = \"alice\"\n").highlight();
     let prop = theme::color_for("property");
     let str_color = theme::color_for("string");
 
@@ -109,8 +105,7 @@ fn highlight_key_uses_property_not_string() {
 
 #[test]
 fn highlight_section_header_uses_type_color() {
-    let h = hl();
-    let out = h.highlight("[package]\n");
+    let out = hl("[package]\n").highlight();
     let ty = theme::color_for("type");
     let idx = out.find("package").expect("section path must appear");
     let preceding = &out[..idx];
@@ -123,8 +118,7 @@ fn highlight_section_header_uses_type_color() {
 
 #[test]
 fn highlight_array_of_tables_header_uses_type_color() {
-    let h = hl();
-    let out = h.highlight("[[bin]]\n");
+    let out = hl("[[bin]]\n").highlight();
     let ty = theme::color_for("type");
     let idx = out.find("bin").expect("section path must appear");
     let preceding = &out[..idx];
@@ -138,7 +132,6 @@ fn highlight_array_of_tables_header_uses_type_color() {
 #[test]
 fn highlighting_preserves_input_text() {
     // Stripping ANSI codes must yield the original input byte-for-byte.
-    let h = hl();
     let input = r#"# A realistic snippet.
 [package]
 name = "demo"
@@ -154,7 +147,7 @@ serde = { version = "1.0", features = ["derive"] }
 name = "demo"
 path = "src/main.rs"
 "#;
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     let stripped = strip_ansi(&out);
     assert_eq!(stripped, input);
 }
@@ -163,26 +156,23 @@ path = "src/main.rs"
 fn blank_lines_and_trailing_comments_are_preserved() {
     // Blank lines between entries and trailing end-of-line comments must
     // survive the round trip verbatim.
-    let h = hl();
     let input = "\n\n# leading\n\nkey = 1 # trailing\n\n\n";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }
 
 #[test]
 fn partial_match_unterminated_string_still_round_trips() {
     // The load-bearing strip_ansi invariant must hold on malformed input.
-    let h = hl();
     let input = "key = \"oops\n";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }
 
 #[test]
 fn partial_match_unclosed_table_header_still_round_trips() {
-    let h = hl();
     let input = "[package\nname = \"x\"";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input);
 }
 
@@ -190,9 +180,8 @@ fn partial_match_unclosed_table_header_still_round_trips() {
 fn partial_match_renders_prefix_styled_and_tail_plain() {
     // The valid prefix should carry some ANSI styling; the trailing
     // garbage should render verbatim in the output.
-    let h = hl();
     let input = "key = 1\n!!garbage";
-    let out = h.highlight(input);
+    let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input, "round-trip must hold");
     assert!(
         out.contains(theme::color_for("number")),

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -1,0 +1,94 @@
+//! Integration tests for the incremental-parsing public surface.
+//!
+//! Exercises the full loop: run a VM, reclaim the `MemoCache`, seed a
+//! fresh VM with it, and confirm the second run hits the cache and
+//! produces identical output. Parse-edit-reparse equivalence tests over
+//! real grammars arrive alongside the `IncrementalHighlighter` API in
+//! a follow-up commit.
+
+use std::collections::HashMap;
+
+use syntax_highlighter::pegvm::{compile_grammar, CharSet, MatchResult, MemoCache, Pattern, VM};
+
+fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
+    // start <- word word
+    // word  <- [a-z]+
+    // The outer rule has enough span that default threshold (128) would
+    // skip its entry on small inputs; tests pin threshold=0 to exercise
+    // the mechanism regardless.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::seq(vec![
+            Pattern::NonTerminal("word".into()),
+            Pattern::literal(" "),
+            Pattern::NonTerminal("word".into()),
+        ]),
+    );
+    rules.insert(
+        "word".into(),
+        Pattern::RepeatOne(Box::new(Pattern::CharClass(CharSet::from_ranges(&[(
+            b'a', b'z',
+        )])))),
+    );
+    compile_grammar(&rules, "start").unwrap()
+}
+
+#[test]
+fn second_parse_with_seeded_cache_hits_every_cached_rule() {
+    let prog = two_rule_grammar();
+
+    // Cold parse populates the cache with entries for every memoized
+    // rule invocation.
+    let (cold_result, cold_stats, cache) = VM::new(&prog.code, b"hello world")
+        .with_memo_threshold(0)
+        .run_with_cache();
+    assert!(cold_result.complete);
+    assert_eq!(cold_result.matched, 11);
+    assert_eq!(cold_stats.hits, 0, "cold run starts empty");
+    assert!(cold_stats.misses > 0, "cold run must produce entries");
+    assert_eq!(cache.len(), cold_stats.misses);
+
+    // Warm parse with the same input: every MemoOpen for a rule
+    // already in the cache should hit. Misses drop to zero when the
+    // seeded cache covers every rule invocation.
+    let (warm_result, warm_stats, _warm_cache) =
+        VM::new_with_cache(&prog.code, b"hello world", cache)
+            .with_memo_threshold(0)
+            .run_with_cache();
+    assert_eq!(
+        warm_result, cold_result,
+        "warm re-parse must produce identical output"
+    );
+    assert!(warm_stats.hits > 0, "warm run should hit the seeded cache");
+    assert_eq!(
+        warm_stats.misses, 0,
+        "seeded cache covered every invocation; expected zero misses"
+    );
+}
+
+#[test]
+fn seeded_cache_survives_second_parse() {
+    let prog = two_rule_grammar();
+    let (_, _, cache) = VM::new(&prog.code, b"hello world")
+        .with_memo_threshold(0)
+        .run_with_cache();
+    let len_before = cache.len();
+    let (_, _, cache_after) = VM::new_with_cache(&prog.code, b"hello world", cache)
+        .with_memo_threshold(0)
+        .run_with_cache();
+    assert_eq!(
+        cache_after.len(),
+        len_before,
+        "re-parse on identical input should neither add nor drop entries"
+    );
+}
+
+#[test]
+fn empty_cache_behaves_like_fresh_vm() {
+    let prog = two_rule_grammar();
+    let input = b"hi there";
+    let fresh: MatchResult = VM::new(&prog.code, input).run();
+    let seeded: MatchResult = VM::new_with_cache(&prog.code, input, MemoCache::new()).run();
+    assert_eq!(fresh, seeded);
+}

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -1,13 +1,21 @@
 //! Integration tests for the incremental-parsing public surface.
 //!
-//! Exercises the full loop: run a VM, reclaim the `MemoCache`, seed a
-//! fresh VM with it, and confirm the second run hits the cache and
-//! produces identical output. Parse-edit-reparse equivalence tests over
-//! real grammars arrive alongside the `IncrementalHighlighter` API in
-//! a follow-up commit.
+//! Two layers:
+//!
+//! 1. **VM ↔ `MemoCache` round-trip.** Runs a VM, reclaims the
+//!    `MemoCache`, seeds a fresh VM with it, confirms the second run
+//!    hits the cache and produces identical output.
+//! 2. **`Highlighter` equivalence under edits.** For each shipped
+//!    grammar, runs a fixed sequence of edits through one `Highlighter`
+//!    and compares the post-edit captures against a second `Highlighter`
+//!    driven only via `set_input(current_input)`. The equality
+//!    `inc.captures() == fresh.captures()` is the strongest
+//!    correctness property this crate has — if any edit invalidates
+//!    more or fewer entries than it should, this test catches it.
 
 use std::collections::HashMap;
 
+use syntax_highlighter::highlight::Highlighter;
 use syntax_highlighter::pegvm::{compile_grammar, CharSet, MatchResult, MemoCache, Pattern, VM};
 
 fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
@@ -91,4 +99,152 @@ fn empty_cache_behaves_like_fresh_vm() {
     let fresh: MatchResult = VM::new(&prog.code, input).run();
     let seeded: MatchResult = VM::new_with_cache(&prog.code, input, MemoCache::new()).run();
     assert_eq!(fresh, seeded);
+}
+
+const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+
+/// Compare the stateful `inc` against a fresh `Highlighter` driven via
+/// `set_input(inc.input())`. The only correctness contract exposed to
+/// users is that the two must agree bit-for-bit on captures and
+/// `matched` at every observable step.
+fn assert_equivalent(inc: &Highlighter, grammar: &str, tag: &str) {
+    let mut fresh = Highlighter::new(grammar).expect("grammar compiles");
+    fresh.set_input(inc.input().to_string());
+    assert_eq!(
+        inc.captures(),
+        fresh.captures(),
+        "captures diverged at {tag}"
+    );
+    assert_eq!(
+        inc.highlight(),
+        fresh.highlight(),
+        "rendered output diverged at {tag}"
+    );
+}
+
+#[test]
+fn json_incremental_matches_fresh_across_edit_sequence() {
+    let mut inc = Highlighter::new(JSON_GRAMMAR).unwrap();
+    inc.set_input(r#"{"a": 1, "b": [true, null, 3]}"#.to_string());
+    assert_equivalent(&inc, JSON_GRAMMAR, "json initial");
+
+    // Replace the number 1 with a longer number.
+    let pos = inc.input().find('1').unwrap();
+    inc.edit(pos, pos + 1, "12345");
+    assert_equivalent(&inc, JSON_GRAMMAR, "json replace number");
+
+    // Insert a new property before the closing brace.
+    let close = inc.input().rfind('}').unwrap();
+    inc.edit(close, close, r#", "c": "hi""#);
+    assert_equivalent(&inc, JSON_GRAMMAR, "json insert property");
+
+    // Delete the "b" array entirely.
+    let b_start = inc.input().find(r#", "b""#).unwrap();
+    let arr_end = inc.input()[b_start..].find(']').unwrap() + b_start + 1;
+    inc.edit(b_start, arr_end, "");
+    assert_equivalent(&inc, JSON_GRAMMAR, "json delete array");
+
+    // Replace everything — the set_input fast path.
+    inc.set_input("null".to_string());
+    assert_equivalent(&inc, JSON_GRAMMAR, "json set_input reset");
+}
+
+#[test]
+fn toml_incremental_matches_fresh_across_edit_sequence() {
+    let mut inc = Highlighter::new(TOML_GRAMMAR).unwrap();
+    inc.set_input("[package]\nname = \"demo\"\nversion = \"0.1.0\"\n".to_string());
+    assert_equivalent(&inc, TOML_GRAMMAR, "toml initial");
+
+    // Append a new section — streaming pattern.
+    inc.append("\n[dependencies]\nserde = \"1.0\"\n");
+    assert_equivalent(&inc, TOML_GRAMMAR, "toml append section");
+
+    // Rename [package] to [pkg].
+    let start = inc.input().find("[package]").unwrap();
+    inc.edit(start, start + "[package]".len(), "[pkg]");
+    assert_equivalent(&inc, TOML_GRAMMAR, "toml rename section");
+
+    // Delete the version line.
+    let vstart = inc.input().find("version").unwrap();
+    let vend = inc.input()[vstart..].find('\n').unwrap() + vstart + 1;
+    inc.edit(vstart, vend, "");
+    assert_equivalent(&inc, TOML_GRAMMAR, "toml delete version");
+}
+
+#[test]
+fn sql_incremental_matches_fresh_across_edit_sequence() {
+    let mut inc = Highlighter::new(SQL_GRAMMAR).unwrap();
+    inc.set_input("SELECT id, name FROM users WHERE active = 1;".to_string());
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql initial");
+
+    // Insert an ORDER BY clause.
+    let semi = inc.input().rfind(';').unwrap();
+    inc.edit(semi, semi, " ORDER BY id DESC");
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql insert order by");
+
+    // Replace the table name.
+    let users = inc.input().find("users").unwrap();
+    inc.edit(users, users + "users".len(), "customers");
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql rename table");
+
+    // Delete the WHERE clause.
+    let where_start = inc.input().find(" WHERE").unwrap();
+    let where_end = inc.input().find(" ORDER BY").unwrap();
+    inc.edit(where_start, where_end, "");
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql delete where");
+}
+
+#[test]
+fn append_char_by_char_matches_fresh_on_every_step() {
+    // Streaming-LLM scenario: the classic case incremental parsing is
+    // designed to accelerate. Equivalence must hold at every single
+    // character boundary, not just at the end.
+    let target = r#"{"a": 1, "b": [true, null]}"#;
+    let mut inc = Highlighter::new(JSON_GRAMMAR).unwrap();
+    inc.set_input(String::new());
+    for (i, ch) in target.char_indices() {
+        inc.append(&target[i..i + ch.len_utf8()]);
+        assert_equivalent(&inc, JSON_GRAMMAR, &format!("json char-by-char step {i}"));
+    }
+}
+
+#[test]
+fn set_input_resets_cache_cleanly() {
+    // Consecutive set_input calls on unrelated inputs must not leak
+    // state between parses — every set_input rebuilds the cache from
+    // scratch, so the equivalence property holds trivially after each
+    // reset.
+    let mut inc = Highlighter::new(JSON_GRAMMAR).unwrap();
+    inc.set_input(r#"{"a": 1}"#.to_string());
+    assert_equivalent(&inc, JSON_GRAMMAR, "reset step 1");
+    inc.set_input(r#"[1, 2, 3]"#.to_string());
+    assert_equivalent(&inc, JSON_GRAMMAR, "reset step 2");
+    inc.set_input("null".to_string());
+    assert_equivalent(&inc, JSON_GRAMMAR, "reset step 3");
+}
+
+#[test]
+fn toml_section_rename_then_delete_preserves_max_sp_after_partial_parse() {
+    // Regression pin: renaming a section to something malformed leaves
+    // a top-level failure entry in the cache. A subsequent delete used
+    // to short-circuit `MemoOpen` to `fail()` without updating
+    // `max_sp` / `max_captures`, so the incremental parse reported
+    // `matched == 0` while a fresh parse on the same input reached the
+    // end of the valid prefix. Fix: failure entries are dropped
+    // unconditionally on every `apply_edit`.
+    let mut inc = Highlighter::new(TOML_GRAMMAR).unwrap();
+    inc.set_input("[package]\nname = \"demo\"\nversion = \"0.1.0\"\n".to_string());
+
+    // Break the section header.
+    let pos = inc.input().find('[').unwrap();
+    inc.edit(pos, pos + 1, "!");
+    assert_equivalent(&inc, TOML_GRAMMAR, "after break");
+
+    // Now delete a byte inside the broken prefix. The cached top-level
+    // failure must not short-circuit the warm parse into reporting an
+    // empty captures vector.
+    inc.edit(pos, pos + 1, "");
+    assert_equivalent(&inc, TOML_GRAMMAR, "after second edit");
 }


### PR DESCRIPTION
Implements the "Incremental parsing" roadmap item from `README.md`: edits to the input reuse the memo table from the previous parse instead of reparsing from scratch. Covers both append-only streaming and arbitrary-position edits.

## Shape of the change

Five commits, each building and testing independently:

1. `examined_max` per memo entry — the invalidation bound (`src/pegvm/vm.rs`).
2. `MemoCache::apply_edit` — invalidation + shift protocol, new module `src/pegvm/incremental.rs`.
3. `VM::new_with_cache` / `run_with_cache` — seed and reclaim the memo across parses.
4. `Highlighter` rewritten as stateful + always-incremental: `set_input` / `edit` / `append` / `captures` / `highlight` / `last_stats`. Equivalence tests against a second `Highlighter` instance in `tests/incremental_tests.rs`.
5. `benches/incremental.rs` + `scripts/bench-compare.sh` — cold vs warm sweep with JSONL output and a worktree-based A/B compare script for commit-by-commit perf tracking. Pointer added to the `memo-bench` skill.

## Breaking API change

`Highlighter` no longer exposes `captures(&self, input: &str)` or `highlight(&self, input: &str)`. The crate now has a single entry point that owns the input and cache:

```rust
// before
let h = Highlighter::new(grammar)?;
let out = h.highlight(input);

// after
let mut h = Highlighter::new(grammar)?;
h.set_input(input.into());
let out = h.highlight();
```

The split between a stateless `Highlighter` and a stateful `IncrementalHighlighter` was considered during the work on this branch and dropped: the duplication is small and a single type is less to document. Only consumer today is `src/main.rs`.

## Notable design points

- **Failure entries are dropped unconditionally on `apply_edit`** (see the doc on `MemoCache::apply_edit`). Storing the farthest-sp capture snapshot on every failure entry would be the alternative; that work isn't warranted for cross-edit short-circuiting. Intra-parse failure caching is unaffected.
- **Initial perf on shipped fixtures**: append-at-end hits 10–150× warm speedup on large inputs; mid-range inserts/deletes land 1.3–8× depending on how much of the cache survives the invalidation. Numbers depend on hardware — the harness is there to make the question repeatable rather than to publish a benchmark.

## Test plan

Covered by CI. Additional coverage worth noting:
- End-to-end equivalence tests in `tests/incremental_tests.rs` exercise every shipped grammar with streaming append, mid-file insert/delete, wholesale replacement, and char-by-char append. A TOML test pins the regression for the failure-entry-drop fix.
- `./scripts/bench-compare.sh HEAD HEAD incremental` is a useful self-check — the mechanism is healthy when deltas stay in the single-digit-percent noise band.