### PR TITLE
Add error recovery via `*^` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
+Grammars that opt into the `*^` recovery operator on a top-level
+repetition resync past broken regions instead — see the SQL grammar
+(`grammars/sqlite.peg`) for the shipped example.
 
 `Highlighter` owns its input and reuses the memo table across edits:
 append-only streaming and arbitrary-position edits reparse only the
@@ -79,9 +82,11 @@ printf 'SELECT id FROM users WHERE active;\n' | cargo run -- -l sql
 ## Grammar format
 
 See `grammars/json.peg` for a complete example. The format follows standard
-PEG notation with a single extension: `@name{pattern}` declares a capture
-with the given highlight name. Names are mapped to ANSI colors by the
-highlighter's built-in theme (see `src/highlight/theme.rs`).
+PEG notation with two extensions: `@name{pattern}` declares a capture with
+the given highlight name (mapped to ANSI colors by the built-in theme in
+`src/highlight/theme.rs`), and `p*^` / `p+^` mark a repetition for
+skip-byte error recovery (see `Pattern::RecoverRepeat` in
+`src/pegc/pattern.rs` and the emission pattern in `src/pegc/compiler.rs`).
 
 ## Roadmap
 
@@ -126,7 +131,10 @@ Each item is a self-contained feature that unlocks further work.
   filter. Warth/Douglass/Millstein 2008 is the seminal paper and the
   most widely cited approach, but it couples seed-and-grow to the memo
   table itself — which would fight the threshold filter — and inherits
-  the nullable-LR bugs Medeiros 2014 §6 documents.
+  the nullable-LR bugs Medeiros 2014 §6 documents. Integration note:
+  the L table must be unwound through the same `fail()` path that
+  already commits `Memo` frames and that the shipped `*^` recovery
+  operator relies on.
 - **Explicit memoization opt-out.** Maybe. Per-rule or per-expression
   annotation (e.g. `Rule <-! body` or `{{! expr }}`) disabling caching
   on named hot spots. Grammar authors should not have to reason about
@@ -141,17 +149,6 @@ Each item is a self-contained feature that unlocks further work.
   also expose a `Parser::from_program(Program)` constructor so the deep
   `parser` module accepts pre-compiled bytecode without callers falling
   back to the `pegvm` primitives.
-- **Error recovery / parsing past syntax errors.** PEG is strict by
-  default — a parse either succeeds or fails. For syntax highlighting,
-  the input is frequently incomplete or malformed (mid-edit buffers,
-  streaming responses, in-progress code). The ability to recover past
-  a syntax error and continue highlighting the rest of the input is
-  important; this is a real extension to the VM and a known research
-  area in PEG implementations. If left recursion lands first, the
-  recovery protocol must unwind Medeiros' L table consistently
-  alongside the VM stack — analogous to how `fail()` already handles
-  `Memo` frames.
-
 ### Self-hosting — parsing PEG grammars using pegvm itself
 
 The long-form project: replace the hand-written recursive-descent parser

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -39,7 +39,7 @@
 
 # --- Top level --------------------------------------------------------
 
-sql_file   <- ws (statement (stmt_sep statement)*)? stmt_sep? ws !.
+sql_file   <- ws (statement stmt_sep?)*^ ws !.
 stmt_sep   <- ws @punctuation{';'} ws
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -41,6 +41,16 @@
 //! rather than the whole input going unstyled on the first character
 //! that fails to parse.
 //!
+//! Grammars that opt into the `p*^` recovery operator (see
+//! [`crate::pegc::Pattern::RecoverRepeat`]) can do better: the VM
+//! resyncs past failed inner attempts, emitting `recovery`-kind
+//! captures over the skipped bytes. The renderer is kind-agnostic and
+//! `recovery` maps to the empty ANSI string by default
+//! ([`theme::color_for`]), so recovered regions render verbatim
+//! between styled regions in a single pass — no separate "tail plain"
+//! code path. The strip-ANSI invariant below holds across recovery
+//! boundaries.
+//!
 //! # UTF-8 invariant
 //!
 //! `Parser` stores input as bytes. `Highlighter` accepts only

--- a/src/highlight/theme.rs
+++ b/src/highlight/theme.rs
@@ -15,6 +15,10 @@ pub fn color_for(kind: &str) -> &'static str {
         "constant" => "\x1b[35m",    // magenta
         "property" => "\x1b[36m",    // cyan
         "variable" => "\x1b[37m",    // white
