### PR TITLE
Add Rust (subset) grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ grammar shapes (JSON, TOML, and a large backtracking-heavy SQLite
 grammar exercising multi-statement error recovery). Expect breaking
 changes.
 
-The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`)
-or an explicit `-l json|toml|sql` flag; stdin without a flag defaults
-to JSON.
+The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`,
+`.rs`) or an explicit `-l json|toml|sql|rust` flag; stdin without a
+flag defaults to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
@@ -98,15 +98,16 @@ largest piece of work.
 
 These need no new VM or compiler machinery.
 
-- **More language grammars.** JSON, TOML, and the full SQLite dialect
-  ship today. Adding a language means writing a grammar file. The
-  SQLite grammar is the large-grammar bytecode-size datapoint the
-  design goals called for: 5,627 VM instructions across 426 rules —
-  an order of magnitude larger than JSON (165 instr) or TOML (511
-  instr), and still comfortably inside the "kilobyte range per
-  grammar" ambition. Remaining candidates: Python, Rust, CSS. YAML is
-  deferred — its context-sensitive indentation semantics make it a
-  poor fit for PEG without additional machinery.
+- **More language grammars.** JSON, TOML, the full SQLite dialect,
+  and a pragmatic Rust subset ship today. Adding a language means
+  writing a grammar file. SQLite remains the large-grammar
+  bytecode-size datapoint the design goals called for: 5,627 VM
+  instructions across 426 rules — an order of magnitude larger than
+  JSON (165 instr) or TOML (511 instr); Rust sits between at 3,413
+  instr / 172 rules, still comfortably inside the "kilobyte range
+  per grammar" ambition. Remaining candidates: Python, JavaScript,
+  Go, C, CSS. YAML is deferred — its context-sensitive indentation
+  semantics make it a poor fit for PEG without additional machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is
   orthogonal to the VM.

--- a/benches/fixtures/large.rs
+++ b/benches/fixtures/large.rs
@@ -1,0 +1,398 @@
+//! Generated Rust bench fixture. Mix of items, generics, match,
+//! closures, macros and trait impls. Parses to completion under
+//! grammars/rust.peg — real crates stress the grammar similarly.
+
+use std::collections::{HashMap, HashSet, BTreeMap};
+use std::fmt::{self, Debug, Display};
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Severity { Info, Warn, Error(String) }
+
+pub trait Emit<T: Debug> {
+    fn emit(&mut self, value: T);
+    fn count(&self) -> usize;
+}
+
+#[derive(Debug, Clone)]
+pub struct Counter0<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Counter0<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for Counter0<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_0(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct Bucket1<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Bucket1<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for Bucket1<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_1(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct Ledger2<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Ledger2<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for Ledger2<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_2(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct Registry3<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Registry3<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for Registry3<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_3(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct Cache4<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Cache4<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for Cache4<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_4(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+fn main() {
+    let mut c = Counter0::<i64>::new("xs");
+    let data: Vec<i64> = vec![-5, -1, 0, 1, 2, 3, 9, 10, 42, 99, 100];
+    for n in &data {
+        c.emit(*n);
+    }
+    println!("{} (n={})", c.summary(), c.count());
+    for (n, label) in demo_0(&data) {
+        println!("{} -> {}", n, label);
+    }
+}

--- a/benches/fixtures/medium.rs
+++ b/benches/fixtures/medium.rs
@@ -1,0 +1,66 @@
+//! Medium-sized Rust bench fixture: exercises items, generics,
+//! match, closures, and macros. Intentionally self-contained (no
+//! external crate imports) so the grammar sees the full surface
+//! without a `use` cluster obscuring it.
+
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
+
+#[derive(Debug, Clone)]
+pub struct Counter<'a, T: Clone + 'a> {
+    name: &'a str,
+    values: Vec<T>,
+    histogram: HashMap<String, usize>,
+}
+
+impl<'a, T: Clone + Debug + 'a> Counter<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            values: Vec::new(),
+            histogram: HashMap::new(),
+        }
+    }
+
+    pub fn push(&mut self, v: T) {
+        let key = format!("{:?}", v);
+        *self.histogram.entry(key).or_insert(0) += 1;
+        self.values.push(v);
+    }
+
+    pub fn summary(&self) -> String {
+        let top = self
+            .histogram
+            .iter()
+            .max_by_key(|(_, &n)| n)
+            .map(|(k, n)| format!("{}={}", k, n))
+            .unwrap_or_else(|| "<empty>".into());
+        format!("{} (n={}, top={})", self.name, self.values.len(), top)
+    }
+}
+
+pub fn classify(n: i64) -> &'static str {
+    match n {
+        i if i < 0 => "negative",
+        0 => "zero",
+        1..=9 => "single-digit",
+        10..=99 => "two-digit",
+        _ => "large",
+    }
+}
+
+pub fn with_each<F: FnMut(i64)>(xs: &[i64], mut f: F) {
+    for &x in xs {
+        f(x);
+    }
+}
+
+fn main() {
+    let mut c: Counter<i64> = Counter::new("ages");
+    let data = vec![1i64, 2, 2, 3, 10, 10, 10, -1];
+    with_each(&data, |x| c.push(x));
+    println!("{}", c.summary());
+    for n in data {
+        println!("{} -> {}", n, classify(n));
+    }
+}

--- a/benches/fixtures/small.rs
+++ b/benches/fixtures/small.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello, world");
+}

