### PR TITLE
Direct left recursion support

### DIFF
--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -152,9 +152,12 @@ this; grammar authors must ensure `p` consumes input on success.
   is tried only if `p1` fails.
 - **Predicates consume no input.** `!p` and `&p` rewind any `sp`
   advance `p` would have made, and emit no captures.
-- **No left recursion.** `A <- A ...` infinite-loops. Rewrite as
-  right recursion or an iterative form; left-recursion support is
-  tracked in #40.
+- **Direct left recursion is supported.** `A <- A α / β` and similar
+  shapes parse left-associatively via bounded LR (Medeiros et al.
+  2014 §5; see [`src/pegvm/README.md`](../pegvm/README.md#left-recursion)).
+  **Indirect** left recursion (`A <- B …; B <- A …`) is rejected
+  with `CompileError::IndirectLeftRecursion`; tracked as a
+  follow-up to #40.
 - **Byte-oriented.** Character classes are sets of `u8`; UTF-8 is
   never decoded. Direction for Unicode support is under evaluation
   in #45.

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::pattern::Pattern;
 use crate::pegvm::{CaptureKind, Instruction, Label, MemoId, Program};
@@ -7,6 +7,11 @@ use crate::pegvm::{CaptureKind, Instruction, Label, MemoId, Program};
 pub enum CompileError {
     UndefinedRule(String),
     UnknownStartRule(String),
+    /// One or more rules participate in a left-recursive cycle longer
+    /// than length 1 (e.g. `A <- B …; B <- A …`). v1 of LR support
+    /// handles direct LR only; the cycle's rules are listed for the
+    /// grammar author. Tracked as a follow-up to #40.
+    IndirectLeftRecursion(Vec<String>),
 }
 
 impl std::fmt::Display for CompileError {
@@ -14,6 +19,11 @@ impl std::fmt::Display for CompileError {
         match self {
             CompileError::UndefinedRule(name) => write!(f, "undefined rule: {}", name),
             CompileError::UnknownStartRule(name) => write!(f, "unknown start rule: {}", name),
+            CompileError::IndirectLeftRecursion(cycle) => write!(
+                f,
+                "indirect left recursion across rules [{}] (only direct left recursion is supported)",
+                cycle.join(", ")
+            ),
         }
     }
 }
@@ -256,6 +266,15 @@ pub(crate) fn compile_rules(
         return Err(CompileError::UnknownStartRule(start.to_string()));
     }
 
+    // Detect undefined NonTerminal references up front so the LR analysis
+    // doesn't have to defend against missing rules in the call graph.
+    for (rule_name, body) in rules {
+        check_refs(rule_name, body, rules)?;
+    }
+
+    // Identify directly left-recursive rules; reject indirect LR.
+    let direct_lr = analyze_left_recursion(rules)?;
+
     let mut c = Compiler::new();
     c.emit(Instruction::Call(Label(0))); // patched below
     c.emit(Instruction::End);
@@ -276,14 +295,27 @@ pub(crate) fn compile_rules(
         rule_addrs.insert(name.clone(), c.pos());
         let memo_id = MemoId(memo_count);
         memo_count += 1;
-        // MemoOpen's Label is patched to the Return address below so a cache
-        // hit can skip straight past the body to the rule's Return.
-        let memo_open = c.emit(Instruction::MemoOpen(memo_id, Label(0)));
-        c.compile_pat(&rules[name]);
-        c.emit(Instruction::MemoClose(memo_id));
-        let return_addr = c.pos();
-        c.emit(Instruction::Return);
-        c.patch_jump(memo_open, return_addr);
+        if direct_lr.contains(name.as_str()) {
+            // LR rule: LRBody … body … LRTail ; Return. No MemoOpen /
+            // MemoClose — the L-frame replaces packrat caching for this
+            // rule (LR rules are not memoized in v1).
+            let lr_body = c.emit(Instruction::LRBody(memo_id, Label(0)));
+            let body_start = c.pos();
+            c.compile_pat(&rules[name]);
+            c.emit(Instruction::LRTail(memo_id, Label(body_start)));
+            let return_addr = c.pos();
+            c.emit(Instruction::Return);
+            c.patch_jump(lr_body, return_addr);
+        } else {
+            // MemoOpen's Label is patched to the Return address below so a cache
+            // hit can skip straight past the body to the rule's Return.
+            let memo_open = c.emit(Instruction::MemoOpen(memo_id, Label(0)));
+            c.compile_pat(&rules[name]);
+            c.emit(Instruction::MemoClose(memo_id));
+            let return_addr = c.pos();
+            c.emit(Instruction::Return);
+            c.patch_jump(memo_open, return_addr);
+        }
     }
 
     // Patch the bootstrap Call.
@@ -304,4 +336,228 @@ pub(crate) fn compile_rules(
         capture_kinds: c.capture_names,
         memo_count: memo_count as usize,
     })
+}
+
+/// Walk a pattern reporting any `NonTerminal(name)` whose name isn't in
+/// `rules`. Splits the undefined-rule check out of the bytecode-emit pass
+/// so the LR analysis can assume every reference resolves.
+fn check_refs(
+    _rule: &str,
+    pat: &Pattern,
+    rules: &HashMap<String, Pattern>,
+) -> Result<(), CompileError> {
+    match pat {
+        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => Ok(()),
+        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
+            for it in items {
+                check_refs(_rule, it, rules)?;
+            }
+            Ok(())
+        }
+        Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner)
+        | Pattern::Optional(inner)
+        | Pattern::NotPredicate(inner)
+        | Pattern::AndPredicate(inner)
+        | Pattern::Capture(_, inner) => check_refs(_rule, inner, rules),
+        Pattern::RecoverRepeat { inner, .. } => check_refs(_rule, inner, rules),
+        Pattern::NonTerminal(name) => {
+            if rules.contains_key(name) {
+                Ok(())
+            } else {
+                Err(CompileError::UndefinedRule(name.clone()))
+            }
+        }
+    }
+}
+
+/// Returns the set of rule names that are *directly* left-recursive
+/// (`A <- A α / β` and equivalent shapes). Indirect left recursion
+/// (cycle length > 1) is rejected with `CompileError::IndirectLeftRecursion`.
+///
+/// Algorithm:
+/// 1. Compute may-match-empty (nullability) per rule via a fixpoint.
+/// 2. Build the "first-call" graph: edge `A → B` iff `A`'s body can call
+///    `B` before consuming any input.
+/// 3. Find strongly connected components in that graph (Tarjan's). An SCC
+///    of size > 1 is indirect LR (rejected). An SCC of size 1 is direct
+///    LR iff the rule has a self-edge in the first-call graph.
+fn analyze_left_recursion(
+    rules: &HashMap<String, Pattern>,
+) -> Result<HashSet<String>, CompileError> {
+    let nullable = compute_nullable(rules);
+    let first_calls = compute_first_calls(rules, &nullable);
+
+    let sccs = tarjan_sccs(rules, &first_calls);
+    let mut direct_lr = HashSet::new();
+    for scc in &sccs {
+        if scc.len() > 1 {
+            let mut cycle = scc.clone();
+            cycle.sort();
+            return Err(CompileError::IndirectLeftRecursion(cycle));
+        }
+        let only = &scc[0];
+        if first_calls
+            .get(only)
+            .map(|s| s.contains(only))
+            .unwrap_or(false)
+        {
+            direct_lr.insert(only.clone());
+        }
+    }
+    Ok(direct_lr)
+}
+
+/// Per-rule nullability via fixpoint over the Pattern AST. A rule is
+/// nullable iff its body can match the empty string.
+fn compute_nullable(rules: &HashMap<String, Pattern>) -> HashSet<String> {
+    let mut nullable: HashSet<String> = HashSet::new();
+    loop {
+        let mut changed = false;
+        for (name, body) in rules {
+            if !nullable.contains(name) && pattern_nullable(body, &nullable) {
+                nullable.insert(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    nullable
+}
+
+fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> bool {
+    match pat {
+        Pattern::Literal(bytes) => bytes.is_empty(),
+        Pattern::CharClass(_) | Pattern::AnyChar => false,
+        Pattern::Sequence(items) => items.iter().all(|p| pattern_nullable(p, nullable)),
+        Pattern::OrderedChoice(items) => items.iter().any(|p| pattern_nullable(p, nullable)),
+        Pattern::Repeat(_) | Pattern::Optional(_) => true,
+        Pattern::RepeatOne(inner) => pattern_nullable(inner, nullable),
+        // Predicates consume no input, so they always succeed-or-fail
+        // without advancing — treated as nullable for sequence
+        // propagation. They can still left-recurse: !A α matches only
+        // if A would fail at sp, and A's evaluation can left-recurse
+        // through itself just like a direct call.
+        Pattern::NotPredicate(_) | Pattern::AndPredicate(_) => true,
+        Pattern::Capture(_, inner) => pattern_nullable(inner, nullable),
+        Pattern::RecoverRepeat { .. } => true,
+        Pattern::NonTerminal(name) => nullable.contains(name),
+    }
+}
+
+/// First-call graph: `first_calls[A]` is the set of rules `A`'s body can
+/// invoke before consuming any input. Used to find left-recursive cycles.
+fn compute_first_calls(
+    rules: &HashMap<String, Pattern>,
+    nullable: &HashSet<String>,
+) -> HashMap<String, HashSet<String>> {
+    let mut out = HashMap::new();
+    for (name, body) in rules {
+        let mut s = HashSet::new();
+        collect_first_calls(body, nullable, &mut s);
+        out.insert(name.clone(), s);
+    }
+    out
+}
+
+fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut HashSet<String>) {
+    match pat {
+        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
+        Pattern::Sequence(items) => {
+            for it in items {
+                collect_first_calls(it, nullable, out);
+                if !pattern_nullable(it, nullable) {
+                    break;
+                }
+            }
+        }
+        Pattern::OrderedChoice(items) => {
+            for it in items {
+                collect_first_calls(it, nullable, out);
+            }
+        }
+        Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner)
+        | Pattern::Optional(inner)
+        | Pattern::NotPredicate(inner)
+        | Pattern::AndPredicate(inner)
+        | Pattern::Capture(_, inner) => collect_first_calls(inner, nullable, out),
+        Pattern::RecoverRepeat { inner, .. } => collect_first_calls(inner, nullable, out),
+        Pattern::NonTerminal(name) => {
+            out.insert(name.clone());
+        }
+    }
+}
+
+/// Tarjan's strongly-connected-components on the first-call graph.
+/// Returned SCCs are non-empty; their internal order is not specified.
+fn tarjan_sccs(
+    rules: &HashMap<String, Pattern>,
+    edges: &HashMap<String, HashSet<String>>,
+) -> Vec<Vec<String>> {
+    struct State<'a> {
+        edges: &'a HashMap<String, HashSet<String>>,
+        index: usize,
+        indices: HashMap<String, usize>,
+        lowlink: HashMap<String, usize>,
+        on_stack: HashSet<String>,
+        stack: Vec<String>,
+        sccs: Vec<Vec<String>>,
+    }
+    let mut st = State {
+        edges,
+        index: 0,
+        indices: HashMap::new(),
+        lowlink: HashMap::new(),
+        on_stack: HashSet::new(),
+        stack: Vec::new(),
+        sccs: Vec::new(),
+    };
+    fn strongconnect(st: &mut State<'_>, v: &str) {
+        st.indices.insert(v.to_string(), st.index);
+        st.lowlink.insert(v.to_string(), st.index);
+        st.index += 1;
+        st.stack.push(v.to_string());
+        st.on_stack.insert(v.to_string());
+        let succs: Vec<String> = st
+            .edges
+            .get(v)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+        for w in succs {
+            if !st.indices.contains_key(&w) {
+                strongconnect(st, &w);
+                let wl = st.lowlink[&w];
+                let vl = st.lowlink[v];
+                st.lowlink.insert(v.to_string(), vl.min(wl));
+            } else if st.on_stack.contains(&w) {
+                let wi = st.indices[&w];
+                let vl = st.lowlink[v];
+                st.lowlink.insert(v.to_string(), vl.min(wi));
+            }
+        }
+        if st.lowlink[v] == st.indices[v] {
+            let mut scc = Vec::new();
+            loop {
+                let w = st.stack.pop().expect("tarjan: stack underflow");
+                st.on_stack.remove(&w);
+                let done = w == v;
+                scc.push(w);
+                if done {
+                    break;
+                }
+            }
+            st.sccs.push(scc);
+        }
+    }
+    let mut keys: Vec<&String> = rules.keys().collect();
+    keys.sort();
+    for k in keys {
+        if !st.indices.contains_key(k) {
+            strongconnect(&mut st, k);
+        }
+    }
+    st.sccs
 }

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -71,6 +71,8 @@ impl Compiler {
             Instruction::TestSet(s, _) => Instruction::TestSet(*s, target),
             Instruction::Call(_) => Instruction::Call(target),
             Instruction::MemoOpen(id, _) => Instruction::MemoOpen(*id, target),
+            Instruction::LRBody(id, _) => Instruction::LRBody(*id, target),
+            Instruction::LRTail(id, _) => Instruction::LRTail(*id, target),
             other => panic!("patch_jump: not a jump instruction: {:?}", other),
         };
         self.code[idx] = new;

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -82,6 +82,7 @@ Each `Pattern` variant maps to a small fixed sequence of `Instruction`s. The ins
 | Control flow | `Jump`, `Choice`, `Commit`, `PartialCommit`, `BackCommit`, `FailTwice`, `Fail` | Express ordered choice, repetition, and predicates in terms of pushing and popping backtrack records. |
 | Calls | `Call`, `Return` | Invoke a named rule and return from it — the `NonTerminal` variant compiles to `Call(address)`. |
 | Memoization | `MemoOpen`, `MemoClose` | Rule-level packrat cache. The compiler wraps every rule body with a pair; on a hit `MemoOpen` replays cached captures and jumps to the rule's `Return`; on a miss it pushes a `Memo` frame that `MemoClose` commits as a success entry or `fail()` commits as a failure entry. |
+| Left recursion | `LRBody`, `LRTail` | Replace `MemoOpen` / `MemoClose` for rules the compiler detected as directly left-recursive. `LRBody` walks the stack for an in-flight `LFrame` at `(memo_id, sp)`: a hit replays the seed (`None` ⇒ fail, `Some` ⇒ jump to Return), a miss pushes a fresh `LFrame`. `LRTail` is the seed-and-grow controller — growth re-iterates from `start_sp`, no growth commits the seed and falls through. LR rules are not packrat-cached in v1. |
 | Captures | `CaptureBegin`, `CaptureEnd` | Bracket a matched span with a kind tag so the VM can record it. |
 | Termination | `End` | Mark the end of a successful match. |
 
@@ -184,6 +185,28 @@ This partial result is what lets the highlighter render a styled prefix and a pl
 
 A grammar that opts into the `*^` recovery operator on a top-level repetition can flip a parse that would otherwise be partial into `complete: true`: the loop emits `recovery_kind`-tagged captures over the bytes it skipped past inner failures and exits cleanly at end of input. Captures returned in that case interleave the successful `inner` captures with the recovery captures in input order.
 
+## Left recursion
+
+The compiler detects directly-left-recursive rules (`A <- A α / β` and equivalent shapes; see `analyze_left_recursion` in `src/pegc/compiler.rs`) and emits `LRBody` / `LRTail` in place of `MemoOpen` / `MemoClose`. Indirect left recursion (cycles longer than 1) is rejected at compile time — see `CompileError::IndirectLeftRecursion`.
+
+Bytecode shape for an LR rule:
+
+```
+rule_addr:    LRBody(memo_id, return_addr)
+body_start:   <body>
+              LRTail(memo_id, body_start)
+return_addr:  Return
+```
+
+The runtime algorithm is **bounded left recursion** (Medeiros, Mascarenhas & Ierusalimschy 2014, §3.2 / §5):
+
+1. **First entry at `sp`**: `LRBody` pushes `StackEntry::LFrame { memo_id, start_sp, capture_start_len, return_addr, seed: None }`. Body executes.
+2. **Recursive entry at the same `sp`**: `LRBody` finds the existing `LFrame` on the stack. `seed: None` ⇒ `fail()`. `seed: Some(end_sp, captures)` ⇒ replay captures, set `sp = end_sp`, jump to `return_addr` so the recursive call appears to return the seed.
+3. **Body succeeds**: `LRTail` decides. Growth (`sp > seed.end_sp`, or first success with `seed: None`) updates the seed and re-iterates from `start_sp`. No growth commits the seed and falls through to `Return`.
+4. **Body fails**: `fail()`'s `LFrame` arm rescues with the prior seed when `seed.is_some()` (returns `true`, resumes at `return_addr`); when `seed.is_none()` it continues unwinding (the LR rule failed without ever growing).
+
+The L table is stack-structured and lives only on `self.stack`; nothing is written to `self.memo` for an LR rule in v1. The `memo_examined` watermark is pushed/popped in lockstep with `LFrame`, so an enclosing rule's `examined_max` correctly subsumes positions the LR body looked at.
+
 ## Error types
 
 Grammar-source errors (`ParseError`, `CompileError`, unified `Error`) belong to the compiler — see [`src/pegc/README.md`](../pegc/README.md#errors). The VM's contract is simpler: `VM::run` always returns a `MatchResult`; its `complete` flag distinguishes a successful match from a non-match. A non-match is not an error — the distinction is between *author bugs* (grammar) and *data bugs* (input).
@@ -200,6 +223,8 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 6. **`VM::fail` records every `Memo` frame it traverses.** When unwinding to find a `Backtrack`, each `Memo` frame encountered is committed as a failure entry before being discarded. Silently dropping a frame would leak re-executions on future calls at the same sp. The loop is an exhaustive `match` over `StackEntry` specifically to make omissions a compiler error.
 7. **`MemoOpen` calls `maybe_snapshot` after applying a success hit.** The hit advances `sp` past code that didn't execute; without the snapshot call the farthest-failure bookkeeping would miss the advance and `MatchResult.complete == false` would report a stale deepest point.
 8. **`RecoverRepeat` emits a fresh `Choice`/`Commit` pair per iteration, never `PartialCommit`.** The loop's retry baseline must sit at the *advanced* `sp` after each successful iteration; `PartialCommit`'s in-place mutation of a stale backtrack frame would corrupt that baseline and re-trigger invariant 1's hazard. See `compile_pat`'s `RecoverRepeat` arm in `src/pegc/compiler.rs`.
+9. **`LRTail`'s `Label` payload targets the instruction after `LRBody`, not `LRBody` itself.** The seed-and-grow loop must re-execute the body, not re-push the `LFrame` — re-pushing would lose the prior seed and turn growth into an infinite loop. See `compile_rules`' LR-rule branch in `src/pegc/compiler.rs`.
+10. **`fail()`'s `LFrame` arm pops `memo_examined` before any rescue branch.** The watermark stack and `LFrame` push/pop in lockstep; if the rescue path took the early `return true` without popping, the next `MemoClose` / `LRTail` would underflow `memo_examined`. See `VM::fail`'s `StackEntry::LFrame` arm.
 
 ## References
 
@@ -209,12 +234,12 @@ Some properties the module relies on can't be encoded in the Rust type system. T
 - Sérgio Medeiros and Roberto Ierusalimschy, [*A Parsing Machine for PEGs*](https://www.inf.puc-rio.br/~roberto/docs/ry08-4.pdf). DLS 2008.
 - Roberto Ierusalimschy, [*A Text Pattern-Matching Tool based on Parsing Expression Grammars*](https://www.inf.puc-rio.br/~roberto/docs/peg.pdf). Software: Practice and Experience, 39(3):221–258, 2009.
 - Zachary Yedidia, [*Incremental PEG Parsing*](https://zyedidia.github.io/notes/yedidia_thesis.pdf). Ph.D. thesis, 2021. Chapter 3 ("A PEG Parsing Machine") is the clearest modern presentation of the instruction set used here and the reference to read first.
+- Sérgio Medeiros, Fabio Mascarenhas, and Roberto Ierusalimschy, [*Left recursion in parsing expression grammars*](https://arxiv.org/pdf/1207.0443.pdf). Science of Computer Programming 96:177–190, 2014. "Bounded left recursion" semantics with §5 giving the parsing-machine extension implemented as `LRBody` / `LRTail`; L table stack-structured and separate from the packrat memo. Fixes nullable-LR bugs that Warth 2008's algorithm exhibits.
 
-Left recursion (roadmap-adjacent; not implemented):
+Left recursion (historical context; alternative algorithms not implemented):
 
 - Alessandro Warth, James R. Douglass, and Todd Millstein, [*Packrat Parsers Can Support Left Recursion*](https://web.cs.ucla.edu/~todd/research/pepm08.pdf). PEPM 2008. Seminal seed-and-grow algorithm; couples left-recursion handling to the packrat memo table.
 - Laurence Tratt, [*Direct Left-Recursive Parsing Expression Grammars*](http://tratt.net/laurie/research/pubs/papers/tratt__direct_left_recursive_parsing_expression_grammars.pdf). Middlesex University Technical Report EIS-10-01, 2010. Adapts Warth's idea to PEGs without packrat memoization; direct left recursion only.
-- Sérgio Medeiros, Fabio Mascarenhas, and Roberto Ierusalimschy, [*Left recursion in parsing expression grammars*](https://arxiv.org/pdf/1207.0443.pdf). Science of Computer Programming 96:177–190, 2014. "Bounded left recursion" semantics with §5 giving a parsing-machine extension matching ours; L table is stack-structured and separate from the packrat memo. Fixes nullable-LR bugs that Warth's algorithm has.
 
 ### Reference implementations
 

--- a/src/pegvm/incremental.rs
+++ b/src/pegvm/incremental.rs
@@ -41,8 +41,12 @@
 //! working set sizes we care about; a position-indexed structure (e.g.
 //! `BTreeMap<usize, ...>`) is a future optimization if cache size grows.
 //!
-//! Note for future work: when left-recursion support lands, its L-table
-//! will need its own invalidation pass in parallel with this one.
+//! Left recursion: the LR table is **transient per run** — `LFrame`s live
+//! on the execution stack only and never enter [`MemoCache`], so this
+//! invalidation pass is unaffected. A future extension that caches
+//! converged LR seeds in the packrat memo would need a separate decision
+//! about what `examined_max` means across iterations of the seed-and-grow
+//! loop; tracked alongside `#40`.
 
 use std::collections::HashMap;
 

--- a/src/pegvm/instruction.rs
+++ b/src/pegvm/instruction.rs
@@ -168,6 +168,28 @@ pub enum Instruction {
     /// `start_sp`.
     MemoClose(MemoId),
 
+    /// Left-recursion prologue. Replaces `MemoOpen` at the head of rules the
+    /// compiler detected as directly left-recursive. On entry, walks the
+    /// stack for an `LFrame { memo_id, start_sp }` matching `(memo_id, sp)`:
+    /// - **Hit** (recursive re-entry): apply the seed. `seed: None` enters
+    ///   `fail()`; `seed: Some(end_sp, captures)` replays captures, sets
+    ///   `sp = end_sp`, and jumps to the `Label` — the rule's `Return`
+    ///   address — so the recursive call appears to have returned the seed.
+    /// - **Miss** (first invocation at this `sp`): push an `LFrame` with
+    ///   `seed: None` and the `Label` stored as `return_addr`; fall through
+    ///   to the rule body.
+    LRBody(MemoId, Label),
+    /// Left-recursion iteration controller. Sits between the body and the
+    /// rule's `Return`. Peeks the topmost `LFrame` (must match `MemoId`).
+    /// Decision:
+    /// - Body grew (`sp > seed.end_sp`, or first success with seed `None`):
+    ///   update seed to `Some(sp, captures-since-baseline)`, rewind to
+    ///   `start_sp`, truncate captures to the baseline, jump to the `Label`
+    ///   (body start) to re-run.
+    /// - No growth: apply the seed (replay captures, set `sp = seed.end_sp`),
+    ///   pop the `LFrame`, fall through to `Return`.
+    LRTail(MemoId, Label),
+
     CaptureBegin(CaptureKind),
     CaptureEnd,
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -30,6 +30,30 @@ enum StackEntry {
         start_sp: usize,
         capture_start_len: usize,
     },
+    /// Frame for an in-flight left-recursive rule invocation. Pushed by
+    /// `LRBody` on the first entry at a given `sp`; popped by `LRTail` when
+    /// the seed-and-grow loop converges, or by `fail()` (which uses the
+    /// `seed` to decide between rescuing the rule with the prior seed or
+    /// continuing to unwind). LR rules are not packrat-cached in v1, so
+    /// nothing is written to `self.memo` when this frame is dropped.
+    LFrame {
+        memo_id: MemoId,
+        start_sp: usize,
+        capture_start_len: usize,
+        return_addr: usize,
+        seed: Option<LSeed>,
+    },
+}
+
+/// Successful seed of a left-recursive rule's prior iteration: the `sp` the
+/// body matched up to, and the closed captures it produced past the
+/// `LFrame`'s `capture_start_len`. Replayed verbatim on recursive entries
+/// (where the recursive call must appear to have returned this seed) and on
+/// the convergence step (where the rule itself exits with this match).
+#[derive(Debug, Clone)]
+struct LSeed {
+    end_sp: usize,
+    captures: Vec<Capture>,
 }
 
 /// Outcome of running a compiled [`Program`](super::Program) against an input.
@@ -507,6 +531,148 @@ impl<'p, 'i> VM<'p, 'i> {
                     }
                     self.ip += 1;
                 }
+                Instruction::LRBody(memo_id, return_label) => {
+                    // Walk the stack top-down for an LFrame at the same
+                    // (memo_id, sp) — that signals recursive re-entry. For
+                    // direct LR the cycle has length 1, so any matching
+                    // LFrame is this rule's own.
+                    let lookup: Option<Option<LSeed>> = self.stack.iter().rev().find_map(|e| {
+                        if let StackEntry::LFrame {
+                            memo_id: id,
+                            start_sp,
+                            seed,
+                            ..
+                        } = e
+                        {
+                            if *id == *memo_id && *start_sp == self.sp {
+                                return Some(seed.clone());
+                            }
+                        }
+                        None
+                    });
+                    match lookup {
+                        Some(Some(found)) => {
+                            // Recursive entry with a seed: replay captures
+                            // already-closed (mirrors `MemoOpen`'s hit
+                            // path), set sp to seed end, and jump to the
+                            // rule's Return so the caller's `Call`-pushed
+                            // Return frame fires normally.
+                            for c in &found.captures {
+                                self.captures.push(OpenCapture {
+                                    kind: c.kind,
+                                    start: c.start,
+                                    end: Some(c.end),
+                                });
+                            }
+                            self.bump_top_memo_examined(found.end_sp);
+                            self.sp = found.end_sp;
+                            self.ip = return_label.0;
+                            self.maybe_snapshot();
+                        }
+                        Some(None) => {
+                            // Recursive entry with no seed yet — the rule
+                            // has not succeeded once at this position, so
+                            // the recursive call must fail (bound 0).
+                            if !self.fail() {
+                                return self.finalize_partial();
+                            }
+                        }
+                        None => {
+                            // First entry at this sp — push an LFrame and
+                            // a paired memo_examined watermark, then fall
+                            // through to the body.
+                            self.stack.push(StackEntry::LFrame {
+                                memo_id: *memo_id,
+                                start_sp: self.sp,
+                                capture_start_len: self.captures.len(),
+                                return_addr: return_label.0,
+                                seed: None,
+                            });
+                            self.memo_examined.push(self.sp);
+                            self.ip += 1;
+                        }
+                    }
+                }
+                Instruction::LRTail(memo_id, body_start) => {
+                    // Peek the topmost LFrame. The body just succeeded; we
+                    // must decide between growing (re-iterate) and
+                    // accepting (commit and fall through to Return).
+                    let top_idx = self
+                        .stack
+                        .iter()
+                        .rposition(|e| matches!(e, StackEntry::LFrame { .. }))
+                        .expect("LRTail without an enclosing LFrame");
+                    let StackEntry::LFrame {
+                        memo_id: top_id,
+                        start_sp,
+                        capture_start_len,
+                        return_addr: _,
+                        seed,
+                    } = &mut self.stack[top_idx]
+                    else {
+                        unreachable!("rposition matched LFrame")
+                    };
+                    debug_assert_eq!(
+                        *top_id, *memo_id,
+                        "LRTail id mismatch: expected {:?}, found {:?}",
+                        memo_id, top_id,
+                    );
+                    let start_sp = *start_sp;
+                    let capture_start_len = *capture_start_len;
+                    let body_end_sp = self.sp;
+                    let grew = match seed {
+                        None => body_end_sp > start_sp,
+                        Some(prev) => body_end_sp > prev.end_sp,
+                    };
+                    if grew {
+                        // Snapshot the iteration's captures (closed at
+                        // body_end_sp where any still-open ones land) and
+                        // store as the new seed; rewind for re-iteration.
+                        let new_caps: Vec<Capture> = self.captures[capture_start_len..]
+                            .iter()
+                            .map(|c| Capture {
+                                kind: c.kind,
+                                start: c.start,
+                                end: c.end.unwrap_or(body_end_sp),
+                            })
+                            .collect();
+                        *seed = Some(LSeed {
+                            end_sp: body_end_sp,
+                            captures: new_caps,
+                        });
+                        self.captures.truncate(capture_start_len);
+                        self.sp = start_sp;
+                        self.ip = body_start.0;
+                    } else {
+                        // No growth — accept the prior seed. If the seed
+                        // is still None here (body matched empty on first
+                        // try), the rule succeeds with an empty match.
+                        let final_seed = seed.take();
+                        // Pop the LFrame and the paired memo_examined.
+                        let _frame = self.stack.remove(top_idx);
+                        let examined = self
+                            .memo_examined
+                            .pop()
+                            .expect("LRTail: memo_examined underflow");
+                        self.bump_top_memo_examined(examined);
+                        // Replay seed captures (if any), restore sp.
+                        self.captures.truncate(capture_start_len);
+                        if let Some(s) = final_seed {
+                            for c in &s.captures {
+                                self.captures.push(OpenCapture {
+                                    kind: c.kind,
+                                    start: c.start,
+                                    end: Some(c.end),
+                                });
+                            }
+                            self.sp = s.end_sp;
+                        } else {
+                            self.sp = start_sp;
+                        }
+                        self.maybe_snapshot();
+                        self.ip += 1;
+                    }
+                }
                 Instruction::CaptureBegin(kind) => {
                     self.captures.push(OpenCapture {
                         kind: *kind,
@@ -605,6 +771,54 @@ impl<'p, 'i> VM<'p, 'i> {
                     // Rule-call frame unwinding past its caller. The caller's
                     // Backtrack (if any) is deeper on the stack and will be
                     // found by continued popping.
+                }
+                StackEntry::LFrame {
+                    memo_id: _,
+                    start_sp: _,
+                    capture_start_len,
+                    return_addr,
+                    seed,
+                } => {
+                    // Pop the paired examined watermark. LR rules don't
+                    // packrat-cache in v1, so nothing is written to
+                    // self.memo here — the watermark just needs to flow
+                    // up to the parent rule's frame.
+                    let examined_max = self
+                        .memo_examined
+                        .pop()
+                        .expect("fail(): memo_examined underflow on LFrame");
+                    self.bump_top_memo_examined(examined_max);
+                    if let Some(s) = seed {
+                        // Body failed on a re-iteration after the seed
+                        // already grew at least once. Bounded LR
+                        // semantics: accept the prior seed as the rule's
+                        // match. Restore captures to the LFrame baseline,
+                        // replay the seed's closed captures, set sp to
+                        // seed.end_sp, and jump to the rule's Return.
+                        // Returning `true` from `fail()` resumes execution
+                        // at `self.ip` — the Return frame the caller's
+                        // `Call` pushed is still on the stack and will
+                        // pop normally.
+                        self.protect_max_captures(capture_start_len);
+                        self.captures.truncate(capture_start_len);
+                        for c in &s.captures {
+                            self.captures.push(OpenCapture {
+                                kind: c.kind,
+                                start: c.start,
+                                end: Some(c.end),
+                            });
+                        }
+                        self.sp = s.end_sp;
+                        self.ip = return_addr;
+                        self.maybe_snapshot();
+                        return true;
+                    }
+                    // No seed yet — the LR rule has failed without ever
+                    // growing past bound 0. Continue unwinding past this
+                    // frame; the captures-truncate happens at whichever
+                    // Backtrack ultimately catches the unwind (its
+                    // capture_len was snapshotted before LRBody pushed
+                    // this frame).
                 }
             }
         }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -546,3 +546,153 @@ fn grammar_rules_are_wrapped_in_memo_open_close() {
         ]
     );
 }
+
+#[test]
+fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
+    // start <- start "+" "n" / "n"
+    // Layout (no MemoOpen / MemoClose for an LR rule):
+    //   0: Call(2)
+    //   1: End
+    //   2: LRBody(0, <ret>)
+    //   3 (body_start): Choice(7)
+    //   4: Call(2)
+    //   5: Char '+'
+    //   6: Char 'n'
+    //   7: Commit(8)        ; first-alt commit lands at the leaf 'n'
+    //   ...
+    // Exact target labels are validated by running the program; here we
+    // only assert the prologue/epilogue shape.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("start".into()),
+                Pattern::literal("+"),
+                Pattern::literal("n"),
+            ]),
+            Pattern::literal("n"),
+        ]),
+    );
+    let prog = Grammar::new(rules, "start").compile().unwrap();
+    assert_eq!(prog.memo_count, 1);
+    // Prologue is at code[2]; the bootstrap is the usual Call/End pair.
+    assert!(matches!(prog.code[0], Instruction::Call(Label(2))));
+    assert!(matches!(prog.code[1], Instruction::End));
+    assert!(matches!(prog.code[2], Instruction::LRBody(MemoId(0), _)));
+    // Last three instructions: LRTail, then the final Return for the rule.
+    let n = prog.code.len();
+    assert!(matches!(
+        prog.code[n - 2],
+        Instruction::LRTail(MemoId(0), _)
+    ));
+    assert!(matches!(prog.code[n - 1], Instruction::Return));
+    // No MemoOpen / MemoClose anywhere — LR rules are not packrat-cached.
+    for ins in &prog.code {
+        assert!(
+            !matches!(ins, Instruction::MemoOpen(..) | Instruction::MemoClose(..)),
+            "LR rule must not emit MemoOpen/MemoClose: {:?}",
+            ins
+        );
+    }
+    // LRBody's return label points at the rule's Return (last instruction).
+    if let Instruction::LRBody(_, Label(ret)) = prog.code[2] {
+        assert_eq!(ret, n - 1);
+    }
+    // LRTail's body-start label points at the instruction after LRBody.
+    if let Instruction::LRTail(_, Label(body_start)) = prog.code[n - 2] {
+        assert_eq!(body_start, 3);
+    }
+}
+
+#[test]
+fn right_recursive_rule_is_not_marked_lr() {
+    // start <- "n" "+" start / "n"
+    // The recursive call is not in first-call position — "n" consumes
+    // input first. Compile must use the standard MemoOpen / MemoClose.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::literal("n"),
+                Pattern::literal("+"),
+                Pattern::NonTerminal("start".into()),
+            ]),
+            Pattern::literal("n"),
+        ]),
+    );
+    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let has_memo_open = prog
+        .code
+        .iter()
+        .any(|i| matches!(i, Instruction::MemoOpen(..)));
+    let has_lr = prog
+        .code
+        .iter()
+        .any(|i| matches!(i, Instruction::LRBody(..) | Instruction::LRTail(..)));
+    assert!(has_memo_open, "right-recursive rule must use MemoOpen");
+    assert!(!has_lr, "right-recursive rule must not emit LR opcodes");
+}
+
+#[test]
+fn indirect_left_recursion_is_rejected() {
+    // a <- b "x" / "y"
+    // b <- a "z" / "w"
+    // SCC {a, b} of size 2 — must be rejected.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "a".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("b".into()),
+                Pattern::literal("x"),
+            ]),
+            Pattern::literal("y"),
+        ]),
+    );
+    rules.insert(
+        "b".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("a".into()),
+                Pattern::literal("z"),
+            ]),
+            Pattern::literal("w"),
+        ]),
+    );
+    let err = Grammar::new(rules, "a").compile().unwrap_err();
+    let msg = format!("{}", err);
+    assert!(msg.contains("indirect left recursion"), "got: {}", msg);
+    assert!(msg.contains("a") && msg.contains("b"), "got: {}", msg);
+}
+
+#[test]
+fn lr_through_nullable_prefix_is_detected() {
+    // start <- opt start "+" "n" / "n"
+    // opt   <- "x"?
+    // The recursive call is gated by an optional prefix; nullability
+    // analysis must propagate the first-call through `opt`.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("opt".into()),
+                Pattern::NonTerminal("start".into()),
+                Pattern::literal("+"),
+                Pattern::literal("n"),
+            ]),
+            Pattern::literal("n"),
+        ]),
+    );
+    rules.insert(
+        "opt".into(),
+        Pattern::Optional(Box::new(Pattern::literal("x"))),
+    );
+    let prog = Grammar::new(rules, "start").compile().unwrap();
+    assert!(prog
+        .code
+        .iter()
+        .any(|i| matches!(i, Instruction::LRBody(MemoId(0), _))));
+}

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -1,0 +1,241 @@
+//! End-to-end tests for direct left recursion: grammar source → compile
+//! → run, asserting both parse outcomes and capture forests reflect
+//! left-associative matching. Pairs with `compiler_tests.rs` (which
+//! pins the bytecode skeleton) and `vm_tests.rs` (which pins the
+//! VM-level bytecode semantics on hand-built programs).
+
+use syntax_highlighter::pegc::{self, CompileError};
+use syntax_highlighter::pegvm::{Capture, CaptureKind, MatchResult, VM};
+
+fn run(src: &str, input: &[u8]) -> MatchResult {
+    let prog = pegc::compile(src).expect("compile failed");
+    VM::new(&prog.code, input).run()
+}
+
+fn cap(kinds: &[String], name: &str, start: usize, end: usize) -> Capture {
+    let id = kinds
+        .iter()
+        .position(|k| k == name)
+        .unwrap_or_else(|| panic!("capture kind '{}' not in {:?}", name, kinds));
+    Capture {
+        kind: CaptureKind(id as u16),
+        start,
+        end,
+    }
+}
+
+#[test]
+fn left_associative_addition() {
+    // Standard left-associative arithmetic. Each '+' operand under the
+    // 'op' tag, each leaf number under 'num'.
+    let src = r#"
+        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let prog = pegc::compile(src).expect("compile");
+    let r = VM::new(&prog.code, b"1+2+3").run();
+    assert!(r.complete);
+    assert_eq!(r.matched, 5);
+    let kinds = prog.capture_kinds.clone();
+    // Captures are emitted in input order: leaf '1' (the seed),
+    // then '+' '2' (first growth), then '+' '3' (second growth).
+    assert_eq!(
+        r.captures,
+        vec![
+            cap(&kinds, "num", 0, 1),
+            cap(&kinds, "op", 1, 2),
+            cap(&kinds, "num", 2, 3),
+            cap(&kinds, "op", 3, 4),
+            cap(&kinds, "num", 4, 5),
+        ]
+    );
+}
+
+#[test]
+fn left_associative_with_distinct_operators() {
+    // 'expr - x - y' must parse left-associatively, otherwise subtraction
+    // semantics are wrong. The capture forest itself doesn't encode
+    // associativity, but the seed-and-grow loop produces this ordering.
+    let src = r#"
+        expr <- expr @minus{'-'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let r = run(src, b"9-1-2");
+    assert!(r.complete);
+    assert_eq!(r.matched, 5);
+}
+
+#[test]
+fn precedence_via_two_lr_layers() {
+    // expr <- expr '+' term / term
+    // term <- term '*' factor / factor
+    // factor <- [0-9]+ / '(' expr ')'
+    // Both expr and term are directly LR. The compiler must accept
+    // both; the parse must reflect '*' binding tighter than '+'.
+    let src = r#"
+        expr   <- expr @plus{'+'} term / term
+        term   <- term @star{'*'} factor / factor
+        factor <- @num{[0-9]+} / '(' expr ')'
+    "#;
+    let r = run(src, b"1+2*3");
+    assert!(r.complete);
+    assert_eq!(r.matched, 5);
+    // 1, +, 2, *, 3 — captures emitted in input order. The grouping
+    // structure is implicit in how the seed-and-grow ran but the
+    // capture stream must include the '*' between 2 and 3.
+    let prog = pegc::compile(src).unwrap();
+    let kinds = prog.capture_kinds.clone();
+    assert_eq!(
+        r.captures,
+        vec![
+            cap(&kinds, "num", 0, 1),
+            cap(&kinds, "plus", 1, 2),
+            cap(&kinds, "num", 2, 3),
+            cap(&kinds, "star", 3, 4),
+            cap(&kinds, "num", 4, 5),
+        ]
+    );
+}
+
+#[test]
+fn lr_with_parenthesised_subexpression() {
+    let src = r#"
+        expr   <- expr @plus{'+'} term / term
+        term   <- term @star{'*'} factor / factor
+        factor <- @num{[0-9]+} / '(' expr ')'
+    "#;
+    let r = run(src, b"(1+2)*3");
+    assert!(r.complete);
+    assert_eq!(r.matched, 7);
+}
+
+#[test]
+fn lr_failure_returns_partial() {
+    // Input doesn't even start with a valid leaf.
+    let src = r#"
+        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let r = run(src, b"x");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 0);
+    assert!(r.captures.is_empty());
+}
+
+#[test]
+fn lr_partial_chain_returns_longest_prefix() {
+    // The wrapper rule (start, by source order) requires a trailing
+    // '!' after the LR expression. For input "1+2" the LR rule
+    // succeeds with the seed at sp=3, but '!' then fails — the
+    // surrounding parse must report the deepest sp reached, which is
+    // past the LR seed's growth.
+    let src = r#"
+        wrapper <- expr '!'
+        expr    <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let r = run(src, b"1+2");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 3);
+}
+
+#[test]
+fn nullable_lr_terminates() {
+    // Pathological nullable LR: A <- A / "x". Without LR support this
+    // would be an infinite Call → Call loop. Bounded LR semantics
+    // accept the empty match (seed=None, body succeeds with sp
+    // unchanged ⇒ no growth ⇒ commit empty seed). For input "x" the
+    // first iteration runs the recursive `A` (fails, seed None), then
+    // the second alternative 'x' wins; LRTail sees growth (0→1),
+    // updates seed, re-iterates; second iteration recursive `A` hits
+    // seed and replays sp=1, then `Or "x"` retries from sp=1 (no
+    // growth past seed); LRTail commits at sp=1. Just assert it
+    // terminates and matched is 1.
+    let src = r#"
+        a <- a / 'x'
+    "#;
+    let r = run(src, b"x");
+    assert!(r.complete);
+    assert_eq!(r.matched, 1);
+}
+
+#[test]
+fn nullable_lr_on_empty_input_terminates() {
+    // Same grammar, input "". The first iteration's recursive call
+    // fails (seed None); the second alternative 'x' also fails. The
+    // body fails on first iteration with seed None, so the LR rule
+    // fails — partial parse at sp=0.
+    let src = r#"
+        a <- a / 'x'
+    "#;
+    let r = run(src, b"");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 0);
+}
+
+#[test]
+fn right_recursive_grammar_is_not_marked_lr() {
+    // Sanity: a right-recursive grammar must still compile and run
+    // (with the standard MemoOpen/MemoClose path). The compiler-level
+    // assertion is in compiler_tests; here we just confirm runtime
+    // behavior is unchanged.
+    let src = r#"
+        list <- @num{[0-9]+} (',' list)?
+    "#;
+    let r = run(src, b"1,2,3");
+    assert!(r.complete);
+    assert_eq!(r.matched, 5);
+}
+
+#[test]
+fn indirect_lr_in_source_returns_compile_error() {
+    let src = r#"
+        a <- b 'x' / 'y'
+        b <- a 'z' / 'w'
+    "#;
+    match pegc::compile(src) {
+        Err(pegc::Error::Compile(CompileError::IndirectLeftRecursion(cycle))) => {
+            assert!(cycle.contains(&"a".to_string()));
+            assert!(cycle.contains(&"b".to_string()));
+        }
+        other => panic!("expected IndirectLeftRecursion, got {:?}", other),
+    }
+}
+
+#[test]
+fn lr_inside_recover_repeat_resyncs_cleanly() {
+    // top <- (expr ';')*^ !.
+    // expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    //
+    // Input "1+2;BAD;3+4;" — the middle "BAD" can't parse as an expr,
+    // so the *^ recovery branch consumes one byte at a time. The
+    // surrounding LR rule's failure must be rescued to its prior
+    // seed (or its first-iteration failure must propagate cleanly so
+    // *^'s outer Choice/Commit catches it).
+    let src = r#"
+        top  <- (expr ';')*^ !.
+        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let r = run(src, b"1+2;BAD;3+4;");
+    assert!(
+        r.complete,
+        "*^ must terminate cleanly even with mid-stream failure"
+    );
+    assert_eq!(r.matched, 12);
+    // Captures should include the well-formed expressions plus
+    // recovery captures for the BAD region.
+    let prog = pegc::compile(src).unwrap();
+    let kinds = prog.capture_kinds.clone();
+    let nums: Vec<&Capture> = r
+        .captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "num")
+        .collect();
+    // Four numbers across the two valid expressions.
+    assert_eq!(nums.len(), 4, "got: {:?}", r.captures);
+    let recoveries: Vec<&Capture> = r
+        .captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "recovery")
+        .collect();
+    assert!(
+        !recoveries.is_empty(),
+        "the BAD region must produce recovery captures"
+    );
+}

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -1,5 +1,5 @@
 use syntax_highlighter::pegvm::{
-    Capture, CaptureKind, CharSet, Instruction, Label, MatchResult, VM,
+    Capture, CaptureKind, CharSet, Instruction, Label, MatchResult, MemoId, VM,
 };
 
 fn run(program: &[Instruction], input: &[u8]) -> MatchResult {
@@ -461,4 +461,129 @@ fn partial_match_captures_survive_backtrack_below_watermark() {
     assert!(!r.complete);
     assert_eq!(r.matched, 2);
     assert_eq!(r.captures, vec![cap(0, 0, 2)]);
+}
+
+// Hand-built bytecode for direct left-recursion. The compiler doesn't yet
+// emit `LRBody` / `LRTail`; these tests pin the VM-level semantics so the
+// compiler milestone can be layered on with confidence. Equivalent grammar:
+//
+//     expr <- expr "+" "n" / "n"
+//
+// Code layout:
+//
+//      0: Call(2)              ; bootstrap → expr
+//      1: End
+//      2: LRBody(0, 14)        ; LR prologue (return_label = 14, the Return)
+//      3: Choice(11)           ; body: try first alternative
+//      4: Call(2)              ;   recursive call (LRBody hit replays seed
+//                              ;   or fails when seed is None)
+//      5: Char('+')
+//      6: CaptureBegin(0)      ;   tag the right operand as kind=0
+//      7: Char('n')
+//      8: CaptureEnd
+//      9: Commit(13)
+//     10: -- (unused; padding)
+//     11: CaptureBegin(0)      ; second alternative: leaf
+//     12: Char('n')
+//     13: -- end-of-body marker (LRTail follows)
+//     14: -- this is the Return target; we lay LRTail at 13 below
+//
+// The actual instruction stream is simpler than the comment suggests; see
+// the array literals below. The constants are: body_start=3, lrtail=13,
+// return_addr=14.
+fn lr_expr_program() -> Vec<Instruction> {
+    let body_start = 3usize;
+    vec![
+        // 0: bootstrap
+        Instruction::Call(Label(2)),
+        Instruction::End,
+        // 2: LRBody (return_addr = 14)
+        Instruction::LRBody(MemoId(0), Label(14)),
+        // 3 (body_start): Choice → 11 (second alternative)
+        Instruction::Choice(Label(10)),
+        // 4: Call(expr)  -- recursive
+        Instruction::Call(Label(2)),
+        // 5: '+'
+        Instruction::Char(b'+'),
+        // 6: CaptureBegin
+        Instruction::CaptureBegin(CaptureKind(0)),
+        // 7: 'n'
+        Instruction::Char(b'n'),
+        // 8: CaptureEnd
+        Instruction::CaptureEnd,
+        // 9: Commit → 13 (LRTail)
+        Instruction::Commit(Label(13)),
+        // 10: second alt — CaptureBegin
+        Instruction::CaptureBegin(CaptureKind(0)),
+        // 11: 'n'
+        Instruction::Char(b'n'),
+        // 12: CaptureEnd
+        Instruction::CaptureEnd,
+        // 13: LRTail (body_start = 3)
+        Instruction::LRTail(MemoId(0), Label(body_start)),
+        // 14: Return
+        Instruction::Return,
+    ]
+}
+
+#[test]
+fn lr_single_atom_no_growth_returns_seed() {
+    // Input "n": first iteration matches via the second alternative. The
+    // recursive call inside the first alternative fails (seed=None), so
+    // the body falls through to the leaf, sp advances 0→1. LRTail sees
+    // growth (0→1), updates seed, and re-iterates from sp=0. Second
+    // iteration: recursive call now hits the seed (sp=1), returns to
+    // LRTail's caller's continuation. The body tries to match '+', but
+    // input ends — fails. fail() encounters the LFrame with seed=Some,
+    // accepts the seed, returns true at return_addr (14). Final result:
+    // matched=1, one capture for the leaf 'n'.
+    let prog = lr_expr_program();
+    let r = run(&prog, b"n");
+    assert_eq!(r.matched, 1);
+    assert!(r.complete);
+    assert_eq!(r.captures, vec![cap(0, 0, 1)]);
+}
+
+#[test]
+fn lr_left_associative_chain() {
+    // Input "n+n+n": the seed-and-grow loop must produce the
+    // left-associative parse. Captures should emit in input order:
+    // leaf at 0..1, leaf at 2..3, leaf at 4..5.
+    let prog = lr_expr_program();
+    let r = run(&prog, b"n+n+n");
+    assert_eq!(r.matched, 5);
+    assert!(r.complete);
+    assert_eq!(r.captures, vec![cap(0, 0, 1), cap(0, 2, 3), cap(0, 4, 5)]);
+}
+
+#[test]
+fn lr_partial_match_when_input_ends_mid_chain() {
+    // Input "n+n+": after consuming "n+n", the next iteration tries
+    // "n+n + n" but the trailing 'n' is missing. fail() should rescue
+    // with the prior seed (sp=3) and the parse succeeds at matched=3.
+    let prog = lr_expr_program();
+    let r = run(&prog, b"n+n+");
+    assert_eq!(r.matched, 3);
+    assert!(r.complete);
+    assert_eq!(r.captures, vec![cap(0, 0, 1), cap(0, 2, 3)]);
+}
+
+#[test]
+fn lr_no_match_returns_partial() {
+    // Input "x": the leaf 'n' fails on first iteration with no seed.
+    // The LR rule fails (no rescue possible), the parse is partial.
+    let prog = lr_expr_program();
+    let r = run(&prog, b"x");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 0);
+    assert_eq!(r.captures, vec![]);
+}
+
+#[test]
+fn lr_empty_input_returns_partial() {
+    let prog = lr_expr_program();
+    let r = run(&prog, b"");
+    assert!(!r.complete);
+    assert_eq!(r.matched, 0);
+    assert_eq!(r.captures, vec![]);
 }


### PR DESCRIPTION
Closes #40.

Direct left recursion (`A <- A α / β`) lands as a VM/compiler
extension following Medeiros, Mascarenhas & Ierusalimschy 2014 §5.
Algorithm, bytecode shape, and invariants 9 / 10 are documented in
`src/pegvm/README.md`; the LR-detection pass
(`analyze_left_recursion`) lives in `src/pegc/compiler.rs`.

Direct LR rules skip the packrat memo in v1 — the L table is
stack-structured and lives only on the execution stack. The shipped
`MemoCache` invalidation is unaffected. Indirect LR is rejected
with the new `CompileError::IndirectLeftRecursion`.

Follow-ups: #47 (indirect LR), #48 (cache converged seeds), #49
(LR-port shipped expression grammars).