+        // `recovery` captures (emitted by `*^` resync loops) render
+        // verbatim by default. Explicit entry so a user theme can
+        // override without falling back through the unknown branch.
+        "recovery" => "",
         _ => "",
     }
 }

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -180,6 +180,42 @@ impl Compiler {
                 self.compile_pat(inner);
                 self.emit(Instruction::CaptureEnd);
             }
+            Pattern::RecoverRepeat {
+                inner,
+                recovery_kind,
+            } => {
+                // loop_top: Choice rec
+                //           <inner>
+                //           Commit loop_top
+                // rec:      Choice exit       ; Any(1) at EOF exits cleanly
+                //           CaptureBegin <recovery_kind>
+                //           Any(1)
+                //           CaptureEnd
+                //           Commit loop_top
+                // exit:
+                //
+                // Uses fresh Choice/Commit per iteration (not PartialCommit) so
+                // each retry gets a backtrack baseline at the advanced sp; an
+                // in-place PartialCommit on a stale frame would violate the
+                // hazard documented in src/pegvm/README.md invariant 1.
+                let kind = self.intern_capture(recovery_kind);
+                let loop_top = self.pos();
+                let outer_choice = self.emit(Instruction::Choice(Label(0))); // → rec
+                self.compile_pat(inner);
+                self.emit(Instruction::Commit(Label(loop_top)));
+
+                let rec = self.pos();
+                self.patch_jump(outer_choice, rec);
+
+                let inner_choice = self.emit(Instruction::Choice(Label(0))); // → exit
+                self.emit(Instruction::CaptureBegin(kind));
+                self.emit(Instruction::Any(1));
+                self.emit(Instruction::CaptureEnd);
+                self.emit(Instruction::Commit(Label(loop_top)));
+
+                let exit = self.pos();
+                self.patch_jump(inner_choice, exit);
+            }
         }
     }
 }

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -183,11 +183,32 @@ impl<'a> Parser<'a> {
             match self.peek() {
                 Some(b'*') => {
                     self.pos += 1;
-                    atom = Pattern::Repeat(Box::new(atom));
+                    if self.peek() == Some(b'^') {
+                        self.pos += 1;
+                        atom = Pattern::RecoverRepeat {
+                            inner: Box::new(atom),
+                            recovery_kind: "recovery".into(),
+                        };
+                    } else {
+                        atom = Pattern::Repeat(Box::new(atom));
+                    }
                 }
                 Some(b'+') => {
                     self.pos += 1;
-                    atom = Pattern::RepeatOne(Box::new(atom));
+                    if self.peek() == Some(b'^') {
+                        self.pos += 1;
+                        // p+^  ≡  p (p*^)  — at least one inner success required.
+                        let head = atom.clone();
+                        atom = Pattern::seq(vec![
+                            head,
+                            Pattern::RecoverRepeat {
+                                inner: Box::new(atom),
+                                recovery_kind: "recovery".into(),
+                            },
+                        ]);
+                    } else {
+                        atom = Pattern::RepeatOne(Box::new(atom));
+                    }
                 }
                 Some(b'?') => {
                     self.pos += 1;

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -14,6 +14,17 @@ pub enum Pattern {
     AndPredicate(Box<Pattern>),
     NonTerminal(String),
     Capture(String, Box<Pattern>),
+    /// Like `Repeat`, but resync past failures inside the loop by
+    /// consuming one byte under a capture tagged with `recovery_kind`
+    /// and retrying. At end of input the loop terminates cleanly.
+    ///
+    /// Inherits the empty-match livelock of `Repeat`: if `inner` ever
+    /// matches the empty string successfully, the enclosing loop spins
+    /// forever — same hazard as plain `p*`.
+    RecoverRepeat {
+        inner: Box<Pattern>,
+        recovery_kind: String,
+    },
 }
 
 impl Pattern {

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -38,6 +38,7 @@ Every other type in the module exists to serve one of these three stages.
 | `AndPredicate(Box<Pattern>)` | `&p` | Zero-width: succeeds iff `p` would succeed here. Consumes no input. |
 | `NonTerminal(String)` | `rule_name` | References another `Pattern` in the enclosing `Grammar`. |
 | `Capture(String, Box<Pattern>)` | `@name{p}` | Matches `p`; additionally records the matched span under the tag `name`. |
+| `RecoverRepeat { inner, recovery_kind }` | `p*^` / `p+^` | Like `Repeat` / `RepeatOne`, but resync past failures inside the loop by consuming one byte under a capture tagged `recovery_kind` and retrying. The loop terminates cleanly at end of input. |
 
 A `Pattern` is a plain value. It can be constructed programmatically (see the compiler tests) or produced by `pegc::parse` from text. A `Pattern` has no knowledge of its environment: a `NonTerminal("digit")` is a dangling reference until it's placed inside a `Grammar` that defines `digit`.
 
@@ -181,6 +182,8 @@ A `MatchResult` is always returned. The `complete` flag distinguishes the two ca
 
 This partial result is what lets the highlighter render a styled prefix and a plain tail for malformed input, without the VM knowing anything about highlighting.
 
+A grammar that opts into the `*^` recovery operator on a top-level repetition can flip a parse that would otherwise be partial into `complete: true`: the loop emits `recovery_kind`-tagged captures over the bytes it skipped past inner failures and exits cleanly at end of input. Captures returned in that case interleave the successful `inner` captures with the recovery captures in input order.
+
 ## Error types
 
 The module has two error types, one per transformation in the pipeline that can fail ahead of time:
@@ -202,6 +205,7 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 5. **Memo replay is absolute-sp.** Cached captures carry the original `start`/`end` byte offsets; a `MemoOpen` hit only fires when `sp == start_sp`, so the stored values are replayed verbatim. Entries are inserted as already-closed `OpenCapture`s so the enclosing `CaptureEnd`'s innermost-still-open search (`rposition(c.end.is_none())`) binds to the caller's open capture rather than a replayed one.
 6. **`VM::fail` records every `Memo` frame it traverses.** When unwinding to find a `Backtrack`, each `Memo` frame encountered is committed as a failure entry before being discarded. Silently dropping a frame would leak re-executions on future calls at the same sp. The loop is an exhaustive `match` over `StackEntry` specifically to make omissions a compiler error.
 7. **`MemoOpen` calls `maybe_snapshot` after applying a success hit.** The hit advances `sp` past code that didn't execute; without the snapshot call the farthest-failure bookkeeping would miss the advance and `MatchResult.complete == false` would report a stale deepest point.
+8. **`RecoverRepeat` emits a fresh `Choice`/`Commit` pair per iteration, never `PartialCommit`.** The loop's retry baseline must sit at the *advanced* `sp` after each successful iteration; `PartialCommit`'s in-place mutation of a stale backtrack frame would corrupt that baseline and re-trigger invariant 1's hazard. See `compile_pat`'s `RecoverRepeat` arm in `src/pegc/compiler.rs`.
 
 ## References
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -811,4 +811,40 @@ mod examined_max_tests {
             "start's execution examined up to position 3"
         );
     }
+
+    #[test]
+    fn recover_repeat_propagates_examined_max_through_loop_iterations() {
+        // start <- ("ab")*^   against "abxab"
+        //
+        // The recovery loop runs entirely inside start's memo entry.
+        // Across iterations the loop reads positions 0, 1 (success),
+        // 2 (Char 'a' fails on 'x'), 2 (Any(1) consumes 'x' → sp=3),
+        // 3, 4 (success), 5 (Char 'a' at EOF). Whether the failed
+        // EOF read at sp=5 contributes depends on track_read's call
+        // discipline, so the assertion is a lower bound: every
+        // position the loop *successfully* read must appear in
+        // examined_max.
+        let mut rules = HashMap::new();
+        rule(
+            &mut rules,
+            "start",
+            Pattern::RecoverRepeat {
+                inner: Box::new(Pattern::literal("ab")),
+                recovery_kind: "recovery".into(),
+            },
+        );
+        let prog = Grammar::new(rules, "start").compile().unwrap();
+        let (result, _stats, memo) = VM::new(&prog.code, b"abxab")
+            .with_memo_threshold(0)
+            .run_core();
+        assert!(result.complete);
+        assert_eq!(result.matched, 5);
+        let entry = memo.get(&(MemoId(0), 0)).expect("start entry missing");
+        assert_eq!(entry.end_sp, Some(5));
+        assert!(
+            entry.examined_max >= 5,
+            "recovery-loop reads must propagate to enclosing rule's watermark; got {}",
+            entry.examined_max
+        );
+    }
 }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -182,6 +182,121 @@ fn repeat_one_or_more() {
     );
 }
 
+fn recover(inner: Pattern, kind: &str) -> Pattern {
+    Pattern::RecoverRepeat {
+        inner: Box::new(inner),
+        recovery_kind: kind.into(),
+    }
+}
+
+#[test]
+fn recover_repeat_empty_input() {
+    let p = recover(Pattern::literal("a"), "recovery");
+    assert_eq!(
+        run_pattern(&p, b""),
+        MatchResult {
+            matched: 0,
+            captures: vec![],
+            complete: true,
+        }
+    );
+}
+
+#[test]
+fn recover_repeat_all_inner_matches_emit_no_recovery_captures() {
+    let p = recover(Pattern::literal("a"), "recovery");
+    assert_eq!(
+        run_pattern(&p, b"aaa"),
+        MatchResult {
+            matched: 3,
+            captures: vec![],
+            complete: true,
+        }
+    );
+}
+
+#[test]
+fn recover_repeat_all_garbage_emits_one_recovery_capture_per_byte() {
+    let p = recover(Pattern::literal("a"), "recovery");
+    let r = run_pattern(&p, b"xyz");
+    assert!(r.complete);
+    assert_eq!(r.matched, 3);
+    assert_eq!(
+        r.captures,
+        vec![cap(0, 0, 1), cap(0, 1, 2), cap(0, 2, 3)],
+        "one recovery capture per skipped byte; complete parse at EOF",
+    );
+}
+
+#[test]
+fn recover_repeat_mixed_success_and_recovery() {
+    let p = recover(Pattern::literal("a"), "recovery");
+    let r = run_pattern(&p, b"axa");
+    assert!(r.complete);
+    assert_eq!(r.matched, 3);
+    assert_eq!(
+        r.captures,
+        vec![cap(0, 1, 2)],
+        "successful 'a' iterations emit no captures; the middle 'x' is the only recovery span",
+    );
+}
+
+#[test]
+fn recover_repeat_truncates_failed_inner_attempt_captures() {
+    // inner = @open{"a"} "b" — the @open capture opens before the "b"
+    // that may fail. After a failed attempt, that partial @open must NOT
+    // appear in the result; only successful attempts contribute to it.
+    //
+    // Kind interning order: RecoverRepeat enters before recursing into
+    // inner, so "recovery" interns first (id 0), "open" second (id 1).
+    let inner = Pattern::seq(vec![
+        Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+        Pattern::literal("b"),
+    ]);
+    let p = recover(inner, "recovery");
+    let r = run_pattern(&p, b"axab");
+    assert!(r.complete);
+    assert_eq!(r.matched, 4);
+    assert_eq!(
+        r.captures,
+        vec![
+            cap(0, 0, 1), // recovery: 'a' (failed inner attempt's @open(0,1) is gone)
+            cap(0, 1, 2), // recovery: 'x'
+            cap(1, 2, 3), // @open: the successful 'a' at sp=2
+        ],
+        "the failed inner attempt's open capture must not leak into the result",
+    );
+}
+
+#[test]
+fn recover_repeat_inside_called_rule_returns_cleanly() {
+    // start <- "PRE" loop
+    // loop  <- "a"*^
+    //
+    // Against "PREaxa": the *^ runs to EOF, then start's Return must
+    // pop a Return frame — not a Backtrack frame leaked from the loop.
+    // This is the regression analogue of the PartialCommit hazard
+    // documented in src/pegvm/README.md invariant 1.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::seq(vec![
+            Pattern::literal("PRE"),
+            Pattern::NonTerminal("loop".into()),
+        ]),
+    );
+    rules.insert("loop".into(), recover(Pattern::literal("a"), "recovery"));
+    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let r = VM::new(&prog.code, b"PREaxa").run();
+    assert!(
+        r.complete,
+        "Return after *^ loop must not panic on stack shape"
+    );
+    assert_eq!(r.matched, 6);
+    // Recovery capture for the middle 'x'; the two 'a's matched cleanly.
+    assert_eq!(r.captures, vec![cap(0, 4, 5)]);
+}
+
 #[test]
 fn optional_pattern() {
     let p = Pattern::seq(vec![
@@ -359,6 +474,40 @@ fn repeat_emits_partial_commit() {
             Instruction::End,
         ]
     );
+}
+
+#[test]
+fn recover_repeat_emits_choice_commit_skeleton() {
+    let p = recover(Pattern::literal("a"), "recovery");
+    let prog = compile_pattern(&p);
+    // loop_top: Choice rec
+    //           Char 'a'
+    //           Commit loop_top
+    // rec:      Choice exit
+    //           CaptureBegin recovery
+    //           Any(1)
+    //           CaptureEnd
+    //           Commit loop_top
+    // exit:     End
+    //
+    // The recovery loop uses fresh Choice/Commit per iteration (not
+    // PartialCommit) so each retry's backtrack baseline is at the
+    // advanced sp. See src/pegvm/README.md invariant 1.
+    assert_eq!(
+        prog.code,
+        vec![
+            Instruction::Choice(Label(3)),             // → rec
+            Instruction::Char(b'a'),                   // <inner>
+            Instruction::Commit(Label(0)),             // → loop_top
+            Instruction::Choice(Label(8)),             // rec: → exit
+            Instruction::CaptureBegin(CaptureKind(0)), // recovery
+            Instruction::Any(1),
+            Instruction::CaptureEnd,
+            Instruction::Commit(Label(0)), // → loop_top
+            Instruction::End,              // exit
+        ]
+    );
+    assert_eq!(prog.capture_kinds, vec!["recovery".to_string()]);
 }
 
 #[test]

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -61,12 +61,21 @@ fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
     (caps, kinds)
 }
 
