### PR TITLE
Add JavaScript (subset) grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ grammar exercising multi-statement error recovery). Expect breaking
 changes.
 
 The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`,
-`.rs`) or an explicit `-l json|toml|sql|rust` flag; stdin without a
-flag defaults to JSON.
+`.rs`, `.js`/`.mjs`/`.cjs`) or an explicit `-l json|toml|sql|rust|js`
+flag; stdin without a flag defaults to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
@@ -99,14 +99,15 @@ largest piece of work.
 These need no new VM or compiler machinery.
 
 - **More language grammars.** JSON, TOML, the full SQLite dialect,
-  and a pragmatic Rust subset ship today. Adding a language means
-  writing a grammar file. SQLite remains the large-grammar
-  bytecode-size datapoint the design goals called for: 5,627 VM
-  instructions across 426 rules — an order of magnitude larger than
-  JSON (165 instr) or TOML (511 instr); Rust sits between at 3,413
-  instr / 172 rules, still comfortably inside the "kilobyte range
-  per grammar" ambition. Remaining candidates: Python, JavaScript,
-  Go, C, CSS. YAML is deferred — its context-sensitive indentation
+  a pragmatic Rust subset, and an ES2020-ish JavaScript subset ship
+  today. Adding a language means writing a grammar file. SQLite
+  remains the large-grammar bytecode-size datapoint the design goals
+  called for: 5,627 VM instructions across 426 rules — an order of
+  magnitude larger than JSON (165 instr) or TOML (511 instr); Rust
+  (3,413 instr / 172 rules) and JavaScript (2,916 instr / 137 rules)
+  sit between, still comfortably inside the "kilobyte range per
+  grammar" ambition. Remaining candidates: Python, TypeScript, Go,
+  C, CSS. YAML is deferred — its context-sensitive indentation
   semantics make it a poor fit for PEG without additional machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is

--- a/benches/fixtures/large.js
+++ b/benches/fixtures/large.js
@@ -1,0 +1,577 @@
+// Generated JavaScript bench fixture. Not hand-maintained —
+// regenerate via benches/fixtures/gen_js.py if shapes need tweaking.
+// The module is intentionally self-contained (no imports) so the
+// grammar sees the full expression/statement surface.
+
+const DEFAULTS = Object.freeze({ size: 16, verbose: false, tag: "default" });
+
+function classify(n) {
+  switch (true) {
+    case n < 0: return "negative";
+    case n === 0: return "zero";
+    case n < 10: return "single";
+    case n < 100: return "double";
+    case n < 1000: return "triple";
+    default: return "big";
+  }
+}
+
+async function loadSamples(source) {
+  try {
+    const data = await source.read();
+    return data.filter(x => x != null).map(x => Number(x));
+  } catch (e) {
+    console.error(`load failed: ${e.message}`);
+    return [];
+  } finally {
+    source.close?.();
+  }
+}
+
+const utils = {
+  clamp(n, lo, hi) { return n < lo ? lo : n > hi ? hi : n; },
+  tagged(strings, ...values) {
+    return strings.reduce((acc, s, i) => acc + s + (values[i] ?? ""), "");
+  },
+  [Symbol.iterator]() { return [1, 2, 3][Symbol.iterator](); },
+};
+
+class Base0 {}
+class Base1 {}
+class Base2 {}
+class Base3 {}
+class Base4 {}
+
+class Counter0 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter0(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter1 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter1(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter2 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter2(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter3 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter3(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter4 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter4(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter5 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter5(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter6 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter6(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter7 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter7(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter8 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter8(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter9 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter9(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+
+async function main() {
+  const c = new Counter0("root", { size: 32, verbose: true });
+  const samples = [1, 2, 2, 3, 10, 10, 10, -1, "a", "a", "b"];
+  for (const x of samples) c.push(x);
+  const first = samples[0];
+  const rest = samples.slice(1);
+  const [head, ...tail] = rest;
+  const { name, options: { size = 0, verbose } = {} } = c;
+  const label = utils.tagged`counter ${name} size=${size} verbose=${verbose}`;
+  console.log(label);
+  console.log(c.summary());
+  for (const n of samples.map(Number).filter(Boolean)) {
+    console.log(`${n} -> ${classify(n)}`);
+  }
+  const loaded = await loadSamples({
+    async read() { return samples; },
+    close() { /* noop */ },
+  });
+  return loaded.reduce((a, b) => a + b, 0);
+}
+
+main().catch(e => console.error(e?.stack ?? e));

--- a/benches/fixtures/medium.js
+++ b/benches/fixtures/medium.js
@@ -1,0 +1,83 @@
+// Medium-sized JavaScript bench fixture: exercises classes, arrow
+// fns, destructuring, template literals, async/await, and spread.
+// Self-contained so the grammar sees the full surface without an
+// import cluster obscuring it.
+
+const DEFAULTS = Object.freeze({ size: 16, verbose: false });
+
+class Counter {
+  constructor(name, options = {}) {
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n };
+    }
+  }
+
+  summary() {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 3)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    return `${this.name} (n=${this.size}, top=[${top}])`;
+  }
+}
+
+function classify(n) {
+  switch (true) {
+    case n < 0:
+      return "negative";
+    case n === 0:
+      return "zero";
+    case n < 10:
+      return "single";
+    case n < 100:
+      return "double";
+    default:
+      return "large";
+  }
+}
+
+async function loadSamples(source) {
+  try {
+    const data = await source.read();
+    return data.filter(x => x != null).map(x => Number(x));
+  } catch (e) {
+    console.error(`load failed: ${e.message}`);
+    return [];
+  } finally {
+    source.close?.();
+  }
+}
+
+const sink = {
+  log(msg) {
+    console.log(msg);
+  },
+  warn(msg) {
+    console.warn(`WARN: ${msg}`);
+  },
+};
+
+const data = [1, 2, 2, 3, 10, 10, 10, -1];
+const c = new Counter("ages");
+for (const x of data) c.push(x);
+sink.log(c.summary());
+for (const n of data) sink.log(`${n} -> ${classify(n)}`);

--- a/benches/fixtures/small.js
+++ b/benches/fixtures/small.js
@@ -1,0 +1,1 @@
+const greet = name => `hello, ${name}!`;

--- a/benches/fixtures/xlarge.js
+++ b/benches/fixtures/xlarge.js
@@ -1,0 +1,6187 @@
+// Generated JavaScript bench fixture. Not hand-maintained —
+// regenerate via benches/fixtures/gen_js.py if shapes need tweaking.
+// The module is intentionally self-contained (no imports) so the
+// grammar sees the full expression/statement surface.
+
+const DEFAULTS = Object.freeze({ size: 16, verbose: false, tag: "default" });
+
+function classify(n) {
+  switch (true) {
+    case n < 0: return "negative";
+    case n === 0: return "zero";
+    case n < 10: return "single";
+    case n < 100: return "double";
+    case n < 1000: return "triple";
+    default: return "big";
+  }
+}
+
+async function loadSamples(source) {
+  try {
+    const data = await source.read();
+    return data.filter(x => x != null).map(x => Number(x));
+  } catch (e) {
+    console.error(`load failed: ${e.message}`);
+    return [];
+  } finally {
+    source.close?.();
+  }
+}
+
+const utils = {
+  clamp(n, lo, hi) { return n < lo ? lo : n > hi ? hi : n; },
+  tagged(strings, ...values) {
+    return strings.reduce((acc, s, i) => acc + s + (values[i] ?? ""), "");
+  },
+  [Symbol.iterator]() { return [1, 2, 3][Symbol.iterator](); },
+};
+
+class Base0 {}
+class Base1 {}
+class Base2 {}
+class Base3 {}
+class Base4 {}
+
+class Counter0 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter0(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter1 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter1(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter2 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter2(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter3 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter3(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter4 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter4(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter5 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter5(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter6 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter6(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter7 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter7(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter8 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter8(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter9 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter9(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter10 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter10(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter11 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter11(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter12 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter12(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter13 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter13(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter14 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter14(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter15 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter15(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter16 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter16(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter17 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter17(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter18 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter18(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter19 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter19(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter20 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter20(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter21 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter21(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter22 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter22(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter23 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter23(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter24 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter24(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter25 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter25(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter26 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter26(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter27 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter27(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter28 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter28(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter29 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter29(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter30 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter30(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter31 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter31(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter32 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter32(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter33 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter33(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter34 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter34(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter35 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter35(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter36 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter36(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter37 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter37(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter38 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter38(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter39 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter39(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter40 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter40(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter41 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter41(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter42 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter42(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter43 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter43(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter44 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter44(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter45 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter45(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter46 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter46(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter47 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter47(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter48 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter48(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter49 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter49(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter50 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter50(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter51 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter51(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter52 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter52(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter53 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter53(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter54 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter54(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter55 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter55(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter56 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter56(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter57 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter57(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter58 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter58(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter59 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter59(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter60 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter60(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter61 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter61(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter62 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter62(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter63 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter63(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter64 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter64(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter65 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter65(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter66 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter66(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter67 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter67(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter68 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter68(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter69 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter69(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter70 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter70(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter71 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter71(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter72 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter72(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter73 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter73(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter74 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter74(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter75 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter75(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter76 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter76(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter77 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter77(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter78 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter78(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter79 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter79(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter80 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter80(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter81 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter81(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter82 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter82(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter83 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter83(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter84 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter84(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter85 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter85(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter86 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter86(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter87 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter87(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter88 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter88(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter89 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter89(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter90 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter90(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter91 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter91(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter92 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter92(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter93 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter93(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter94 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter94(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter95 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter95(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter96 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter96(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter97 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter97(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter98 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter98(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter99 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter99(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter100 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter100(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter101 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter101(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter102 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter102(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter103 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter103(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter104 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter104(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter105 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter105(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter106 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter106(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter107 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter107(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter108 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter108(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter109 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter109(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter110 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter110(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter111 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter111(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter112 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter112(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter113 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter113(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter114 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter114(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter115 extends Base0 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter115(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter116 extends Base1 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter116(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter117 extends Base2 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter117(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter118 extends Base3 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter118(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+class Counter119 extends Base4 {
+  constructor(name, options = {}) {
+    super();
+    this.name = name;
+    this.options = { ...DEFAULTS, ...options };
+    this.values = [];
+    this.histogram = new Map();
+    this._cache = null;
+  }
+
+  push(v) {
+    const key = typeof v === "string" ? v : String(v);
+    this.histogram.set(key, (this.histogram.get(key) ?? 0) + 1);
+    this.values.push(v);
+    this._cache = null;
+    return this;
+  }
+
+  get size() {
+    return this.values.length;
+  }
+
+  static make(name, ...rest) {
+    return new Counter119(name, Object.assign({}, ...rest));
+  }
+
+  *entries() {
+    for (const [k, n] of this.histogram) {
+      yield { key: k, count: n, tag: `${this.name}:${k}` };
+    }
+  }
+
+  async flush(sink) {
+    const rows = [...this.entries()];
+    for (const row of rows) {
+      await sink?.write?.(row);
+    }
+    return rows.length;
+  }
+
+  summary(limit = 3) {
+    const top = [...this.histogram.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(", ");
+    const { size } = this;
+    return `${this.name} (n=${size}, top=[${top}])`;
+  }
+}
+
+
+async function main() {
+  const c = new Counter0("root", { size: 32, verbose: true });
+  const samples = [1, 2, 2, 3, 10, 10, 10, -1, "a", "a", "b"];
+  for (const x of samples) c.push(x);
+  const first = samples[0];
+  const rest = samples.slice(1);
+  const [head, ...tail] = rest;
+  const { name, options: { size = 0, verbose } = {} } = c;
+  const label = utils.tagged`counter ${name} size=${size} verbose=${verbose}`;
+  console.log(label);
+  console.log(c.summary());
+  for (const n of samples.map(Number).filter(Boolean)) {
+    console.log(`${n} -> ${classify(n)}`);
+  }
+  const loaded = await loadSamples({
+    async read() { return samples; },
+    close() { /* noop */ },
+  });
+  return loaded.reduce((a, b) => a + b, 0);
+}
+
+main().catch(e => console.error(e?.stack ?? e));

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -27,6 +27,7 @@ const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -47,6 +48,11 @@ const RUST_SMALL: &str = include_str!("fixtures/small.rs");
 const RUST_MEDIUM: &str = include_str!("fixtures/medium.rs");
 const RUST_LARGE: &str = include_str!("fixtures/large.rs");
 const RUST_XLARGE: &str = include_str!("fixtures/xlarge.rs");
+
+const JS_SMALL: &str = include_str!("fixtures/small.js");
+const JS_MEDIUM: &str = include_str!("fixtures/medium.js");
+const JS_LARGE: &str = include_str!("fixtures/large.js");
+const JS_XLARGE: &str = include_str!("fixtures/xlarge.js");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -285,6 +291,16 @@ fn main() {
                 ("medium", RUST_MEDIUM),
                 ("large", RUST_LARGE),
                 ("xlarge", RUST_XLARGE),
+            ],
+        },
+        GrammarCase {
+            label: "js",
+            source: JS_GRAMMAR,
+            fixtures: &[
+                ("small", JS_SMALL),
+                ("medium", JS_MEDIUM),
+                ("large", JS_LARGE),
+                ("xlarge", JS_XLARGE),
             ],
         },
     ];

--- a/benches/memo.rs
+++ b/benches/memo.rs
@@ -27,6 +27,7 @@ const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -47,6 +48,11 @@ const RUST_SMALL: &str = include_str!("fixtures/small.rs");
 const RUST_MEDIUM: &str = include_str!("fixtures/medium.rs");
 const RUST_LARGE: &str = include_str!("fixtures/large.rs");
 const RUST_XLARGE: &str = include_str!("fixtures/xlarge.rs");
+
+const JS_SMALL: &str = include_str!("fixtures/small.js");
+const JS_MEDIUM: &str = include_str!("fixtures/medium.js");
+const JS_LARGE: &str = include_str!("fixtures/large.js");
+const JS_XLARGE: &str = include_str!("fixtures/xlarge.js");
 
 const THRESHOLDS: &[usize] = &[0, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 const RUNS_PER_CELL: usize = 11;
@@ -197,6 +203,16 @@ fn main() {
                 ("medium", RUST_MEDIUM.as_bytes()),
                 ("large", RUST_LARGE.as_bytes()),
                 ("xlarge", RUST_XLARGE.as_bytes()),
+            ],
+        },
+        GrammarCase {
+            name: "js",
+            program: compile_case("js", JS_GRAMMAR),
+            inputs: vec![
+                ("small", JS_SMALL.as_bytes()),
+                ("medium", JS_MEDIUM.as_bytes()),
+                ("large", JS_LARGE.as_bytes()),
+                ("xlarge", JS_XLARGE.as_bytes()),
             ],
         },
     ];

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -1,0 +1,361 @@
+# JavaScript (pragmatic subset) grammar with highlight annotations.
+# The first rule is the start rule.
+#
+# Scope: highlighting, not execution. Parses ES2020-ish JavaScript at
+# the token level. Precedence is not enforced and semantic constraints
+# (binding rules, strict-mode, generator-vs-function context) are not
+# checked. The bench value lives in the shared-prefix backtracking
+# induced by arrow-fn-vs-paren-expr and template-literal expression
+# splicing.
+#
+# ASI (automatic semicolon insertion) is handled loosely: `;` is
+# accepted but not required at statement boundaries. Tokens that
+# would be invalid under a real ASI pass are still accepted here
+# because highlighting does not need to agree with the engine.
+#
+# Capture kinds used (all present in src/highlight/theme.rs):
+#   keyword, string, number, comment, operator, punctuation, type,
+#   function, constant, property, variable, recovery.
+#
+# Intentionally out of scope:
+#   - JSX. Requires its own expression/statement mode.
+#   - Regex literals. Disambiguation from division requires parser
+#     state the VM does not carry; `/re/` is rare enough that giving
+#     up on it is a fair trade.
+#   - Decorator proposals.
+#   - TypeScript type annotations.
+#
+# Recovery: top-level uses `*^` so malformed statements don't abort
+# the whole file.
+
+js_file        <- ws (stmt)*^ ws !.
+
+# --- Statements -------------------------------------------------------
+#
+# Order matters (PEG first-match). Declaration-shaped items precede
+# expression-statements so their leading keywords aren't misparsed as
+# identifiers.
+
+stmt           <- import_decl
+                / export_decl
+                / fn_decl
+                / class_decl
+                / var_decl ws opt_semi
+                / if_stmt
+                / for_stmt
+                / while_stmt
+                / do_while_stmt
+                / switch_stmt
+                / try_stmt
+                / throw_stmt
+                / return_stmt
+                / break_stmt
+                / continue_stmt
+                / debugger_stmt
+                / labeled_stmt
+                / block_stmt
+                / empty_stmt
+                / expr ws opt_semi
+
+opt_semi       <- (@punctuation{';'} ws)?
+empty_stmt     <- @punctuation{';'} ws
+
+# --- Imports / exports ------------------------------------------------
+
+import_decl    <- @keyword{'import'} ws import_body ws opt_semi
+import_body    <- import_clause ws @keyword{'from'} ws string_lit
+                / string_lit
+import_clause  <- import_default ws @punctuation{','} ws import_ns_or_named
+                / import_default
+                / import_ns_or_named
+import_default <- @variable{ident}
+import_ns_or_named <- import_namespace / import_named
+import_namespace <- @operator{'*'} ws @keyword{'as'} ws @variable{ident}
+import_named   <- @punctuation{'{'} ws import_specifier_list? ws @punctuation{'}'}
+import_specifier_list <- import_specifier (ws @punctuation{','} ws import_specifier)* (ws @punctuation{','})?
+import_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+                  / @variable{ident}
+
+export_decl    <- @keyword{'export'} ws @keyword{'default'} ws export_default_body
+                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident} ws)? @keyword{'from'} ws string_lit ws opt_semi
+                / @keyword{'export'} ws export_named
+                / @keyword{'export'} ws fn_decl
+                / @keyword{'export'} ws class_decl
+                / @keyword{'export'} ws var_decl ws opt_semi
+export_default_body <- fn_decl
+                     / class_decl
+                     / expr ws opt_semi
+export_named   <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
+export_specifier_list <- export_specifier (ws @punctuation{','} ws export_specifier)* (ws @punctuation{','})?
+export_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+                  / @variable{ident}
+
+# --- Function / class declarations ------------------------------------
+
+fn_decl        <- @keyword{'async'} ws fn_decl_core
+                / fn_decl_core
+fn_decl_core   <- @keyword{'function'} (ws @operator{'*'})? ws @function{ident} ws fn_params ws block
+
+class_decl     <- @keyword{'class'} ws @type{ident} ws class_heritage? ws class_body
+class_heritage <- @keyword{'extends'} ws expr_lhs
+class_body     <- @punctuation{'{'} ws class_member* ws @punctuation{'}'}
+class_member   <- @punctuation{';'} ws
+                / class_method_or_field
+class_method_or_field <- (@keyword{'static'} ws)? (class_method / class_field)
+class_method   <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block ws
+                / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block ws
+method_head    <- computed_prop
+                / @function{ident}
+                / string_lit
+                / number_lit
+class_field    <- (computed_prop / @property{ident}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
+
+# --- Variable declarations -------------------------------------------
+
+var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) ws var_declarator_list
+var_declarator_list <- var_declarator (ws @punctuation{','} ws var_declarator)*
+var_declarator <- pattern (ws @operator{'='} ws expr_no_comma)?
+
+# --- Control flow -----------------------------------------------------
+
+if_stmt        <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
+                  (ws @keyword{'else'} ws stmt)?
+for_stmt       <- @keyword{'for'} (ws @keyword{'await'})? ws @punctuation{'('} ws for_head ws @punctuation{')'} ws stmt
+for_head       <- for_c_style
+                / for_in_of
+for_c_style    <- for_init? ws @punctuation{';'} ws expr? ws @punctuation{';'} ws expr?
+for_in_of      <- for_binding ws (@keyword{'in'} / @keyword{'of'}) ws expr
+for_init       <- var_decl
+                / expr
+for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) ws pattern
+                / pattern
+
+while_stmt     <- @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
+do_while_stmt  <- @keyword{'do'} ws stmt ws @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws opt_semi
+switch_stmt    <- @keyword{'switch'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws
+                  @punctuation{'{'} ws switch_case* ws @punctuation{'}'}
+switch_case    <- @keyword{'case'} ws expr ws @punctuation{':'} ws (!switch_case_term stmt)*
+                / @keyword{'default'} ws @punctuation{':'} ws (!switch_case_term stmt)*
+switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
+try_stmt       <- @keyword{'try'} ws block (ws catch_clause)? (ws finally_clause)?
+catch_clause   <- @keyword{'catch'} (ws @punctuation{'('} ws pattern ws @punctuation{')'})? ws block
+finally_clause <- @keyword{'finally'} ws block
+throw_stmt     <- @keyword{'throw'} ws expr ws opt_semi
+return_stmt    <- @keyword{'return'} (ws expr)? ws opt_semi
+break_stmt     <- @keyword{'break'} (ws @variable{ident})? ws opt_semi
+continue_stmt  <- @keyword{'continue'} (ws @variable{ident})? ws opt_semi
+debugger_stmt  <- @keyword{'debugger'} ws opt_semi
+labeled_stmt   <- @variable{ident} ws @punctuation{':'} ws stmt
+block_stmt     <- block
+block          <- @punctuation{'{'} ws stmt* ws @punctuation{'}'}
+
+# --- Function params and patterns -------------------------------------
+
+fn_params      <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
+fn_param_list  <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
+fn_param       <- @operator{'...'} pattern
+                / pattern (ws @operator{'='} ws expr_no_comma)?
+
+# --- Destructuring patterns ------------------------------------------
+
+pattern        <- array_pattern / object_pattern / @variable{ident}
+array_pattern  <- @punctuation{'['} ws array_pattern_list? ws @punctuation{']'}
+array_pattern_list <- array_pattern_el (ws @punctuation{','} ws array_pattern_el)* (ws @punctuation{','})?
+array_pattern_el <- @operator{'...'} pattern
+                  / pattern (ws @operator{'='} ws expr_no_comma)?
+                  / ''
+object_pattern <- @punctuation{'{'} ws object_pattern_list? ws @punctuation{'}'}
+object_pattern_list <- object_pattern_prop (ws @punctuation{','} ws object_pattern_prop)* (ws @punctuation{','})?
+object_pattern_prop <- @operator{'...'} pattern
+                     / (computed_prop / @property{ident}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
+                     / @property{ident} (ws @operator{'='} ws expr_no_comma)?
+
+computed_prop  <- @punctuation{'['} ws expr ws @punctuation{']'}
+
+# --- Expressions ------------------------------------------------------
+
+expr           <- expr_no_comma (ws @punctuation{','} ws expr_no_comma)*
+expr_no_comma  <- expr_assign
+expr_assign    <- expr_arrow
+                / expr_yield
+                / expr_conditional (ws assign_op ws expr_assign)?
+
+assign_op      <- @operator{'**='}
+                / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
+                / @operator{'||='} / @operator{'&&='} / @operator{'??='}
+                / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
+                / @operator{'='} !'='
+
+# Arrow functions tried first. `async x => ...`, `x => ...`,
+# `(a, b) => ...`, `() => ...`.
+expr_arrow     <- arrow_head ws @operator{'=>'} ws arrow_body
+arrow_head     <- @keyword{'async'} ws arrow_params
+                / arrow_params
+arrow_params   <- @variable{ident}
+                / arrow_paren_params
+arrow_paren_params <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
+arrow_body     <- block
+                / expr_no_comma
+
+expr_yield     <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
+
+# Ternary.
+expr_conditional <- expr_bin (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
+
+# Binary / logical / bitwise — flattened, precedence not enforced.
+expr_bin       <- expr_unary (ws bin_op ws expr_unary)*
+bin_op         <- @operator{'??'}
+                / @operator{'||'} / @operator{'&&'}
+                / @operator{'==='} / @operator{'!=='}
+                / @operator{'=='} / @operator{'!='}
+                / @operator{'<='} / @operator{'>='}
+                / @operator{'<<'} / @operator{'>>>'} / @operator{'>>'}
+                / @operator{'**'}
+                / @operator{'+'} / @operator{'-'}
+                / @operator{'*'} / @operator{'/'} / @operator{'%'}
+                / @operator{'&'} / @operator{'|'} / @operator{'^'}
+                / @operator{'<'} / @operator{'>'}
+                / @keyword{'instanceof'}
+                / @keyword{'in'}
+
+expr_unary     <- (unary_op ws)* expr_postfix
+unary_op       <- @keyword{'typeof'}
+                / @keyword{'void'}
+                / @keyword{'delete'}
+                / @keyword{'await'}
+                / @operator{'++'} / @operator{'--'}
+                / @operator{'+'} / @operator{'-'}
+                / @operator{'!'} / @operator{'~'}
+
+# Postfix: calls, member, optional chain, index, `++`/`--`.
+expr_postfix   <- expr_lhs (ws postfix_op)*
+postfix_op     <- @operator{'++'}
+                / @operator{'--'}
+                / @operator{'?.'} ws postfix_after_optional
+                / @punctuation{'.'} member_target
+                / @punctuation{'['} ws expr ws @punctuation{']'}
+                / call_args
+                / template_lit
+postfix_after_optional <- call_args
+                        / @punctuation{'['} ws expr ws @punctuation{']'}
+                        / member_target
+member_target  <- @function{ident} &(ws @punctuation{'('})
+                / @property{ident}
+call_args      <- @punctuation{'('} ws arg_list? ws @punctuation{')'}
+arg_list       <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
+arg            <- @operator{'...'} expr_no_comma
+                / expr_no_comma
+
+expr_lhs       <- expr_new / expr_primary
+expr_new       <- @keyword{'new'} ws expr_new_target
+expr_new_target <- @type{upper_ident} new_tail?
+                 / @variable{lower_ident} new_tail?
+                 / expr_primary new_tail?
+new_tail       <- (ws postfix_op)+
+
+expr_primary   <- literal
+                / expr_this
+                / expr_super
+                / expr_fn
+                / expr_class
+                / expr_array
+                / expr_object
+                / expr_paren
+                / call_ident
+                / @type{upper_ident}
+                / @variable{lower_ident}
+
+call_ident     <- @function{ident} &(ws @punctuation{'('})
+
+expr_this      <- @keyword{'this'}
+expr_super     <- @keyword{'super'}
+expr_fn        <- (@keyword{'async'} ws)? @keyword{'function'} (ws @operator{'*'})? ws (@function{ident} ws)? fn_params ws block
+expr_class     <- @keyword{'class'} (ws @type{ident})? ws class_heritage? ws class_body
+expr_array     <- @punctuation{'['} ws array_elem_list? ws @punctuation{']'}
+array_elem_list <- array_elem (ws @punctuation{','} ws array_elem)* (ws @punctuation{','})?
+array_elem     <- @operator{'...'} expr_no_comma
+                / expr_no_comma
+                / ''
+expr_object    <- @punctuation{'{'} ws object_props? ws @punctuation{'}'}
+object_props   <- object_prop (ws @punctuation{','} ws object_prop)* (ws @punctuation{','})?
+object_prop    <- @operator{'...'} expr_no_comma
+                / object_method
+                / (computed_prop / string_lit / number_lit / @property{ident}) ws @punctuation{':'} ws expr_no_comma
+                / @property{ident}
+object_method  <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block
+                / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block
+expr_paren     <- @punctuation{'('} ws expr ws @punctuation{')'}
+
+# --- Literals ---------------------------------------------------------
+
+literal        <- template_lit
+                / string_lit
+                / number_lit
+                / @constant{bool_lit}
+                / @constant{null_lit}
+                / @constant{undefined_lit}
+
+bool_lit       <- 'true' !ident_body
+                / 'false' !ident_body
+null_lit       <- 'null' !ident_body
+undefined_lit  <- 'undefined' !ident_body
+
+string_lit     <- @string{sq_string / dq_string}
+sq_string      <- "'" (str_escape / !"'" !'\n' .)* "'"
+dq_string      <- '"' (str_escape / !'"' !'\n' .)* '"'
+str_escape     <- '\\' .
+
+# Template literals with ${...} interpolation. Chunks outside the
+# interpolations get @string; the interpolation braces stay
+# @punctuation and the inner expression is parsed as normal.
+template_lit   <- @string{'`'} template_body @string{'`'}
+template_body  <- (template_chunk / template_interp)*
+template_chunk <- @string{('\\' . / !'`' !'${' .)+}
+template_interp <- @punctuation{'${'} ws expr ws @punctuation{'}'}
+
+number_lit     <- @number{num_body}
+num_body       <- '0x' hex_digits bigint?
+                / '0o' oct_digits bigint?
+                / '0b' bin_digits bigint?
+                / decimal_num bigint?
+decimal_num    <- digit_seq '.' digit_seq? exp_part?
+                / '.' digit_seq exp_part?
+                / digit_seq exp_part?
+digit_seq      <- [0-9] ([0-9_])*
+hex_digits     <- [0-9a-fA-F] [0-9a-fA-F_]*
+oct_digits     <- [0-7] [0-7_]*
+bin_digits     <- [01] [01_]*
+exp_part       <- [eE] [+\-]? [0-9]+
+bigint         <- 'n'
+
+# --- Identifiers / reserved words ------------------------------------
+
+ident          <- !reserved ident_start ident_body*
+upper_ident    <- !reserved [A-Z] ident_body*
+lower_ident    <- !reserved [a-z_$] ident_body*
+ident_start    <- [A-Za-z_$]
+ident_body     <- [A-Za-z0-9_$]
+
+# Reserved words that must not appear as identifiers. The grammar uses
+# explicit `@keyword{...}` at each call site, so this list only blocks
+# accidental ident capture. Contextual keywords (`async`, `await`,
+# `of`, `from`, `as`, `get`, `set`, `static`, `yield` outside
+# generators) are intentionally omitted so they can still be used as
+# identifiers where the language allows.
+reserved       <- reserved_word !ident_body
+reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
+                / 'debugger' / 'default' / 'delete' / 'do' / 'else'
+                / 'export' / 'extends' / 'false' / 'finally' / 'for'
+                / 'function' / 'if' / 'import' / 'instanceof' / 'in'
+                / 'new' / 'null' / 'return' / 'super' / 'switch'
+                / 'this' / 'throw' / 'true' / 'try' / 'typeof' / 'var'
+                / 'void' / 'while' / 'with' / 'yield'
+
+# --- Whitespace / comments --------------------------------------------
+
+comment        <- @comment{line_comment / block_comment}
+line_comment   <- '//' (!'\n' .)*
+block_comment  <- '/*' (!'*/' .)* '*/'
+
+ws             <- (comment / [ \t\r\n])*

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 
 #[derive(Clone, Copy)]
 enum Lang {
@@ -15,6 +16,7 @@ enum Lang {
     Toml,
     Sql,
     Rust,
+    JavaScript,
 }
 
 impl Lang {
@@ -24,6 +26,7 @@ impl Lang {
             Lang::Toml => TOML_GRAMMAR,
             Lang::Sql => SQLITE_GRAMMAR,
             Lang::Rust => RUST_GRAMMAR,
+            Lang::JavaScript => JS_GRAMMAR,
         }
     }
 
@@ -33,6 +36,7 @@ impl Lang {
             "toml" => Some(Lang::Toml),
             "sql" | "sqlite" => Some(Lang::Sql),
             "rs" | "rust" => Some(Lang::Rust),
+            "js" | "javascript" | "mjs" | "cjs" => Some(Lang::JavaScript),
             _ => None,
         }
     }
@@ -58,15 +62,15 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
             "-l" | "--lang" => {
                 let name = it
                     .next()
-                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust)", arg))?;
+                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust|js)", arg))?;
                 lang = Some(Lang::from_name(&name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql|rust)", name)
+                    format!("unknown language {:?} (expected json|toml|sql|rust|js)", name)
                 })?);
             }
             other if other.starts_with("--lang=") => {
                 let name = &other["--lang=".len()..];
                 lang = Some(Lang::from_name(name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql|rust)", name)
+                    format!("unknown language {:?} (expected json|toml|sql|rust|js)", name)
                 })?);
             }
             _ => {
@@ -87,7 +91,7 @@ fn pick_lang(cli: &Cli) -> Result<Lang, String> {
     match &cli.path {
         Some(p) => Lang::from_extension(Path::new(p)).ok_or_else(|| {
             format!(
-                "cannot infer language from path {:?}; pass --lang json|toml|sql|rust",
+                "cannot infer language from path {:?}; pass --lang json|toml|sql|rust|js",
                 p
             )
         }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,13 +64,19 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
                     .next()
                     .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust|js)", arg))?;
                 lang = Some(Lang::from_name(&name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql|rust|js)", name)
+                    format!(
+                        "unknown language {:?} (expected json|toml|sql|rust|js)",
+                        name
+                    )
                 })?);
             }
             other if other.starts_with("--lang=") => {
                 let name = &other["--lang=".len()..];
                 lang = Some(Lang::from_name(name).ok_or_else(|| {
-                    format!("unknown language {:?} (expected json|toml|sql|rust|js)", name)
+                    format!(
+                        "unknown language {:?} (expected json|toml|sql|rust|js)",
+                        name
+                    )
                 })?);
             }
             _ => {

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -103,7 +103,11 @@ fn simple_function_decl_parses() {
         "expected `function` as keyword: {:?}",
         k
     );
-    assert!(k.contains(&"function"), "expected main as function: {:?}", k);
+    assert!(
+        k.contains(&"function"),
+        "expected main as function: {:?}",
+        k
+    );
 }
 
 #[test]
