### PR TITLE
Defer `max_captures` clone until needed

### DIFF
--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -78,7 +78,19 @@ pub struct VM<'p, 'i> {
     stack: Vec<StackEntry>,
     captures: Vec<OpenCapture>,
     max_sp: usize,
-    max_captures: Vec<OpenCapture>,
+    /// Length of `captures` at the moment `sp` reached `max_sp`. The
+    /// captures themselves live in `captures[..max_captures_len]` until a
+    /// `fail()` or `BackCommit` truncates the vector below that watermark,
+    /// at which point `protect_max_captures` materializes a copy into
+    /// `max_captures_saved`. Deferring the clone makes `maybe_snapshot`
+    /// O(1) instead of O(n) per sp-advance — critical on large inputs
+    /// where the eager-clone variant went quadratic in captures count.
+    max_captures_len: usize,
+    /// Populated lazily the first time a truncate would drop captures
+    /// below `max_captures_len`. `None` means the canonical captures
+    /// still reside in `captures[..max_captures_len]`. Cleared whenever
+    /// `max_sp` advances (the prior snapshot becomes stale).
+    max_captures_saved: Option<Vec<OpenCapture>>,
     /// Packrat memo table, keyed by `(memo_id, start_sp)`. Populated by
     /// `MemoClose` on success and by `fail()` on failure escape (Commit 5).
     memo: HashMap<(MemoId, usize), MemoEntry>,
@@ -156,7 +168,8 @@ impl<'p, 'i> VM<'p, 'i> {
             stack: Vec::new(),
             captures: Vec::new(),
             max_sp: 0,
-            max_captures: Vec::new(),
+            max_captures_len: 0,
+            max_captures_saved: None,
             memo: HashMap::new(),
             memo_hits: 0,
             memo_misses: 0,
@@ -315,6 +328,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     } = entry
                     {
                         self.sp = sp;
+                        self.protect_max_captures(capture_len);
                         self.captures.truncate(capture_len);
                     }
                     self.ip = label.0;
@@ -551,6 +565,7 @@ impl<'p, 'i> VM<'p, 'i> {
                 } => {
                     self.ip = ip;
                     self.sp = sp;
+                    self.protect_max_captures(capture_len);
                     self.captures.truncate(capture_len);
                     return true;
                 }
@@ -624,10 +639,28 @@ impl<'p, 'i> VM<'p, 'i> {
     /// [`fail`](Self::fail) and the `BackCommit` handler — plus defensively
     /// at finalize time. Between retreats `sp` is monotone non-decreasing,
     /// so these hooks capture the true deepest point.
+    ///
+    /// O(1) per call: stores a length only; the captures are materialized
+    /// lazily via [`protect_max_captures`](Self::protect_max_captures) or
+    /// [`finalize_partial`](Self::finalize_partial). The eager-clone
+    /// variant went quadratic in captures count on large inputs and was
+    /// pure overhead on the success path (which never reads the
+    /// snapshot).
     fn maybe_snapshot(&mut self) {
         if self.sp > self.max_sp {
             self.max_sp = self.sp;
-            self.max_captures = self.captures.clone();
+            self.max_captures_len = self.captures.len();
+            self.max_captures_saved = None;
+        }
+    }
+
+    /// Called before truncating `captures` to `new_len`. If the truncate
+    /// would drop captures the farthest-failure snapshot still needs,
+    /// copy them aside first. Runs at most once per `max_sp` epoch —
+    /// subsequent truncates below the same watermark are no-ops.
+    fn protect_max_captures(&mut self, new_len: usize) {
+        if new_len < self.max_captures_len && self.max_captures_saved.is_none() {
+            self.max_captures_saved = Some(self.captures[..self.max_captures_len].to_vec());
         }
     }
 
@@ -638,9 +671,17 @@ impl<'p, 'i> VM<'p, 'i> {
             hits: self.memo_hits,
             misses: self.memo_misses,
         };
+        // Materialize the farthest-failure captures exactly once. If a
+        // prior truncate below the watermark forced an early save, take
+        // that; otherwise the canonical captures are still sitting in
+        // `self.captures[..max_captures_len]`.
+        let max_captures = self
+            .max_captures_saved
+            .take()
+            .unwrap_or_else(|| self.captures[..self.max_captures_len].to_vec());
         let result = MatchResult {
             matched: self.max_sp,
-            captures: close_captures(self.max_captures, self.max_sp),
+            captures: close_captures(max_captures, self.max_sp),
             complete: false,
         };
         (result, stats, self.memo)

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -418,3 +418,47 @@ fn partial_match_prefers_deepest_point_across_backtracks() {
     assert!(!r.complete);
     assert_eq!(r.matched, 2);
 }
+
+#[test]
+fn partial_match_captures_survive_backtrack_below_watermark() {
+    // Regression for the lazy-snapshot path: an open capture created
+    // inside a failing first alternative must still appear in the
+    // partial-match result even though `fail()` truncates the captures
+    // vector below the `max_sp` watermark before the second alternative
+    // runs. The lazy snapshot has to rescue those captures before the
+    // truncate; otherwise the final result loses them.
+    //
+    // Grammar: `@mark{ "abc" } / "ab" "x"` against input "abdX".
+    //  0: Choice L1 (=6)
+    //  1: CaptureBegin 0
+    //  2: Char a
+    //  3: Char b
+    //  4: Char c       <- fails here on 'd', sp was 2 → max_sp=2,
+    //                     captures=[{kind:0,start:0,end:None}]
+    //  5: CaptureEnd
+    //  6: Commit L2 (=11) — unreached; Char c failure triggers Backtrack
+    //                         unwind that truncates captures to 0.
+    //  7: Char a     (L1, second alternative)
+    //  8: Char b
+    //  9: Char x      <- fails here on 'd'
+    // 10: End        (L2, unreached)
+    //
+    // Expect: complete=false, matched=2, one capture (kind=0, 0..2).
+    let prog = [
+        Instruction::Choice(Label(7)),
+        Instruction::CaptureBegin(CaptureKind(0)),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'b'),
+        Instruction::Char(b'c'),
+        Instruction::CaptureEnd,
+        Instruction::Commit(Label(10)),
+        Instruction::Char(b'a'),
+        Instruction::Char(b'b'),
+        Instruction::Char(b'x'),
+        Instruction::End,
+    ];
+    let r = run(&prog, b"abdX");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 2);
+    assert_eq!(r.captures, vec![cap(0, 0, 2)]);
+}


### PR DESCRIPTION
## Summary

- `VM::maybe_snapshot` in `src/pegvm/vm.rs` was cloning the captures vector on every `sp`-advance past `max_sp`. Monotone `sp` on tens of KB pushed the work to O(captures × max_sp) — quadratic — and the clone was pure overhead on any parse that completes, because `finalize_partial` (the only reader) never runs on success.
- Replace the eager clone with `(max_sp, max_captures_len)` + a lazy `Option<Vec>`. `protect_max_captures` rescues captures once, before the first `fail()` or `BackCommit` truncate that would breach the watermark; `finalize_partial` takes that save or slices from the still-intact prefix.
- New regression test `partial_match_captures_survive_backtrack_below_watermark` in `tests/vm_tests.rs` locks in the first-alternative-capture-then-backtrack case.

Prerequisite for #10 — the issue's "Pitfalls to watch for at scale" section called this out. Confirmed on the xlarge fixtures in the follow-up PR: JSON xlarge drops from 85ms to 18ms, SQL xlarge from 766ms to 485ms.

## Test plan

Covered by CI plus the new `tests/vm_tests.rs` case.