### PR TITLE
Expand SQLite grammar to the full dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ that can scale to many languages without binary bloat.
 
 ## Status
 
-Early MVP. Ships JSON, TOML, and SQLite-SELECT grammars and an
+Early MVP. Ships JSON, TOML, and the full SQLite dialect, plus an
 ANSI-coloring CLI. The properties described in *Why this approach*
 below are **design goals that this MVP is trying to prove** — the
 architecture supports them, and cross-language validation spans three
-grammar shapes (JSON, TOML, and a backtracking-heavy SQL SELECT
-subset). Expect breaking changes.
+grammar shapes (JSON, TOML, and a large backtracking-heavy SQLite
+grammar exercising multi-statement error recovery). Expect breaking
+changes.
 
 The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`)
 or an explicit `-l json|toml|sql` flag; stdin without a flag defaults
@@ -92,16 +93,15 @@ largest piece of work.
 
 These need no new VM or compiler machinery.
 
-- **More language grammars.** JSON, TOML, and a SQLite SELECT subset
-  ship today. Adding a language means writing a grammar file.
-  Expanding the SQLite grammar to the full dialect (INSERT/UPDATE/
-  DELETE/DDL/triggers) is the intended vehicle for two roadmap
-  deliverables it is uniquely positioned to support: a large-grammar
-  bytecode-size datapoint (JSON and TOML are both compact formats) and
-  a multi-statement error-recovery use case (single-SELECT does not
-  exercise it). Remaining candidates beyond SQLite: Python, Rust, CSS.
-  YAML is deferred — its context-sensitive indentation semantics make
-  it a poor fit for PEG without additional machinery.
+- **More language grammars.** JSON, TOML, and the full SQLite dialect
+  ship today. Adding a language means writing a grammar file. The
+  SQLite grammar is the large-grammar bytecode-size datapoint the
+  design goals called for: 5,627 VM instructions across 426 rules —
+  an order of magnitude larger than JSON (165 instr) or TOML (511
+  instr), and still comfortably inside the "kilobyte range per
+  grammar" ambition. Remaining candidates: Python, Rust, CSS. YAML is
+  deferred — its context-sensitive indentation semantics make it a
+  poor fit for PEG without additional machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is
   orthogonal to the VM.

--- a/benches/fixtures/large.sql
+++ b/benches/fixtures/large.sql
@@ -1,102 +1,168 @@
--- A larger corpus of realistic SELECT statements, intentionally exercising
--- the shared-prefix expression backtracking that motivates memoization:
--- function_call vs qualified_column_ref vs column_ref_bare all start with
--- an identifier.
+-- Large SQLite fixture exercising the full-dialect surface: DDL with
+-- constraints and generated columns, DML with UPSERT and RETURNING,
+-- triggers with multi-statement bodies, window functions, transactions,
+-- PRAGMA, and the administrative statements. Designed for both the
+-- memoization bench (shared-prefix expression backtracking) and as a
+-- visual smoke test for the highlighter.
 
--- Q1: nested CTE chain with multi-column aggregation.
-WITH daily_orders AS (
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = 'wal';
+
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS customers (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  name       TEXT NOT NULL COLLATE NOCASE,
+  email      TEXT UNIQUE,
+  tier       TEXT DEFAULT 'standard' CHECK (tier IN ('standard', 'gold', 'vip')),
+  created_at DATETIME DEFAULT (CURRENT_TIMESTAMP),
+  updated_at DATETIME,
+  CONSTRAINT customers_email_lower CHECK (email = LOWER(email))
+) STRICT;
+
+CREATE TABLE orders (
+  id          INTEGER PRIMARY KEY,
+  customer_id INTEGER NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  created_at  DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  total       NUMERIC(10, 2) NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'pending',
+  total_cents INTEGER GENERATED ALWAYS AS (CAST(total * 100 AS INTEGER)) STORED,
+  FOREIGN KEY (customer_id) REFERENCES customers(id)
+    DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS customers_email_idx
+  ON customers (email) WHERE email IS NOT NULL;
+
+CREATE INDEX orders_by_day_idx
+  ON orders (DATE(created_at), customer_id) WHERE status != 'cancelled';
+
+CREATE VIEW customer_revenue (customer_id, revenue_total, last_order) AS
+  SELECT customer_id, SUM(total), MAX(created_at)
+  FROM orders
+  WHERE status = 'completed'
+  GROUP BY customer_id;
+
+CREATE TRIGGER customers_touch_updated_at
+  AFTER UPDATE ON customers
+  FOR EACH ROW
+  WHEN NEW.updated_at IS OLD.updated_at
+BEGIN
+  UPDATE customers SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER orders_audit AFTER INSERT ON orders FOR EACH ROW
+BEGIN
+  INSERT INTO audit_log (op, entity, entity_id, payload)
+    VALUES ('insert', 'order', NEW.id, NEW.total);
+  UPDATE stats SET n_orders = n_orders + 1 WHERE key = 'global';
+END;
+
+COMMIT;
+
+-- Day-to-day DML with UPSERT, RETURNING, INSERT OR X prefixes, and
+-- DELETE with a CTE-qualified row-set.
+
+INSERT INTO customers (name, email, tier) VALUES
+  ('Ada Lovelace',    'ada@example.com',    'vip'),
+  ('Grace Hopper',    'grace@example.com',  'gold'),
+  ('Alan Turing',     'alan@example.com',   'standard')
+ON CONFLICT (email) DO UPDATE
+  SET name = excluded.name, tier = excluded.tier
+  WHERE customers.tier != 'vip'
+RETURNING id, name, tier;
+
+INSERT OR REPLACE INTO stats (key, n_orders) VALUES ('global', 0);
+
+REPLACE INTO feature_flags (key, enabled) VALUES ('beta_ui', 1);
+
+UPDATE customers
+   SET tier = 'gold'
+  FROM orders AS o
+ WHERE customers.id = o.customer_id AND o.total > 1000
+RETURNING customers.id, customers.tier;
+
+UPDATE OR IGNORE stats SET n_orders = n_orders - 1 WHERE key = 'global';
+
+WITH stale AS (
+  SELECT id FROM customers WHERE updated_at < '2020-01-01'
+)
+DELETE FROM customers
+ WHERE id IN (SELECT id FROM stale)
+ RETURNING *;
+
+-- Analytical SELECT: recursive CTE, compound SELECT, window functions,
+-- FILTER clause, named windows, CASE expressions, CAST, EXISTS.
+
+WITH RECURSIVE days(d) AS (
+  SELECT DATE('2026-01-01')
+  UNION ALL
+  SELECT DATE(d, '+1 day') FROM days WHERE d < DATE('2026-01-31')
+),
+daily_orders AS (
   SELECT
     customer_id,
     DATE(created_at) AS day,
     COUNT(*) AS n,
-    SUM(total) AS revenue
+    SUM(total) AS revenue,
+    SUM(total) FILTER (WHERE status = 'completed') AS revenue_completed
   FROM orders
   WHERE created_at >= '2026-01-01' AND status != 'cancelled'
   GROUP BY customer_id, DATE(created_at)
-),
-customer_summary AS (
-  SELECT
-    customer_id,
-    SUM(n) AS orders_total,
-    SUM(revenue) AS revenue_total,
-    AVG(revenue) AS revenue_avg,
-    MAX(day) AS last_day
-  FROM daily_orders
-  GROUP BY customer_id
 )
 SELECT
   c.id AS customer_id,
   c.name AS customer_name,
   c.tier AS tier,
-  cs.orders_total,
-  cs.revenue_total,
-  CAST(cs.revenue_avg AS INTEGER) AS revenue_avg_int,
-  cs.last_day,
+  do.day,
+  do.n,
+  do.revenue,
+  SUM(do.revenue) OVER w_trail AS revenue_7d,
+  RANK()          OVER w_rank  AS daily_rank,
   CASE
-    WHEN cs.revenue_total >= 10000 THEN 'gold'
-    WHEN cs.revenue_total >=  1000 THEN 'silver'
-    WHEN cs.revenue_total >=   100 THEN 'bronze'
-    ELSE 'basic'
-  END AS segment
-FROM customers c
-LEFT JOIN customer_summary cs ON c.id = cs.customer_id
-WHERE c.active = 1
-  AND c.created_at <= '2026-04-01'
-  AND (c.tier IN ('gold', 'silver', 'bronze') OR c.tier IS NULL)
-  AND EXISTS (SELECT 1 FROM orders o WHERE o.customer_id = c.id)
-ORDER BY cs.revenue_total DESC, c.name ASC
-LIMIT 100 OFFSET 0;
+    WHEN do.revenue > 10000 THEN 'platinum'
+    WHEN do.revenue > 1000  THEN 'gold'
+    ELSE c.tier
+  END AS effective_tier,
+  CAST(do.revenue AS INTEGER) AS revenue_int,
+  EXISTS (SELECT 1 FROM orders o2 WHERE o2.customer_id = c.id AND o2.total > 5000) AS is_big_spender
+FROM daily_orders AS do
+JOIN customers  AS c ON c.id = do.customer_id
+LEFT JOIN churn AS k ON k.customer_id = c.id
+WINDOW
+  w_trail AS (PARTITION BY do.customer_id ORDER BY do.day
+              ROWS BETWEEN 6 PRECEDING AND CURRENT ROW),
+  w_rank  AS (PARTITION BY do.day ORDER BY do.revenue DESC)
+ORDER BY do.day, do.customer_id
+LIMIT 500 OFFSET 0;
 
--- Q2: multi-join with GROUP BY and HAVING, exercises aliased_expr and
--- qualified_column_ref paths heavily.
-SELECT
-  p.id AS product_id,
-  p.sku,
-  p.name,
-  cat.name AS category,
-  SUM(oi.quantity)           AS units_sold,
-  SUM(oi.quantity * oi.price) AS revenue,
-  COUNT(DISTINCT o.customer_id) AS distinct_buyers
-FROM products p
-INNER JOIN categories cat ON p.category_id = cat.id
-INNER JOIN order_items oi ON oi.product_id = p.id
-INNER JOIN orders o ON o.id = oi.order_id
-WHERE o.status = 'shipped'
-  AND o.created_at BETWEEN '2026-01-01' AND '2026-04-01'
-  AND p.discontinued = 0
-GROUP BY p.id, p.sku, p.name, cat.name
-HAVING SUM(oi.quantity) > 10
-ORDER BY revenue DESC
-LIMIT 200;
+SELECT id FROM orders WHERE id = 1
+UNION ALL SELECT id FROM orders WHERE id = 2
+INTERSECT SELECT id FROM orders WHERE id > 0
+EXCEPT    SELECT id FROM orders WHERE status = 'cancelled';
 
--- Q3: compound SELECT via UNION ALL with scalar subqueries.
-SELECT 'a' AS src, id, name FROM users_archive WHERE active = 1
-UNION ALL
-SELECT 'b' AS src, id, name FROM users_live    WHERE active = 1
-UNION ALL
-SELECT 'c' AS src, id, name FROM users_pending WHERE active IS NOT NULL;
+-- Schema changes, virtual table, admin statements.
 
--- Q4: IN / LIKE / BETWEEN to exercise the cmp_tail alternatives.
-SELECT id, name, email
-FROM users
-WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-  AND email LIKE '%@example.com'
-  AND name NOT LIKE '_test%'
-  AND score BETWEEN 0.25 AND 0.95
-  AND created_at GLOB '2026-*'
-ORDER BY id;
+ALTER TABLE customers ADD COLUMN notes TEXT;
+ALTER TABLE customers RENAME COLUMN tier TO membership_tier;
+ALTER TABLE orders DROP COLUMN total_cents;
 
--- Q5: nested scalar subquery in the result list (shared-prefix primary
--- alternative paren_primary vs function_call vs column_ref hot path).
-SELECT
-  u.id,
-  u.name,
-  (SELECT COUNT(*) FROM orders o WHERE o.customer_id = u.id)    AS order_count,
-  (SELECT MAX(created_at) FROM orders o WHERE o.customer_id = u.id) AS last_order
-FROM users u
-WHERE u.active = 1
-ORDER BY order_count DESC
-LIMIT 25;
+CREATE VIRTUAL TABLE fts_customers USING fts5(name, email, content='customers');
 
--- Q6: bind parameters of every supported shape.
-SELECT id FROM t WHERE a = ? AND b = ?1 AND c = :name AND d = @name AND e = $name;
+ATTACH DATABASE 'backup.db' AS backup;
+DETACH DATABASE backup;
+
+REINDEX customers_email_idx;
+ANALYZE main.orders;
+VACUUM INTO 'snapshot.db';
+
+EXPLAIN QUERY PLAN SELECT * FROM orders WHERE customer_id = 42;
+
+SAVEPOINT post_migration;
+ROLLBACK TO SAVEPOINT post_migration;
+RELEASE SAVEPOINT post_migration;
+
+DROP TRIGGER IF EXISTS orders_audit;
+DROP VIEW   IF EXISTS customer_revenue;
+DROP INDEX  IF EXISTS orders_by_day_idx;
+DROP TABLE  IF EXISTS stale_imports;

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -44,9 +44,11 @@ statement  <- select_stmt
             / create_table_stmt
             / create_index_stmt
             / create_view_stmt
+            / create_trigger_stmt
             / drop_table_stmt
             / drop_index_stmt
             / drop_view_stmt
+            / drop_trigger_stmt
             / alter_table_stmt
 
 # --- SELECT statement -------------------------------------------------
@@ -295,6 +297,29 @@ create_view_stmt  <- kw_create (ws (kw_temporary / kw_temp))? ws kw_view
 
 drop_view_stmt    <- kw_drop ws kw_view (ws kw_if ws kw_exists)? ws qualified_table_name
 
+# --- DDL: CREATE / DROP TRIGGER --------------------------------------
+# Trigger bodies are `;`-separated sequences of DML/SELECT wrapped in
+# BEGIN...END. The inner `;` is mandatory after each body statement,
+# which keeps the nesting disjoint from sql_file's top-level stmt_sep.
+
+create_trigger_stmt <- kw_create (ws (kw_temporary / kw_temp))? ws kw_trigger
+                       (ws kw_if ws kw_not ws kw_exists)?
+                       ws qualified_table_name
+                       (ws (kw_before / kw_after / kw_instead ws kw_of))?
+                       ws trigger_event
+                       ws kw_on ws @type{bare_ident_nonkw}
+                       (ws kw_for ws kw_each ws kw_row)?
+                       (ws kw_when ws expr)?
+                       ws kw_begin
+                       ws (trigger_body_stmt ws @punctuation{';'} ws)+
+                       kw_end
+trigger_event     <- kw_delete
+                   / kw_insert
+                   / kw_update (ws kw_of ws ident_list)?
+trigger_body_stmt <- insert_stmt / update_stmt / delete_stmt / select_stmt
+
+drop_trigger_stmt <- kw_drop ws kw_trigger (ws kw_if ws kw_exists)? ws qualified_table_name
+
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
 # matches the next-higher level or chains several of them with an
@@ -540,6 +565,14 @@ kw_without   <- @keyword{without_body !ident_char}
 kw_to        <- @keyword{to_body !ident_char}
 kw_index     <- @keyword{index_body !ident_char}
 kw_view      <- @keyword{view_body !ident_char}
+kw_trigger   <- @keyword{trigger_body !ident_char}
+kw_before    <- @keyword{before_body !ident_char}
+kw_after     <- @keyword{after_body !ident_char}
+kw_instead   <- @keyword{instead_body !ident_char}
+kw_of        <- @keyword{of_body !ident_char}
+kw_for       <- @keyword{for_body !ident_char}
+kw_each      <- @keyword{each_body !ident_char}
+kw_begin     <- @keyword{begin_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
@@ -658,6 +691,14 @@ without_body   <- [wW][iI][tT][hH][oO][uU][tT]
 to_body        <- [tT][oO]
 index_body     <- [iI][nN][dD][eE][xX]
 view_body      <- [vV][iI][eE][wW]
+trigger_body   <- [tT][rR][iI][gG][gG][eE][rR]
+before_body    <- [bB][eE][fF][oO][rR][eE]
+after_body     <- [aA][fF][tT][eE][rR]
+instead_body   <- [iI][nN][sS][tT][eE][aA][dD]
+of_body        <- [oO][fF]
+for_body       <- [fF][oO][rR]
+each_body      <- [eE][aA][cC][hH]
+begin_body     <- [bB][eE][gG][iI][nN]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -697,14 +738,17 @@ keyword_word <-
     / collate_body         # 7
     / default_body         # 7
     / foreign_body         # 7
+    / instead_body         # 7
     / natural_body         # 7
     / nothing_body         # 7
     / primary_body         # 7
     / replace_body         # 7
+    / trigger_body         # 7
     / virtual_body         # 7
     / without_body         # 7
     / action_body          # 6
     / always_body          # 6
+    / before_body          # 6
     / column_body          # 6
     / create_body          # 6
     / delete_body          # 6
@@ -725,7 +769,9 @@ keyword_word <-
     / values_body          # 6
     / window_body          # 6
     / abort_body           # 5
+    / after_body           # 5
     / alter_body           # 5
+    / begin_body           # 5
     / bool_body            # 5 (FALSE) / 4 (TRUE); alternation handles both
     / check_body           # 5
     / cross_body           # 5
@@ -746,6 +792,7 @@ keyword_word <-
     / cast_body            # 4
     / desc_body            # 4
     / drop_body            # 4
+    / each_body            # 4
     / else_body            # 4
     / fail_body            # 4
     / from_body            # 4
@@ -767,6 +814,7 @@ keyword_word <-
     / and_body             # 3
     / asc_body             # 3
     / end_body             # 3
+    / for_body             # 3
     / key_body             # 3
     / not_body             # 3
     / set_body             # 3
@@ -777,6 +825,7 @@ keyword_word <-
     / in_body              # 2
     / is_body              # 2
     / no_body              # 2
+    / of_body              # 2
     / on_body              # 2
     / or_body              # 2
     / to_body              # 2

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -1,37 +1,41 @@
-# SQLite SELECT grammar with highlight annotations.
+# Full SQLite grammar with highlight annotations.
 # The first rule is the start rule.
 #
-# Scope: SQLite SELECT statements sufficient to highlight realistic
-# read-only queries. Covers expressions, JOINs, simple (non-recursive)
-# CTEs, compound SELECT (UNION / INTERSECT / EXCEPT), CASE, CAST, EXISTS,
-# scalar subqueries, function calls, bind parameters, string / BLOB /
-# numeric / NULL / boolean literals, and line / block comments.
-#
-# Deferred: INSERT / UPDATE / DELETE / DDL / triggers / PRAGMA /
-# transactions; WITH RECURSIVE; window functions (`OVER(...)`).
-# Expanding to the full SQLite dialect is intended future work with two
-# specific payoffs (see README.md roadmap):
-#   - a large-grammar bytecode-size datapoint (vs. JSON and TOML)
-#   - a multi-statement error-recovery use case, which single-SELECT
-#     does not exercise
+# Scope: the SQLite dialect. SELECT (with WITH RECURSIVE, compound
+# SELECT, CTEs, window functions), DML (INSERT with UPSERT and
+# RETURNING, UPDATE with FROM, DELETE), DDL (CREATE / DROP / ALTER
+# TABLE with the full constraint vocabulary, generated columns,
+# WITHOUT ROWID / STRICT, foreign-key actions, INDEX, VIEW, TRIGGER,
+# VIRTUAL TABLE), transactions and savepoints, PRAGMA, EXPLAIN
+# [QUERY PLAN], and the administrative statements (VACUUM, ATTACH /
+# DETACH, REINDEX, ANALYZE).
 #
 # Capture kinds (all present in src/highlight/theme.rs):
 #   keyword, string, number, comment, operator, punctuation,
 #   type, function, constant, variable.
 #
 # Capture-kind notes:
-#   - Table names in FROM / JOIN / CTE heads are @type; column
-#     references are @variable. The same lexeme gets a different kind
-#     depending on syntactic position — a genuine win of grammar-driven
-#     highlighting over scope-based matchers.
-#   - BLOB literals X'...' are @string (byte strings; no @bytes kind).
-#   - Bind parameters (?, ?N, :name, @name, $name) are @variable.
-#   - Quoted identifiers ("...", `...`, [...]) are @variable.
+#   - Table names in FROM / JOIN / CTE heads and schema-object names
+#     (indexes, views, triggers, schemas in ATTACH / PRAGMA) are
+#     `@type`; column references are `@variable`. The same lexeme
+#     gets a different kind depending on syntactic position — a
+#     genuine win of grammar-driven highlighting over scope-based
+#     matchers.
+#   - Type names in column definitions (including multi-word forms
+#     like `DOUBLE PRECISION`) are `@type`, matching CAST targets.
+#   - BLOB literals `X'...'` are `@string` (byte strings; no `@bytes`
+#     kind).
+#   - Bind parameters (`?`, `?N`, `:name`, `@name`, `$name`) are
+#     `@variable`.
+#   - Quoted identifiers (`"..."`, backtick, `[...]`) are `@variable`.
+#   - CREATE VIRTUAL TABLE module name after USING is `@function` —
+#     the module is invoked, not merely referenced.
 #
 # This grammar deliberately exercises shared-prefix backtracking in the
 # expression rules (function_call vs qualified_column_ref vs bare
-# column_ref; paren_expr vs scalar subquery). These patterns motivate
-# the memoization work in the README roadmap.
+# column_ref; paren_expr vs scalar subquery) and in the CREATE-family
+# top-level alternatives (CREATE [TEMP] [VIRTUAL] TABLE / INDEX / VIEW
+# / TRIGGER). These patterns motivate the memoization layer.
 
 # --- Top level --------------------------------------------------------
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -50,6 +50,11 @@ statement  <- select_stmt
             / drop_view_stmt
             / drop_trigger_stmt
             / alter_table_stmt
+            / begin_stmt
+            / commit_stmt
+            / rollback_stmt
+            / savepoint_stmt
+            / release_stmt
 
 # --- SELECT statement -------------------------------------------------
 
@@ -320,6 +325,16 @@ trigger_body_stmt <- insert_stmt / update_stmt / delete_stmt / select_stmt
 
 drop_trigger_stmt <- kw_drop ws kw_trigger (ws kw_if ws kw_exists)? ws qualified_table_name
 
+# --- Transactions & savepoints ---------------------------------------
+
+begin_stmt     <- kw_begin (ws (kw_deferred / kw_immediate / kw_exclusive))?
+                  (ws kw_transaction)?
+commit_stmt    <- (kw_commit / kw_end) (ws kw_transaction)?
+rollback_stmt  <- kw_rollback (ws kw_transaction)?
+                  (ws kw_to (ws kw_savepoint)? ws @variable{bare_ident_nonkw})?
+savepoint_stmt <- kw_savepoint ws @variable{bare_ident_nonkw}
+release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
+
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
 # matches the next-higher level or chains several of them with an
@@ -573,6 +588,11 @@ kw_of        <- @keyword{of_body !ident_char}
 kw_for       <- @keyword{for_body !ident_char}
 kw_each      <- @keyword{each_body !ident_char}
 kw_begin     <- @keyword{begin_body !ident_char}
+kw_commit    <- @keyword{commit_body !ident_char}
+kw_transaction <- @keyword{transaction_body !ident_char}
+kw_savepoint <- @keyword{savepoint_body !ident_char}
+kw_release   <- @keyword{release_body !ident_char}
+kw_exclusive <- @keyword{exclusive_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
@@ -699,6 +719,11 @@ of_body        <- [oO][fF]
 for_body       <- [fF][oO][rR]
 each_body      <- [eE][aA][cC][hH]
 begin_body     <- [bB][eE][gG][iI][nN]
+commit_body    <- [cC][oO][mM][mM][iI][tT]
+transaction_body <- [tT][rR][aA][nN][sS][aA][cC][tT][iI][oO][nN]
+savepoint_body <- [sS][aA][vV][eE][pP][oO][iI][nN][tT]
+release_body   <- [rR][eE][lL][eE][aA][sS][eE]
+exclusive_body <- [eE][xX][cC][lL][uU][sS][iI][vV][eE]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -719,14 +744,17 @@ begin_body     <- [bB][eE][gG][iI][nN]
 # boundary-free.
 keyword_word <-
     ( autoincrement_body   # 13
+    / transaction_body     # 11
     / constraint_body      # 10
     / deferrable_body      # 10
     / references_body      # 10
+    / exclusive_body       # 9
     / generated_body       # 9
     / immediate_body       # 9
     / initially_body       # 9
     / intersect_body       # 9
     / returning_body       # 9
+    / savepoint_body       # 9
     / temporary_body       # 9
     / conflict_body        # 8
     / deferred_body        # 8
@@ -742,6 +770,7 @@ keyword_word <-
     / natural_body         # 7
     / nothing_body         # 7
     / primary_body         # 7
+    / release_body         # 7
     / replace_body         # 7
     / trigger_body         # 7
     / virtual_body         # 7
@@ -750,6 +779,7 @@ keyword_word <-
     / always_body          # 6
     / before_body          # 6
     / column_body          # 6
+    / commit_body          # 6
     / create_body          # 6
     / delete_body          # 6
     / escape_body          # 6

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -921,12 +921,10 @@ keyword_word <-
     / asc_body             # 3
     / end_body             # 3
     / for_body             # 3
-    / key_body             # 3
     / not_body             # 3
     / set_body             # 3
     / as_body              # 2
     / by_body              # 2
-    / do_body              # 2
     / if_body              # 2
     / in_body              # 2
     / is_body              # 2

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -43,11 +43,14 @@ statement  <- select_stmt
 
 select_stmt    <- with_clause? select_core compound_tail* order_clause? limit_clause?
 
-with_clause    <- kw_with ws cte_defn (ws @punctuation{','} ws cte_defn)* ws
-cte_defn       <- @type{bare_ident} ws kw_as ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
+with_clause    <- kw_with (ws kw_recursive)? ws cte_defn (ws @punctuation{','} ws cte_defn)* ws
+cte_defn       <- @type{bare_ident}
+                  (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
+                  ws kw_as ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
 
 select_core    <- kw_select (ws (kw_distinct / kw_all))? ws result_list
                   (ws from_clause)? (ws where_clause)? (ws group_clause)? (ws having_clause)?
+                  (ws window_clause)?
 
 result_list    <- result_column (ws @punctuation{','} ws result_column)*
 result_column  <- table_star / @operator{'*'} / aliased_expr
@@ -87,6 +90,43 @@ order_item     <- expr (ws (kw_asc / kw_desc))?
 
 limit_clause   <- ws kw_limit ws expr (ws kw_offset ws expr
                                      / ws @punctuation{','} ws expr)?
+
+# --- Window functions & WINDOW clause --------------------------------
+# Not counted as reserved keywords in SQLite aside from WINDOW and
+# OVER — PARTITION, FILTER, RANGE, ROWS, GROUPS, PRECEDING, FOLLOWING,
+# UNBOUNDED, CURRENT, EXCLUDE, TIES, OTHERS, NO, ROW and RECURSIVE
+# are matched positionally here, so existing SELECTs that use any of
+# those as identifiers keep working.
+
+window_clause  <- kw_window ws named_window (ws @punctuation{','} ws named_window)*
+named_window   <- @variable{bare_ident_nonkw} ws kw_as ws window_defn
+
+filter_clause  <- kw_filter ws @punctuation{'('} ws kw_where ws expr ws @punctuation{')'}
+
+window_defn    <- @punctuation{'('} ws
+                      (!window_section_keyword @variable{bare_ident_nonkw} ws)?
+                      (kw_partition ws kw_by ws expr (ws @punctuation{','} ws expr)* ws)?
+                      (window_order_body ws)?
+                      (frame_spec ws)? @punctuation{')'}
+# Guard the optional base-window-name slot against consuming a keyword
+# that actually starts the next positional section (PARTITION / ORDER /
+# RANGE / ROWS / GROUPS). Without the lookahead, PEG would eat
+# `PARTITION` as a bare identifier and then fail on the partition clause.
+window_section_keyword <- kw_partition / kw_order / kw_range / kw_rows / kw_groups
+window_order_body <- kw_order ws kw_by ws order_item (ws @punctuation{','} ws order_item)*
+window_ref     <- window_defn / @variable{bare_ident_nonkw}
+
+frame_spec     <- (kw_range / kw_rows / kw_groups) ws
+                  (kw_between ws frame_bound ws kw_and ws frame_bound
+                   / frame_bound)
+                  (ws kw_exclude ws frame_exclude)?
+frame_bound    <- kw_unbounded ws (kw_preceding / kw_following)
+                / kw_current ws kw_row
+                / expr ws (kw_preceding / kw_following)
+frame_exclude  <- kw_no ws kw_others
+                / kw_current ws kw_row
+                / kw_group
+                / kw_ties
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
@@ -136,6 +176,8 @@ primary     <- literal
 paren_primary <- @punctuation{'('} ws (select_stmt / expr) ws @punctuation{')'}
 
 function_call <- @function{bare_ident_nonkw} ws @punctuation{'('} ws func_args? ws @punctuation{')'}
+                 (ws filter_clause)?
+                 (ws kw_over ws window_ref)?
 func_args   <- @operator{'*'}
              / (kw_distinct ws)? expr (ws @punctuation{','} ws expr)*
 
@@ -254,6 +296,27 @@ kw_cast      <- @keyword{cast_body !ident_char}
 kw_exists    <- @keyword{exists_body !ident_char}
 kw_collate   <- @keyword{collate_body !ident_char}
 
+# Window-function vocabulary. Only WINDOW and OVER are reserved; the
+# rest are matched positionally inside window_defn / frame_spec and
+# remain usable as identifiers outside those positions.
+kw_recursive <- @keyword{recursive_body !ident_char}
+kw_window    <- @keyword{window_body !ident_char}
+kw_over      <- @keyword{over_body !ident_char}
+kw_filter    <- @keyword{filter_body !ident_char}
+kw_partition <- @keyword{partition_body !ident_char}
+kw_range     <- @keyword{range_body !ident_char}
+kw_rows      <- @keyword{rows_body !ident_char}
+kw_groups    <- @keyword{groups_body !ident_char}
+kw_unbounded <- @keyword{unbounded_body !ident_char}
+kw_preceding <- @keyword{preceding_body !ident_char}
+kw_following <- @keyword{following_body !ident_char}
+kw_current   <- @keyword{current_body !ident_char}
+kw_row       <- @keyword{row_body !ident_char}
+kw_exclude   <- @keyword{exclude_body !ident_char}
+kw_ties      <- @keyword{ties_body !ident_char}
+kw_others    <- @keyword{others_body !ident_char}
+kw_no        <- @keyword{no_body !ident_char}
+
 # Keyword bodies — raw letter matchers, no boundary check.
 
 sel_body       <- [sS][eE][lL][eE][cC][tT]
@@ -303,6 +366,23 @@ end_body       <- [eE][nN][dD]
 cast_body      <- [cC][aA][sS][tT]
 exists_body    <- [eE][xX][iI][sS][tT][sS]
 collate_body   <- [cC][oO][lL][lL][aA][tT][eE]
+recursive_body <- [rR][eE][cC][uU][rR][sS][iI][vV][eE]
+window_body    <- [wW][iI][nN][dD][oO][wW]
+over_body      <- [oO][vV][eE][rR]
+filter_body    <- [fF][iI][lL][tT][eE][rR]
+partition_body <- [pP][aA][rR][tT][iI][tT][iI][oO][nN]
+range_body     <- [rR][aA][nN][gG][eE]
+rows_body      <- [rR][oO][wW][sS]
+groups_body    <- [gG][rR][oO][uU][pP][sS]
+unbounded_body <- [uU][nN][bB][oO][uU][nN][dD][eE][dD]
+preceding_body <- [pP][rR][eE][cC][eE][dD][iI][nN][gG]
+following_body <- [fF][oO][lL][lL][oO][wW][iI][nN][gG]
+current_body   <- [cC][uU][rR][rR][eE][nN][tT]
+row_body       <- [rR][oO][wW]
+exclude_body   <- [eE][xX][cC][lL][uU][dD][eE]
+ties_body      <- [tT][iI][eE][sS]
+others_body    <- [oO][tT][hH][eE][rR][sS]
+no_body        <- [nN][oO]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -334,6 +414,7 @@ keyword_word <-
     / offset_body          # 6
     / regexp_body          # 6
     / sel_body             # 6 (SELECT)
+    / window_body          # 6
     / bool_body            # 5 (FALSE) / 4 (TRUE); alternation handles both
     / cross_body           # 5
     / group_body           # 5
@@ -357,6 +438,7 @@ keyword_word <-
     / left_body            # 4
     / like_body            # 4
     / null_body            # 4
+    / over_body            # 4
     / then_body            # 4
     / when_body            # 4
     / with_body            # 4

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -41,6 +41,9 @@ statement  <- select_stmt
             / insert_stmt
             / update_stmt
             / delete_stmt
+            / create_table_stmt
+            / drop_table_stmt
+            / alter_table_stmt
 
 # --- SELECT statement -------------------------------------------------
 
@@ -192,6 +195,82 @@ delete_stmt <- with_clause? kw_delete ws kw_from ws qualified_table_name (ws tab
                order_clause?
                limit_clause?
                (ws returning_clause)?
+
+# --- DDL: CREATE / DROP / ALTER TABLE --------------------------------
+# Interleaves column_def with table_constraint because SQLite does
+# accept constraints in any order, not just trailing. Column vs table
+# constraint disambiguation falls out of PEG first-match: column_def
+# requires a non-keyword leading identifier, while table_constraint
+# starts with CONSTRAINT, PRIMARY, UNIQUE, CHECK, or FOREIGN.
+
+create_table_stmt <- kw_create (ws (kw_temporary / kw_temp))? ws kw_table
+                     (ws kw_if ws kw_not ws kw_exists)?
+                     ws qualified_table_name
+                     ws (@punctuation{'('} ws
+                             (column_def / table_constraint)
+                             (ws @punctuation{','} ws (column_def / table_constraint))*
+                         ws @punctuation{')'}
+                         (ws table_option (ws @punctuation{','} ws table_option)*)?
+                       / kw_as ws select_stmt)
+
+column_def     <- @variable{bare_ident_nonkw}
+                  (ws type_name)?
+                  (ws column_constraint)*
+
+# SQLite accepts multi-word type names like `DOUBLE PRECISION` and
+# `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
+type_name      <- @type{bare_ident_nonkw} (ws @type{bare_ident_nonkw})*
+                  (ws @punctuation{'('} ws signed_number
+                       (ws @punctuation{','} ws signed_number)? ws @punctuation{')'})?
+
+signed_number  <- (@operator{'-'} / @operator{'+'})? ws @number{number_body}
+
+column_constraint      <- (kw_constraint ws @variable{bare_ident_nonkw} ws)? column_constraint_body
+column_constraint_body <-
+      kw_primary ws kw_key (ws (kw_asc / kw_desc))? (ws conflict_clause)? (ws kw_autoincrement)?
+    / (kw_not ws)? kw_null (ws conflict_clause)?
+    / kw_unique (ws conflict_clause)?
+    / kw_check ws @punctuation{'('} ws expr ws @punctuation{')'}
+    / kw_default ws (signed_number / literal / @punctuation{'('} ws expr ws @punctuation{')'})
+    / kw_collate ws @type{bare_ident}
+    / foreign_key_clause
+    / (kw_generated ws kw_always ws)? kw_as ws @punctuation{'('} ws expr ws @punctuation{')'}
+      (ws (kw_stored / kw_virtual))?
+
+table_constraint      <- (kw_constraint ws @variable{bare_ident_nonkw} ws)? table_constraint_body
+table_constraint_body <-
+      (kw_primary ws kw_key / kw_unique)
+          ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'}
+          (ws conflict_clause)?
+    / kw_check ws @punctuation{'('} ws expr ws @punctuation{')'}
+    / kw_foreign ws kw_key ws @punctuation{'('} ws ident_list ws @punctuation{')'}
+          ws foreign_key_clause
+
+foreign_key_clause <- kw_references ws @type{bare_ident_nonkw}
+                      (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
+                      (ws fk_action)*
+                      (ws fk_deferrable)?
+fk_action      <- kw_on ws (kw_delete / kw_update) ws fk_action_body
+                / kw_match ws @variable{bare_ident_nonkw}
+fk_action_body <- kw_set ws (kw_null / kw_default)
+                / kw_cascade
+                / kw_restrict
+                / kw_no ws kw_action
+fk_deferrable  <- (kw_not ws)? kw_deferrable (ws kw_initially ws (kw_immediate / kw_deferred))?
+
+conflict_clause <- kw_on ws kw_conflict ws conflict_action
+
+table_option   <- kw_without ws kw_rowid / kw_strict
+
+drop_table_stmt <- kw_drop ws kw_table (ws kw_if ws kw_exists)? ws qualified_table_name
+
+alter_table_stmt <- kw_alter ws kw_table ws qualified_table_name ws (
+      kw_rename ws kw_to ws @type{bare_ident_nonkw}
+    / kw_rename (ws kw_column)? ws @variable{bare_ident_nonkw}
+        ws kw_to ws @variable{bare_ident_nonkw}
+    / kw_add (ws kw_column)? ws column_def
+    / kw_drop (ws kw_column)? ws @variable{bare_ident_nonkw}
+  )
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
@@ -401,6 +480,42 @@ kw_returning <- @keyword{returning_body !ident_char}
 kw_update    <- @keyword{update_body !ident_char}
 kw_delete    <- @keyword{delete_body !ident_char}
 
+# DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
+kw_create    <- @keyword{create_body !ident_char}
+kw_table     <- @keyword{table_body !ident_char}
+kw_alter     <- @keyword{alter_body !ident_char}
+kw_drop      <- @keyword{drop_body !ident_char}
+kw_rename    <- @keyword{rename_body !ident_char}
+kw_add       <- @keyword{add_body !ident_char}
+kw_column    <- @keyword{column_body !ident_char}
+kw_if        <- @keyword{if_body !ident_char}
+kw_temp      <- @keyword{temp_body !ident_char}
+kw_temporary <- @keyword{temporary_body !ident_char}
+kw_primary   <- @keyword{primary_body !ident_char}
+kw_key       <- @keyword{key_body !ident_char}
+kw_unique    <- @keyword{unique_body !ident_char}
+kw_check     <- @keyword{check_body !ident_char}
+kw_null      <- @keyword{null_body !ident_char}
+kw_references <- @keyword{references_body !ident_char}
+kw_generated <- @keyword{generated_body !ident_char}
+kw_always    <- @keyword{always_body !ident_char}
+kw_stored    <- @keyword{stored_body !ident_char}
+kw_virtual   <- @keyword{virtual_body !ident_char}
+kw_constraint<- @keyword{constraint_body !ident_char}
+kw_foreign   <- @keyword{foreign_body !ident_char}
+kw_action    <- @keyword{action_body !ident_char}
+kw_cascade   <- @keyword{cascade_body !ident_char}
+kw_restrict  <- @keyword{restrict_body !ident_char}
+kw_deferrable<- @keyword{deferrable_body !ident_char}
+kw_initially <- @keyword{initially_body !ident_char}
+kw_immediate <- @keyword{immediate_body !ident_char}
+kw_deferred  <- @keyword{deferred_body !ident_char}
+kw_autoincrement <- @keyword{autoincrement_body !ident_char}
+kw_rowid     <- @keyword{rowid_body !ident_char}
+kw_strict    <- @keyword{strict_body !ident_char}
+kw_without   <- @keyword{without_body !ident_char}
+kw_to        <- @keyword{to_body !ident_char}
+
 # Keyword bodies — raw letter matchers, no boundary check.
 
 sel_body       <- [sS][eE][lL][eE][cC][tT]
@@ -483,6 +598,39 @@ set_body       <- [sS][eE][tT]
 returning_body <- [rR][eE][tT][uU][rR][nN][iI][nN][gG]
 update_body    <- [uU][pP][dD][aA][tT][eE]
 delete_body    <- [dD][eE][lL][eE][tT][eE]
+create_body    <- [cC][rR][eE][aA][tT][eE]
+table_body     <- [tT][aA][bB][lL][eE]
+alter_body     <- [aA][lL][tT][eE][rR]
+drop_body      <- [dD][rR][oO][pP]
+rename_body    <- [rR][eE][nN][aA][mM][eE]
+add_body       <- [aA][dD][dD]
+column_body    <- [cC][oO][lL][uU][mM][nN]
+if_body        <- [iI][fF]
+temp_body      <- [tT][eE][mM][pP]
+temporary_body <- [tT][eE][mM][pP][oO][rR][aA][rR][yY]
+primary_body   <- [pP][rR][iI][mM][aA][rR][yY]
+key_body       <- [kK][eE][yY]
+unique_body    <- [uU][nN][iI][qQ][uU][eE]
+check_body     <- [cC][hH][eE][cC][kK]
+references_body <- [rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]
+generated_body <- [gG][eE][nN][eE][rR][aA][tT][eE][dD]
+always_body    <- [aA][lL][wW][aA][yY][sS]
+stored_body    <- [sS][tT][oO][rR][eE][dD]
+virtual_body   <- [vV][iI][rR][tT][uU][aA][lL]
+constraint_body<- [cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]
+foreign_body   <- [fF][oO][rR][eE][iI][gG][nN]
+action_body    <- [aA][cC][tT][iI][oO][nN]
+cascade_body   <- [cC][aA][sS][cC][aA][dD][eE]
+restrict_body  <- [rR][eE][sS][tT][rR][iI][cC][tT]
+deferrable_body<- [dD][eE][fF][eE][rR][rR][aA][bB][lL][eE]
+initially_body <- [iI][nN][iI][tT][iI][aA][lL][lL][yY]
+immediate_body <- [iI][mM][mM][eE][dD][iI][aA][tT][eE]
+deferred_body  <- [dD][eE][fF][eE][rR][rR][eE][dD]
+autoincrement_body <- [aA][uU][tT][oO][iI][nN][cC][rR][eE][mM][eE][nN][tT]
+rowid_body     <- [rR][oO][wW][iI][dD]
+strict_body    <- [sS][tT][rR][iI][cC][tT]
+without_body   <- [wW][iI][tT][hH][oO][uU][tT]
+to_body        <- [tT][oO]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -502,17 +650,36 @@ delete_body    <- [dD][eE][lL][eE][tT][eE]
 # `!ident_char` is applied once on the outside so each body stays
 # boundary-free.
 keyword_word <-
-    ( intersect_body       # 9
+    ( autoincrement_body   # 13
+    / constraint_body      # 10
+    / deferrable_body      # 10
+    / references_body      # 10
+    / generated_body       # 9
+    / immediate_body       # 9
+    / initially_body       # 9
+    / intersect_body       # 9
     / returning_body       # 9
+    / temporary_body       # 9
     / conflict_body        # 8
+    / deferred_body        # 8
     / distinct_body        # 8
+    / restrict_body        # 8
     / rollback_body        # 8
     / between_body         # 7
+    / cascade_body         # 7
     / collate_body         # 7
     / default_body         # 7
+    / foreign_body         # 7
     / natural_body         # 7
     / nothing_body         # 7
+    / primary_body         # 7
     / replace_body         # 7
+    / virtual_body         # 7
+    / without_body         # 7
+    / action_body          # 6
+    / always_body          # 6
+    / column_body          # 6
+    / create_body          # 6
     / delete_body          # 6
     / escape_body          # 6
     / except_body          # 6
@@ -522,12 +689,18 @@ keyword_word <-
     / insert_body          # 6
     / offset_body          # 6
     / regexp_body          # 6
+    / rename_body          # 6
     / sel_body             # 6 (SELECT)
+    / stored_body          # 6
+    / strict_body          # 6
+    / unique_body          # 6
     / update_body          # 6
     / values_body          # 6
     / window_body          # 6
     / abort_body           # 5
+    / alter_body           # 5
     / bool_body            # 5 (FALSE) / 4 (TRUE); alternation handles both
+    / check_body           # 5
     / cross_body           # 5
     / group_body           # 5
     / inner_body           # 5
@@ -536,12 +709,15 @@ keyword_word <-
     / order_body           # 5
     / outer_body           # 5
     / right_body           # 5
+    / rowid_body           # 5
+    / table_body           # 5
     / union_body           # 5
     / using_body           # 5
     / where_body           # 5
     / case_body            # 4
     / cast_body            # 4
     / desc_body            # 4
+    / drop_body            # 4
     / else_body            # 4
     / fail_body            # 4
     / from_body            # 4
@@ -553,22 +729,28 @@ keyword_word <-
     / like_body            # 4
     / null_body            # 4
     / over_body            # 4
+    / temp_body            # 4
     / then_body            # 4
     / when_body            # 4
     / with_body            # 4
+    / add_body             # 3
     / all_body             # 3
     / and_body             # 3
     / asc_body             # 3
     / end_body             # 3
+    / key_body             # 3
     / not_body             # 3
     / set_body             # 3
     / as_body              # 2
     / by_body              # 2
     / do_body              # 2
+    / if_body              # 2
     / in_body              # 2
     / is_body              # 2
+    / no_body              # 2
     / on_body              # 2
     / or_body              # 2
+    / to_body              # 2
     ) !ident_char
 
 # --- Whitespace & comments -------------------------------------------

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -42,7 +42,11 @@ statement  <- select_stmt
             / update_stmt
             / delete_stmt
             / create_table_stmt
+            / create_index_stmt
+            / create_view_stmt
             / drop_table_stmt
+            / drop_index_stmt
+            / drop_view_stmt
             / alter_table_stmt
 
 # --- SELECT statement -------------------------------------------------
@@ -271,6 +275,25 @@ alter_table_stmt <- kw_alter ws kw_table ws qualified_table_name ws (
     / kw_add (ws kw_column)? ws column_def
     / kw_drop (ws kw_column)? ws @variable{bare_ident_nonkw}
   )
+
+# --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
+
+create_index_stmt <- kw_create (ws kw_unique)? ws kw_index
+                     (ws kw_if ws kw_not ws kw_exists)?
+                     ws qualified_table_name
+                     ws kw_on ws @type{bare_ident_nonkw}
+                     ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'}
+                     (ws where_clause)?
+
+drop_index_stmt   <- kw_drop ws kw_index (ws kw_if ws kw_exists)? ws qualified_table_name
+
+create_view_stmt  <- kw_create (ws (kw_temporary / kw_temp))? ws kw_view
+                     (ws kw_if ws kw_not ws kw_exists)?
+                     ws qualified_table_name
+                     (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
+                     ws kw_as ws select_stmt
+
+drop_view_stmt    <- kw_drop ws kw_view (ws kw_if ws kw_exists)? ws qualified_table_name
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
@@ -515,6 +538,8 @@ kw_rowid     <- @keyword{rowid_body !ident_char}
 kw_strict    <- @keyword{strict_body !ident_char}
 kw_without   <- @keyword{without_body !ident_char}
 kw_to        <- @keyword{to_body !ident_char}
+kw_index     <- @keyword{index_body !ident_char}
+kw_view      <- @keyword{view_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
@@ -631,6 +656,8 @@ rowid_body     <- [rR][oO][wW][iI][dD]
 strict_body    <- [sS][tT][rR][iI][cC][tT]
 without_body   <- [wW][iI][tT][hH][oO][uU][tT]
 to_body        <- [tT][oO]
+index_body     <- [iI][nN][dD][eE][xX]
+view_body      <- [vV][iI][eE][wW]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -703,6 +730,7 @@ keyword_word <-
     / check_body           # 5
     / cross_body           # 5
     / group_body           # 5
+    / index_body           # 5
     / inner_body           # 5
     / limit_body           # 5
     / match_body           # 5
@@ -731,6 +759,7 @@ keyword_word <-
     / over_body            # 4
     / temp_body            # 4
     / then_body            # 4
+    / view_body            # 4
     / when_body            # 4
     / with_body            # 4
     / add_body             # 3

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -37,24 +37,32 @@
 
 sql_file   <- ws (statement (stmt_sep statement)*)? stmt_sep? ws !.
 stmt_sep   <- ws @punctuation{';'} ws
-statement  <- select_stmt
-            / insert_stmt
-            / update_stmt
-            / delete_stmt
-            / create_table_stmt
-            / create_index_stmt
-            / create_view_stmt
-            / create_trigger_stmt
-            / drop_table_stmt
-            / drop_index_stmt
-            / drop_view_stmt
-            / drop_trigger_stmt
-            / alter_table_stmt
-            / begin_stmt
-            / commit_stmt
-            / rollback_stmt
-            / savepoint_stmt
-            / release_stmt
+statement       <- explain_stmt / statement_body
+statement_body  <- select_stmt
+                 / insert_stmt
+                 / update_stmt
+                 / delete_stmt
+                 / create_virtual_table_stmt
+                 / create_table_stmt
+                 / create_index_stmt
+                 / create_view_stmt
+                 / create_trigger_stmt
+                 / drop_table_stmt
+                 / drop_index_stmt
+                 / drop_view_stmt
+                 / drop_trigger_stmt
+                 / alter_table_stmt
+                 / begin_stmt
+                 / commit_stmt
+                 / rollback_stmt
+                 / savepoint_stmt
+                 / release_stmt
+                 / pragma_stmt
+                 / vacuum_stmt
+                 / attach_stmt
+                 / detach_stmt
+                 / reindex_stmt
+                 / analyze_stmt
 
 # --- SELECT statement -------------------------------------------------
 
@@ -335,6 +343,40 @@ rollback_stmt  <- kw_rollback (ws kw_transaction)?
 savepoint_stmt <- kw_savepoint ws @variable{bare_ident_nonkw}
 release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
 
+# --- PRAGMA, admin statements, EXPLAIN, CREATE VIRTUAL TABLE ---------
+# EXPLAIN wraps statement_body rather than statement, so
+# `EXPLAIN EXPLAIN …` is rejected. PRAGMA names and ATTACH schema
+# names reuse the `schema.name` shape as @type (namespace / handle).
+# CREATE VIRTUAL TABLE's module name after USING is @function —
+# the module is invoked, not merely referenced.
+
+pragma_stmt     <- kw_pragma ws qualified_table_name
+                   (ws @operator{'='} ws pragma_value
+                    / ws @punctuation{'('} ws pragma_value ws @punctuation{')'})?
+pragma_value    <- signed_number / string_lit / @variable{bare_ident}
+
+vacuum_stmt     <- kw_vacuum (ws @type{bare_ident_nonkw})? (ws kw_into ws string_lit)?
+
+attach_stmt     <- kw_attach (ws kw_database)? ws expr ws kw_as
+                   ws @type{bare_ident_nonkw}
+detach_stmt     <- kw_detach (ws kw_database)? ws @type{bare_ident_nonkw}
+
+reindex_stmt    <- kw_reindex (ws qualified_table_name)?
+analyze_stmt    <- kw_analyze (ws qualified_table_name)?
+
+explain_stmt    <- kw_explain (ws kw_query ws kw_plan)? ws statement_body
+
+create_virtual_table_stmt <-
+    kw_create ws kw_virtual ws kw_table
+    (ws kw_if ws kw_not ws kw_exists)?
+    ws qualified_table_name
+    ws kw_using ws @function{bare_ident_nonkw}
+    (ws @punctuation{'('} ws vtab_args? ws @punctuation{')'})?
+vtab_args       <- vtab_arg (ws @punctuation{','} ws vtab_arg)*
+# Module args are deliberately permissive — fts5/rtree/etc have
+# module-specific mini-grammars that are not worth modelling.
+vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
+
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
 # matches the next-higher level or chains several of them with an
@@ -593,6 +635,16 @@ kw_transaction <- @keyword{transaction_body !ident_char}
 kw_savepoint <- @keyword{savepoint_body !ident_char}
 kw_release   <- @keyword{release_body !ident_char}
 kw_exclusive <- @keyword{exclusive_body !ident_char}
+kw_pragma    <- @keyword{pragma_body !ident_char}
+kw_vacuum    <- @keyword{vacuum_body !ident_char}
+kw_attach    <- @keyword{attach_body !ident_char}
+kw_detach    <- @keyword{detach_body !ident_char}
+kw_database  <- @keyword{database_body !ident_char}
+kw_reindex   <- @keyword{reindex_body !ident_char}
+kw_analyze   <- @keyword{analyze_body !ident_char}
+kw_explain   <- @keyword{explain_body !ident_char}
+kw_query     <- @keyword{query_body !ident_char}
+kw_plan      <- @keyword{plan_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
@@ -724,6 +776,16 @@ transaction_body <- [tT][rR][aA][nN][sS][aA][cC][tT][iI][oO][nN]
 savepoint_body <- [sS][aA][vV][eE][pP][oO][iI][nN][tT]
 release_body   <- [rR][eE][lL][eE][aA][sS][eE]
 exclusive_body <- [eE][xX][cC][lL][uU][sS][iI][vV][eE]
+pragma_body    <- [pP][rR][aA][gG][mM][aA]
+vacuum_body    <- [vV][aA][cC][uU][uU][mM]
+attach_body    <- [aA][tT][tT][aA][cC][hH]
+detach_body    <- [dD][eE][tT][aA][cC][hH]
+database_body  <- [dD][aA][tT][aA][bB][aA][sS][eE]
+reindex_body   <- [rR][eE][iI][nN][dD][eE][xX]
+analyze_body   <- [aA][nN][aA][lL][yY][zZ][eE]
+explain_body   <- [eE][xX][pP][lL][aA][iI][nN]
+query_body     <- [qQ][uU][eE][rR][yY]
+plan_body      <- [pP][lL][aA][nN]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -757,19 +819,23 @@ keyword_word <-
     / savepoint_body       # 9
     / temporary_body       # 9
     / conflict_body        # 8
+    / database_body        # 8
     / deferred_body        # 8
     / distinct_body        # 8
     / restrict_body        # 8
     / rollback_body        # 8
+    / analyze_body         # 7
     / between_body         # 7
     / cascade_body         # 7
     / collate_body         # 7
     / default_body         # 7
+    / explain_body         # 7
     / foreign_body         # 7
     / instead_body         # 7
     / natural_body         # 7
     / nothing_body         # 7
     / primary_body         # 7
+    / reindex_body         # 7
     / release_body         # 7
     / replace_body         # 7
     / trigger_body         # 7
@@ -777,11 +843,13 @@ keyword_word <-
     / without_body         # 7
     / action_body          # 6
     / always_body          # 6
+    / attach_body          # 6
     / before_body          # 6
     / column_body          # 6
     / commit_body          # 6
     / create_body          # 6
     / delete_body          # 6
+    / detach_body          # 6
     / escape_body          # 6
     / except_body          # 6
     / exists_body          # 6
@@ -789,6 +857,7 @@ keyword_word <-
     / ignore_body          # 6
     / insert_body          # 6
     / offset_body          # 6
+    / pragma_body          # 6
     / regexp_body          # 6
     / rename_body          # 6
     / sel_body             # 6 (SELECT)
@@ -796,6 +865,7 @@ keyword_word <-
     / strict_body          # 6
     / unique_body          # 6
     / update_body          # 6
+    / vacuum_body          # 6
     / values_body          # 6
     / window_body          # 6
     / abort_body           # 5
@@ -812,6 +882,7 @@ keyword_word <-
     / match_body           # 5
     / order_body           # 5
     / outer_body           # 5
+    / query_body           # 5
     / right_body           # 5
     / rowid_body           # 5
     / table_body           # 5
@@ -834,6 +905,7 @@ keyword_word <-
     / like_body            # 4
     / null_body            # 4
     / over_body            # 4
+    / plan_body            # 4
     / temp_body            # 4
     / then_body            # 4
     / view_body            # 4

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -39,6 +39,8 @@ sql_file   <- ws (statement (stmt_sep statement)*)? stmt_sep? ws !.
 stmt_sep   <- ws @punctuation{';'} ws
 statement  <- select_stmt
             / insert_stmt
+            / update_stmt
+            / delete_stmt
 
 # --- SELECT statement -------------------------------------------------
 
@@ -160,9 +162,36 @@ indexed_col      <- expr (ws kw_collate ws @type{bare_ident})? (ws (kw_asc / kw_
 
 update_set_list <- update_set_item (ws @punctuation{','} ws update_set_item)*
 update_set_item <- @variable{bare_ident_nonkw} ws @operator{'='} ws expr
-                 / @punctuation{'('} ws ident_list ws @punctuation{')'} ws @operator{'='} ws expr
+                 / @punctuation{'('} ws ident_list ws @punctuation{')'} ws @operator{'='} ws row_value
+# RHS of a column-tuple assignment: parens-wrapped row-value (literal
+# list or sub-select) or a single expression that yields a row.
+row_value        <- @punctuation{'('} ws
+                    (select_stmt / expr (ws @punctuation{','} ws expr)*)
+                    ws @punctuation{')'}
+                  / expr
 
 returning_clause <- kw_returning ws result_list
+
+# --- DML: UPDATE, DELETE ---------------------------------------------
+# UPDATE FROM and DELETE reuse `from_clause` and `where_clause` from
+# the SELECT section. ORDER BY + LIMIT are accepted even on builds
+# compiled without SQLITE_ENABLE_UPDATE_DELETE_LIMIT — highlighting
+# should not pretend the syntax doesn't exist.
+
+update_stmt <- with_clause? kw_update (ws kw_or ws conflict_action)? ws
+               qualified_table_name (ws table_alias)?
+               ws kw_set ws update_set_list
+               (ws from_clause)?
+               (ws where_clause)?
+               order_clause?
+               limit_clause?
+               (ws returning_clause)?
+
+delete_stmt <- with_clause? kw_delete ws kw_from ws qualified_table_name (ws table_alias)?
+               (ws where_clause)?
+               order_clause?
+               limit_clause?
+               (ws returning_clause)?
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
@@ -370,6 +399,7 @@ kw_ignore    <- @keyword{ignore_body !ident_char}
 kw_set       <- @keyword{set_body !ident_char}
 kw_returning <- @keyword{returning_body !ident_char}
 kw_update    <- @keyword{update_body !ident_char}
+kw_delete    <- @keyword{delete_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
@@ -452,6 +482,7 @@ ignore_body    <- [iI][gG][nN][oO][rR][eE]
 set_body       <- [sS][eE][tT]
 returning_body <- [rR][eE][tT][uU][rR][nN][iI][nN][gG]
 update_body    <- [uU][pP][dD][aA][tT][eE]
+delete_body    <- [dD][eE][lL][eE][tT][eE]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -482,6 +513,7 @@ keyword_word <-
     / natural_body         # 7
     / nothing_body         # 7
     / replace_body         # 7
+    / delete_body          # 6
     / escape_body          # 6
     / except_body          # 6
     / exists_body          # 6

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -38,6 +38,7 @@
 sql_file   <- ws (statement (stmt_sep statement)*)? stmt_sep? ws !.
 stmt_sep   <- ws @punctuation{';'} ws
 statement  <- select_stmt
+            / insert_stmt
 
 # --- SELECT statement -------------------------------------------------
 
@@ -127,6 +128,41 @@ frame_exclude  <- kw_no ws kw_others
                 / kw_current ws kw_row
                 / kw_group
                 / kw_ties
+
+# --- DML: INSERT ------------------------------------------------------
+# UPSERT's DO UPDATE path and UPDATE (added in a later commit) share
+# `update_set_list`, which is defined here.
+
+insert_stmt    <- with_clause? insert_prefix ws kw_into ws qualified_table_name
+                  (ws kw_as ws @variable{bare_ident_nonkw})?
+                  (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
+                  ws insert_source
+                  (ws upsert_clause)*
+                  (ws returning_clause)?
+
+insert_prefix  <- kw_insert (ws kw_or ws conflict_action)?
+                / kw_replace
+
+insert_source  <- kw_default ws kw_values
+                / kw_values ws values_row (ws @punctuation{','} ws values_row)*
+                / select_stmt
+values_row     <- @punctuation{'('} ws expr (ws @punctuation{','} ws expr)* ws @punctuation{')'}
+
+conflict_action <- kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
+
+upsert_clause  <- kw_on ws kw_conflict
+                  (ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'} (ws where_clause)?)?
+                  ws kw_do ws (kw_nothing
+                             / kw_update ws kw_set ws update_set_list (ws where_clause)?)
+
+indexed_col_list <- indexed_col (ws @punctuation{','} ws indexed_col)*
+indexed_col      <- expr (ws kw_collate ws @type{bare_ident})? (ws (kw_asc / kw_desc))?
+
+update_set_list <- update_set_item (ws @punctuation{','} ws update_set_item)*
+update_set_item <- @variable{bare_ident_nonkw} ws @operator{'='} ws expr
+                 / @punctuation{'('} ws ident_list ws @punctuation{')'} ws @operator{'='} ws expr
+
+returning_clause <- kw_returning ws result_list
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
@@ -317,6 +353,24 @@ kw_ties      <- @keyword{ties_body !ident_char}
 kw_others    <- @keyword{others_body !ident_char}
 kw_no        <- @keyword{no_body !ident_char}
 
+# DML (INSERT family). UPDATE lands in a later commit but its keyword
+# rule goes here so UPSERT's DO UPDATE path can use it now.
+kw_insert    <- @keyword{insert_body !ident_char}
+kw_replace   <- @keyword{replace_body !ident_char}
+kw_into      <- @keyword{into_body !ident_char}
+kw_values    <- @keyword{values_body !ident_char}
+kw_default   <- @keyword{default_body !ident_char}
+kw_conflict  <- @keyword{conflict_body !ident_char}
+kw_do        <- @keyword{do_body !ident_char}
+kw_nothing   <- @keyword{nothing_body !ident_char}
+kw_rollback  <- @keyword{rollback_body !ident_char}
+kw_abort     <- @keyword{abort_body !ident_char}
+kw_fail      <- @keyword{fail_body !ident_char}
+kw_ignore    <- @keyword{ignore_body !ident_char}
+kw_set       <- @keyword{set_body !ident_char}
+kw_returning <- @keyword{returning_body !ident_char}
+kw_update    <- @keyword{update_body !ident_char}
+
 # Keyword bodies — raw letter matchers, no boundary check.
 
 sel_body       <- [sS][eE][lL][eE][cC][tT]
@@ -383,6 +437,21 @@ exclude_body   <- [eE][xX][cC][lL][uU][dD][eE]
 ties_body      <- [tT][iI][eE][sS]
 others_body    <- [oO][tT][hH][eE][rR][sS]
 no_body        <- [nN][oO]
+insert_body    <- [iI][nN][sS][eE][rR][tT]
+replace_body   <- [rR][eE][pP][lL][aA][cC][eE]
+into_body      <- [iI][nN][tT][oO]
+values_body    <- [vV][aA][lL][uU][eE][sS]
+default_body   <- [dD][eE][fF][aA][uU][lL][tT]
+conflict_body  <- [cC][oO][nN][fF][lL][iI][cC][tT]
+do_body        <- [dD][oO]
+nothing_body   <- [nN][oO][tT][hH][iI][nN][gG]
+rollback_body  <- [rR][oO][lL][lL][bB][aA][cC][kK]
+abort_body     <- [aA][bB][oO][rR][tT]
+fail_body      <- [fF][aA][iI][lL]
+ignore_body    <- [iI][gG][nN][oO][rR][eE]
+set_body       <- [sS][eE][tT]
+returning_body <- [rR][eE][tT][uU][rR][nN][iI][nN][gG]
+update_body    <- [uU][pP][dD][aA][tT][eE]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -403,18 +472,29 @@ no_body        <- [nN][oO]
 # boundary-free.
 keyword_word <-
     ( intersect_body       # 9
+    / returning_body       # 9
+    / conflict_body        # 8
     / distinct_body        # 8
+    / rollback_body        # 8
     / between_body         # 7
     / collate_body         # 7
+    / default_body         # 7
     / natural_body         # 7
+    / nothing_body         # 7
+    / replace_body         # 7
     / escape_body          # 6
     / except_body          # 6
     / exists_body          # 6
     / having_body          # 6
+    / ignore_body          # 6
+    / insert_body          # 6
     / offset_body          # 6
     / regexp_body          # 6
     / sel_body             # 6 (SELECT)
+    / update_body          # 6
+    / values_body          # 6
     / window_body          # 6
+    / abort_body           # 5
     / bool_body            # 5 (FALSE) / 4 (TRUE); alternation handles both
     / cross_body           # 5
     / group_body           # 5
@@ -431,9 +511,11 @@ keyword_word <-
     / cast_body            # 4
     / desc_body            # 4
     / else_body            # 4
+    / fail_body            # 4
     / from_body            # 4
     / full_body            # 4
     / glob_body            # 4
+    / into_body            # 4
     / join_body            # 4
     / left_body            # 4
     / like_body            # 4
@@ -447,8 +529,10 @@ keyword_word <-
     / asc_body             # 3
     / end_body             # 3
     / not_body             # 3
+    / set_body             # 3
     / as_body              # 2
     / by_body              # 2
+    / do_body              # 2
     / in_body              # 2
     / is_body              # 2
     / on_body              # 2

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -304,24 +304,73 @@ cast_body      <- [cC][aA][sS][tT]
 exists_body    <- [eE][xX][iI][sS][tT][sS]
 collate_body   <- [cC][oO][lL][lL][aA][tT][eE]
 
-# Keyword negative-lookahead for the identifier rule. Ordering: among
-# alternatives that share a prefix, put the longer body first so PEG
-# first-match doesn't accept a shorter keyword when a longer one would
-# match (e.g. INTERSECT before IN, NATURAL before NOT, DISTINCT before
-# DESC, OUTER before OR). `!ident_char` is applied once at the outside
-# so each body stays boundary-free.
+# Keyword negative-lookahead for the identifier rule.
+#
+# Invariant: among alternatives that share a prefix, the longer body
+# must come first so PEG first-match doesn't accept a shorter keyword
+# when a longer one also matches (e.g. INTERSECT before IN). We enforce
+# it by sorting the whole list strictly length-descending, then
+# alphabetically within each length tier. New keywords slot in by
+# length alone — no per-cluster reasoning needed. The known shared-
+# prefix clusters (all satisfied by length-descending ordering):
+#
+#   INTERSECT > IN / IS             (I-prefix)
+#   DISTINCT > DESC                 (D-prefix)
+#   NATURAL > NULL > NOT            (N-prefix)
+#   OFFSET > ORDER / OUTER > ON / OR (O-prefix)
+#
+# `!ident_char` is applied once on the outside so each body stays
+# boundary-free.
 keyword_word <-
-    ( intersect_body / between_body / distinct_body / collate_body
-    / natural_body / regexp_body / outer_body / offset_body
-    / having_body / except_body / exists_body / escape_body
-    / sel_body / union_body / inner_body / right_body
-    / group_body / order_body / where_body / match_body / cross_body
-    / limit_body / from_body / join_body / left_body
-    / full_body / glob_body / desc_body / with_body / cast_body
-    / case_body / when_body / then_body / else_body / like_body
-    / null_body / bool_body / using_body / asc_body / all_body
-    / end_body / and_body / not_body
-    / in_body / is_body / on_body / or_body / as_body / by_body
+    ( intersect_body       # 9
+    / distinct_body        # 8
+    / between_body         # 7
+    / collate_body         # 7
+    / natural_body         # 7
+    / escape_body          # 6
+    / except_body          # 6
+    / exists_body          # 6
+    / having_body          # 6
+    / offset_body          # 6
+    / regexp_body          # 6
+    / sel_body             # 6 (SELECT)
+    / bool_body            # 5 (FALSE) / 4 (TRUE); alternation handles both
+    / cross_body           # 5
+    / group_body           # 5
+    / inner_body           # 5
+    / limit_body           # 5
+    / match_body           # 5
+    / order_body           # 5
+    / outer_body           # 5
+    / right_body           # 5
+    / union_body           # 5
+    / using_body           # 5
+    / where_body           # 5
+    / case_body            # 4
+    / cast_body            # 4
+    / desc_body            # 4
+    / else_body            # 4
+    / from_body            # 4
+    / full_body            # 4
+    / glob_body            # 4
+    / join_body            # 4
+    / left_body            # 4
+    / like_body            # 4
+    / null_body            # 4
+    / then_body            # 4
+    / when_body            # 4
+    / with_body            # 4
+    / all_body             # 3
+    / and_body             # 3
+    / asc_body             # 3
+    / end_body             # 3
+    / not_body             # 3
+    / as_body              # 2
+    / by_body              # 2
+    / in_body              # 2
+    / is_body              # 2
+    / on_body              # 2
+    / or_body              # 2
     ) !ident_char
 
 # --- Whitespace & comments -------------------------------------------

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -612,6 +612,77 @@ fn insert_into_emits_type_on_table() {
 }
 
 #[test]
+fn update_basic() {
+    assert_complete_full("UPDATE t SET a = 1");
+}
+
+#[test]
+fn update_multi_set_with_where() {
+    assert_complete_full("UPDATE t SET a = 1, b = 2 WHERE c = 3");
+}
+
+#[test]
+fn update_column_tuple() {
+    assert_complete_full("UPDATE t SET (a, b) = (1, 2)");
+}
+
+#[test]
+fn update_or_rollback() {
+    for prefix in [
+        "UPDATE OR ROLLBACK",
+        "UPDATE OR ABORT",
+        "UPDATE OR REPLACE",
+        "UPDATE OR FAIL",
+        "UPDATE OR IGNORE",
+    ] {
+        let input = format!("{prefix} t SET a = 1");
+        assert_complete_full(&input);
+    }
+}
+
+#[test]
+fn update_with_from() {
+    assert_complete_full("UPDATE t SET a = s.a FROM s WHERE t.id = s.id");
+}
+
+#[test]
+fn update_with_returning() {
+    assert_complete_full("UPDATE t SET a = 1 WHERE b > 0 RETURNING a, b");
+}
+
+#[test]
+fn update_with_order_limit() {
+    assert_complete_full("UPDATE t SET a = a + 1 ORDER BY id LIMIT 10");
+}
+
+#[test]
+fn delete_basic() {
+    assert_complete_full("DELETE FROM t");
+}
+
+#[test]
+fn delete_with_where() {
+    assert_complete_full("DELETE FROM t WHERE a = 1");
+}
+
+#[test]
+fn delete_with_returning() {
+    assert_complete_full("DELETE FROM t WHERE a = 1 RETURNING *");
+}
+
+#[test]
+fn delete_with_order_limit() {
+    assert_complete_full("DELETE FROM t WHERE a = 1 ORDER BY id LIMIT 10");
+}
+
+#[test]
+fn delete_with_cte() {
+    assert_complete_full(
+        "WITH cur AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM cur)",
+    );
+}
+
+#[test]
 fn window_captures_include_over_and_partition() {
     let input = "SELECT SUM(x) OVER (PARTITION BY y ORDER BY z) FROM t";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -961,6 +961,78 @@ fn savepoint_and_release() {
 }
 
 #[test]
+fn pragma_variants() {
+    assert_complete_full("PRAGMA cache_size");
+    assert_complete_full("PRAGMA cache_size = 2000");
+    assert_complete_full("PRAGMA cache_size(2000)");
+    assert_complete_full("PRAGMA main.cache_size = 1000");
+    assert_complete_full("PRAGMA foreign_keys = ON");
+    assert_complete_full("PRAGMA journal_mode = 'wal'");
+}
+
+#[test]
+fn vacuum_variants() {
+    assert_complete_full("VACUUM");
+    assert_complete_full("VACUUM main");
+    assert_complete_full("VACUUM INTO 'backup.db'");
+}
+
+#[test]
+fn attach_detach() {
+    assert_complete_full("ATTACH DATABASE 'x.db' AS backup");
+    assert_complete_full("ATTACH 'x.db' AS backup");
+    assert_complete_full("DETACH DATABASE backup");
+    assert_complete_full("DETACH backup");
+}
+
+#[test]
+fn reindex_variants() {
+    assert_complete_full("REINDEX");
+    assert_complete_full("REINDEX t");
+    assert_complete_full("REINDEX main.t");
+}
+
+#[test]
+fn analyze_variants() {
+    assert_complete_full("ANALYZE");
+    assert_complete_full("ANALYZE main.t");
+}
+
+#[test]
+fn explain_variants() {
+    assert_complete_full("EXPLAIN SELECT 1");
+    assert_complete_full("EXPLAIN QUERY PLAN SELECT 1");
+    assert_complete_full("EXPLAIN INSERT INTO t VALUES (1)");
+}
+
+#[test]
+fn explain_explain_rejected() {
+    // `EXPLAIN EXPLAIN ...` is not valid — explain_stmt wraps
+    // statement_body, not statement.
+    assert_rejects("EXPLAIN EXPLAIN SELECT 1");
+}
+
+#[test]
+fn create_virtual_table_fts5() {
+    assert_complete_full("CREATE VIRTUAL TABLE fts USING fts5(a, b)");
+}
+
+#[test]
+fn create_virtual_table_if_not_exists() {
+    assert_complete_full("CREATE VIRTUAL TABLE IF NOT EXISTS fts USING fts5(a UNINDEXED, b)");
+}
+
+#[test]
+fn create_virtual_table_rtree() {
+    assert_complete_full("CREATE VIRTUAL TABLE boxes USING rtree(id, x0, x1, y0, y1)");
+}
+
+#[test]
+fn create_virtual_table_no_args() {
+    assert_complete_full("CREATE VIRTUAL TABLE t USING module_name");
+}
+
+#[test]
 fn trigger_then_select_multi_statement() {
     // Two top-level statements separated by `;`: a trigger (whose body
     // has its own inner `;`-terminated statements) and a SELECT.

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -810,6 +810,59 @@ fn alter_table_drop_column() {
 }
 
 #[test]
+fn create_index_basic() {
+    assert_complete_full("CREATE INDEX i ON t (a)");
+}
+
+#[test]
+fn create_unique_index_multi_col() {
+    assert_complete_full("CREATE UNIQUE INDEX i ON t (a, b)");
+}
+
+#[test]
+fn create_partial_index() {
+    assert_complete_full("CREATE INDEX i ON t (a) WHERE a > 0");
+}
+
+#[test]
+fn create_expression_index() {
+    assert_complete_full("CREATE INDEX i ON t (LOWER(a))");
+}
+
+#[test]
+fn create_index_if_not_exists() {
+    assert_complete_full("CREATE INDEX IF NOT EXISTS i ON t (a)");
+}
+
+#[test]
+fn drop_index_variants() {
+    assert_complete_full("DROP INDEX i");
+    assert_complete_full("DROP INDEX IF EXISTS main.i");
+}
+
+#[test]
+fn create_view_basic() {
+    assert_complete_full("CREATE VIEW v AS SELECT * FROM t");
+}
+
+#[test]
+fn create_view_with_columns() {
+    assert_complete_full("CREATE VIEW v (a, b) AS SELECT x, y FROM t");
+}
+
+#[test]
+fn create_temp_view() {
+    assert_complete_full("CREATE TEMP VIEW v AS SELECT 1");
+    assert_complete_full("CREATE TEMPORARY VIEW v AS SELECT 1");
+}
+
+#[test]
+fn drop_view_variants() {
+    assert_complete_full("DROP VIEW v");
+    assert_complete_full("DROP VIEW IF EXISTS v");
+}
+
+#[test]
 fn create_table_column_kinds() {
     let input = "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -863,6 +863,79 @@ fn drop_view_variants() {
 }
 
 #[test]
+fn create_trigger_after_insert() {
+    assert_complete_full(
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN INSERT INTO log VALUES (1); END",
+    );
+}
+
+#[test]
+fn create_trigger_before_update() {
+    assert_complete_full(
+        "CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN UPDATE log SET n = n + 1; END",
+    );
+}
+
+#[test]
+fn create_trigger_instead_of_delete() {
+    assert_complete_full(
+        "CREATE TRIGGER tr INSTEAD OF DELETE ON v BEGIN DELETE FROM u WHERE id = OLD.id; END",
+    );
+}
+
+#[test]
+fn create_trigger_update_of_columns() {
+    assert_complete_full("CREATE TRIGGER tr AFTER UPDATE OF a, b ON t BEGIN SELECT 1; END");
+}
+
+#[test]
+fn create_trigger_for_each_row() {
+    assert_complete_full("CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW BEGIN SELECT 1; END");
+}
+
+#[test]
+fn create_trigger_when_clause() {
+    assert_complete_full(
+        "CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW WHEN NEW.a > 0 \
+         BEGIN INSERT INTO log VALUES (NEW.a); END",
+    );
+}
+
+#[test]
+fn create_trigger_multi_statement_body() {
+    assert_complete_full(
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN \
+           INSERT INTO log VALUES (1); \
+           UPDATE stats SET n = n + 1; \
+           DELETE FROM tmp WHERE id = NEW.id; \
+         END",
+    );
+}
+
+#[test]
+fn create_trigger_if_not_exists() {
+    assert_complete_full("CREATE TRIGGER IF NOT EXISTS tr AFTER INSERT ON t BEGIN SELECT 1; END");
+}
+
+#[test]
+fn create_temp_trigger() {
+    assert_complete_full("CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END");
+}
+
+#[test]
+fn drop_trigger_variants() {
+    assert_complete_full("DROP TRIGGER tr");
+    assert_complete_full("DROP TRIGGER IF EXISTS main.tr");
+}
+
+#[test]
+fn trigger_then_select_multi_statement() {
+    // Two top-level statements separated by `;`: a trigger (whose body
+    // has its own inner `;`-terminated statements) and a SELECT.
+    assert_complete_full("CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END; SELECT 2");
+}
+
+#[test]
 fn create_table_column_kinds() {
     let input = "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -929,6 +929,38 @@ fn drop_trigger_variants() {
 }
 
 #[test]
+fn begin_variants() {
+    assert_complete_full("BEGIN");
+    assert_complete_full("BEGIN TRANSACTION");
+    assert_complete_full("BEGIN DEFERRED");
+    assert_complete_full("BEGIN IMMEDIATE TRANSACTION");
+    assert_complete_full("BEGIN EXCLUSIVE");
+}
+
+#[test]
+fn commit_and_end_aliases() {
+    assert_complete_full("COMMIT");
+    assert_complete_full("END");
+    assert_complete_full("COMMIT TRANSACTION");
+    assert_complete_full("END TRANSACTION");
+}
+
+#[test]
+fn rollback_variants() {
+    assert_complete_full("ROLLBACK");
+    assert_complete_full("ROLLBACK TRANSACTION");
+    assert_complete_full("ROLLBACK TO sp");
+    assert_complete_full("ROLLBACK TRANSACTION TO SAVEPOINT sp");
+}
+
+#[test]
+fn savepoint_and_release() {
+    assert_complete_full("SAVEPOINT sp");
+    assert_complete_full("RELEASE sp");
+    assert_complete_full("RELEASE SAVEPOINT sp");
+}
+
+#[test]
 fn trigger_then_select_multi_statement() {
     // Two top-level statements separated by `;`: a trigger (whose body
     // has its own inner `;`-terminated statements) and a SELECT.

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -683,6 +683,163 @@ fn delete_with_cte() {
 }
 
 #[test]
+fn create_table_basic() {
+    assert_complete_full("CREATE TABLE t (a INTEGER)");
+}
+
+#[test]
+fn create_table_typeless_columns() {
+    assert_complete_full("CREATE TABLE t (a, b)");
+}
+
+#[test]
+fn create_table_mixed_constraints() {
+    assert_complete_full(
+        "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT NOT NULL UNIQUE, c INT NULL)",
+    );
+}
+
+#[test]
+fn create_table_check_constraint() {
+    assert_complete_full("CREATE TABLE t (a INT CHECK (a > 0))");
+}
+
+#[test]
+fn create_table_defaults() {
+    assert_complete_full(
+        "CREATE TABLE t (a INT DEFAULT 0, b TEXT DEFAULT 'x', c DATETIME DEFAULT (CURRENT_TIMESTAMP))",
+    );
+}
+
+#[test]
+fn create_table_column_collate() {
+    assert_complete_full("CREATE TABLE t (a TEXT COLLATE NOCASE)");
+}
+
+#[test]
+fn create_table_generated_column_shorthand() {
+    assert_complete_full("CREATE TABLE t (a INT, b INT AS (a + 1) STORED)");
+}
+
+#[test]
+fn create_table_generated_column_always() {
+    assert_complete_full("CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a + 1) VIRTUAL)");
+}
+
+#[test]
+fn create_table_table_primary_key() {
+    assert_complete_full("CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b))");
+}
+
+#[test]
+fn create_table_named_constraint() {
+    assert_complete_full("CREATE TABLE t (a INT, CONSTRAINT pk PRIMARY KEY (a))");
+}
+
+#[test]
+fn create_table_foreign_key() {
+    assert_complete_full(
+        "CREATE TABLE t (a INT, b INT, FOREIGN KEY (a) REFERENCES u(x) ON DELETE CASCADE)",
+    );
+}
+
+#[test]
+fn create_table_foreign_key_deferrable() {
+    assert_complete_full("CREATE TABLE t (a INT REFERENCES u(x) DEFERRABLE INITIALLY DEFERRED)");
+}
+
+#[test]
+fn create_table_without_rowid_strict() {
+    assert_complete_full("CREATE TABLE t (a INT PRIMARY KEY) WITHOUT ROWID, STRICT");
+}
+
+#[test]
+fn create_table_if_not_exists() {
+    assert_complete_full("CREATE TABLE IF NOT EXISTS t (a INT)");
+}
+
+#[test]
+fn create_temp_table() {
+    assert_complete_full("CREATE TEMP TABLE t (a INT)");
+    assert_complete_full("CREATE TEMPORARY TABLE t (a INT)");
+}
+
+#[test]
+fn create_table_as_select() {
+    assert_complete_full("CREATE TABLE t AS SELECT * FROM s");
+}
+
+#[test]
+fn create_table_multi_word_types() {
+    assert_complete_full(
+        "CREATE TABLE t (a DOUBLE PRECISION, b UNSIGNED BIG INT, c VARCHAR(255), d NUMERIC(10, 2))",
+    );
+}
+
+#[test]
+fn drop_table_basic() {
+    assert_complete_full("DROP TABLE t");
+}
+
+#[test]
+fn drop_table_if_exists() {
+    assert_complete_full("DROP TABLE IF EXISTS t");
+}
+
+#[test]
+fn alter_table_rename_to() {
+    assert_complete_full("ALTER TABLE t RENAME TO t2");
+}
+
+#[test]
+fn alter_table_rename_column() {
+    assert_complete_full("ALTER TABLE t RENAME COLUMN a TO b");
+    assert_complete_full("ALTER TABLE t RENAME a TO b");
+}
+
+#[test]
+fn alter_table_add_column() {
+    assert_complete_full("ALTER TABLE t ADD COLUMN c INT DEFAULT 0");
+    assert_complete_full("ALTER TABLE t ADD c INT");
+}
+
+#[test]
+fn alter_table_drop_column() {
+    assert_complete_full("ALTER TABLE t DROP COLUMN c");
+    assert_complete_full("ALTER TABLE t DROP c");
+}
+
+#[test]
+fn create_table_column_kinds() {
+    let input = "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)";
+    let (caps, kinds) = assert_complete_full(input);
+    // Table name and type names are @type.
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert!(
+        types.contains(&"users"),
+        "expected users as @type, got {types:?}"
+    );
+    assert!(
+        types.contains(&"INTEGER"),
+        "expected INTEGER as @type, got {types:?}"
+    );
+    assert!(
+        types.contains(&"TEXT"),
+        "expected TEXT as @type, got {types:?}"
+    );
+    // Column names are @variable.
+    let vars = spans_for(&caps, &kinds, "variable", input);
+    assert!(
+        vars.contains(&"id"),
+        "expected id as @variable, got {vars:?}"
+    );
+    assert!(
+        vars.contains(&"name"),
+        "expected name as @variable, got {vars:?}"
+    );
+}
+
+#[test]
 fn window_captures_include_over_and_partition() {
     let input = "SELECT SUM(x) OVER (PARTITION BY y ORDER BY z) FROM t";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -1,12 +1,15 @@
 use std::collections::HashSet;
+use std::sync::OnceLock;
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 
-fn compile_sql() -> Program {
-    pegc::compile(SQLITE_GRAMMAR).expect("SQLite grammar should compile")
+fn compile_sql() -> &'static Program {
+    static SQLITE_PROGRAM: OnceLock<Program> = OnceLock::new();
+    SQLITE_PROGRAM
+        .get_or_init(|| pegc::compile(SQLITE_GRAMMAR).expect("SQLite grammar should compile"))
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
@@ -56,6 +59,15 @@ fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
         input
     );
     (caps, kinds)
+}
+
+fn assert_rejects(input: &str) {
+    let (matched, _caps, _kinds, complete) = run(input);
+    assert!(
+        !complete || matched < input.len(),
+        "expected rejection for {:?}, got complete full-input match",
+        input
+    );
 }
 
 #[test]
@@ -404,4 +416,23 @@ fn quoted_identifiers() {
     assert_complete_full("SELECT \"a\".\"b\" FROM \"a\"");
     assert_complete_full("SELECT `a`.`b` FROM `a`");
     assert_complete_full("SELECT [a].[b] FROM [a]");
+}
+
+#[test]
+fn non_reserved_words_parse_as_identifiers() {
+    // Guards the longest-first invariant in `keyword_word`: words that
+    // look like dialect vocabulary but are not reserved in SQLite must
+    // still parse as bare identifiers in column/table position.
+    assert_complete_full("SELECT integer FROM t");
+    assert_complete_full("SELECT recursive FROM t");
+    assert_complete_full("SELECT window FROM t WHERE fail = 1");
+    assert_complete_full("SELECT x FROM natural_joins");
+}
+
+#[test]
+fn rejects_blatantly_invalid_input() {
+    // Seeds `assert_rejects` usage. Two consecutive SELECTs without a
+    // separator or expression between them are never valid.
+    assert_rejects("SELECT SELECT");
+    assert_rejects("SELECT FROM");
 }

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -521,6 +521,97 @@ fn top_level_window_clause() {
 }
 
 #[test]
+fn insert_values_basic() {
+    assert_complete_full("INSERT INTO t VALUES (1, 2, 3)");
+}
+
+#[test]
+fn insert_with_column_list() {
+    assert_complete_full("INSERT INTO t (a, b) VALUES (1, 2)");
+}
+
+#[test]
+fn insert_multi_row_values() {
+    assert_complete_full("INSERT INTO t (a) VALUES (1), (2), (3)");
+}
+
+#[test]
+fn insert_default_values() {
+    assert_complete_full("INSERT INTO t DEFAULT VALUES");
+}
+
+#[test]
+fn insert_from_select() {
+    assert_complete_full("INSERT INTO t SELECT * FROM s");
+}
+
+#[test]
+fn insert_or_variants() {
+    for prefix in [
+        "INSERT OR REPLACE",
+        "INSERT OR ROLLBACK",
+        "INSERT OR ABORT",
+        "INSERT OR FAIL",
+        "INSERT OR IGNORE",
+    ] {
+        let input = format!("{prefix} INTO t VALUES (1)");
+        assert_complete_full(&input);
+    }
+}
+
+#[test]
+fn replace_shorthand() {
+    // Bare REPLACE INTO is equivalent to INSERT OR REPLACE.
+    assert_complete_full("REPLACE INTO t VALUES (1)");
+}
+
+#[test]
+fn insert_with_alias() {
+    assert_complete_full("INSERT INTO t AS x (a) VALUES (1)");
+}
+
+#[test]
+fn insert_on_conflict_do_nothing() {
+    assert_complete_full("INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO NOTHING");
+}
+
+#[test]
+fn insert_on_conflict_do_update() {
+    assert_complete_full(
+        "INSERT INTO t (a, b) VALUES (1, 2) \
+         ON CONFLICT (a) DO UPDATE SET b = excluded.b WHERE b > 0",
+    );
+}
+
+#[test]
+fn insert_on_conflict_without_target() {
+    assert_complete_full("INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING");
+}
+
+#[test]
+fn insert_returning_star() {
+    assert_complete_full("INSERT INTO t VALUES (1) RETURNING *");
+}
+
+#[test]
+fn insert_returning_columns() {
+    assert_complete_full("INSERT INTO t (a, b) VALUES (1, 2) RETURNING a, b AS bb");
+}
+
+#[test]
+fn insert_with_cte() {
+    assert_complete_full("WITH src AS (SELECT 1 AS a) INSERT INTO t (a) SELECT a FROM src");
+}
+
+#[test]
+fn insert_into_emits_type_on_table() {
+    let input = "INSERT INTO t VALUES (1)";
+    let (caps, kinds) = assert_complete_full(input);
+    let types = spans_for(&caps, &kinds, "type", input);
+    assert_eq!(types, vec!["t"]);
+}
+
+#[test]
 fn window_captures_include_over_and_partition() {
     let input = "SELECT SUM(x) OVER (PARTITION BY y ORDER BY z) FROM t";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -442,6 +442,11 @@ fn non_reserved_words_parse_as_identifiers() {
     assert_complete_full("SELECT recursive FROM t");
     assert_complete_full("SELECT partition FROM t WHERE following = 1");
     assert_complete_full("SELECT x FROM natural_joins");
+    // `key` and `do` are syntactically keywords (PRIMARY KEY, DO
+    // UPDATE) but too common as column / alias names to reserve.
+    assert_complete_full("SELECT key FROM config WHERE key = 'x'");
+    assert_complete_full("INSERT INTO config (key, value) VALUES ('k', 'v')");
+    assert_complete_full("SELECT * FROM orders AS do");
 }
 
 #[test]

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -84,6 +84,21 @@ fn grammar_parses_and_compiles() {
 }
 
 #[test]
+fn bytecode_size_within_expected_range() {
+    // Soft guard: the full dialect currently compiles to ~5.6k
+    // instructions. A drift outside this bracket probably means
+    // something either shrank surprisingly (a regression) or grew
+    // surprisingly (review warranted). Recompute if the change is
+    // intentional.
+    let n_instr = compile_sql().code.len();
+    assert!(
+        (4500..=7500).contains(&n_instr),
+        "bytecode size {n_instr} outside expected range [4500, 7500]; \
+         recompute the bracket if this is an intentional change"
+    );
+}
+
+#[test]
 fn capture_kinds_are_only_theme_kinds() {
     let prog = compile_sql();
     let expected: HashSet<&str> = [

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -425,7 +425,7 @@ fn non_reserved_words_parse_as_identifiers() {
     // still parse as bare identifiers in column/table position.
     assert_complete_full("SELECT integer FROM t");
     assert_complete_full("SELECT recursive FROM t");
-    assert_complete_full("SELECT window FROM t WHERE fail = 1");
+    assert_complete_full("SELECT partition FROM t WHERE following = 1");
     assert_complete_full("SELECT x FROM natural_joins");
 }
 
@@ -435,4 +435,100 @@ fn rejects_blatantly_invalid_input() {
     // separator or expression between them are never valid.
     assert_rejects("SELECT SELECT");
     assert_rejects("SELECT FROM");
+}
+
+#[test]
+fn with_recursive_accepted() {
+    assert_complete_full(
+        "WITH RECURSIVE counter(n) AS (SELECT 1 UNION ALL SELECT n FROM counter) \
+         SELECT n FROM counter",
+    );
+}
+
+#[test]
+fn with_non_recursive_still_works() {
+    // The RECURSIVE token is optional — classic CTE shape must stay valid.
+    assert_complete_full("WITH t AS (SELECT 1) SELECT * FROM t");
+}
+
+#[test]
+fn window_function_empty_over() {
+    assert_complete_full("SELECT COUNT(*) OVER () FROM t");
+}
+
+#[test]
+fn window_function_partition_by() {
+    assert_complete_full("SELECT SUM(x) OVER (PARTITION BY y) FROM t");
+}
+
+#[test]
+fn window_function_order_by() {
+    assert_complete_full("SELECT SUM(x) OVER (ORDER BY y) FROM t");
+}
+
+#[test]
+fn window_function_partition_and_order() {
+    assert_complete_full("SELECT SUM(x) OVER (PARTITION BY a ORDER BY b DESC) FROM t");
+}
+
+#[test]
+fn window_frame_rows_between() {
+    assert_complete_full(
+        "SELECT SUM(x) OVER (ORDER BY y ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t",
+    );
+}
+
+#[test]
+fn window_frame_range_exclude_ties() {
+    assert_complete_full(
+        "SELECT AVG(x) OVER (ORDER BY y RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING EXCLUDE TIES) \
+         FROM t",
+    );
+}
+
+#[test]
+fn window_frame_groups() {
+    assert_complete_full(
+        "SELECT MAX(x) OVER (ORDER BY y GROUPS 3 PRECEDING EXCLUDE CURRENT ROW) FROM t",
+    );
+}
+
+#[test]
+fn window_frame_exclude_no_others() {
+    assert_complete_full(
+        "SELECT SUM(x) OVER (ORDER BY y ROWS UNBOUNDED PRECEDING EXCLUDE NO OTHERS) FROM t",
+    );
+}
+
+#[test]
+fn filter_clause() {
+    assert_complete_full("SELECT SUM(x) FILTER (WHERE y > 0) FROM t");
+}
+
+#[test]
+fn filter_with_over() {
+    assert_complete_full("SELECT SUM(x) FILTER (WHERE y > 0) OVER (PARTITION BY z) FROM t");
+}
+
+#[test]
+fn over_named_window() {
+    assert_complete_full("SELECT SUM(x) OVER w FROM t WINDOW w AS (PARTITION BY y)");
+}
+
+#[test]
+fn top_level_window_clause() {
+    assert_complete_full("SELECT x FROM t WINDOW w1 AS (PARTITION BY a), w2 AS (ORDER BY b)");
+}
+
+#[test]
+fn window_captures_include_over_and_partition() {
+    let input = "SELECT SUM(x) OVER (PARTITION BY y ORDER BY z) FROM t";
+    let (caps, kinds) = assert_complete_full(input);
+    let ks = kinds_for(&caps, &kinds);
+    let kw_count = ks.iter().filter(|k| **k == "keyword").count();
+    // SELECT OVER PARTITION BY ORDER BY FROM = 7 keywords at minimum.
+    assert!(
+        kw_count >= 7,
+        "expected >=7 keywords, got {kw_count}: {ks:?}"
+    );
 }

--- a/tests/highlight_sql_tests.rs
+++ b/tests/highlight_sql_tests.rs
@@ -195,6 +195,25 @@ fn partial_match_renders_prefix_styled_and_tail_plain() {
 }
 
 #[test]
+fn large_fixture_parses_to_completion() {
+    // Round-trip on the memo-bench fixture: every byte must parse.
+    // This is the end-to-end guard that catches false-reject regressions
+    // (e.g. reserving an identifier that real SQL uses as a column name).
+    let input = include_str!("../benches/fixtures/large.sql");
+    let mut h = Highlighter::new(SQLITE_GRAMMAR).expect("grammar compiles");
+    h.set_input(input.to_string());
+    let (matched, _caps) = h.captures();
+    assert_eq!(
+        matched,
+        input.len(),
+        "expected full parse of benches/fixtures/large.sql; stopped at byte {} before {:?}",
+        matched,
+        &input[matched..matched.saturating_add(80).min(input.len())]
+    );
+    assert_eq!(strip_ansi(&h.highlight()), input, "round-trip must hold");
+}
+
+#[test]
 fn multi_statement_error_recovery() {
     // The full SQLite grammar exercises farthest-failure tracking across
     // a `;`-separated script: DDL and DML preceding a malformed chunk

--- a/tests/highlight_sql_tests.rs
+++ b/tests/highlight_sql_tests.rs
@@ -193,3 +193,34 @@ fn partial_match_renders_prefix_styled_and_tail_plain() {
         out
     );
 }
+
+#[test]
+fn multi_statement_error_recovery() {
+    // The full SQLite grammar exercises farthest-failure tracking across
+    // a `;`-separated script: DDL and DML preceding a malformed chunk
+    // should stay styled; the tail from `!!!` onward renders plain.
+    let input = "CREATE TABLE t (a INTEGER);\n\
+                 INSERT INTO t VALUES (1);\n\
+                 !!! oops\n\
+                 SELECT * FROM t;";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input, "round-trip must hold");
+    assert!(
+        out.contains(theme::color_for("keyword")),
+        "expected the CREATE/INSERT prefix to carry keyword styling"
+    );
+    assert!(
+        out.contains("!!! oops"),
+        "invalid middle chunk must render verbatim"
+    );
+    // The trailing SELECT is past the farthest-failure point, so it
+    // renders plain rather than styled.
+    let tail_idx = out
+        .find("!!! oops")
+        .expect("garbage marker must appear in output");
+    let tail = &out[tail_idx..];
+    assert!(
+        !tail.contains(theme::color_for("keyword")),
+        "tail past the error should render without styling, got {tail:?}"
+    );
+}


### PR DESCRIPTION
Lands the "full SQLite dialect" deliverable for the README's [*More language grammars*](https://github.com/stefanobaghino/syntax-highlighter/blob/main/README.md#standalone-additions) roadmap bullet: DML (INSERT with UPSERT + RETURNING, UPDATE with FROM, DELETE), DDL (CREATE/DROP/ALTER TABLE with the full constraint vocabulary, INDEX, VIEW, TRIGGER, VIRTUAL TABLE), transactions and savepoints, PRAGMA, EXPLAIN [QUERY PLAN], and admin statements (VACUUM, ATTACH/DETACH, REINDEX, ANALYZE) — plus WITH RECURSIVE and window functions on the SELECT side.

## Shape of the change

10 milestone commits + a pragmatic follow-up; each builds and tests green on its own. Sequenced so every intermediate state still parses the prior SELECT fixture:

- `bdc8c19` — Reshape `keyword_word` longest-first; seed shadowing regressions
- `185fd32` — Add WITH RECURSIVE and window functions to SELECT
- `3468633` — Add INSERT with UPSERT, RETURNING, and INSERT OR variants
- `697806c` — Add UPDATE and DELETE, sharing SELECT machinery
- `829f904` — Add CREATE / DROP / ALTER TABLE with full constraint vocabulary
- `00787db` — Add CREATE / DROP INDEX and VIEW
- `1fcf202` — Add CREATE / DROP TRIGGER with DML body
- `93107fd` — Add transactions and savepoints
- `57e2373` — Add PRAGMA, admin statements, EXPLAIN wrapper, CREATE VIRTUAL TABLE
- `de9990f` — Lock in full-dialect docs, fixture, and bytecode-size bracket
- `e925ffa` — Un-reserve KEY and DO; add large-fixture round-trip guard

## Large-grammar bytecode-size datapoint

The roadmap called this expansion out specifically as the first large-grammar sizing datapoint:

| Grammar          | Instructions | Rules |
|---|---:|---:|
| JSON             |   165 |  ~30 |
| TOML             |   511 |  ~90 |
| **SQLite (full)**| **5,621** | **426** |

Comfortably inside the "kilobyte range per grammar" ambition. Captured by `bytecode_size_within_expected_range` in `tests/grammar_sql_tests.rs` as a soft bracket (4500..=7500); recompute if that's breached intentionally.

## Multi-statement error-recovery use case

`multi_statement_error_recovery` in `tests/highlight_sql_tests.rs` exercises the farthest-failure machinery across a `;`-separated script that includes DDL + DML + malformed garbage + trailing SELECT — the partial-match contract that single-SELECT never got to stress. This is the second deliverable the roadmap named; the real error-recovery feature itself remains a roadmap item.

## Grammar-authoring pain surfaced by the expansion

Three surface-language improvements this PR motivates but does not implement, now with post-expansion data:

- [#5](https://github.com/stefanobaghino/syntax-highlighter/issues/5) — case-insensitive literals (150 `*_body` rules could collapse)
- [#6](https://github.com/stefanobaghino/syntax-highlighter/issues/6) — word-boundary / parameterized-rule sugar (145 `!ident_char` sites + 86 `@punctuation{…}` + 29 `@operator{…}`)
- [#13](https://github.com/stefanobaghino/syntax-highlighter/issues/13) — `keyword_word` ordering invariant (new; the correctness-sensitive hand-sort that tripped several times across the commit sequence)

## Test plan

CI covers everything new — `cargo fmt`, `cargo clippy -D warnings`, `cargo build`, `cargo test`. The grammar suite grew from 30 to 133 tests; highlight suite from 15 to 17. The only check not in CI is `cargo run -- benches/fixtures/large.sql | strip-ansi | diff -` as a visual smoke; the `large_fixture_parses_to_completion` test in `tests/highlight_sql_tests.rs` is the automated version of that signal and would catch the same regressions.