### PR TITLE
Add Go (subset) grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ grammar exercising multi-statement error recovery). Expect breaking
 changes.
 
 The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`,
-`.rs`, `.js`/`.mjs`/`.cjs`) or an explicit `-l json|toml|sql|rust|js`
-flag; stdin without a flag defaults to JSON.
+`.rs`, `.js`/`.mjs`/`.cjs`, `.go`) or an explicit
+`-l json|toml|sql|rust|js|go` flag; stdin without a flag defaults to
+JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).
@@ -99,16 +100,17 @@ largest piece of work.
 These need no new VM or compiler machinery.
 
 - **More language grammars.** JSON, TOML, the full SQLite dialect,
-  a pragmatic Rust subset, and an ES2020-ish JavaScript subset ship
-  today. Adding a language means writing a grammar file. SQLite
-  remains the large-grammar bytecode-size datapoint the design goals
-  called for: 5,627 VM instructions across 426 rules — an order of
-  magnitude larger than JSON (165 instr) or TOML (511 instr); Rust
-  (3,413 instr / 172 rules) and JavaScript (2,916 instr / 137 rules)
-  sit between, still comfortably inside the "kilobyte range per
-  grammar" ambition. Remaining candidates: Python, TypeScript, Go,
-  C, CSS. YAML is deferred — its context-sensitive indentation
-  semantics make it a poor fit for PEG without additional machinery.
+  a pragmatic Rust subset, an ES2020-ish JavaScript subset, and a
+  Go subset ship today. Adding a language means writing a grammar
+  file. SQLite remains the large-grammar bytecode-size datapoint
+  the design goals called for: 5,627 VM instructions across 426
+  rules — an order of magnitude larger than JSON (165 instr) or
+  TOML (511 instr); Rust (3,413 instr / 172 rules), Go (3,118 instr
+  / 145 rules), and JavaScript (2,916 instr / 137 rules) sit
+  between, still comfortably inside the "kilobyte range per grammar"
+  ambition. Remaining candidates: Python, TypeScript, C, CSS. YAML
+  is deferred — its context-sensitive indentation semantics make it
+  a poor fit for PEG without additional machinery.
 - **User-configurable themes.** The capture-name → ANSI mapping is
   hard-coded today; lifting it to a theme file (TOML or similar) is
   orthogonal to the VM.

--- a/benches/fixtures/large.go
+++ b/benches/fixtures/large.go
@@ -1,0 +1,668 @@
+// Generated Go bench fixture. Not hand-maintained —
+// regenerate via benches/fixtures/gen_go.py if shapes need tweaking.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Reader interface {
+	Read(p []byte) (n int, err error)
+}
+
+func classify(n int) string {
+	switch {
+	case n < 0:
+		return "negative"
+	case n == 0:
+		return "zero"
+	case n < 10:
+		return "single"
+	case n < 100:
+		return "double"
+	default:
+		return "large"
+	}
+}
+
+var errEmpty = errors.New("empty")
+
+func parseAll(r Reader) ([]int, error) {
+	buf := make([]byte, 64)
+	xs := []int{}
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			for _, b := range buf[:n] {
+				xs = append(xs, int(b))
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(xs) == 0 {
+		return nil, errEmpty
+	}
+	return xs, nil
+}
+
+
+type Counter0[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter0[T comparable](name string, tag T) *Counter0[T] {
+	return &Counter0[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter0[T]) Push(v T) *Counter0[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter0[T]) Size() int { return len(c.values) }
+
+func (c *Counter0[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter0[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe0(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter1[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter1[T comparable](name string, tag T) *Counter1[T] {
+	return &Counter1[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter1[T]) Push(v T) *Counter1[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter1[T]) Size() int { return len(c.values) }
+
+func (c *Counter1[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter1[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe1(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter2[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter2[T comparable](name string, tag T) *Counter2[T] {
+	return &Counter2[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter2[T]) Push(v T) *Counter2[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter2[T]) Size() int { return len(c.values) }
+
+func (c *Counter2[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter2[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe2(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter3[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter3[T comparable](name string, tag T) *Counter3[T] {
+	return &Counter3[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter3[T]) Push(v T) *Counter3[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter3[T]) Size() int { return len(c.values) }
+
+func (c *Counter3[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter3[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe3(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter4[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter4[T comparable](name string, tag T) *Counter4[T] {
+	return &Counter4[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter4[T]) Push(v T) *Counter4[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter4[T]) Size() int { return len(c.values) }
+
+func (c *Counter4[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter4[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe4(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter5[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter5[T comparable](name string, tag T) *Counter5[T] {
+	return &Counter5[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter5[T]) Push(v T) *Counter5[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter5[T]) Size() int { return len(c.values) }
+
+func (c *Counter5[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter5[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe5(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter6[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter6[T comparable](name string, tag T) *Counter6[T] {
+	return &Counter6[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter6[T]) Push(v T) *Counter6[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter6[T]) Size() int { return len(c.values) }
+
+func (c *Counter6[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter6[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe6(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter7[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter7[T comparable](name string, tag T) *Counter7[T] {
+	return &Counter7[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter7[T]) Push(v T) *Counter7[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter7[T]) Size() int { return len(c.values) }
+
+func (c *Counter7[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter7[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe7(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter8[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter8[T comparable](name string, tag T) *Counter8[T] {
+	return &Counter8[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter8[T]) Push(v T) *Counter8[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter8[T]) Size() int { return len(c.values) }
+
+func (c *Counter8[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter8[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe8(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter9[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter9[T comparable](name string, tag T) *Counter9[T] {
+	return &Counter9[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter9[T]) Push(v T) *Counter9[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter9[T]) Size() int { return len(c.values) }
+
+func (c *Counter9[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter9[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe9(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+func main() {
+	c := NewCounter0[int]("ages", 0)
+	data := []int{1, 2, 2, 3, 10, 10, 10, -1}
+	for _, v := range data {
+		c.Push(v)
+	}
+	fmt.Println(c.Summary())
+	for _, n := range data {
+		fmt.Printf("%d -> %s\n", n, classify(n))
+	}
+}

--- a/benches/fixtures/medium.go
+++ b/benches/fixtures/medium.go
@@ -1,0 +1,112 @@
+// Medium-sized Go bench fixture: exercises package/import,
+// struct/interface/method, generics, range, composite literals,
+// closures, select, and error handling.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Counter[T comparable] struct {
+	Name      string
+	values    []T
+	histogram map[string]int
+}
+
+func NewCounter[T comparable](name string) *Counter[T] {
+	return &Counter[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+	}
+}
+
+func (c *Counter[T]) Push(v T) *Counter[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+type Reader interface {
+	Read(p []byte) (n int, err error)
+}
+
+func classify(n int) string {
+	switch {
+	case n < 0:
+		return "negative"
+	case n == 0:
+		return "zero"
+	case n < 10:
+		return "single"
+	case n < 100:
+		return "double"
+	default:
+		return "large"
+	}
+}
+
+func pipe(ch chan int, done <-chan struct{}) {
+	for {
+		select {
+		case v, ok := <-ch:
+			if !ok {
+				return
+			}
+			fmt.Println(v)
+		case <-done:
+			return
+		}
+	}
+}
+
+var errEmpty = errors.New("empty")
+
+func parseAll(r Reader) ([]int, error) {
+	buf := make([]byte, 64)
+	xs := []int{}
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			for _, b := range buf[:n] {
+				xs = append(xs, int(b))
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(xs) == 0 {
+		return nil, errEmpty
+	}
+	return xs, nil
+}
+
+func main() {
+	c := NewCounter[int]("ages")
+	data := []int{1, 2, 2, 3, 10, 10, 10, -1}
+	for _, v := range data {
+		c.Push(v)
+	}
+	fmt.Println(c.Summary())
+	for _, n := range data {
+		fmt.Printf("%d -> %s\n", n, classify(n))
+	}
+}

--- a/benches/fixtures/small.go
+++ b/benches/fixtures/small.go
@@ -1,0 +1,3 @@
+package main
+
+func greet(name string) string { return "hello, " + name }

--- a/benches/fixtures/xlarge.go
+++ b/benches/fixtures/xlarge.go
@@ -1,0 +1,6068 @@
+// Generated Go bench fixture. Not hand-maintained —
+// regenerate via benches/fixtures/gen_go.py if shapes need tweaking.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Reader interface {
+	Read(p []byte) (n int, err error)
+}
+
+func classify(n int) string {
+	switch {
+	case n < 0:
+		return "negative"
+	case n == 0:
+		return "zero"
+	case n < 10:
+		return "single"
+	case n < 100:
+		return "double"
+	default:
+		return "large"
+	}
+}
+
+var errEmpty = errors.New("empty")
+
+func parseAll(r Reader) ([]int, error) {
+	buf := make([]byte, 64)
+	xs := []int{}
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			for _, b := range buf[:n] {
+				xs = append(xs, int(b))
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(xs) == 0 {
+		return nil, errEmpty
+	}
+	return xs, nil
+}
+
+
+type Counter0[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter0[T comparable](name string, tag T) *Counter0[T] {
+	return &Counter0[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter0[T]) Push(v T) *Counter0[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter0[T]) Size() int { return len(c.values) }
+
+func (c *Counter0[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter0[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe0(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter1[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter1[T comparable](name string, tag T) *Counter1[T] {
+	return &Counter1[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter1[T]) Push(v T) *Counter1[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter1[T]) Size() int { return len(c.values) }
+
+func (c *Counter1[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter1[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe1(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter2[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter2[T comparable](name string, tag T) *Counter2[T] {
+	return &Counter2[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter2[T]) Push(v T) *Counter2[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter2[T]) Size() int { return len(c.values) }
+
+func (c *Counter2[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter2[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe2(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter3[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter3[T comparable](name string, tag T) *Counter3[T] {
+	return &Counter3[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter3[T]) Push(v T) *Counter3[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter3[T]) Size() int { return len(c.values) }
+
+func (c *Counter3[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter3[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe3(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter4[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter4[T comparable](name string, tag T) *Counter4[T] {
+	return &Counter4[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter4[T]) Push(v T) *Counter4[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter4[T]) Size() int { return len(c.values) }
+
+func (c *Counter4[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter4[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe4(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter5[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter5[T comparable](name string, tag T) *Counter5[T] {
+	return &Counter5[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter5[T]) Push(v T) *Counter5[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter5[T]) Size() int { return len(c.values) }
+
+func (c *Counter5[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter5[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe5(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter6[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter6[T comparable](name string, tag T) *Counter6[T] {
+	return &Counter6[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter6[T]) Push(v T) *Counter6[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter6[T]) Size() int { return len(c.values) }
+
+func (c *Counter6[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter6[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe6(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter7[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter7[T comparable](name string, tag T) *Counter7[T] {
+	return &Counter7[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter7[T]) Push(v T) *Counter7[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter7[T]) Size() int { return len(c.values) }
+
+func (c *Counter7[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter7[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe7(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter8[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter8[T comparable](name string, tag T) *Counter8[T] {
+	return &Counter8[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter8[T]) Push(v T) *Counter8[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter8[T]) Size() int { return len(c.values) }
+
+func (c *Counter8[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter8[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe8(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter9[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter9[T comparable](name string, tag T) *Counter9[T] {
+	return &Counter9[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter9[T]) Push(v T) *Counter9[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter9[T]) Size() int { return len(c.values) }
+
+func (c *Counter9[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter9[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe9(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter10[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter10[T comparable](name string, tag T) *Counter10[T] {
+	return &Counter10[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter10[T]) Push(v T) *Counter10[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter10[T]) Size() int { return len(c.values) }
+
+func (c *Counter10[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter10[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe10(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter11[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter11[T comparable](name string, tag T) *Counter11[T] {
+	return &Counter11[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter11[T]) Push(v T) *Counter11[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter11[T]) Size() int { return len(c.values) }
+
+func (c *Counter11[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter11[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe11(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter12[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter12[T comparable](name string, tag T) *Counter12[T] {
+	return &Counter12[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter12[T]) Push(v T) *Counter12[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter12[T]) Size() int { return len(c.values) }
+
+func (c *Counter12[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter12[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe12(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter13[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter13[T comparable](name string, tag T) *Counter13[T] {
+	return &Counter13[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter13[T]) Push(v T) *Counter13[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter13[T]) Size() int { return len(c.values) }
+
+func (c *Counter13[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter13[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe13(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter14[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter14[T comparable](name string, tag T) *Counter14[T] {
+	return &Counter14[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter14[T]) Push(v T) *Counter14[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter14[T]) Size() int { return len(c.values) }
+
+func (c *Counter14[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter14[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe14(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter15[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter15[T comparable](name string, tag T) *Counter15[T] {
+	return &Counter15[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter15[T]) Push(v T) *Counter15[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter15[T]) Size() int { return len(c.values) }
+
+func (c *Counter15[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter15[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe15(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter16[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter16[T comparable](name string, tag T) *Counter16[T] {
+	return &Counter16[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter16[T]) Push(v T) *Counter16[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter16[T]) Size() int { return len(c.values) }
+
+func (c *Counter16[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter16[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe16(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter17[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter17[T comparable](name string, tag T) *Counter17[T] {
+	return &Counter17[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter17[T]) Push(v T) *Counter17[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter17[T]) Size() int { return len(c.values) }
+
+func (c *Counter17[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter17[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe17(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter18[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter18[T comparable](name string, tag T) *Counter18[T] {
+	return &Counter18[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter18[T]) Push(v T) *Counter18[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter18[T]) Size() int { return len(c.values) }
+
+func (c *Counter18[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter18[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe18(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter19[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter19[T comparable](name string, tag T) *Counter19[T] {
+	return &Counter19[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter19[T]) Push(v T) *Counter19[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter19[T]) Size() int { return len(c.values) }
+
+func (c *Counter19[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter19[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe19(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter20[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter20[T comparable](name string, tag T) *Counter20[T] {
+	return &Counter20[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter20[T]) Push(v T) *Counter20[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter20[T]) Size() int { return len(c.values) }
+
+func (c *Counter20[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter20[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe20(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter21[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter21[T comparable](name string, tag T) *Counter21[T] {
+	return &Counter21[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter21[T]) Push(v T) *Counter21[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter21[T]) Size() int { return len(c.values) }
+
+func (c *Counter21[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter21[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe21(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter22[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter22[T comparable](name string, tag T) *Counter22[T] {
+	return &Counter22[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter22[T]) Push(v T) *Counter22[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter22[T]) Size() int { return len(c.values) }
+
+func (c *Counter22[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter22[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe22(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter23[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter23[T comparable](name string, tag T) *Counter23[T] {
+	return &Counter23[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter23[T]) Push(v T) *Counter23[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter23[T]) Size() int { return len(c.values) }
+
+func (c *Counter23[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter23[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe23(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter24[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter24[T comparable](name string, tag T) *Counter24[T] {
+	return &Counter24[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter24[T]) Push(v T) *Counter24[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter24[T]) Size() int { return len(c.values) }
+
+func (c *Counter24[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter24[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe24(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter25[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter25[T comparable](name string, tag T) *Counter25[T] {
+	return &Counter25[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter25[T]) Push(v T) *Counter25[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter25[T]) Size() int { return len(c.values) }
+
+func (c *Counter25[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter25[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe25(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter26[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter26[T comparable](name string, tag T) *Counter26[T] {
+	return &Counter26[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter26[T]) Push(v T) *Counter26[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter26[T]) Size() int { return len(c.values) }
+
+func (c *Counter26[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter26[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe26(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter27[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter27[T comparable](name string, tag T) *Counter27[T] {
+	return &Counter27[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter27[T]) Push(v T) *Counter27[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter27[T]) Size() int { return len(c.values) }
+
+func (c *Counter27[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter27[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe27(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter28[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter28[T comparable](name string, tag T) *Counter28[T] {
+	return &Counter28[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter28[T]) Push(v T) *Counter28[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter28[T]) Size() int { return len(c.values) }
+
+func (c *Counter28[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter28[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe28(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter29[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter29[T comparable](name string, tag T) *Counter29[T] {
+	return &Counter29[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter29[T]) Push(v T) *Counter29[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter29[T]) Size() int { return len(c.values) }
+
+func (c *Counter29[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter29[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe29(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter30[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter30[T comparable](name string, tag T) *Counter30[T] {
+	return &Counter30[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter30[T]) Push(v T) *Counter30[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter30[T]) Size() int { return len(c.values) }
+
+func (c *Counter30[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter30[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe30(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter31[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter31[T comparable](name string, tag T) *Counter31[T] {
+	return &Counter31[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter31[T]) Push(v T) *Counter31[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter31[T]) Size() int { return len(c.values) }
+
+func (c *Counter31[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter31[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe31(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter32[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter32[T comparable](name string, tag T) *Counter32[T] {
+	return &Counter32[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter32[T]) Push(v T) *Counter32[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter32[T]) Size() int { return len(c.values) }
+
+func (c *Counter32[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter32[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe32(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter33[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter33[T comparable](name string, tag T) *Counter33[T] {
+	return &Counter33[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter33[T]) Push(v T) *Counter33[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter33[T]) Size() int { return len(c.values) }
+
+func (c *Counter33[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter33[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe33(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter34[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter34[T comparable](name string, tag T) *Counter34[T] {
+	return &Counter34[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter34[T]) Push(v T) *Counter34[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter34[T]) Size() int { return len(c.values) }
+
+func (c *Counter34[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter34[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe34(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter35[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter35[T comparable](name string, tag T) *Counter35[T] {
+	return &Counter35[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter35[T]) Push(v T) *Counter35[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter35[T]) Size() int { return len(c.values) }
+
+func (c *Counter35[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter35[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe35(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter36[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter36[T comparable](name string, tag T) *Counter36[T] {
+	return &Counter36[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter36[T]) Push(v T) *Counter36[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter36[T]) Size() int { return len(c.values) }
+
+func (c *Counter36[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter36[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe36(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter37[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter37[T comparable](name string, tag T) *Counter37[T] {
+	return &Counter37[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter37[T]) Push(v T) *Counter37[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter37[T]) Size() int { return len(c.values) }
+
+func (c *Counter37[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter37[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe37(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter38[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter38[T comparable](name string, tag T) *Counter38[T] {
+	return &Counter38[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter38[T]) Push(v T) *Counter38[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter38[T]) Size() int { return len(c.values) }
+
+func (c *Counter38[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter38[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe38(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter39[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter39[T comparable](name string, tag T) *Counter39[T] {
+	return &Counter39[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter39[T]) Push(v T) *Counter39[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter39[T]) Size() int { return len(c.values) }
+
+func (c *Counter39[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter39[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe39(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter40[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter40[T comparable](name string, tag T) *Counter40[T] {
+	return &Counter40[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter40[T]) Push(v T) *Counter40[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter40[T]) Size() int { return len(c.values) }
+
+func (c *Counter40[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter40[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe40(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter41[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter41[T comparable](name string, tag T) *Counter41[T] {
+	return &Counter41[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter41[T]) Push(v T) *Counter41[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter41[T]) Size() int { return len(c.values) }
+
+func (c *Counter41[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter41[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe41(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter42[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter42[T comparable](name string, tag T) *Counter42[T] {
+	return &Counter42[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter42[T]) Push(v T) *Counter42[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter42[T]) Size() int { return len(c.values) }
+
+func (c *Counter42[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter42[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe42(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter43[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter43[T comparable](name string, tag T) *Counter43[T] {
+	return &Counter43[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter43[T]) Push(v T) *Counter43[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter43[T]) Size() int { return len(c.values) }
+
+func (c *Counter43[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter43[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe43(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter44[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter44[T comparable](name string, tag T) *Counter44[T] {
+	return &Counter44[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter44[T]) Push(v T) *Counter44[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter44[T]) Size() int { return len(c.values) }
+
+func (c *Counter44[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter44[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe44(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter45[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter45[T comparable](name string, tag T) *Counter45[T] {
+	return &Counter45[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter45[T]) Push(v T) *Counter45[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter45[T]) Size() int { return len(c.values) }
+
+func (c *Counter45[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter45[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe45(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter46[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter46[T comparable](name string, tag T) *Counter46[T] {
+	return &Counter46[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter46[T]) Push(v T) *Counter46[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter46[T]) Size() int { return len(c.values) }
+
+func (c *Counter46[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter46[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe46(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter47[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter47[T comparable](name string, tag T) *Counter47[T] {
+	return &Counter47[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter47[T]) Push(v T) *Counter47[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter47[T]) Size() int { return len(c.values) }
+
+func (c *Counter47[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter47[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe47(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter48[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter48[T comparable](name string, tag T) *Counter48[T] {
+	return &Counter48[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter48[T]) Push(v T) *Counter48[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter48[T]) Size() int { return len(c.values) }
+
+func (c *Counter48[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter48[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe48(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter49[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter49[T comparable](name string, tag T) *Counter49[T] {
+	return &Counter49[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter49[T]) Push(v T) *Counter49[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter49[T]) Size() int { return len(c.values) }
+
+func (c *Counter49[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter49[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe49(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter50[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter50[T comparable](name string, tag T) *Counter50[T] {
+	return &Counter50[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter50[T]) Push(v T) *Counter50[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter50[T]) Size() int { return len(c.values) }
+
+func (c *Counter50[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter50[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe50(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter51[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter51[T comparable](name string, tag T) *Counter51[T] {
+	return &Counter51[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter51[T]) Push(v T) *Counter51[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter51[T]) Size() int { return len(c.values) }
+
+func (c *Counter51[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter51[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe51(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter52[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter52[T comparable](name string, tag T) *Counter52[T] {
+	return &Counter52[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter52[T]) Push(v T) *Counter52[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter52[T]) Size() int { return len(c.values) }
+
+func (c *Counter52[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter52[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe52(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter53[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter53[T comparable](name string, tag T) *Counter53[T] {
+	return &Counter53[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter53[T]) Push(v T) *Counter53[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter53[T]) Size() int { return len(c.values) }
+
+func (c *Counter53[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter53[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe53(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter54[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter54[T comparable](name string, tag T) *Counter54[T] {
+	return &Counter54[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter54[T]) Push(v T) *Counter54[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter54[T]) Size() int { return len(c.values) }
+
+func (c *Counter54[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter54[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe54(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter55[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter55[T comparable](name string, tag T) *Counter55[T] {
+	return &Counter55[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter55[T]) Push(v T) *Counter55[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter55[T]) Size() int { return len(c.values) }
+
+func (c *Counter55[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter55[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe55(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter56[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter56[T comparable](name string, tag T) *Counter56[T] {
+	return &Counter56[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter56[T]) Push(v T) *Counter56[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter56[T]) Size() int { return len(c.values) }
+
+func (c *Counter56[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter56[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe56(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter57[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter57[T comparable](name string, tag T) *Counter57[T] {
+	return &Counter57[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter57[T]) Push(v T) *Counter57[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter57[T]) Size() int { return len(c.values) }
+
+func (c *Counter57[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter57[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe57(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter58[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter58[T comparable](name string, tag T) *Counter58[T] {
+	return &Counter58[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter58[T]) Push(v T) *Counter58[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter58[T]) Size() int { return len(c.values) }
+
+func (c *Counter58[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter58[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe58(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter59[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter59[T comparable](name string, tag T) *Counter59[T] {
+	return &Counter59[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter59[T]) Push(v T) *Counter59[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter59[T]) Size() int { return len(c.values) }
+
+func (c *Counter59[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter59[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe59(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter60[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter60[T comparable](name string, tag T) *Counter60[T] {
+	return &Counter60[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter60[T]) Push(v T) *Counter60[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter60[T]) Size() int { return len(c.values) }
+
+func (c *Counter60[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter60[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe60(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter61[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter61[T comparable](name string, tag T) *Counter61[T] {
+	return &Counter61[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter61[T]) Push(v T) *Counter61[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter61[T]) Size() int { return len(c.values) }
+
+func (c *Counter61[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter61[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe61(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter62[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter62[T comparable](name string, tag T) *Counter62[T] {
+	return &Counter62[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter62[T]) Push(v T) *Counter62[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter62[T]) Size() int { return len(c.values) }
+
+func (c *Counter62[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter62[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe62(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter63[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter63[T comparable](name string, tag T) *Counter63[T] {
+	return &Counter63[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter63[T]) Push(v T) *Counter63[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter63[T]) Size() int { return len(c.values) }
+
+func (c *Counter63[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter63[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe63(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter64[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter64[T comparable](name string, tag T) *Counter64[T] {
+	return &Counter64[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter64[T]) Push(v T) *Counter64[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter64[T]) Size() int { return len(c.values) }
+
+func (c *Counter64[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter64[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe64(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter65[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter65[T comparable](name string, tag T) *Counter65[T] {
+	return &Counter65[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter65[T]) Push(v T) *Counter65[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter65[T]) Size() int { return len(c.values) }
+
+func (c *Counter65[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter65[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe65(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter66[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter66[T comparable](name string, tag T) *Counter66[T] {
+	return &Counter66[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter66[T]) Push(v T) *Counter66[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter66[T]) Size() int { return len(c.values) }
+
+func (c *Counter66[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter66[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe66(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter67[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter67[T comparable](name string, tag T) *Counter67[T] {
+	return &Counter67[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter67[T]) Push(v T) *Counter67[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter67[T]) Size() int { return len(c.values) }
+
+func (c *Counter67[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter67[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe67(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter68[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter68[T comparable](name string, tag T) *Counter68[T] {
+	return &Counter68[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter68[T]) Push(v T) *Counter68[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter68[T]) Size() int { return len(c.values) }
+
+func (c *Counter68[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter68[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe68(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter69[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter69[T comparable](name string, tag T) *Counter69[T] {
+	return &Counter69[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter69[T]) Push(v T) *Counter69[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter69[T]) Size() int { return len(c.values) }
+
+func (c *Counter69[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter69[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe69(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter70[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter70[T comparable](name string, tag T) *Counter70[T] {
+	return &Counter70[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter70[T]) Push(v T) *Counter70[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter70[T]) Size() int { return len(c.values) }
+
+func (c *Counter70[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter70[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe70(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter71[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter71[T comparable](name string, tag T) *Counter71[T] {
+	return &Counter71[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter71[T]) Push(v T) *Counter71[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter71[T]) Size() int { return len(c.values) }
+
+func (c *Counter71[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter71[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe71(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter72[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter72[T comparable](name string, tag T) *Counter72[T] {
+	return &Counter72[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter72[T]) Push(v T) *Counter72[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter72[T]) Size() int { return len(c.values) }
+
+func (c *Counter72[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter72[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe72(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter73[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter73[T comparable](name string, tag T) *Counter73[T] {
+	return &Counter73[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter73[T]) Push(v T) *Counter73[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter73[T]) Size() int { return len(c.values) }
+
+func (c *Counter73[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter73[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe73(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter74[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter74[T comparable](name string, tag T) *Counter74[T] {
+	return &Counter74[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter74[T]) Push(v T) *Counter74[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter74[T]) Size() int { return len(c.values) }
+
+func (c *Counter74[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter74[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe74(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter75[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter75[T comparable](name string, tag T) *Counter75[T] {
+	return &Counter75[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter75[T]) Push(v T) *Counter75[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter75[T]) Size() int { return len(c.values) }
+
+func (c *Counter75[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter75[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe75(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter76[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter76[T comparable](name string, tag T) *Counter76[T] {
+	return &Counter76[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter76[T]) Push(v T) *Counter76[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter76[T]) Size() int { return len(c.values) }
+
+func (c *Counter76[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter76[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe76(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter77[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter77[T comparable](name string, tag T) *Counter77[T] {
+	return &Counter77[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter77[T]) Push(v T) *Counter77[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter77[T]) Size() int { return len(c.values) }
+
+func (c *Counter77[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter77[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe77(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter78[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter78[T comparable](name string, tag T) *Counter78[T] {
+	return &Counter78[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter78[T]) Push(v T) *Counter78[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter78[T]) Size() int { return len(c.values) }
+
+func (c *Counter78[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter78[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe78(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter79[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter79[T comparable](name string, tag T) *Counter79[T] {
+	return &Counter79[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter79[T]) Push(v T) *Counter79[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter79[T]) Size() int { return len(c.values) }
+
+func (c *Counter79[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter79[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe79(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter80[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter80[T comparable](name string, tag T) *Counter80[T] {
+	return &Counter80[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter80[T]) Push(v T) *Counter80[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter80[T]) Size() int { return len(c.values) }
+
+func (c *Counter80[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter80[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe80(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter81[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter81[T comparable](name string, tag T) *Counter81[T] {
+	return &Counter81[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter81[T]) Push(v T) *Counter81[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter81[T]) Size() int { return len(c.values) }
+
+func (c *Counter81[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter81[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe81(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter82[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter82[T comparable](name string, tag T) *Counter82[T] {
+	return &Counter82[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter82[T]) Push(v T) *Counter82[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter82[T]) Size() int { return len(c.values) }
+
+func (c *Counter82[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter82[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe82(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter83[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter83[T comparable](name string, tag T) *Counter83[T] {
+	return &Counter83[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter83[T]) Push(v T) *Counter83[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter83[T]) Size() int { return len(c.values) }
+
+func (c *Counter83[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter83[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe83(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter84[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter84[T comparable](name string, tag T) *Counter84[T] {
+	return &Counter84[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter84[T]) Push(v T) *Counter84[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter84[T]) Size() int { return len(c.values) }
+
+func (c *Counter84[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter84[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe84(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter85[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter85[T comparable](name string, tag T) *Counter85[T] {
+	return &Counter85[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter85[T]) Push(v T) *Counter85[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter85[T]) Size() int { return len(c.values) }
+
+func (c *Counter85[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter85[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe85(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter86[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter86[T comparable](name string, tag T) *Counter86[T] {
+	return &Counter86[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter86[T]) Push(v T) *Counter86[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter86[T]) Size() int { return len(c.values) }
+
+func (c *Counter86[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter86[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe86(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter87[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter87[T comparable](name string, tag T) *Counter87[T] {
+	return &Counter87[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter87[T]) Push(v T) *Counter87[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter87[T]) Size() int { return len(c.values) }
+
+func (c *Counter87[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter87[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe87(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter88[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter88[T comparable](name string, tag T) *Counter88[T] {
+	return &Counter88[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter88[T]) Push(v T) *Counter88[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter88[T]) Size() int { return len(c.values) }
+
+func (c *Counter88[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter88[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe88(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter89[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter89[T comparable](name string, tag T) *Counter89[T] {
+	return &Counter89[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter89[T]) Push(v T) *Counter89[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter89[T]) Size() int { return len(c.values) }
+
+func (c *Counter89[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter89[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe89(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter90[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter90[T comparable](name string, tag T) *Counter90[T] {
+	return &Counter90[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter90[T]) Push(v T) *Counter90[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter90[T]) Size() int { return len(c.values) }
+
+func (c *Counter90[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter90[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe90(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter91[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter91[T comparable](name string, tag T) *Counter91[T] {
+	return &Counter91[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter91[T]) Push(v T) *Counter91[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter91[T]) Size() int { return len(c.values) }
+
+func (c *Counter91[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter91[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe91(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter92[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter92[T comparable](name string, tag T) *Counter92[T] {
+	return &Counter92[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter92[T]) Push(v T) *Counter92[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter92[T]) Size() int { return len(c.values) }
+
+func (c *Counter92[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter92[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe92(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter93[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter93[T comparable](name string, tag T) *Counter93[T] {
+	return &Counter93[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter93[T]) Push(v T) *Counter93[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter93[T]) Size() int { return len(c.values) }
+
+func (c *Counter93[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter93[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe93(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter94[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter94[T comparable](name string, tag T) *Counter94[T] {
+	return &Counter94[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter94[T]) Push(v T) *Counter94[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter94[T]) Size() int { return len(c.values) }
+
+func (c *Counter94[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter94[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe94(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter95[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter95[T comparable](name string, tag T) *Counter95[T] {
+	return &Counter95[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter95[T]) Push(v T) *Counter95[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter95[T]) Size() int { return len(c.values) }
+
+func (c *Counter95[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter95[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe95(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter96[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter96[T comparable](name string, tag T) *Counter96[T] {
+	return &Counter96[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter96[T]) Push(v T) *Counter96[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter96[T]) Size() int { return len(c.values) }
+
+func (c *Counter96[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter96[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe96(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter97[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter97[T comparable](name string, tag T) *Counter97[T] {
+	return &Counter97[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter97[T]) Push(v T) *Counter97[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter97[T]) Size() int { return len(c.values) }
+
+func (c *Counter97[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter97[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe97(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter98[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter98[T comparable](name string, tag T) *Counter98[T] {
+	return &Counter98[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter98[T]) Push(v T) *Counter98[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter98[T]) Size() int { return len(c.values) }
+
+func (c *Counter98[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter98[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe98(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+type Counter99[T comparable] struct {
+	Name      string  `json:"name"`
+	values    []T
+	histogram map[string]int
+	Tag       T
+}
+
+func NewCounter99[T comparable](name string, tag T) *Counter99[T] {
+	return &Counter99[T]{
+		Name:      name,
+		values:    make([]T, 0, 16),
+		histogram: map[string]int{},
+		Tag:       tag,
+	}
+}
+
+func (c *Counter99[T]) Push(v T) *Counter99[T] {
+	key := fmt.Sprintf("%v", v)
+	c.histogram[key]++
+	c.values = append(c.values, v)
+	return c
+}
+
+func (c *Counter99[T]) Size() int { return len(c.values) }
+
+func (c *Counter99[T]) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (n=%d)", c.Name, len(c.values))
+	for k, n := range c.histogram {
+		fmt.Fprintf(&b, " %s=%d", k, n)
+	}
+	return b.String()
+}
+
+func (c *Counter99[T]) Flush(out chan<- string) {
+	defer close(out)
+	for k, n := range c.histogram {
+		select {
+		case out <- fmt.Sprintf("%s=%d", k, n):
+		default:
+			return
+		}
+	}
+}
+
+func describe99(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("int:%d", x)
+	case string:
+		return fmt.Sprintf("str:%q", x)
+	case []int:
+		return fmt.Sprintf("ints:%d", len(x))
+	case map[string]int:
+		return fmt.Sprintf("map:%d", len(x))
+	default:
+		return fmt.Sprintf("other:%T", x)
+	}
+}
+
+func main() {
+	c := NewCounter0[int]("ages", 0)
+	data := []int{1, 2, 2, 3, 10, 10, 10, -1}
+	for _, v := range data {
+		c.Push(v)
+	}
+	fmt.Println(c.Summary())
+	for _, n := range data {
+		fmt.Printf("%d -> %s\n", n, classify(n))
+	}
+}

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -28,6 +28,7 @@ const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -53,6 +54,11 @@ const JS_SMALL: &str = include_str!("fixtures/small.js");
 const JS_MEDIUM: &str = include_str!("fixtures/medium.js");
 const JS_LARGE: &str = include_str!("fixtures/large.js");
 const JS_XLARGE: &str = include_str!("fixtures/xlarge.js");
+
+const GO_SMALL: &str = include_str!("fixtures/small.go");
+const GO_MEDIUM: &str = include_str!("fixtures/medium.go");
+const GO_LARGE: &str = include_str!("fixtures/large.go");
+const GO_XLARGE: &str = include_str!("fixtures/xlarge.go");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -301,6 +307,16 @@ fn main() {
                 ("medium", JS_MEDIUM),
                 ("large", JS_LARGE),
                 ("xlarge", JS_XLARGE),
+            ],
+        },
+        GrammarCase {
+            label: "go",
+            source: GO_GRAMMAR,
+            fixtures: &[
+                ("small", GO_SMALL),
+                ("medium", GO_MEDIUM),
+                ("large", GO_LARGE),
+                ("xlarge", GO_XLARGE),
             ],
         },
     ];

--- a/benches/memo.rs
+++ b/benches/memo.rs
@@ -28,6 +28,7 @@ const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -53,6 +54,11 @@ const JS_SMALL: &str = include_str!("fixtures/small.js");
 const JS_MEDIUM: &str = include_str!("fixtures/medium.js");
 const JS_LARGE: &str = include_str!("fixtures/large.js");
 const JS_XLARGE: &str = include_str!("fixtures/xlarge.js");
+
+const GO_SMALL: &str = include_str!("fixtures/small.go");
+const GO_MEDIUM: &str = include_str!("fixtures/medium.go");
+const GO_LARGE: &str = include_str!("fixtures/large.go");
+const GO_XLARGE: &str = include_str!("fixtures/xlarge.go");
 
 const THRESHOLDS: &[usize] = &[0, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 const RUNS_PER_CELL: usize = 11;
@@ -213,6 +219,16 @@ fn main() {
                 ("medium", JS_MEDIUM.as_bytes()),
                 ("large", JS_LARGE.as_bytes()),
                 ("xlarge", JS_XLARGE.as_bytes()),
+            ],
+        },
+        GrammarCase {
+            name: "go",
+            program: compile_case("go", GO_GRAMMAR),
+            inputs: vec![
+                ("small", GO_SMALL.as_bytes()),
+                ("medium", GO_MEDIUM.as_bytes()),
+                ("large", GO_LARGE.as_bytes()),
+                ("xlarge", GO_XLARGE.as_bytes()),
             ],
         },
     ];

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -1,0 +1,375 @@
+# Go (pragmatic subset) grammar with highlight annotations.
+# The first rule is the start rule.
+#
+# Scope: highlighting, not compilation. Parses real-world Go at the
+# token/declaration level. Precedence is flattened and semantic
+# constraints (type checking, method set resolution, package lookup)
+# are not enforced. Composite literals in control-flow headers are
+# disambiguated by a dedicated `expr_no_compound` path that Go's
+# actual grammar also needs.
+#
+# Capture kinds used (all present in src/highlight/theme.rs):
+#   keyword, string, number, comment, operator, punctuation, type,
+#   function, constant, property, variable, recovery.
+#
+# Intentionally out of scope:
+#   - Generics with type parameters are accepted structurally
+#     (`func F[T any](x T) T`) but no constraint checking.
+#   - Build tags and line directives are skipped as comments.
+#   - Raw identifier-vs-type semantic disambiguation (we color by
+#     shape: predeclared names → @type, PascalCase → @type,
+#     lowercase → @variable or @function by context).
+#
+# Recovery: top-level uses `*^` so malformed top-level declarations
+# don't abort the whole file.
+
+go_file       <- ws package_clause ws (import_decl ws)* (top_decl)*^ ws !.
+
+# --- Package / imports ----------------------------------------------
+
+package_clause <- @keyword{'package'} ws @variable{ident} ws opt_semi
+
+import_decl   <- @keyword{'import'} ws import_spec_group ws opt_semi
+               / @keyword{'import'} ws import_spec ws opt_semi
+import_spec_group <- @punctuation{'('} ws (import_spec ws opt_semi)* ws @punctuation{')'}
+import_spec   <- import_alias? string_lit
+import_alias  <- @punctuation{'.'} ws
+               / @variable{ident} ws
+
+# --- Top-level declarations -----------------------------------------
+
+top_decl      <- decl
+                 / func_decl
+                 / method_decl
+
+decl          <- @keyword{'var'} ws var_spec_group
+               / @keyword{'var'} ws var_spec ws opt_semi
+               / @keyword{'const'} ws const_spec_group
+               / @keyword{'const'} ws const_spec ws opt_semi
+               / @keyword{'type'} ws type_spec_group
+               / @keyword{'type'} ws type_spec ws opt_semi
+
+var_spec_group <- @punctuation{'('} ws (var_spec ws opt_semi)* ws @punctuation{')'}
+var_spec      <- ident_list ws type_expr ws @operator{'='} ws expr_list
+               / ident_list ws type_expr
+               / ident_list ws @operator{'='} ws expr_list
+
+const_spec_group <- @punctuation{'('} ws (const_spec ws opt_semi)* ws @punctuation{')'}
+const_spec    <- const_ident_list (ws type_expr)? (ws @operator{'='} ws expr_list)?
+
+type_spec_group <- @punctuation{'('} ws (type_spec ws opt_semi)* ws @punctuation{')'}
+type_spec     <- @type{ident} ws type_params? ws (@operator{'='})? ws type_expr
+
+func_decl     <- @keyword{'func'} ws @function{ident} type_params? ws fn_signature ws block?
+method_decl   <- @keyword{'func'} ws method_receiver ws @function{ident} ws fn_signature ws block?
+method_receiver <- @punctuation{'('} ws (@variable{ident} ws)? type_expr ws @punctuation{')'}
+
+# Generics type parameters: `[T any, U comparable]`.
+type_params   <- @punctuation{'['} ws type_param_list ws @punctuation{']'}
+type_param_list <- type_param (ws @punctuation{','} ws type_param)* (ws @punctuation{','})?
+type_param    <- ident_list ws type_constraint
+type_constraint <- type_union
+type_union    <- type_term (ws @operator{'|'} ws type_term)*
+type_term     <- @operator{'~'} ws type_expr
+               / type_expr
+
+fn_signature  <- fn_params (ws fn_result)?
+fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
+fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
+fn_param      <- ident_list ws (@operator{'...'} ws)? type_expr
+               / (@operator{'...'} ws)? type_expr
+fn_result     <- fn_params
+               / type_expr
+
+# --- Types -----------------------------------------------------------
+
+type_expr     <- type_ptr
+               / type_slice_or_array
+               / type_map
+               / type_chan
+               / type_func
+               / type_struct
+               / type_interface
+               / type_paren
+               / type_name
+
+type_ptr      <- @operator{'*'} ws type_expr
+type_slice_or_array <- @punctuation{'['} ws (@operator{'...'} / expr)? ws @punctuation{']'} ws type_expr
+type_map      <- @keyword{'map'} ws @punctuation{'['} ws type_expr ws @punctuation{']'} ws type_expr
+type_chan     <- @operator{'<-'} ws @keyword{'chan'} ws type_expr
+               / @keyword{'chan'} ws @operator{'<-'} ws type_expr
+               / @keyword{'chan'} ws type_expr
+type_func     <- @keyword{'func'} ws fn_signature
+type_struct   <- @keyword{'struct'} ws @punctuation{'{'} ws struct_field_list? ws @punctuation{'}'}
+struct_field_list <- struct_field (ws opt_semi ws struct_field)* (ws opt_semi)?
+struct_field  <- @property{ident} (ws @punctuation{','} ws @property{ident})* ws type_expr (ws string_lit)?
+               / (@operator{'*'} ws)? type_name (ws string_lit)?       # embedded field
+type_interface <- @keyword{'interface'} ws @punctuation{'{'} ws interface_members? ws @punctuation{'}'}
+interface_members <- interface_member (ws opt_semi ws interface_member)* (ws opt_semi)?
+interface_member <- @function{ident} ws fn_signature
+                  / type_term
+type_paren    <- @punctuation{'('} ws type_expr ws @punctuation{')'}
+type_name     <- @type{qualified_ident} type_args?
+type_args     <- @punctuation{'['} ws type_arg_list ws @punctuation{']'}
+type_arg_list <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation{','})?
+
+# `pkg.Name` or `Name`.
+qualified_ident <- ident (@punctuation{'.'} ident)?
+
+# --- Statements ------------------------------------------------------
+
+block         <- @punctuation{'{'} ws (stmt ws)* @punctuation{'}'}
+
+stmt          <- decl ws opt_semi
+               / block
+               / labeled_stmt
+               / if_stmt
+               / for_stmt
+               / switch_stmt
+               / select_stmt
+               / go_stmt
+               / defer_stmt
+               / return_stmt
+               / break_stmt
+               / continue_stmt
+               / goto_stmt
+               / fallthrough_stmt
+               / simple_stmt ws opt_semi
+               / empty_stmt
+
+empty_stmt    <- @punctuation{';'} ws
+
+simple_stmt   <- send_stmt
+               / inc_dec_stmt
+               / assignment
+               / short_var_decl
+               / expr_stmt
+
+send_stmt     <- expr_no_compound ws @operator{'<-'} ws expr_no_compound
+inc_dec_stmt  <- expr_no_compound ws (@operator{'++'} / @operator{'--'})
+short_var_decl <- ident_list ws @operator{':='} ws expr_list
+assignment    <- expr_no_compound_list ws assign_op ws expr_list
+expr_stmt     <- expr_no_compound
+
+assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+               / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
+               / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
+               / @operator{'='} !'='
+
+labeled_stmt  <- @variable{ident} ws @punctuation{':'} ws stmt
+
+if_stmt       <- @keyword{'if'} ws (simple_stmt ws @punctuation{';'} ws)? expr_no_compound ws block
+                 (ws @keyword{'else'} ws (if_stmt / block))?
+for_stmt      <- @keyword{'for'} ws for_header? ws block
+for_header    <- for_range
+               / for_c_style
+               / expr_no_compound
+for_range     <- (ident_list ws (@operator{'='} / @operator{':='}) ws)? @keyword{'range'} ws expr_no_compound
+for_c_style   <- simple_stmt? ws @punctuation{';'} ws expr_no_compound? ws @punctuation{';'} ws simple_stmt?
+
+switch_stmt   <- @keyword{'switch'} ws type_switch_header ws @punctuation{'{'} ws type_case* ws @punctuation{'}'}
+               / @keyword{'switch'} ws expr_switch_header ws @punctuation{'{'} ws expr_case* ws @punctuation{'}'}
+expr_switch_header <- (simple_stmt ws @punctuation{';'} ws)? expr_no_compound?
+               / ''
+type_switch_header <- (simple_stmt ws @punctuation{';'} ws)? type_switch_guard
+type_switch_guard  <- (@variable{ident} ws @operator{':='} ws)? expr_no_compound @punctuation{'.'} @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}
+expr_case     <- @keyword{'case'} ws expr_list ws @punctuation{':'} ws (stmt ws)*
+               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
+type_case     <- @keyword{'case'} ws type_list ws @punctuation{':'} ws (stmt ws)*
+               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
+type_list     <- type_expr (ws @punctuation{','} ws type_expr)*
+
+select_stmt   <- @keyword{'select'} ws @punctuation{'{'} ws comm_case* ws @punctuation{'}'}
+comm_case     <- @keyword{'case'} ws comm_clause ws @punctuation{':'} ws (stmt ws)*
+               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
+comm_clause   <- send_stmt
+               / recv_stmt
+recv_stmt     <- (ident_list ws (@operator{'='} / @operator{':='}) ws)? expr_no_compound
+
+go_stmt       <- @keyword{'go'} ws expr
+defer_stmt    <- @keyword{'defer'} ws expr
+return_stmt   <- @keyword{'return'} (ws expr_list)?
+break_stmt    <- @keyword{'break'} (ws @variable{ident})?
+continue_stmt <- @keyword{'continue'} (ws @variable{ident})?
+goto_stmt     <- @keyword{'goto'} ws @variable{ident}
+fallthrough_stmt <- @keyword{'fallthrough'}
+
+# --- Expressions -----------------------------------------------------
+#
+# Two tracks: `expr` allows composite literals (`T{...}`); in
+# control-flow headers and simple statements we use `expr_no_compound`
+# to avoid parsing `y { z }` as `y{z}` a la composite literal. Mirrors
+# Go's own disambiguation (see go/parser for `exprLev`).
+
+expr          <- expr_bin
+expr_no_compound <- expr_bin_nc
+
+expr_bin      <- expr_unary (ws bin_op ws expr_unary)*
+expr_bin_nc   <- expr_unary_nc (ws bin_op ws expr_unary_nc)*
+
+bin_op        <- @operator{'&&'} / @operator{'||'}
+               / @operator{'=='} / @operator{'!='}
+               / @operator{'<='} / @operator{'>='}
+               / @operator{'<<'} / @operator{'>>'}
+               / @operator{'&^'}
+               / @operator{'+'} / @operator{'-'}
+               / @operator{'*'} / @operator{'/'} / @operator{'%'}
+               / @operator{'&'} / @operator{'|'} / @operator{'^'}
+               / @operator{'<'} / @operator{'>'}
+
+expr_unary    <- (unary_op ws)* expr_postfix
+expr_unary_nc <- (unary_op ws)* expr_postfix_nc
+unary_op      <- @operator{'!'} / @operator{'+'} / @operator{'-'}
+               / @operator{'^'} / @operator{'*'} / @operator{'&'}
+               / @operator{'<-'}
+
+expr_postfix  <- expr_primary (ws postfix_op)*
+expr_postfix_nc <- expr_primary_nc (ws postfix_op_nc)*
+
+postfix_op    <- @punctuation{'.'} postfix_selector
+               / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
+               / @punctuation{'('} ws call_args? ws @punctuation{')'}
+               / composite_body
+postfix_op_nc <- @punctuation{'.'} postfix_selector
+               / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
+               / @punctuation{'('} ws call_args? ws @punctuation{')'}
+postfix_selector <- @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}           # x.(type) (only in type switch; accepted here too)
+                  / @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
+                  / @function{ident} &(ws @punctuation{'('})
+                  / @property{ident}
+slice_or_index <- expr? ws @punctuation{':'} ws expr? (ws @punctuation{':'} ws expr)?
+               / expr
+
+call_args     <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
+arg           <- expr ws @operator{'...'}
+               / expr
+               / type_expr
+
+# Composite literal body: `{ ... }` after a type expression.
+composite_body <- @punctuation{'{'} ws composite_elems? ws @punctuation{'}'}
+composite_elems <- composite_elem (ws @punctuation{','} ws composite_elem)* (ws @punctuation{','})?
+composite_elem <- composite_key ws @punctuation{':'} ws composite_value
+               / composite_value
+composite_key  <- @property{ident}
+                / @punctuation{'['} ws expr ws @punctuation{']'}
+                / string_lit
+                / number_lit
+composite_value <- composite_body
+                 / expr
+
+expr_primary  <- literal
+               / fn_lit
+               / composite_lit
+               / type_conv
+               / call_ident
+               / @type{upper_ident}
+               / @constant{predeclared_const}
+               / @type{predeclared_type}
+               / @function{predeclared_fn} &(ws @punctuation{'('})
+               / @variable{lower_ident}
+               / paren_expr
+expr_primary_nc <- literal
+                 / fn_lit
+                 / type_conv
+                 / call_ident
+                 / @type{upper_ident}
+                 / @constant{predeclared_const}
+                 / @type{predeclared_type}
+                 / @function{predeclared_fn} &(ws @punctuation{'('})
+                 / @variable{lower_ident}
+                 / paren_expr
+
+paren_expr    <- @punctuation{'('} ws expr ws @punctuation{')'}
+
+# Composite literal: `T{...}` where T is a named/qualified type.
+composite_lit <- @type{qualified_ident} composite_body
+               / @keyword{'map'} ws @punctuation{'['} ws type_expr ws @punctuation{']'} ws type_expr ws composite_body
+               / @punctuation{'['} ws (@operator{'...'} / expr)? ws @punctuation{']'} ws type_expr ws composite_body
+               / @keyword{'struct'} ws type_struct_body ws composite_body
+type_struct_body <- @punctuation{'{'} ws struct_field_list? ws @punctuation{'}'}
+
+# Type conversion: `T(x)` where T is a named type — only triggers if
+# immediately followed by `(`.
+type_conv     <- @type{predeclared_type} @punctuation{'('} ws expr ws @punctuation{')'}
+
+# Function literal.
+fn_lit        <- @keyword{'func'} ws fn_signature ws block
+
+call_ident    <- @function{ident} &(ws @punctuation{'('})
+
+ident_list    <- @variable{ident} (ws @punctuation{','} ws @variable{ident})*
+const_ident_list <- @constant{ident} (ws @punctuation{','} ws @constant{ident})*
+expr_list     <- expr (ws @punctuation{','} ws expr)*
+expr_no_compound_list <- expr_no_compound (ws @punctuation{','} ws expr_no_compound)*
+
+# --- Literals -------------------------------------------------------
+
+literal       <- string_lit / number_lit / rune_lit / @constant{bool_lit} / @constant{nil_lit} / @constant{iota_lit}
+
+bool_lit      <- 'true' !ident_body / 'false' !ident_body
+nil_lit       <- 'nil' !ident_body
+iota_lit      <- 'iota' !ident_body
+
+string_lit    <- @string{raw_string / interp_string}
+raw_string    <- '`' (!'`' .)* '`'
+interp_string <- '"' (str_escape / !'"' !'\n' .)* '"'
+str_escape    <- '\\' .
+
+rune_lit      <- @string{"'" (char_escape / !"'" .)* "'"}
+char_escape   <- '\\' .
+
+number_lit    <- @number{num_body}
+num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? imag?
+               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? imag?
+               / '0o' oct_digits imag?
+               / '0b' bin_digits imag?
+               / digit_seq '.' digit_seq? exp_part? imag?
+               / '.' digit_seq exp_part? imag?
+               / digit_seq exp_part? imag?
+digit_seq     <- [0-9] ([0-9_])*
+hex_digits    <- [0-9a-fA-F] [0-9a-fA-F_]*
+oct_digits    <- [0-7] [0-7_]*
+bin_digits    <- [01] [01_]*
+exp_part      <- [eE] [+\-]? [0-9]+
+imag          <- 'i'
+
+# --- Identifiers / predeclared names ---------------------------------
+
+ident         <- !reserved ident_start ident_body*
+upper_ident   <- !reserved [A-Z] ident_body*
+lower_ident   <- !reserved [a-z_] ident_body*
+ident_start   <- [A-Za-z_]
+ident_body    <- [A-Za-z0-9_]
+
+# Reserved keywords blocking identifier capture.
+reserved      <- reserved_word !ident_body
+reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
+               / 'defer' / 'default' / 'else' / 'fallthrough' / 'for'
+               / 'func' / 'go' / 'goto' / 'if' / 'import' / 'interface'
+               / 'map' / 'package' / 'range' / 'return' / 'select'
+               / 'struct' / 'switch' / 'type' / 'var'
+
+# Predeclared constants / types / builtin funcs — matched as whole
+# identifiers so colouring is consistent without contextual
+# resolution.
+predeclared_const <- ('true' / 'false' / 'nil' / 'iota') !ident_body
+predeclared_type <- ('uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+                   / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
+                   / 'float32' / 'float64' / 'complex64' / 'complex128'
+                   / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
+                   / 'error' / 'any' / 'comparable') !ident_body
+predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
+                 / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
+                 / 'print' / 'println' / 'real' / 'recover') !ident_body
+
+# --- Whitespace / comments / semicolon handling ----------------------
+
+# Go uses newlines as statement terminators (lexer-inserted `;`); here
+# we accept optional explicit `;` and let `ws` eat whitespace.
+opt_semi      <- (@punctuation{';'} ws)?
+
+comment       <- @comment{line_comment / block_comment}
+line_comment  <- '//' (!'\n' .)*
+block_comment <- '/*' (!'*/' .)* '*/'
+
+ws            <- (comment / [ \t\r\n])*

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,9 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
     while let Some(arg) = it.next() {
         match arg.as_str() {
             "-l" | "--lang" => {
-                let name = it
-                    .next()
-                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust|js|go)", arg))?;
+                let name = it.next().ok_or_else(|| {
+                    format!("{} requires a value (json|toml|sql|rust|js|go)", arg)
+                })?;
                 lang = Some(Lang::from_name(&name).ok_or_else(|| {
                     format!(
                         "unknown language {:?} (expected json|toml|sql|rust|js|go)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 
 #[derive(Clone, Copy)]
 enum Lang {
@@ -17,6 +18,7 @@ enum Lang {
     Sql,
     Rust,
     JavaScript,
+    Go,
 }
 
 impl Lang {
@@ -27,6 +29,7 @@ impl Lang {
             Lang::Sql => SQLITE_GRAMMAR,
             Lang::Rust => RUST_GRAMMAR,
             Lang::JavaScript => JS_GRAMMAR,
+            Lang::Go => GO_GRAMMAR,
         }
     }
 
@@ -37,6 +40,7 @@ impl Lang {
             "sql" | "sqlite" => Some(Lang::Sql),
             "rs" | "rust" => Some(Lang::Rust),
             "js" | "javascript" | "mjs" | "cjs" => Some(Lang::JavaScript),
+            "go" => Some(Lang::Go),
             _ => None,
         }
     }
@@ -62,10 +66,10 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
             "-l" | "--lang" => {
                 let name = it
                     .next()
-                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust|js)", arg))?;
+                    .ok_or_else(|| format!("{} requires a value (json|toml|sql|rust|js|go)", arg))?;
                 lang = Some(Lang::from_name(&name).ok_or_else(|| {
                     format!(
-                        "unknown language {:?} (expected json|toml|sql|rust|js)",
+                        "unknown language {:?} (expected json|toml|sql|rust|js|go)",
                         name
                     )
                 })?);
@@ -74,7 +78,7 @@ fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<Cli, String> {
                 let name = &other["--lang=".len()..];
                 lang = Some(Lang::from_name(name).ok_or_else(|| {
                     format!(
-                        "unknown language {:?} (expected json|toml|sql|rust|js)",
+                        "unknown language {:?} (expected json|toml|sql|rust|js|go)",
                         name
                     )
                 })?);
@@ -97,7 +101,7 @@ fn pick_lang(cli: &Cli) -> Result<Lang, String> {
     match &cli.path {
         Some(p) => Lang::from_extension(Path::new(p)).ok_or_else(|| {
             format!(
-                "cannot infer language from path {:?}; pass --lang json|toml|sql|rust|js",
+                "cannot infer language from path {:?}; pass --lang json|toml|sql|rust|js|go",
                 p
             )
         }),

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -81,7 +81,8 @@ fn minimal_package_parses() {
 
 #[test]
 fn hello_world_parses() {
-    let input = "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello, world\")\n}\n";
+    let input =
+        "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello, world\")\n}\n";
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
     assert!(k.contains(&"keyword"), "expected keywords: {:?}", k);
@@ -177,7 +178,8 @@ fn channel_types_parse() {
 
 #[test]
 fn if_with_init_parses() {
-    let input = "package p\n\nfunc f() {\n\tif v, err := parse(); err != nil {\n\t\t_ = v\n\t}\n}\n";
+    let input =
+        "package p\n\nfunc f() {\n\tif v, err := parse(); err != nil {\n\t\t_ = v\n\t}\n}\n";
     let (_, _) = assert_complete_full(input);
 }
 

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -1,0 +1,226 @@
+use std::collections::HashSet;
+
+use syntax_highlighter::pegc;
+use syntax_highlighter::pegvm::{Capture, Program, VM};
+
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
+
+fn compile_go() -> Program {
+    pegc::compile(GO_GRAMMAR).expect("Go grammar should compile")
+}
+
+fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
+    let prog = compile_go();
+    let r = VM::new(&prog.code, input.as_bytes()).run();
+    (
+        r.matched,
+        r.captures,
+        prog.capture_kinds.clone(),
+        r.complete,
+    )
+}
+
+fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(
+        complete,
+        "expected complete match, got matched={} of {}",
+        matched,
+        input.len()
+    );
+    assert_eq!(matched, input.len(), "expected full-input match");
+    (caps, kinds)
+}
+
+fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+        .collect()
+}
+
+#[test]
+fn grammar_parses_and_compiles() {
+    let prog = compile_go();
+    assert!(!prog.code.is_empty());
+    assert!(!prog.capture_kinds.is_empty());
+}
+
+#[test]
+fn capture_kinds_stay_in_theme_vocabulary() {
+    let prog = compile_go();
+    let allowed: HashSet<&str> = [
+        "keyword",
+        "string",
+        "number",
+        "comment",
+        "operator",
+        "punctuation",
+        "type",
+        "function",
+        "constant",
+        "property",
+        "variable",
+        "recovery",
+    ]
+    .into_iter()
+    .collect();
+    for k in &prog.capture_kinds {
+        assert!(
+            allowed.contains(k.as_str()),
+            "capture kind {:?} is not in the theme vocabulary",
+            k
+        );
+    }
+}
+
+#[test]
+fn minimal_package_parses() {
+    let (_, _) = assert_complete_full("package main\n");
+}
+
+#[test]
+fn hello_world_parses() {
+    let input = "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello, world\")\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"keyword"), "expected keywords: {:?}", k);
+    assert!(k.contains(&"string"), "expected string: {:?}", k);
+}
+
+#[test]
+fn grouped_imports_parse() {
+    let input = "package main\n\nimport (\n\t\"fmt\"\n\tio \"io\"\n\t. \"strings\"\n)\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn var_decl_parses() {
+    let input = "package p\n\nvar (\n\tx int\n\ty int = 1\n\tz = 2\n)\n\nvar a, b = 1, 2\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn const_iota_parses() {
+    let input = "package p\n\nconst (\n\tA = iota\n\tB\n\tC\n)\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn type_struct_parses() {
+    let input = "package p\n\ntype Point struct {\n\tX, Y int\n\tName string `json:\"name\"`\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"type"), "expected Point @type: {:?}", k);
+    assert!(k.contains(&"property"), "expected field @property: {:?}", k);
+}
+
+#[test]
+fn type_interface_parses() {
+    let input = "package p\n\ntype Reader interface {\n\tRead(p []byte) (n int, err error)\n\tClose() error\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn method_decl_parses() {
+    let input = "package p\n\nfunc (p *Point) Distance() float64 { return 0 }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn generic_func_parses() {
+    let input = "package p\n\nfunc Map[T, U any](xs []T, f func(T) U) []U { return nil }\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn for_range_parses() {
+    let input = "package p\n\nfunc f() {\n\tfor i, v := range xs {\n\t\t_ = v\n\t\t_ = i\n\t}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn for_c_style_parses() {
+    let input = "package p\n\nfunc f() {\n\tfor i := 0; i < 10; i++ {\n\t\tprintln(i)\n\t}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn switch_type_switch_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch v := x.(type) {\n\tcase int:\n\t\t_ = v\n\tcase string:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn select_parses() {
+    let input = "package p\n\nfunc f(ch chan int) {\n\tselect {\n\tcase v := <-ch:\n\t\t_ = v\n\tcase ch <- 1:\n\tdefault:\n\t}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn composite_literal_parses() {
+    let input = "package p\n\nfunc f() {\n\tp := Point{X: 1, Y: 2}\n\ta := []int{1, 2, 3}\n\tm := map[string]int{\"a\": 1}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn closure_and_defer_parse() {
+    let input = "package p\n\nfunc f() {\n\tdefer func() { recover() }()\n\tgo func(n int) { println(n) }(42)\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn channel_types_parse() {
+    let input = "package p\n\nfunc f(a chan int, b <-chan int, c chan<- int) {}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn if_with_init_parses() {
+    let input = "package p\n\nfunc f() {\n\tif v, err := parse(); err != nil {\n\t\t_ = v\n\t}\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn slicing_parses() {
+    let input = "package p\n\nfunc f(xs []int) {\n\t_ = xs[0]\n\t_ = xs[1:]\n\t_ = xs[:2]\n\t_ = xs[1:3]\n\t_ = xs[1:3:4]\n}\n";
+    let (_, _) = assert_complete_full(input);
+}
+
+#[test]
+fn string_forms_parse() {
+    let input = "package p\n\nvar s1 = \"hello\"\nvar s2 = `raw\nstring`\nvar r = 'a'\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"string"), "expected strings: {:?}", k);
+}
+
+#[test]
+fn numeric_forms_parse() {
+    let input = "package p\n\nvar a = 42\nvar b = 3.14\nvar c = 0xff\nvar d = 0b1010\nvar e = 0o77\nvar f = 1_000\nvar g = 1e10\nvar h = 1i\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"number"), "expected numbers: {:?}", k);
+}
+
+#[test]
+fn line_and_block_comment_parse() {
+    let input = "package p\n// line\n/* block */\nfunc f() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(k.contains(&"comment"), "expected comments: {:?}", k);
+}
+
+#[test]
+fn recovery_absorbs_malformed_item() {
+    let input = "package p\n\nfunc a() {}\n@@@ garbage @@@\nfunc b() {}\n";
+    let (matched, caps, kinds, complete) = run(input);
+    assert!(complete, "recovery should keep parse complete");
+    assert_eq!(matched, input.len());
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        k.contains(&"recovery"),
+        "expected a @recovery capture for the @@@ region, got: {:?}",
+        k
+    );
+}

--- a/tests/highlight_go_tests.rs
+++ b/tests/highlight_go_tests.rs
@@ -1,0 +1,165 @@
+use syntax_highlighter::highlight::{theme, Highlighter};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::strip_ansi;
+
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
+
+fn hl(input: &str) -> Highlighter {
+    let mut h = Highlighter::new(GO_GRAMMAR).expect("Go grammar should compile");
+    h.set_input(input.to_string());
+    h
+}
+
+#[test]
+fn round_trip_strips_to_input() {
+    let cases: &[&str] = &[
+        "package main\n",
+        "package main\n\nimport \"fmt\"\n",
+        "package p\n\nfunc f(x int) int { return x + 1 }\n",
+        "package p\n\ntype T struct { X int }\n",
+        "package p\n\nfunc f() { xs := []int{1, 2, 3}; _ = xs }\n",
+        "package p\n\nfunc f() {\n\tfor i, v := range xs {\n\t\t_ = i\n\t\t_ = v\n\t}\n}\n",
+    ];
+    for &input in cases {
+        let out = hl(input).highlight();
+        assert_eq!(
+            strip_ansi(&out),
+            input,
+            "round-trip mismatch for: {:?}",
+            input
+        );
+    }
+}
+
+#[test]
+fn keyword_uses_keyword_color() {
+    let out = hl("package main\n").highlight();
+    assert!(
+        out.contains(theme::color_for("keyword")),
+        "expected keyword color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn string_uses_string_color() {
+    let out = hl("package p\n\nvar s = \"hello\"\n").highlight();
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn raw_string_uses_string_color() {
+    let out = hl("package p\n\nvar s = `raw`\n").highlight();
+    assert!(
+        out.contains(theme::color_for("string")),
+        "expected string color for raw string in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn number_uses_number_color() {
+    let out = hl("package p\n\nvar n = 42\n").highlight();
+    assert!(
+        out.contains(theme::color_for("number")),
+        "expected number color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn line_comment_uses_comment_color() {
+    let out = hl("package p\n// a line\nfunc f() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn block_comment_uses_comment_color() {
+    let out = hl("package p\n/* a block */\nfunc f() {}\n").highlight();
+    assert!(
+        out.contains(theme::color_for("comment")),
+        "expected comment color in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn fn_name_uses_function_color() {
+    let out = hl("package p\n\nfunc compute() {}\n").highlight();
+    let idx = out.find("compute").expect("`compute` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("function")),
+        "expected function color before `compute`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn type_name_uses_type_color() {
+    let out = hl("package p\n\ntype Point struct {}\n").highlight();
+    let idx = out.find("Point").expect("`Point` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before `Point`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn predeclared_type_uses_type_color() {
+    let out = hl("package p\n\nvar x int = 1\n").highlight();
+    let idx = out.find("int").expect("`int` must appear");
+    let preceding = &out[..idx];
+    assert!(
+        preceding.ends_with(theme::color_for("type")),
+        "expected type color before `int`, got tail {:?}",
+        preceding
+    );
+}
+
+#[test]
+fn nil_uses_constant_color() {
+    let out = hl("package p\n\nvar x = nil\n").highlight();
+    assert!(
+        out.contains(theme::color_for("constant")),
+        "expected constant color for nil in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn assign_operator_present() {
+    let out = hl("package p\n\nfunc f() { x := 1; _ = x }\n").highlight();
+    assert!(
+        out.contains(theme::color_for("operator")),
+        "expected operator color (:=) in: {:?}",
+        out
+    );
+}
+
+#[test]
+fn recovery_renders_malformed_region_plain() {
+    let input = "package p\n\nfunc a() {}\n@@@ garbage @@@\nfunc b() {}\n";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input);
+    assert!(out.contains(theme::color_for("keyword")));
+}
+
+#[test]
+fn partial_match_on_truncated_input() {
+    let input = "package p\n\nfunc incomplete() { x := 1\n";
+    let out = hl(input).highlight();
+    assert_eq!(strip_ansi(&out), input);
+}


### PR DESCRIPTION
Stacked on #21 (JavaScript grammar). Part of the #10 cross-language
expansion.

Adds a pragmatic Go subset (`grammars/go.peg`), tests, CLI wiring
(`-l go`, `.go`), bench fixtures, and README shipping update.

Covers package/imports, struct/interface/method, generics with type
parameters, channel types including directionality, composite
literals (with the standard `expr_no_compound` split that Go's own
parser uses to disambiguate `T{...}` from block bodies), type
switches, `select`, `for ... range`, and `defer`/`go`.

Bytecode size: 3,118 VM instructions / 145 rules — sits between
JavaScript (2,916) and Rust (3,413). Intentionally out of scope:
generic constraint checking, build tags, semantic typedef-vs-ident
resolution.