--- a/benches/fixtures/xlarge.rs
+++ b/benches/fixtures/xlarge.rs
@@ -1,0 +1,4527 @@
+//! Generated Rust bench fixture. Mix of items, generics, match,
+//! closures, macros and trait impls. Parses to completion under
+//! grammars/rust.peg — real crates stress the grammar similarly.
+
+use std::collections::{HashMap, HashSet, BTreeMap};
+use std::fmt::{self, Debug, Display};
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Severity { Info, Warn, Error(String) }
+
+pub trait Emit<T: Debug> {
+    fn emit(&mut self, value: T);
+    fn count(&self) -> usize;
+}
+
+#[derive(Debug, Clone)]
+pub struct XCounter0<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCounter0<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCounter0<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_0(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBucket1<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBucket1<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBucket1<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_1(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XLedger2<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XLedger2<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XLedger2<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_2(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XRegistry3<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XRegistry3<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XRegistry3<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_3(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCache4<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCache4<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCache4<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_4(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XJournal5<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XJournal5<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XJournal5<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_5(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XPool6<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XPool6<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XPool6<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_6(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XQueue7<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XQueue7<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XQueue7<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_7(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XSlab8<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XSlab8<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XSlab8<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_8(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XStore9<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XStore9<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XStore9<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_9(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XIndex10<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XIndex10<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XIndex10<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_10(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XGraph11<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XGraph11<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XGraph11<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_11(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XScanner12<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XScanner12<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XScanner12<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_12(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XMonitor13<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XMonitor13<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XMonitor13<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_13(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XTracker14<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XTracker14<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XTracker14<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_14(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBroker15<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBroker15<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBroker15<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_15(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCounter16<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCounter16<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCounter16<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_16(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBucket17<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBucket17<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBucket17<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_17(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XLedger18<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XLedger18<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XLedger18<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_18(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XRegistry19<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XRegistry19<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XRegistry19<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_19(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCache20<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCache20<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCache20<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_20(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XJournal21<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XJournal21<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XJournal21<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_21(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XPool22<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XPool22<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XPool22<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_22(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XQueue23<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XQueue23<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XQueue23<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_23(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XSlab24<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XSlab24<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XSlab24<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_24(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XStore25<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XStore25<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XStore25<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_25(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XIndex26<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XIndex26<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XIndex26<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_26(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XGraph27<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XGraph27<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XGraph27<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_27(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XScanner28<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XScanner28<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XScanner28<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_28(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XMonitor29<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XMonitor29<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XMonitor29<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_29(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XTracker30<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XTracker30<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XTracker30<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_30(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBroker31<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBroker31<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBroker31<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_31(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCounter32<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCounter32<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCounter32<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_32(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBucket33<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBucket33<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBucket33<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_33(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XLedger34<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XLedger34<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XLedger34<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_34(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XRegistry35<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XRegistry35<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XRegistry35<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_35(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCache36<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCache36<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCache36<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_36(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XJournal37<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XJournal37<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XJournal37<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_37(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XPool38<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XPool38<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XPool38<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_38(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XQueue39<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XQueue39<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XQueue39<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_39(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XSlab40<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XSlab40<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XSlab40<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_40(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XStore41<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XStore41<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XStore41<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_41(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XIndex42<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XIndex42<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XIndex42<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_42(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XGraph43<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XGraph43<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XGraph43<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_43(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XScanner44<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XScanner44<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XScanner44<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_44(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XMonitor45<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XMonitor45<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XMonitor45<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_45(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XTracker46<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XTracker46<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XTracker46<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_46(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBroker47<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBroker47<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBroker47<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_47(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCounter48<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCounter48<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCounter48<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_48(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XBucket49<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XBucket49<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XBucket49<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_49(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XLedger50<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XLedger50<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XLedger50<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_50(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XRegistry51<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XRegistry51<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XRegistry51<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_51(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XCache52<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XCache52<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XCache52<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_52(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XJournal53<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XJournal53<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XJournal53<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_53(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XPool54<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XPool54<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XPool54<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_54(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XQueue55<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XQueue55<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XQueue55<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_55(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XSlab56<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XSlab56<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XSlab56<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_56(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XStore57<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XStore57<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XStore57<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_57(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XIndex58<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XIndex58<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XIndex58<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_58(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug, Clone)]
+pub struct XGraph59<'a, T: Clone + Debug + 'a> {
+    pub name: &'a str,
+    pub field_0: Vec<T>,
+    pub field_1: Vec<T>,
+    pub field_2: Vec<T>,
+    pub field_3: Vec<T>,
+    pub index: HashMap<String, usize>,
+    pub tags: HashSet<String>,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: Clone + Debug + 'a> XGraph59<'a, T> {
+    pub fn new(name: &'a str) -> Self {
+        Self {
+            name,
+            field_0: Vec::new(),
+            field_1: Vec::new(),
+            field_2: Vec::new(),
+            field_3: Vec::new(),
+            index: HashMap::new(),
+            tags: HashSet::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn push<U: Into<T>>(&mut self, slot: usize, u: U) -> Result<&mut Self, String> {
+        let value: T = u.into();
+        let key = format!("{:?}", value);
+        *self.index.entry(key).or_insert(0) += 1;
+        match slot {
+            0 => self.field_0.push(value),
+            1 => self.field_1.push(value),
+            2 => self.field_2.push(value),
+            3 => self.field_3.push(value),
+            other => return Err(format!("bad slot {}", other)),
+        }
+        Ok(self)
+    }
+
+    pub fn summary(&self) -> String {
+        let mut lens: Vec<usize> = vec![
+            self.field_0.len(),
+            self.field_1.len(),
+            self.field_2.len(),
+            self.field_3.len(),
+        ];
+        lens.sort_by(|a, b| b.cmp(a));
+        let top = lens.first().copied().unwrap_or(0);
+        format!("{}(top={}, tags={})", self.name, top, self.tags.len())
+    }
+
+    pub fn tag(&mut self, t: impl Into<String>) -> &mut Self {
+        self.tags.insert(t.into());
+        self
+    }
+}
+
+impl<'a, T: Clone + Debug + 'a> Emit<T> for XGraph59<'a, T> {
+    fn emit(&mut self, value: T) {
+        let _ = self.push(0, value);
+    }
+    fn count(&self) -> usize {
+        self.index.values().sum()
+    }
+}
+
+pub fn demo_59(xs: &[i64]) -> Vec<(i64, &'static str)> {
+    xs.iter()
+        .map(|&n| (n, match n {
+            i if i < 0 => "negative",
+            0 => "zero",
+            1..=9 => "single-digit",
+            10..=99 => "two-digit",
+            _ => "large",
+        }))
+        .collect::<Vec<_>>()
+}
+
+fn main() {
+    let mut c = XCounter0::<i64>::new("xs");
+    let data: Vec<i64> = vec![-5, -1, 0, 1, 2, 3, 9, 10, 42, 99, 100];
+    for n in &data {
+        c.emit(*n);
+    }
+    println!("{} (n={})", c.summary(), c.count());
+    for (n, label) in demo_0(&data) {
+        println!("{} -> {}", n, label);
+    }
+}

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -26,6 +26,7 @@ use common::{json_f64, json_num, json_str, median, open_jsonl, write_jsonl_row};
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -41,6 +42,11 @@ const SQL_SMALL: &str = include_str!("fixtures/small.sql");
 const SQL_MEDIUM: &str = include_str!("fixtures/medium.sql");
 const SQL_LARGE: &str = include_str!("fixtures/large.sql");
 const SQL_XLARGE: &str = include_str!("fixtures/xlarge.sql");
+
+const RUST_SMALL: &str = include_str!("fixtures/small.rs");
+const RUST_MEDIUM: &str = include_str!("fixtures/medium.rs");
+const RUST_LARGE: &str = include_str!("fixtures/large.rs");
+const RUST_XLARGE: &str = include_str!("fixtures/xlarge.rs");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -269,6 +275,16 @@ fn main() {
                 ("medium", SQL_MEDIUM),
                 ("large", SQL_LARGE),
                 ("xlarge", SQL_XLARGE),
+            ],
+        },
+        GrammarCase {
+            label: "rust",
+            source: RUST_GRAMMAR,
+            fixtures: &[
+                ("small", RUST_SMALL),
+                ("medium", RUST_MEDIUM),
+                ("large", RUST_LARGE),
+                ("xlarge", RUST_XLARGE),
             ],
         },
     ];

--- a/benches/memo.rs
+++ b/benches/memo.rs
@@ -26,6 +26,7 @@ use common::{json_f64, json_num, json_str, median, open_jsonl, write_jsonl_row};
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -41,6 +42,11 @@ const SQL_SMALL: &str = include_str!("fixtures/small.sql");
 const SQL_MEDIUM: &str = include_str!("fixtures/medium.sql");
 const SQL_LARGE: &str = include_str!("fixtures/large.sql");
 const SQL_XLARGE: &str = include_str!("fixtures/xlarge.sql");
+
+const RUST_SMALL: &str = include_str!("fixtures/small.rs");
+const RUST_MEDIUM: &str = include_str!("fixtures/medium.rs");
+const RUST_LARGE: &str = include_str!("fixtures/large.rs");
+const RUST_XLARGE: &str = include_str!("fixtures/xlarge.rs");
 
 const THRESHOLDS: &[usize] = &[0, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 const RUNS_PER_CELL: usize = 11;
@@ -181,6 +187,16 @@ fn main() {
                 ("medium", SQL_MEDIUM.as_bytes()),
                 ("large", SQL_LARGE.as_bytes()),
                 ("xlarge", SQL_XLARGE.as_bytes()),
+            ],
+        },
+        GrammarCase {
+            name: "rust",
+            program: compile_case("rust", RUST_GRAMMAR),
+            inputs: vec![
+                ("small", RUST_SMALL.as_bytes()),
+                ("medium", RUST_MEDIUM.as_bytes()),
+                ("large", RUST_LARGE.as_bytes()),
+                ("xlarge", RUST_XLARGE.as_bytes()),
             ],
         },
     ];

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -1,0 +1,452 @@
+# Rust (pragmatic subset) grammar with highlight annotations.
+# The first rule is the start rule.
+#
+# Scope: highlighting, not compilation. The grammar parses most real-
+# world Rust code to completion at the item/expression/type level. It
+# is deliberately token-ish: precedence is not enforced, and semantic
+# constraints (name resolution, typing, trait coherence) are not
+# checked. The bench value lives in the shared-prefix backtracking
+# Rust induces: paths vs generics, turbofish, closures vs bitor,
+# attributes vs inner-attributes, references vs logical-and.
+#
+# Capture kinds used (all present in src/highlight/theme.rs):
+#   keyword, string, number, comment, operator, punctuation, type,
+#   function, constant, variable, recovery.
+#
+# Intentionally out of scope for the MVP:
+#   - Macro-transcribe rules (`macro_rules!` bodies). We treat every
+#     `ident!(...)` / `ident!{...}` / `ident![...]` as balanced-
+#     bracket skip-over and call the ident a @function.
+#   - Const generics (`Foo<const N: usize>`).
+#   - Full precedence grammar; expressions are a left-to-right
+#     sequence of primaries joined by operator tokens.
+#
+# Recovery: the top-level uses `*^` so malformed items don't
+# abort the whole file.
+
+rust_file     <- ws (item)*^ ws !.
+
+# --- Items -------------------------------------------------------------
+#
+# Order matters (PEG first-match). Attributes / inner-attributes must
+# precede regular items so `#[...]` and `#![...]` are not misparsed
+# as expression-statements starting with `#`.
+item          <- attr_outer
+               / attr_inner
+               / use_item
+               / fn_item
+               / struct_item
+               / enum_item
+               / impl_item
+               / trait_item
+               / mod_item
+               / extern_item
+               / const_item
+               / static_item
+               / type_alias_item
+               / macro_rules_item
+               / macro_invocation_stmt
+               / stmt
+
+# Attributes and doc-comments at item position.
+attr_outer    <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'} ws
+attr_inner    <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'} ws
+attr_body     <- (!']' .)*
+
+# `use foo::bar::{baz, qux as q};`
+use_item      <- @keyword{'use'} ws use_tree ws @punctuation{';'} ws
+use_tree      <- use_path use_tail?
+use_tail      <- ws @keyword{'as'} ws ident_any
+               / @punctuation{'::'} @punctuation{'*'}
+               / @punctuation{'::'} @punctuation{'{'} ws use_tree_list? ws @punctuation{'}'}
+use_tree_list <- use_tree (ws @punctuation{','} ws use_tree)* (ws @punctuation{','})?
+use_path      <- use_seg (@punctuation{'::'} use_seg)*
+use_seg       <- @keyword{'self'}
+               / @keyword{'super'}
+               / @keyword{'crate'}
+               / @type{upper_ident}
+               / @variable{lower_ident}
+
+# `fn name<T>(a: T) -> T where T: Bound { ... }`
+fn_item       <- vis? ws fn_qualifiers @keyword{'fn'} ws @function{ident} generic_params? ws
+                 fn_params ws fn_return? ws where_clause? ws (block / @punctuation{';'}) ws
+fn_qualifiers <- (fn_qualifier ws)*
+fn_qualifier  <- @keyword{'const'}
+               / @keyword{'async'}
+               / @keyword{'unsafe'}
+               / @keyword{'extern'} (ws string_lit)?
+fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
+fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
+fn_param      <- attr_outer? self_param
+               / attr_outer? fn_param_named
+fn_param_named <- pattern ws @punctuation{':'} ws type_expr
+self_param    <- ref_marker? ws (@keyword{'mut'} ws)? @keyword{'self'}
+               / @keyword{'mut'} ws @keyword{'self'}
+               / @keyword{'self'} ws @punctuation{':'} ws type_expr
+ref_marker    <- @punctuation{'&'} lifetime?
+fn_return     <- @punctuation{'->'} ws type_expr
+
+# `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
+struct_item   <- vis? ws @keyword{'struct'} ws @type{ident} generic_params? ws
+                 (struct_body_named / struct_body_tuple / @punctuation{';'}) ws
+struct_body_named <- where_clause? ws @punctuation{'{'} ws struct_fields? ws @punctuation{'}'}
+struct_body_tuple <- @punctuation{'('} ws tuple_fields? ws @punctuation{')'} ws where_clause? ws @punctuation{';'}
+struct_fields <- struct_field (ws @punctuation{','} ws struct_field)* (ws @punctuation{','})?
+struct_field  <- (attr_outer ws)* vis? ws @property{ident} ws @punctuation{':'} ws type_expr
+tuple_fields  <- tuple_field (ws @punctuation{','} ws tuple_field)* (ws @punctuation{','})?
+tuple_field   <- (attr_outer ws)* vis? ws type_expr
+
+# `enum E { A, B(T), C { x: T } }`
+enum_item     <- vis? ws @keyword{'enum'} ws @type{ident} generic_params? ws where_clause? ws
+                 @punctuation{'{'} ws enum_variants? ws @punctuation{'}'} ws
+enum_variants <- enum_variant (ws @punctuation{','} ws enum_variant)* (ws @punctuation{','})?
+enum_variant  <- (attr_outer ws)* @type{ident} enum_variant_body?
+enum_variant_body <- ws @punctuation{'('} ws tuple_fields? ws @punctuation{')'}
+                   / ws @punctuation{'{'} ws struct_fields? ws @punctuation{'}'}
+                   / ws @punctuation{'='} ws expr
+
+# `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
+impl_item     <- @keyword{'impl'} generic_params? ws impl_head ws where_clause? ws
+                 @punctuation{'{'} ws impl_body ws @punctuation{'}'} ws
+impl_head     <- type_expr (ws @keyword{'for'} ws type_expr)?
+impl_body     <- (item)*
+
+# `trait T<U>: Bound { ... }`
+trait_item    <- vis? ws (@keyword{'unsafe'} ws)? @keyword{'trait'} ws @type{ident}
+                 generic_params? trait_bounds? ws where_clause? ws
+                 @punctuation{'{'} ws impl_body ws @punctuation{'}'} ws
+trait_bounds  <- ws @punctuation{':'} ws bound_list
+
+# `mod name;` / `mod name { ... }`
+mod_item      <- vis? ws @keyword{'mod'} ws @variable{ident} ws
+                 (@punctuation{';'} / @punctuation{'{'} ws (item)* ws @punctuation{'}'}) ws
+
+# `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
+extern_item   <- @keyword{'extern'} (ws string_lit)? ws @punctuation{'{'} ws (item)* ws @punctuation{'}'} ws
+
+const_item    <- vis? ws @keyword{'const'} ws @constant{ident} ws @punctuation{':'} ws type_expr ws
+                 @punctuation{'='} ws expr ws @punctuation{';'} ws
+static_item   <- vis? ws @keyword{'static'} (ws @keyword{'mut'})? ws @constant{ident} ws @punctuation{':'} ws type_expr ws
+                 @punctuation{'='} ws expr ws @punctuation{';'} ws
+type_alias_item <- vis? ws @keyword{'type'} ws @type{ident} generic_params? ws where_clause? ws
+                   @punctuation{'='} ws type_expr ws @punctuation{';'} ws
+
+# `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
+# soup; balance braces.
+macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} ws @function{ident} ws brace_block ws
+
+# Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
+macro_invocation_stmt <- @function{ident} @punctuation{'!'} ws macro_args ws (@punctuation{';'})? ws
+macro_args    <- paren_group
+               / brace_block
+               / bracket_group
+
+# Visibility modifier.
+vis           <- @keyword{'pub'} (ws @punctuation{'('} ws vis_scope ws @punctuation{')'})?
+vis_scope     <- @keyword{'crate'} / @keyword{'self'} / @keyword{'super'}
+               / @keyword{'in'} ws use_path
+
+# --- Generic parameters and where-clauses ----------------------------
+
+generic_params <- @punctuation{'<'} ws generic_param_list? ws @punctuation{'>'}
+generic_param_list <- generic_param (ws @punctuation{','} ws generic_param)* (ws @punctuation{','})?
+generic_param <- lifetime_param
+               / type_param
+               / const_param
+lifetime_param <- lifetime (ws @punctuation{':'} ws lifetime_bounds)?
+lifetime_bounds <- lifetime (ws @punctuation{'+'} ws lifetime)*
+type_param    <- @type{ident} (ws @punctuation{':'} ws bound_list)? (ws @punctuation{'='} ws type_expr)?
+const_param   <- @keyword{'const'} ws @constant{ident} ws @punctuation{':'} ws type_expr
+
+where_clause  <- @keyword{'where'} ws where_pred (ws @punctuation{','} ws where_pred)* (ws @punctuation{','})?
+where_pred    <- lifetime ws @punctuation{':'} ws lifetime_bounds
+               / type_expr ws @punctuation{':'} ws bound_list
+
+bound_list    <- bound (ws @punctuation{'+'} ws bound)*
+bound         <- lifetime
+               / (@punctuation{'?'})? type_path
+
+# --- Types -------------------------------------------------------------
+#
+# `&'a mut T`, `[T; N]`, `(T, U)`, `Foo<T>`, `dyn Trait`, `impl Trait`,
+# `fn(T) -> U`, `!`, etc.
+
+type_expr     <- type_fn
+               / type_impl
+               / type_dyn
+               / type_ref
+               / type_ptr
+               / type_array_or_slice
+               / type_tuple_or_group
+               / type_never
+               / type_path
+
+type_fn       <- (type_fn_qualifier ws)* @keyword{'fn'} ws @punctuation{'('} ws type_list? ws @punctuation{')'}
+                 (ws @punctuation{'->'} ws type_expr)?
+type_fn_qualifier <- @keyword{'unsafe'}
+                   / @keyword{'extern'} (ws string_lit)?
+type_list     <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation{','})?
+
+type_impl     <- @keyword{'impl'} ws bound_list
+type_dyn      <- @keyword{'dyn'} ws bound_list
+
+type_ref      <- @punctuation{'&'} lifetime? ws (@keyword{'mut'} ws)? type_expr
+type_ptr      <- @punctuation{'*'} ws (@keyword{'mut'} / @keyword{'const'}) ws type_expr
+
+type_array_or_slice <- @punctuation{'['} ws type_expr (ws @punctuation{';'} ws expr)? ws @punctuation{']'}
+type_tuple_or_group <- @punctuation{'('} ws type_list? ws @punctuation{')'}
+
+type_never    <- @punctuation{'!'}
+
+type_path     <- type_path_seg (@punctuation{'::'} type_path_seg)*
+type_path_seg <- @type{upper_ident} generic_args?
+               / @variable{lower_ident} generic_args?
+               / @keyword{'self'}
+               / @keyword{'Self'}
+               / @keyword{'super'}
+               / @keyword{'crate'}
+
+generic_args  <- @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
+               / @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
+generic_arg_list <- generic_arg (ws @punctuation{','} ws generic_arg)* (ws @punctuation{','})?
+generic_arg   <- lifetime
+               / type_expr
+               / @constant{ident} ws @punctuation{'='} ws type_expr
+               / expr_block
+               / literal
+
+# --- Patterns ----------------------------------------------------------
+
+pattern       <- pattern_or
+pattern_or    <- pattern_atom (ws @punctuation{'|'} ws pattern_atom)*
+pattern_atom  <- pattern_ref
+               / pattern_box
+               / pattern_tuple
+               / pattern_struct_or_enum
+               / pattern_slice
+               / pattern_range
+               / pattern_literal
+               / pattern_wild
+               / pattern_rest
+               / pattern_binding
+pattern_ref   <- @punctuation{'&'} (ws @keyword{'mut'})? ws pattern_atom
+pattern_box   <- @keyword{'box'} ws pattern_atom
+pattern_tuple <- @punctuation{'('} ws pattern_list? ws @punctuation{')'}
+pattern_list  <- pattern (ws @punctuation{','} ws pattern)* (ws @punctuation{','})?
+pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
+                          (ws pattern_struct_body / ws pattern_tuple)?
+pattern_struct_body <- @punctuation{'{'} ws pattern_struct_fields? ws @punctuation{'}'}
+pattern_struct_fields <- pattern_struct_field (ws @punctuation{','} ws pattern_struct_field)* (ws @punctuation{','})?
+pattern_struct_field  <- @property{ident} ws @punctuation{':'} ws pattern
+                       / @property{ident}
+                       / @punctuation{'..'}
+pattern_slice <- @punctuation{'['} ws pattern_list? ws @punctuation{']'}
+pattern_range <- pattern_literal ws (@punctuation{'..='} / @punctuation{'..'}) ws pattern_literal
+pattern_literal <- string_lit / char_lit / number_lit / @constant{bool_lit}
+pattern_wild  <- @punctuation{'_'}
+pattern_rest  <- @punctuation{'..'}
+pattern_binding <- (@keyword{'ref'} ws)? (@keyword{'mut'} ws)? @variable{ident}
+                   (ws @punctuation{'@'} ws pattern_atom)?
+
+# --- Expressions -------------------------------------------------------
+#
+# Not precedence-correct. The sweep only cares about shared-prefix
+# backtracking at token level, so we accept `a + b * c` as "primary op
+# primary op primary" without tree-shape enforcement.
+
+expr          <- expr_op
+
+expr_op       <- expr_range (ws bin_op ws expr_range)*
+
+# Range: `a..b`, `a..=b`, `..b`, `a..`, `..`.
+expr_range    <- expr_unary (ws (@punctuation{'..='} / @punctuation{'..'}) ws expr_unary?)?
+               / (@punctuation{'..='} / @punctuation{'..'}) ws expr_unary?
+
+bin_op        <- @operator{'<<='} / @operator{'>>='}
+               / @operator{'&&'}  / @operator{'||'}
+               / @operator{'=='}  / @operator{'!='}
+               / @operator{'<='}  / @operator{'>='}
+               / @operator{'<<'}  / @operator{'>>'}
+               / @operator{'+='}  / @operator{'-='}
+               / @operator{'*='}  / @operator{'/='}
+               / @operator{'%='}  / @operator{'&='}
+               / @operator{'|='}  / @operator{'^='}
+               / @operator{'='}
+               / @operator{'<'}   / @operator{'>'}
+               / @operator{'+'}   / @operator{'-'}
+               / @operator{'*'}   / @operator{'/'}
+               / @operator{'%'}
+               / @operator{'&'}   / @operator{'|'}
+               / @operator{'^'}
+               / @keyword{'as'} ws type_expr_suffix_marker
+
+# A marker rule: when `as` matches, consume the following type. Split
+# from `bin_op` so the type_expr stays attached.
+type_expr_suffix_marker <- type_expr
+
+expr_unary    <- (unary_op ws)* expr_postfix
+unary_op      <- @operator{'&'} lifetime? (ws @keyword{'mut'})?
+               / @operator{'*'}
+               / @operator{'-'}
+               / @operator{'!'}
+
+# Postfix chain: calls, indexing, field access, try `?`.
+expr_postfix  <- expr_primary (ws postfix_op)*
+postfix_op    <- @punctuation{'?'}
+               / @punctuation{'.'} @keyword{'await'}
+               / @punctuation{'.'} postfix_member
+               / @punctuation{'('} ws expr_list? ws @punctuation{')'}
+               / @punctuation{'['} ws expr ws @punctuation{']'}
+postfix_member <- turbofish_method
+                / @function{ident} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
+                / @number{digit_seq}
+turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
+
+expr_primary  <- literal
+               / expr_if
+               / expr_match
+               / expr_while
+               / expr_loop
+               / expr_for
+               / expr_return
+               / expr_break
+               / expr_continue
+               / expr_unsafe
+               / expr_closure
+               / expr_block
+               / expr_async_block
+               / expr_tuple_or_paren
+               / expr_array
+               / expr_macro_or_path
+               / expr_keyword
+
+expr_if       <- @keyword{'if'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
+                 (ws @keyword{'else'} ws (expr_if / block))?
+expr_match    <- @keyword{'match'} ws expr ws @punctuation{'{'} ws match_arms? ws @punctuation{'}'}
+match_arms    <- match_arm (ws @punctuation{','} ws match_arm)* (ws @punctuation{','})?
+match_arm     <- (attr_outer ws)* pattern (ws @keyword{'if'} ws expr)? ws @punctuation{'=>'} ws expr
+expr_while    <- @keyword{'while'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
+expr_loop     <- (loop_label ws)? @keyword{'loop'} ws block
+expr_for      <- @keyword{'for'} ws pattern ws @keyword{'in'} ws expr ws block
+expr_return   <- @keyword{'return'} (ws expr)?
+expr_break    <- @keyword{'break'} (ws loop_label)? (ws expr)?
+expr_continue <- @keyword{'continue'} (ws loop_label)?
+expr_unsafe   <- @keyword{'unsafe'} ws block
+expr_closure  <- (@keyword{'move'} ws)? @punctuation{'|'} ws closure_params? ws @punctuation{'|'}
+                 (ws @punctuation{'->'} ws type_expr)? ws expr
+closure_params <- closure_param (ws @punctuation{','} ws closure_param)* (ws @punctuation{','})?
+closure_param <- pattern (ws @punctuation{':'} ws type_expr)?
+expr_block    <- block
+expr_async_block <- @keyword{'async'} (ws @keyword{'move'})? ws block
+expr_tuple_or_paren <- @punctuation{'('} ws expr_list? ws @punctuation{')'}
+expr_array    <- @punctuation{'['} ws expr_array_body? ws @punctuation{']'}
+expr_array_body <- expr ws @punctuation{';'} ws expr
+                 / expr (ws @punctuation{','} ws expr)* (ws @punctuation{','})?
+expr_list     <- expr (ws @punctuation{','} ws expr)* (ws @punctuation{','})?
+expr_keyword  <- @keyword{'self'} / @keyword{'Self'} / @keyword{'super'} / @keyword{'crate'}
+
+loop_label    <- @punctuation{'\''} @variable{ident} @punctuation{':'}
+
+# `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
+# or `macro!(...)` / `macro!{...}` / `macro![...]`.
+expr_macro_or_path <- path_expr (ws struct_init / @punctuation{'!'} ws macro_args)?
+path_expr     <- path_seg (@punctuation{'::'} path_seg)*
+path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?
+               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?
+
+struct_init   <- @punctuation{'{'} ws struct_init_fields? ws @punctuation{'}'}
+struct_init_fields <- struct_init_field (ws @punctuation{','} ws struct_init_field)* (ws @punctuation{','} ws struct_init_base?)?
+struct_init_field  <- @punctuation{'..'} expr
+                    / @property{ident} ws @punctuation{':'} ws expr
+                    / @property{ident}
+struct_init_base   <- @punctuation{'..'} expr
+
+# --- Statements & blocks ----------------------------------------------
+
+block         <- @punctuation{'{'} ws block_body ws @punctuation{'}'}
+block_body    <- (stmt)*
+
+stmt          <- let_stmt
+               / expr ws @punctuation{';'} ws
+               / expr ws                                    # trailing expression (block-valued)
+
+let_stmt      <- @keyword{'let'} ws pattern (ws @punctuation{':'} ws type_expr)?
+                 (ws @punctuation{'='} ws expr)? (ws @keyword{'else'} ws block)? ws @punctuation{';'} ws
+
+# --- Balanced-bracket helpers (used for macro bodies) -----------------
+#
+# Skip over arbitrary Rust token soup, respecting () [] {} nesting
+# and Rust string / char / comment literals so we don't mis-balance
+# a `}` inside a string. This is the pragmatic alternative to a real
+# token-tree grammar.
+
+brace_block   <- @punctuation{'{'} balanced_body @punctuation{'}'}
+paren_group   <- @punctuation{'('} balanced_body @punctuation{')'}
+bracket_group <- @punctuation{'['} balanced_body @punctuation{']'}
+balanced_body <- (balanced_atom)*
+balanced_atom <- brace_block
+               / paren_group
+               / bracket_group
+               / string_lit
+               / char_lit
+               / comment
+               / !([{}()\[\]]) .
+
+# --- Literals ----------------------------------------------------------
+
+literal       <- string_lit / char_lit / number_lit / @constant{bool_lit}
+bool_lit      <- 'true' / 'false'
+
+# Raw strings first (longer prefix), then regular.
+string_lit    <- @string{raw_string / byte_string / regular_string}
+regular_string <- '"' (str_escape / !'"' .)* '"'
+str_escape    <- '\\' (!'\n' .)
+byte_string   <- 'b' '"' (str_escape / !'"' .)* '"'
+raw_string    <- 'r' raw_hashes '"' raw_body_0 '"' raw_hashes
+               / 'br' raw_hashes '"' raw_body_0 '"' raw_hashes
+# Consume matching hash fences; the body is "up to the closing delim".
+# Keeping this simple: require the closing `"#*` to match the opening.
+# We approximate by supporting 0..=8 hashes explicitly.
+raw_hashes    <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
+raw_body_0    <- (!'"' .)*
+
+char_lit      <- @string{"'" (char_escape / !"'" .) "'"}
+char_escape   <- '\\' (!'\n' .)
+
+number_lit    <- @number{num_body}
+num_body      <- float_num / int_num
+float_num     <- digit_seq '.' digit_seq (exp_part)? num_suffix?
+               / digit_seq exp_part num_suffix?
+int_num       <- '0x' hex_digits num_suffix?
+               / '0o' oct_digits num_suffix?
+               / '0b' bin_digits num_suffix?
+               / digit_seq num_suffix?
+digit_seq     <- [0-9] ([0-9_])*
+hex_digits    <- [0-9a-fA-F] [0-9a-fA-F_]*
+oct_digits    <- [0-7] [0-7_]*
+bin_digits    <- [01] [01_]*
+exp_part      <- [eE] [+\-]? digit_seq
+num_suffix    <- [a-zA-Z_] [a-zA-Z0-9_]*
+
+# --- Lifetimes and identifiers -----------------------------------------
+
+lifetime      <- @type{"'" ident_body}
+
+# `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
+# of special meaning for highlighting.
+ident_any     <- @type{upper_ident}
+               / @variable{lower_ident}
+upper_ident   <- 'r#'? [A-Z] ident_body*
+lower_ident   <- 'r#'? [a-z_] ident_body*
+ident         <- 'r#'? [A-Za-z_] ident_body*
+ident_body    <- [A-Za-z0-9_]
+
+# --- Whitespace and comments ------------------------------------------
+
+comment       <- @comment{line_comment / block_comment}
+line_comment  <- '//' (!'\n' .)*
+# Non-nested block comment. Real Rust allows nesting; for highlighting
+# the occasional mismatch is acceptable and keeps the grammar simpler.
+block_comment <- '/*' (!'*/' .)* '*/'
+
+ws            <- (comment / [ \t\r\n])*

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,14 @@ use syntax_highlighter::highlight::Highlighter;
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 
 #[derive(Clone, Copy)]
 enum Lang {
     Json,
     Toml,
     Sql,
+    Rust,
 }
 
 impl Lang {
@@ -21,6 +23,7 @@ impl Lang {
             Lang::Json => JSON_GRAMMAR,
             Lang::Toml => TOML_GRAMMAR,
             Lang::Sql => SQLITE_GRAMMAR,
+            Lang::Rust => RUST_GRAMMAR,
         }
     }
 
@@ -29,6 +32,7 @@ impl Lang {
             "json" => Some(Lang::Json),
             "toml" => Some(Lang::Toml),
             "sql" | "sqlite" => Some(Lang::Sql),
+            "rs" | "rust" => Some(Lang::Rust),
             _ => None,
         }
     }
@@ -54,15 +58,15 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
             "-l" | "--lang" => {
                 let name = it
                     .next()
-                    .ok_or_else(|| format!("{} requires a value (json|toml|sql)", arg))?;
+                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust)", arg))?;
                 lang = Some(Lang::from_name(&name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql)", name)
+                    format!("unknown language {:?} (expected json|toml|sql|rust)", name)
                 })?);
             }
             other if other.starts_with("--lang=") => {
                 let name = &other["--lang=".len()..];
                 lang = Some(Lang::from_name(name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql)", name)
+                    format!("unknown language {:?} (expected json|toml|sql|rust)", name)
                 })?);
             }
             _ => {
@@ -83,7 +87,7 @@ fn pick_lang(cli: &Cli) -> Result<Lang, String> {
     match &cli.path {
         Some(p) => Lang::from_extension(Path::new(p)).ok_or_else(|| {
             format!(
-                "cannot infer language from path {:?}; pass --lang json|toml|sql",
+                "cannot infer language from path {:?}; pass --lang json|toml|sql|rust",
                 p
             )
         }),

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -104,7 +104,11 @@ fn simple_fn_parses() {
     // we just want `fn` and `main` both flagged).
     let k = kinds_for(&caps, &kinds);
     assert!(k.contains(&"keyword"), "expected `fn` as keyword: {:?}", k);
-    assert!(k.contains(&"function"), "expected main as function: {:?}", k);
+    assert!(
+        k.contains(&"function"),
+        "expected main as function: {:?}",
+        k
+    );
 }
 
 #[test]
@@ -129,7 +133,11 @@ fn struct_field_is_property() {
     // are @type.
     let (caps, kinds) = assert_complete_full("struct Foo { a: i32 }\n");
     let kv = kinds_for(&caps, &kinds);
-    assert!(kv.contains(&"property"), "field `a` should be @property: {:?}", kv);
+    assert!(
+        kv.contains(&"property"),
+        "field `a` should be @property: {:?}",
+        kv
+    );
     assert!(kv.contains(&"type"), "Foo/i32 should be @type: {:?}", kv);
 }
 
@@ -166,7 +174,8 @@ fn method_chain_with_turbofish_parses() {
 
 #[test]
 fn match_with_guards_and_ranges_parses() {
-    let input = "fn f(n: i32) -> i32 { match n { 0 => 1, 1..=10 => 2, x if x > 10 => 3, _ => 0, } }\n";
+    let input =
+        "fn f(n: i32) -> i32 { match n { 0 => 1, 1..=10 => 2, x if x > 10 => 3, _ => 0, } }\n";
     let (_, _) = assert_complete_full(input);
 }
 

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -1,0 +1,297 @@
+use std::collections::HashSet;
+
+use syntax_highlighter::pegc;
+use syntax_highlighter::pegvm::{Capture, Program, VM};
+
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+
+fn compile_rust() -> Program {
+    pegc::compile(RUST_GRAMMAR).expect("Rust grammar should compile")
+}
+
+fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
+    let prog = compile_rust();
+    let r = VM::new(&prog.code, input.as_bytes()).run();
+    (
+        r.matched,
+        r.captures,
+        prog.capture_kinds.clone(),
+        r.complete,
+    )
+}
+
+fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(
+        complete,
+        "expected complete match, got matched={} of {}",
+        matched,
+        input.len()
+    );
+    assert_eq!(matched, input.len(), "expected full-input match");
+    (caps, kinds)
+}
+
+fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+        .collect()
+}
+
+fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == kind)
+        .map(|c| format!("{}..{}", c.start, c.end))
+        .collect()
+}
+
+#[test]
+fn grammar_parses_and_compiles() {
+    let prog = compile_rust();
+    assert!(!prog.code.is_empty());
+    assert!(!prog.capture_kinds.is_empty());
+}
+
+#[test]
+fn capture_kinds_stay_in_theme_vocabulary() {
+    // The grammar must not invent capture names outside the hardcoded
+    // theme vocabulary in src/highlight/theme.rs.
+    let prog = compile_rust();
+    let allowed: HashSet<&str> = [
+        "keyword",
+        "string",
+        "number",
+        "comment",
+        "operator",
+        "punctuation",
+        "type",
+        "function",
+        "constant",
+        "property",
+        "variable",
+        "recovery",
+    ]
+    .into_iter()
+    .collect();
+    for k in &prog.capture_kinds {
+        assert!(
+            allowed.contains(k.as_str()),
+            "capture kind {:?} is not in the theme vocabulary",
+            k
+        );
+    }
+}
+
+#[test]
+fn empty_document_matches() {
+    let (caps, _) = assert_complete_full("");
+    assert!(caps.is_empty());
+}
+
+#[test]
+fn only_whitespace_matches() {
+    let (caps, _) = assert_complete_full("   \n\t\n");
+    assert!(caps.is_empty());
+}
+
+#[test]
+fn simple_fn_parses() {
+    let (caps, kinds) = assert_complete_full("fn main() {}\n");
+    // `fn` keyword + `main` function + two punctuation groups for
+    // parens and braces (order and punctuation count don't matter —
+    // we just want `fn` and `main` both flagged).
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"keyword"), "expected `fn` as keyword: {:?}", k);
+    assert!(k.contains(&"function"), "expected main as function: {:?}", k);
+}
+
+#[test]
+fn use_item_segments_are_typed() {
+    // `std::collections::HashMap` — upper-case segment = @type,
+    // lower-case segment = @variable.
+    let input = "use std::collections::HashMap;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"keyword"), "missing `use` keyword: {:?}", kv);
+    assert!(kv.contains(&"type"), "HashMap should be @type: {:?}", kv);
+    assert!(
+        kv.contains(&"variable"),
+        "std/collections should be @variable: {:?}",
+        kv
+    );
+}
+
+#[test]
+fn struct_field_is_property() {
+    // `struct Foo { a: i32 }` — `a` is a @property, `Foo` and `i32`
+    // are @type.
+    let (caps, kinds) = assert_complete_full("struct Foo { a: i32 }\n");
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"property"), "field `a` should be @property: {:?}", kv);
+    assert!(kv.contains(&"type"), "Foo/i32 should be @type: {:?}", kv);
+}
+
+#[test]
+fn turbofish_parses() {
+    let input = "fn f() { let x = parse::<i32>(\"42\"); }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn closure_disambiguates_from_bitor() {
+    // Closure body uses `|` for params (not bitor).
+    let input = "fn f() { let add = |a: i32, b: i32| -> i32 { a + b }; }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn bitor_still_works_outside_closure_position() {
+    let input = "fn f() -> u32 { 0b1100 | 0b0011 }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let ops = kind_spans(&caps, &kinds, "operator");
+    assert!(
+        ops.iter().any(|s| s.contains("..")),
+        "expected at least one operator span: {:?}",
+        ops
+    );
+}
+
+#[test]
+fn method_chain_with_turbofish_parses() {
+    let input = "fn f() { v.iter().map(|x| x + 1).collect::<Vec<_>>(); }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn match_with_guards_and_ranges_parses() {
+    let input = "fn f(n: i32) -> i32 { match n { 0 => 1, 1..=10 => 2, x if x > 10 => 3, _ => 0, } }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn lifetime_parses_as_type() {
+    let input = "fn f<'a>(s: &'a str) -> &'a str { s }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        kv.contains(&"type"),
+        "lifetime `'a` should be captured as @type: {:?}",
+        kv
+    );
+}
+
+#[test]
+fn where_clause_parses() {
+    let input = "fn f<T>(x: T) where T: Clone + Send + 'static {}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn impl_with_generic_params_parses() {
+    let input = "impl<T: Clone> Foo<T> { pub fn new() -> Self { Self { a: T::default() } } }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn attribute_parses_before_item() {
+    let input = "#[derive(Debug, Clone)]\npub struct Foo;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"keyword"), "missing keyword: {:?}", kv);
+    assert!(kv.contains(&"type"), "missing @type Foo: {:?}", kv);
+}
+
+#[test]
+fn inner_attribute_parses() {
+    let input = "#![allow(dead_code)]\nfn main() {}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn raw_string_parses() {
+    // Raw strings with hash fences. `r#"..."#` contains `"` freely.
+    let input = "fn f() { let s = r#\"he said \"hi\" to her\"#; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"string"), "raw string missing: {:?}", kv);
+}
+
+#[test]
+fn macro_invocation_function_color() {
+    let input = "fn main() { println!(\"hi\"); }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let fns = kind_spans(&caps, &kinds, "function");
+    // Both `main` and `println` should be @function.
+    assert!(
+        fns.len() >= 2,
+        "expected both `main` and `println` as @function, got: {:?}",
+        fns
+    );
+}
+
+#[test]
+fn recovery_absorbs_malformed_item() {
+    // Top-level `*^` recovery keeps the surrounding items parsed even
+    // when a middle item is garbage. `@@@` is unparseable at item
+    // position (no rule begins with it) so the outer `*^` catches it.
+    let input = "fn a() {}\n@@@ garbage @@@\nfn b() {}\n";
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(complete, "recovery should keep parse complete");
+    assert_eq!(matched, input.len());
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        kv.contains(&"recovery"),
+        "expected a @recovery capture for the @@@ region, got: {:?}",
+        kv
+    );
+}
+
+#[test]
+fn trailing_comma_tolerated_in_struct_fields() {
+    let input = "struct Foo { a: i32, b: u32, }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn nested_generics_parse() {
+    let input = "fn f() -> Option<Result<Vec<u8>, String>> { None }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn as_cast_parses() {
+    let input = "fn f() { let y = (x as u32) + (z as u64); }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn numeric_literal_with_suffix_parses() {
+    let input = "fn f() { let a = 42u32; let b = 3.14f64; let c = 0xdeadBEEFu64; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"number"), "expected @number: {:?}", kv);
+}
+
+#[test]
+fn block_comment_parses() {
+    let input = "/* a block */ fn f() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"comment"), "expected @comment: {:?}", kv);
+}
+
+#[test]
+fn line_comment_parses() {
+    let input = "// a line\nfn f() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(kv.contains(&"comment"), "expected @comment: {:?}", kv);
+}
+
+#[test]
+fn raw_identifier_parses() {
+    let input = "fn r#match() {}\n";
+    let (_, _) = assert_complete_full(input);
+}

--- a/tests/highlight_rust_tests.rs
+++ b/tests/highlight_rust_tests.rs
@@ -1,0 +1,182 @@
+use syntax_highlighter::highlight::{theme, Highlighter};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(RUST_GRAMMAR).expect("Rust grammar should compile");
+    h.set_input(input.to_string());
+    h
+}
+
+#[test]
+fn round_trip_strips_to_input() {
+    let cases: &[&str] = &[
+        "fn main() {}\n",
+        "use std::collections::HashMap;\n",
+        "struct Foo { a: i32, b: u32 }\n",
+        "fn add(a: i32, b: i32) -> i32 { a + b }\n",
+        "#[derive(Debug)]\npub enum E { A, B(u32) }\n",
+        "fn f<'a>(s: &'a str) -> &'a str { s }\n",
+    ];
+    for &input in cases {
+        let out = hl(input).highlight();
+        assert_eq!(
+            strip_ansi(&out),
+            input,
+            "round-trip mismatch for: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn keyword_uses_keyword_color() {
+    let out = hl("fn main() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("keyword")),
+        "expected keyword color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn string_uses_string_color() {
+    let out = hl("fn f() { let s = \"hello\"; }\n").highlight();
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color in: {:?}",
+        out
+    );
+    assert!(out.contains("hello"));
+}
+
+#[test]
+fn number_uses_number_color() {
+    let out = hl("fn f() -> i32 { 42 }\n").highlight();
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected number color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn line_comment_uses_comment_color() {
+    let out = hl("// a line\nfn f() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn block_comment_uses_comment_color() {
+    let out = hl("/* a block */ fn f() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn lifetime_uses_type_color() {
+    // Lifetimes are captured as @type in this grammar — the hardcoded
+    // theme has no dedicated lifetime color, and grouping with other
+    // type-shaped syntax is the consistent choice.
+    let out = hl("fn f<'a>(s: &'a str) {}\n").highlight();
+    let idx = out.find("'a").expect("'a must appear in output");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before 'a, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn fn_name_uses_function_color() {
+    let out = hl("fn compute() {}\n").highlight();
+    let idx = out.find("compute").expect("`compute` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("function")),
+        "expected function color before `compute`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn macro_invocation_uses_function_color() {
+    // `println` in `println!("...")` — the macro name itself is @function.
+    let out = hl("fn main() { println!(\"hi\"); }\n").highlight();
+    let idx = out.find("println").expect("`println` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("function")),
+        "expected function color before `println`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn bool_uses_constant_color() {
+    let out = hl("fn f() -> bool { true }\n").highlight();
+    assert!(
+        out.contains(theme::color_for("constant")),
+        "expected constant color for `true` in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn attribute_punctuation_present() {
+    // `#[derive(...)]` — `#` and `[` `]` are punctuation; the grammar
+    // should emit punctuation captures around them.
+    let out = hl("#[derive(Debug)]\nfn f() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("punctuation")),
+        "expected punctuation color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn upper_ident_in_path_uses_type_color() {
+    // `HashMap` as a path segment should be @type.
+    let out = hl("use std::collections::HashMap;\n").highlight();
+    let idx = out.find("HashMap").expect("HashMap must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before HashMap, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn recovery_renders_malformed_region_plain() {
+    // `*^` recovery emits the unmatched region under @recovery, which
+    // maps to "no color" in the hardcoded theme. Surrounding items
+    // still get styled.
+    let input = "fn a() {}\n@@@ garbage @@@\nfn b() {}\n";
+    let out = hl(input).highlight();
+    // Round-trip still works — every byte preserved.
+    assert_eq!(strip_ansi(&out), input);
+    // `fn` keywords from both a and b are colored.
+    assert!(out.contains(theme::color_for("keyword")));
+}
+
+#[test]
+fn partial_match_on_truncated_input() {
+    // Truncated input (missing `}`) still renders the matched prefix
+    // styled and the remainder plain.
+    let input = "fn incomplete() { let x = 1\n";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input);
+}


### PR DESCRIPTION
## Summary

- New \`grammars/rust.peg\` (452 lines, 3,413 VM instructions, 172 rules) covers items, expressions, types, attributes, lifetimes, match, and macro invocations via balanced-bracket skip. Stays inside the shipped 12-name capture vocabulary.
- Parse-structure tests in \`tests/grammar_rust_tests.rs\` pin the shared-prefix backtracking corners (turbofish, closure-vs-bitor, lifetimes, recovery); round-trip + color tests in \`tests/highlight_rust_tests.rs\`.
- CLI picks up \`.rs\` automatically; explicit \`-l rust\` or \`-l rs\` also work.
- Fixtures \`benches/fixtures/{small,medium,large,xlarge}.rs\` wired into \`memo.rs\` and \`incremental.rs\`; the xlarge row shows a clean hit-rate climb from 14.9% at t=0 to 33% at t=512, so \`DEFAULT_MEMO_THRESHOLD = 128\` stays defensible.

Part of #10 (Strong candidate from item 2). Stacked on #19.

## Test plan

Covered by CI plus the memo sweep's baseline (\`complete=true\` required on every fixture).