-fn assert_rejects(input: &str) {
-    let (matched, _caps, _kinds, complete) = run(input);
+/// Assert that the input is not a clean parse: either the VM rejects
+/// it outright, or `sql_file`'s top-level `*^` resync salvages it by
+/// emitting at least one `recovery` capture. Either way, the input is
+/// not a sequence of well-formed statements.
+fn assert_not_clean_parse(input: &str) {
+    let (matched, caps, kinds, complete) = run(input);
+    let parse_failed = !complete || matched < input.len();
+    let recovery_idx = kinds.iter().position(|k| k == "recovery");
+    let has_recovery = recovery_idx
+        .map(|i| caps.iter().any(|c| c.kind.0 as usize == i))
+        .unwrap_or(false);
     assert!(
-        !complete || matched < input.len(),
-        "expected rejection for {:?}, got complete full-input match",
-        input
+        parse_failed || has_recovery,
+        "expected {:?} to fail or trigger recovery, got clean full-input match",
+        input,
     );
 }
 
@@ -112,6 +121,9 @@ fn capture_kinds_are_only_theme_kinds() {
         "function",
         "constant",
         "variable",
+        // Emitted by `sql_file`'s top-level `*^` resync loop; mapped
+        // to verbatim output by src/highlight/theme.rs.
+        "recovery",
     ]
     .into_iter()
     .collect();
@@ -450,11 +462,13 @@ fn non_reserved_words_parse_as_identifiers() {
 }
 
 #[test]
-fn rejects_blatantly_invalid_input() {
-    // Seeds `assert_rejects` usage. Two consecutive SELECTs without a
-    // separator or expression between them are never valid.
-    assert_rejects("SELECT SELECT");
-    assert_rejects("SELECT FROM");
+fn blatantly_invalid_input_is_not_a_clean_parse() {
+    // Two consecutive SELECTs without a separator or expression between
+    // them are never valid as a single clean parse — `sql_file`'s
+    // top-level `*^` either rejects or salvages such input via the
+    // `recovery` capture, but never accepts it as well-formed.
+    assert_not_clean_parse("SELECT SELECT");
+    assert_not_clean_parse("SELECT FROM");
 }
 
 #[test]
@@ -1026,10 +1040,11 @@ fn explain_variants() {
 }
 
 #[test]
-fn explain_explain_rejected() {
+fn explain_explain_is_not_a_clean_parse() {
     // `EXPLAIN EXPLAIN ...` is not valid — explain_stmt wraps
-    // statement_body, not statement.
-    assert_rejects("EXPLAIN EXPLAIN SELECT 1");
+    // statement_body, not statement. Top-level `*^` may salvage it,
+    // but the inner statement parse must not accept the nesting.
+    assert_not_clean_parse("EXPLAIN EXPLAIN SELECT 1");
 }
 
 #[test]

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -63,6 +63,34 @@ fn postfix_operators() {
 }
 
 #[test]
+fn recover_repeat_postfix_star_caret() {
+    let g = parse("r <- 'x'*^");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::RecoverRepeat {
+            inner: Box::new(Pattern::literal("x")),
+            recovery_kind: "recovery".into(),
+        }
+    );
+}
+
+#[test]
+fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
+    // p+^  ≡  p (p*^)  — at least one inner success required.
+    let g = parse("r <- 'x'+^");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            Pattern::RecoverRepeat {
+                inner: Box::new(Pattern::literal("x")),
+                recovery_kind: "recovery".into(),
+            },
+        ])
+    );
+}
+
+#[test]
 fn predicate_operators() {
     let g = parse("a <- !'x' .\nb <- &'y' 'y'");
     assert_eq!(
@@ -179,6 +207,25 @@ fn end_to_end_grammar_compile_run() {
     let r = VM::new(&prog.code, b"42abc").run();
     assert!(r.complete);
     assert_eq!(r.matched, 2);
+}
+
+#[test]
+fn end_to_end_recover_repeat_compile_run() {
+    use syntax_highlighter::pegvm::VM;
+    // Top-level `*^` resyncs past garbage one byte at a time; the parse
+    // completes at EOF, with one "recovery"-tagged capture per skipped byte.
+    let g = parse("doc <- @kw{\"foo\"}*^");
+    let prog = g.compile().unwrap();
+    let r = VM::new(&prog.code, b"fooXXfoo").run();
+    assert!(r.complete);
+    assert_eq!(r.matched, 8);
+    // Capture-kind interning order in the bytecode: "recovery" first
+    // (RecoverRepeat enters before its inner), "kw" second.
+    assert_eq!(prog.capture_kinds, vec!["recovery", "kw"]);
+    let kinds: Vec<u16> = r.captures.iter().map(|c| c.kind.0).collect();
+    let spans: Vec<(usize, usize)> = r.captures.iter().map(|c| (c.start, c.end)).collect();
+    assert_eq!(kinds, vec![1, 0, 0, 1]);
+    assert_eq!(spans, vec![(0, 3), (3, 4), (4, 5), (5, 8)]);
 }
 
 #[test]

--- a/tests/highlight_sql_tests.rs
+++ b/tests/highlight_sql_tests.rs
@@ -215,31 +215,31 @@ fn large_fixture_parses_to_completion() {
 
 #[test]
 fn multi_statement_error_recovery() {
-    // The full SQLite grammar exercises farthest-failure tracking across
-    // a `;`-separated script: DDL and DML preceding a malformed chunk
-    // should stay styled; the tail from `!!!` onward renders plain.
+    // `sql_file` opts the top-level statement loop into `*^` resync:
+    // every well-formed statement around a malformed chunk stays styled,
+    // the malformed bytes render verbatim under the `recovery` capture,
+    // and the round-trip invariant holds across the boundary.
     let input = "CREATE TABLE t (a INTEGER);\n\
                  INSERT INTO t VALUES (1);\n\
                  !!! oops\n\
                  SELECT * FROM t;";
     let out = hl(input).highlight();
     assert_eq!(strip_ansi(&out), input, "round-trip must hold");
-    assert!(
-        out.contains(theme::color_for("keyword")),
-        "expected the CREATE/INSERT prefix to carry keyword styling"
-    );
-    assert!(
-        out.contains("!!! oops"),
-        "invalid middle chunk must render verbatim"
-    );
-    // The trailing SELECT is past the farthest-failure point, so it
-    // renders plain rather than styled.
+    let kw = theme::color_for("keyword");
+    // CREATE / INSERT (prefix) and SELECT / FROM (tail) all keyword-styled.
+    assert!(out.contains(kw), "expected keyword styling somewhere");
     let tail_idx = out
         .find("!!! oops")
         .expect("garbage marker must appear in output");
     let tail = &out[tail_idx..];
     assert!(
-        !tail.contains(theme::color_for("keyword")),
-        "tail past the error should render without styling, got {tail:?}"
+        tail.contains(kw),
+        "tail past the recovered region must regain keyword styling, got {tail:?}",
+    );
+    // The malformed middle chunk renders verbatim (recovery captures
+    // map to the empty ANSI string by default).
+    assert!(
+        out.contains("!!! oops"),
+        "recovered middle chunk must render verbatim"
     );
 }

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -182,6 +182,35 @@ fn partial_match_renders_prefix_styled_and_tail_plain() {
 }
 
 #[test]
+fn recover_repeat_renders_styled_then_plain_then_styled() {
+    // Synthetic grammar with a single `*^` toplevel: `foo` runs are
+    // keyword-styled, anything else is consumed by the recovery branch
+    // and renders verbatim. Both sides of a recovered region must keep
+    // their styling, and the round-trip invariant must hold.
+    let grammar = "doc <- @keyword{\"foo\"}*^";
+    let mut h = Highlighter::new(grammar).expect("recovery grammar should compile");
+    let input = "foo!fooBARfoo";
+    h.set_input(input.to_string());
+    let out = h.highlight();
+    assert_eq!(
+        strip_ansi(&out),
+        input,
+        "round-trip must hold across recovery"
+    );
+    let kw = theme::color_for("keyword");
+    assert_eq!(
+        out.matches(kw).count(),
+        3,
+        "expected three keyword-styled `foo` runs, got {:?}",
+        out
+    );
+    // The recovered substrings appear verbatim — no ANSI codes wrap them.
+    let after_first = out.find('!').expect("`!` must appear in output");
+    let around = &out[after_first..after_first + 1];
+    assert_eq!(around, "!", "recovery byte must render without styling");
+}
+
+#[test]
 fn unterminated_string_still_round_trips() {
     // The load-bearing strip_ansi invariant must hold even when the input
     // is malformed — partial-match rendering must not reorder, drop, or

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -215,6 +215,34 @@ fn sql_incremental_matches_fresh_across_edit_sequence() {
 }
 
 #[test]
+fn sql_incremental_matches_fresh_across_recovery_boundary_edits() {
+    // `sql_file`'s top-level `*^` produces `recovery` captures around
+    // syntactically-broken chunks. Equivalence with a fresh parse must
+    // hold across edits that move, fix, or introduce such chunks — the
+    // memo cache must not retain stale entries that span an edit
+    // crossing recovery territory.
+    let mut inc = parser_for(
+        SQL_GRAMMAR,
+        "CREATE TABLE t (a INTEGER);\n!!! oops\nSELECT * FROM t;",
+    );
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql recovery initial");
+
+    // Fix the broken middle by replacing the garbage with a real statement.
+    let oops_start = find_subslice(inc.input(), b"!!! oops").unwrap();
+    inc.edit(
+        oops_start,
+        oops_start + "!!! oops".len(),
+        b"INSERT INTO t VALUES (1);",
+    );
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql recovery fixed");
+
+    // Re-introduce a broken chunk at a different position.
+    let select = find_subslice(inc.input(), b"SELECT").unwrap();
+    inc.edit(select, select, b"???\n");
+    assert_equivalent(&inc, SQL_GRAMMAR, "sql recovery reintroduced");
+}
+
+#[test]
 fn append_char_by_char_matches_fresh_on_every_step() {
     // Streaming-LLM scenario: the classic case incremental parsing is
     // designed to accelerate. Equivalence must hold at every single


### PR DESCRIPTION
## Summary

- New PEG postfix operator `p*^` / `p+^` (`Pattern::RecoverRepeat`) for skip-byte error recovery on a repetition: when the inner pattern fails, the loop consumes one byte under a `recovery`-tagged capture and retries until EOF.
- Pure compiler emission over the existing instruction set — no new opcode, no change to `fail()`. See the new invariant 8 in `src/pegvm/README.md` for why the loop uses fresh `Choice`/`Commit` per iteration rather than `PartialCommit`.
- Adopted in `grammars/sqlite.peg`'s `sql_file` top-level loop. The shipped example is `tests/highlight_sql_tests.rs::multi_statement_error_recovery`.

## Test plan

CI covers the full suite, clippy, and fmt. Additional checks run for this PR:

- [x] `cargo bench --bench memo` — per-grammar threshold knee unchanged.
- [x] Manual smoke: `printf 'CREATE TABLE t (a INT);\n!!! oops\nSELECT * FROM t;\n' | cargo run -- -l sql` styles both statements with the malformed middle rendered verbatim.

The bench could be promoted into CI as a soft regression guard if useful; the smoke test is already covered by `multi_statement_error_recovery`.