@@ -136,7 +140,11 @@ fn template_literal_parses_with_interp() {
     let input = "const s = `hello ${name}, age ${age + 1}`;\n";
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
-    assert!(k.contains(&"string"), "expected @string for template: {:?}", k);
+    assert!(
+        k.contains(&"string"),
+        "expected @string for template: {:?}",
+        k
+    );
 }
 
 #[test]
@@ -181,9 +189,8 @@ fn spread_in_call_and_array_parses() {
 
 #[test]
 fn for_of_and_for_in_parse() {
-    let (_, _) = assert_complete_full(
-        "for (const x of arr) { log(x); }\nfor (let k in obj) { log(k); }\n",
-    );
+    let (_, _) =
+        assert_complete_full("for (const x of arr) { log(x); }\nfor (let k in obj) { log(k); }\n");
 }
 
 #[test]
@@ -203,9 +210,8 @@ fn nullish_coalescing_parses() {
 
 #[test]
 fn try_catch_finally_parses() {
-    let (_, _) = assert_complete_full(
-        "try { f(); } catch (e) { log(e); } finally { cleanup(); }\n",
-    );
+    let (_, _) =
+        assert_complete_full("try { f(); } catch (e) { log(e); } finally { cleanup(); }\n");
 }
 
 #[test]
@@ -219,7 +225,11 @@ fn import_named_parses() {
     let input = "import { a, b as c } from 'mod';\n";
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
-    assert!(k.contains(&"keyword"), "expected import/from keywords: {:?}", k);
+    assert!(
+        k.contains(&"keyword"),
+        "expected import/from keywords: {:?}",
+        k
+    );
     assert!(k.contains(&"string"), "expected string for module: {:?}", k);
 }
 
@@ -247,14 +257,17 @@ fn new_expression_parses() {
     let input = "const x = new Foo(1, 2);\n";
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
-    assert!(k.contains(&"type"), "expected Foo as @type after new: {:?}", k);
+    assert!(
+        k.contains(&"type"),
+        "expected Foo as @type after new: {:?}",
+        k
+    );
 }
 
 #[test]
 fn typeof_instanceof_parse() {
-    let (_, _) = assert_complete_full(
-        "const t = typeof x === 'string'; const y = obj instanceof Foo;\n",
-    );
+    let (_, _) =
+        assert_complete_full("const t = typeof x === 'string'; const y = obj instanceof Foo;\n");
 }
 
 #[test]
@@ -340,7 +353,6 @@ fn ternary_parses() {
 
 #[test]
 fn labeled_statement_and_break_parse() {
-    let (_, _) = assert_complete_full(
-        "outer: for (let i = 0; i < 10; i++) { if (i === 5) break outer; }\n",
-    );
+    let (_, _) =
+        assert_complete_full("outer: for (let i = 0; i < 10; i++) { if (i === 5) break outer; }\n");
 }

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -1,0 +1,346 @@
+use std::collections::HashSet;
+
+use syntax_highlighter::pegc;
+use syntax_highlighter::pegvm::{Capture, Program, VM};
+
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+
+fn compile_js() -> Program {
+    pegc::compile(JS_GRAMMAR).expect("JavaScript grammar should compile")
+}
+
+fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
+    let prog = compile_js();
+    let r = VM::new(&prog.code, input.as_bytes()).run();
+    (
+        r.matched,
+        r.captures,
+        prog.capture_kinds.clone(),
+        r.complete,
+    )
+}
+
+fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(
+        complete,
+        "expected complete match, got matched={} of {}",
+        matched,
+        input.len()
+    );
+    assert_eq!(matched, input.len(), "expected full-input match");
+    (caps, kinds)
+}
+
+fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+        .collect()
+}
+
+fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == kind)
+        .map(|c| format!("{}..{}", c.start, c.end))
+        .collect()
+}
+
+#[test]
+fn grammar_parses_and_compiles() {
+    let prog = compile_js();
+    assert!(!prog.code.is_empty());
+    assert!(!prog.capture_kinds.is_empty());
+}
+
+#[test]
+fn capture_kinds_stay_in_theme_vocabulary() {
+    let prog = compile_js();
+    let allowed: HashSet<&str> = [
+        "keyword",
+        "string",
+        "number",
+        "comment",
+        "operator",
+        "punctuation",
+        "type",
+        "function",
+        "constant",
+        "property",
+        "variable",
+        "recovery",
+    ]
+    .into_iter()
+    .collect();
+    for k in &prog.capture_kinds {
+        assert!(
+            allowed.contains(k.as_str()),
+            "capture kind {:?} is not in the theme vocabulary",
+            k
+        );
+    }
+}
+
+#[test]
+fn empty_document_matches() {
+    let (caps, _) = assert_complete_full("");
+    assert!(caps.is_empty());
+}
+
+#[test]
+fn only_whitespace_matches() {
+    let (caps, _) = assert_complete_full("   \n\t\n");
+    assert!(caps.is_empty());
+}
+
+#[test]
+fn simple_function_decl_parses() {
+    let (caps, kinds) = assert_complete_full("function main() {}\n");
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        k.contains(&"keyword"),
+        "expected `function` as keyword: {:?}",
+        k
+    );
+    assert!(k.contains(&"function"), "expected main as function: {:?}", k);
+}
+
+#[test]
+fn arrow_fn_with_paren_params_parses() {
+    let input = "const add = (a, b) => a + b;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"keyword"), "expected `const` keyword: {:?}", k);
+    assert!(
+        k.contains(&"operator"),
+        "expected `=>` operator capture: {:?}",
+        k
+    );
+}
+
+#[test]
+fn arrow_fn_with_single_ident_param_parses() {
+    let (_, _) = assert_complete_full("const sq = x => x * x;\n");
+}
+
+#[test]
+fn parenthesized_expr_without_arrow_parses() {
+    // `(a, b)` not followed by `=>` — must still parse via expression
+    // path after arrow backtracks.
+    let (_, _) = assert_complete_full("const x = (1, 2);\n");
+}
+
+#[test]
+fn template_literal_parses_with_interp() {
+    let input = "const s = `hello ${name}, age ${age + 1}`;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"string"), "expected @string for template: {:?}", k);
+}
+
+#[test]
+fn tagged_template_parses() {
+    let (_, _) = assert_complete_full("const s = html`<div>${x}</div>`;\n");
+}
+
+#[test]
+fn class_with_methods_parses() {
+    let input = "class Foo extends Bar { constructor(x) { super(); this.x = x; } get x() { return this._x; } static make() { return new Foo(0); } }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"keyword"), "expected class/extends: {:?}", k);
+    assert!(k.contains(&"type"), "expected Foo/Bar @type: {:?}", k);
+}
+
+#[test]
+fn class_field_parses() {
+    let (_, _) = assert_complete_full("class Foo { x = 1; static y = 2; }\n");
+}
+
+#[test]
+fn destructuring_object_parses() {
+    let (_, _) = assert_complete_full("const { a, b: c, d = 1, ...rest } = obj;\n");
+}
+
+#[test]
+fn destructuring_array_parses() {
+    let (_, _) = assert_complete_full("const [a, , b = 1, ...rest] = arr;\n");
+}
+
+#[test]
+fn object_literal_with_shorthand_and_computed_parses() {
+    let input = "const o = { a, b: 1, [key]: value, get x() { return 1; }, method() {} };\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn spread_in_call_and_array_parses() {
+    let (_, _) = assert_complete_full("const a = [1, ...b, 3]; f(...a);\n");
+}
+
+#[test]
+fn for_of_and_for_in_parse() {
+    let (_, _) = assert_complete_full(
+        "for (const x of arr) { log(x); }\nfor (let k in obj) { log(k); }\n",
+    );
+}
+
+#[test]
+fn for_c_style_parses() {
+    let (_, _) = assert_complete_full("for (let i = 0; i < 10; i++) { log(i); }\n");
+}
+
+#[test]
+fn optional_chaining_parses() {
+    let (_, _) = assert_complete_full("const x = a?.b?.c?.();\n");
+}
+
+#[test]
+fn nullish_coalescing_parses() {
+    let (_, _) = assert_complete_full("const x = a ?? b ?? c;\n");
+}
+
+#[test]
+fn try_catch_finally_parses() {
+    let (_, _) = assert_complete_full(
+        "try { f(); } catch (e) { log(e); } finally { cleanup(); }\n",
+    );
+}
+
+#[test]
+fn switch_case_parses() {
+    let input = "switch (x) { case 1: a(); break; case 2: b(); break; default: c(); }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn import_named_parses() {
+    let input = "import { a, b as c } from 'mod';\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"keyword"), "expected import/from keywords: {:?}", k);
+    assert!(k.contains(&"string"), "expected string for module: {:?}", k);
+}
+
+#[test]
+fn import_default_and_namespace_parse() {
+    let (_, _) = assert_complete_full("import def from 'd';\n");
+    let (_, _) = assert_complete_full("import * as M from 'm';\n");
+    let (_, _) = assert_complete_full("import def, { a } from 'm';\n");
+    let (_, _) = assert_complete_full("import def, * as M from 'm';\n");
+}
+
+#[test]
+fn export_forms_parse() {
+    let (_, _) = assert_complete_full("export const x = 1;\n");
+    let (_, _) = assert_complete_full("export function f() {}\n");
+    let (_, _) = assert_complete_full("export class C {}\n");
+    let (_, _) = assert_complete_full("export default 42;\n");
+    let (_, _) = assert_complete_full("export default function () {}\n");
+    let (_, _) = assert_complete_full("export { a, b as c };\n");
+    let (_, _) = assert_complete_full("export * from 'm';\n");
+}
+
+#[test]
+fn new_expression_parses() {
+    let input = "const x = new Foo(1, 2);\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"type"), "expected Foo as @type after new: {:?}", k);
+}
+
+#[test]
+fn typeof_instanceof_parse() {
+    let (_, _) = assert_complete_full(
+        "const t = typeof x === 'string'; const y = obj instanceof Foo;\n",
+    );
+}
+
+#[test]
+fn async_await_parse() {
+    let input = "async function f() { const x = await g(); return x; }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn generator_and_yield_parse() {
+    let input = "function* gen() { yield 1; yield* other; }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn regex_like_division_parses() {
+    // Without regex support, `/` is always division. Must not choke.
+    let (_, _) = assert_complete_full("const r = a / b / c;\n");
+}
+
+#[test]
+fn numeric_literals_parse() {
+    let input = "const a = 42; const b = 3.14; const c = 0xdeadBEEF; const d = 0b1010; const e = 0o777; const f = 1_000_000; const g = 1n; const h = .5; const i = 5e10;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"number"), "expected @number: {:?}", k);
+}
+
+#[test]
+fn line_comment_parses() {
+    let input = "// hello\nconst x = 1;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"comment"), "expected @comment: {:?}", k);
+}
+
+#[test]
+fn block_comment_parses() {
+    let input = "/* block */ const x = 1;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"comment"), "expected @comment: {:?}", k);
+}
+
+#[test]
+fn recovery_absorbs_malformed_item() {
+    // `@@@` has no valid interpretation at statement position, so the
+    // top-level `*^` recovery catches it.
+    let input = "function a() {}\n@@@ garbage @@@\nfunction b() {}\n";
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(complete, "recovery should keep parse complete");
+    assert_eq!(matched, input.len());
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        kv.contains(&"recovery"),
+        "expected a @recovery capture for the @@@ region, got: {:?}",
+        kv
+    );
+}
+
+#[test]
+fn method_chain_with_call_parses() {
+    let input = "const r = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let fns = kind_spans(&caps, &kinds, "function");
+    assert!(
+        !fns.is_empty(),
+        "expected chained method names as @function: {:?}",
+        fns
+    );
+}
+
+#[test]
+fn assignment_operators_parse() {
+    let input = "x = 1; x += 1; x -= 1; x *= 2; x /= 2; x **= 2; x &&= y; x ||= y; x ??= y;\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn ternary_parses() {
+    let (_, _) = assert_complete_full("const x = a ? b : c;\n");
+}
+
+#[test]
+fn labeled_statement_and_break_parse() {
+    let (_, _) = assert_complete_full(
+        "outer: for (let i = 0; i < 10; i++) { if (i === 5) break outer; }\n",
+    );
+}

--- a/tests/highlight_javascript_tests.rs
+++ b/tests/highlight_javascript_tests.rs
@@ -1,0 +1,183 @@
+use syntax_highlighter::highlight::{theme, Highlighter};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(JS_GRAMMAR).expect("JavaScript grammar should compile");
+    h.set_input(input.to_string());
+    h
+}
+
+#[test]
+fn round_trip_strips_to_input() {
+    let cases: &[&str] = &[
+        "function main() {}\n",
+        "const x = 42;\n",
+        "import { a, b as c } from 'mod';\n",
+        "const add = (a, b) => a + b;\n",
+        "class Foo extends Bar { constructor(x) { super(); this.x = x; } }\n",
+        "const s = `hello ${name}`;\n",
+        "async function f() { const x = await g(); return x; }\n",
+        "for (const x of arr) { log(x); }\n",
+        "// comment\nconst x = 1;\n",
+    ];
+    for &input in cases {
+        let out = hl(input).highlight();
+        assert_eq!(
+            strip_ansi(&out),
+            input,
+            "round-trip mismatch for: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn keyword_uses_keyword_color() {
+    let out = hl("function main() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("keyword")),
+        "expected keyword color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn string_uses_string_color() {
+    let out = hl("const s = \"hello\";\n").highlight();
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color in: {:?}",
+        out
+    );
+    assert!(out.contains("hello"));
+}
+
+#[test]
+fn template_literal_uses_string_color() {
+    let out = hl("const s = `hello ${name}`;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color for template: {:?}",
+        out
+    );
+}
+
+#[test]
+fn number_uses_number_color() {
+    let out = hl("const x = 42;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected number color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn line_comment_uses_comment_color() {
+    let out = hl("// a line\nconst x = 1;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn block_comment_uses_comment_color() {
+    let out = hl("/* a block */ const x = 1;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn fn_name_uses_function_color() {
+    let out = hl("function compute() {}\n").highlight();
+    let idx = out.find("compute").expect("`compute` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("function")),
+        "expected function color before `compute`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn class_name_uses_type_color() {
+    let out = hl("class Foo {}\n").highlight();
+    let idx = out.find("Foo").expect("`Foo` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before `Foo`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn new_target_uses_type_color() {
+    let out = hl("const x = new Foo(1);\n").highlight();
+    let idx = out.find("Foo").expect("`Foo` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before `Foo` after new, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn bool_and_null_use_constant_color() {
+    let out = hl("const x = true; const y = null;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("constant")),
+        "expected constant color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn arrow_operator_punctuation_present() {
+    let out = hl("const f = x => x;\n").highlight();
+    assert!(
+        out.contains(theme::color_for("operator")),
+        "expected operator color (=>) in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn call_uses_function_color() {
+    let out = hl("compute(1, 2);\n").highlight();
+    let idx = out.find("compute").expect("`compute` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("function")),
+        "expected function color before call target, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn recovery_renders_malformed_region_plain() {
+    let input = "function a() {}\n@@@ garbage @@@\nfunction b() {}\n";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input);
+    assert!(out.contains(theme::color_for("keyword")));
+}
+
+#[test]
+fn partial_match_on_truncated_input() {
+    // Missing closing brace — matched prefix should still render with
+    // styling and the remainder plain.
+    let input = "function incomplete() { const x = 1\n";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input);
+}


### PR DESCRIPTION
Stacked on #20 (Rust grammar). Part of the #10 cross-language expansion.

Adds a pragmatic ES2020-ish JavaScript grammar (`grammars/javascript.peg`),
tests, CLI wiring (`-l js`, `.js`/`.mjs`/`.cjs`), bench fixtures, and
README shipping update.

The bench-interesting shapes this grammar induces: arrow-fn vs
parenthesized-expr disambiguation, template-literal `${...}` splicing,
class-member vs object-property parsing, and optional chaining `?.`.

Bytecode size: 2,916 VM instructions across ~137 rules — comfortably
inside the kilobyte-per-grammar target. Intentionally out of scope:
JSX, regex literals (division disambiguation), decorators, TS type
annotations.