### PR TITLE
Indirect left recursion support

### DIFF
--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -152,12 +152,13 @@ this; grammar authors must ensure `p` consumes input on success.
   is tried only if `p1` fails.
 - **Predicates consume no input.** `!p` and `&p` rewind any `sp`
   advance `p` would have made, and emit no captures.
-- **Direct left recursion is supported.** `A <- A α / β` and similar
-  shapes parse left-associatively via bounded LR (Medeiros et al.
-  2014 §5; see [`src/pegvm/README.md`](../pegvm/README.md#left-recursion)).
-  **Indirect** left recursion (`A <- B …; B <- A …`) is rejected
-  with `CompileError::IndirectLeftRecursion`; tracked as a
-  follow-up to #40.
+- **Left recursion is supported.** Both direct (`A <- A α / β`) and
+  indirect (`A <- B …; B <- A …`) shapes parse left-associatively via
+  bounded LR (Medeiros et al. 2014 §5; see
+  [`src/pegvm/README.md`](../pegvm/README.md#left-recursion)). The
+  compiler wraps every member of any non-trivial first-call SCC with
+  the LR prologue/epilogue, and the VM's stack-based L-table handles
+  cross-rule cycles transparently.
 - **Byte-oriented.** Character classes are sets of `u8`; UTF-8 is
   never decoded. Direction for Unicode support is under evaluation
   in #45.

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -7,11 +7,6 @@ use crate::pegvm::{CaptureKind, Instruction, Label, MemoId, Program};
 pub enum CompileError {
     UndefinedRule(String),
     UnknownStartRule(String),
-    /// One or more rules participate in a left-recursive cycle longer
-    /// than length 1 (e.g. `A <- B …; B <- A …`). v1 of LR support
-    /// handles direct LR only; the cycle's rules are listed for the
-    /// grammar author. Tracked as a follow-up to #40.
-    IndirectLeftRecursion(Vec<String>),
 }
 
 impl std::fmt::Display for CompileError {
@@ -19,11 +14,6 @@ impl std::fmt::Display for CompileError {
         match self {
             CompileError::UndefinedRule(name) => write!(f, "undefined rule: {}", name),
             CompileError::UnknownStartRule(name) => write!(f, "unknown start rule: {}", name),
-            CompileError::IndirectLeftRecursion(cycle) => write!(
-                f,
-                "indirect left recursion across rules [{}] (only direct left recursion is supported)",
-                cycle.join(", ")
-            ),
         }
     }
 }
@@ -272,8 +262,8 @@ pub(crate) fn compile_rules(
         check_refs(rule_name, body, rules)?;
     }
 
-    // Identify directly left-recursive rules; reject indirect LR.
-    let direct_lr = analyze_left_recursion(rules)?;
+    // Identify left-recursive rules (direct and indirect).
+    let lr_rules = analyze_left_recursion(rules)?;
 
     let mut c = Compiler::new();
     c.emit(Instruction::Call(Label(0))); // patched below
@@ -295,10 +285,11 @@ pub(crate) fn compile_rules(
         rule_addrs.insert(name.clone(), c.pos());
         let memo_id = MemoId(memo_count);
         memo_count += 1;
-        if direct_lr.contains(name.as_str()) {
-            // LR rule: LRBody … body … LRTail ; Return. No MemoOpen /
-            // MemoClose — the L-frame replaces packrat caching for this
-            // rule (LR rules are not memoized in v1).
+        if lr_rules.contains(name.as_str()) {
+            // LR rule (direct or indirect): LRBody … body … LRTail ;
+            // Return. No MemoOpen / MemoClose — the L-frame replaces
+            // packrat caching for this rule (LR rules are not memoized
+            // in v1).
             let lr_body = c.emit(Instruction::LRBody(memo_id, Label(0)));
             let body_start = c.pos();
             c.compile_pat(&rules[name]);
@@ -371,17 +362,21 @@ fn check_refs(
     }
 }
 
-/// Returns the set of rule names that are *directly* left-recursive
-/// (`A <- A α / β` and equivalent shapes). Indirect left recursion
-/// (cycle length > 1) is rejected with `CompileError::IndirectLeftRecursion`.
+/// Returns the set of rule names that are left-recursive — both direct
+/// (`A <- A α / β`) and indirect (`A <- B …; B <- A …`). Each such rule
+/// must use the LR prologue/epilogue (`LRBody` / `LRTail`) instead of
+/// the standard `MemoOpen` / `MemoClose`, so its packrat slot isn't
+/// written with a value that depends on an in-progress LR seed of a
+/// sibling in the same cycle.
 ///
 /// Algorithm:
 /// 1. Compute may-match-empty (nullability) per rule via a fixpoint.
 /// 2. Build the "first-call" graph: edge `A → B` iff `A`'s body can call
 ///    `B` before consuming any input.
-/// 3. Find strongly connected components in that graph (Tarjan's). An SCC
-///    of size > 1 is indirect LR (rejected). An SCC of size 1 is direct
-///    LR iff the rule has a self-edge in the first-call graph.
+/// 3. Find strongly connected components in that graph (Tarjan's). Any
+///    SCC of size > 1 is an indirect-LR cycle — every member is wrapped.
+///    A size-1 SCC is direct LR iff the rule has a self-edge in the
+///    first-call graph.
 fn analyze_left_recursion(
     rules: &HashMap<String, Pattern>,
 ) -> Result<HashSet<String>, CompileError> {
@@ -389,23 +384,24 @@ fn analyze_left_recursion(
     let first_calls = compute_first_calls(rules, &nullable);
 
     let sccs = tarjan_sccs(rules, &first_calls);
-    let mut direct_lr = HashSet::new();
+    let mut lr_rules = HashSet::new();
     for scc in &sccs {
         if scc.len() > 1 {
-            let mut cycle = scc.clone();
-            cycle.sort();
-            return Err(CompileError::IndirectLeftRecursion(cycle));
-        }
-        let only = &scc[0];
-        if first_calls
-            .get(only)
-            .map(|s| s.contains(only))
-            .unwrap_or(false)
-        {
-            direct_lr.insert(only.clone());
+            for r in scc {
+                lr_rules.insert(r.clone());
+            }
+        } else {
+            let only = &scc[0];
+            if first_calls
+                .get(only)
+                .map(|s| s.contains(only))
+                .unwrap_or(false)
+            {
+                lr_rules.insert(only.clone());
+            }
         }
     }
-    Ok(direct_lr)
+    Ok(lr_rules)
 }
 
 /// Per-rule nullability via fixpoint over the Pattern AST. A rule is

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -187,7 +187,7 @@ A grammar that opts into the `*^` recovery operator on a top-level repetition ca
 
 ## Left recursion
 
-The compiler detects directly-left-recursive rules (`A <- A α / β` and equivalent shapes; see `analyze_left_recursion` in `src/pegc/compiler.rs`) and emits `LRBody` / `LRTail` in place of `MemoOpen` / `MemoClose`. Indirect left recursion (cycles longer than 1) is rejected at compile time — see `CompileError::IndirectLeftRecursion`.
+The compiler detects left-recursive rules — both direct (`A <- A α / β`) and indirect (`A <- B …; B <- A …`) — by finding strongly connected components in the first-call graph (see `analyze_left_recursion` in `src/pegc/compiler.rs`). Every member of any non-trivial SCC, plus any size-1 SCC with a self-edge, emits `LRBody` / `LRTail` in place of `MemoOpen` / `MemoClose`. Cross-rule cycles need no extra runtime support: `LRBody`'s `(memo_id, sp)` lookup walks the stack and finds the right `LFrame` regardless of how many other rules sit between the call site and the frame.
 
 Bytecode shape for an LR rule:
 

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -636,38 +636,6 @@ fn right_recursive_rule_is_not_marked_lr() {
 }
 
 #[test]
-fn indirect_left_recursion_is_rejected() {
-    // a <- b "x" / "y"
-    // b <- a "z" / "w"
-    // SCC {a, b} of size 2 — must be rejected.
-    let mut rules = HashMap::new();
-    rules.insert(
-        "a".into(),
-        Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("b".into()),
-                Pattern::literal("x"),
-            ]),
-            Pattern::literal("y"),
-        ]),
-    );
-    rules.insert(
-        "b".into(),
-        Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("a".into()),
-                Pattern::literal("z"),
-            ]),
-            Pattern::literal("w"),
-        ]),
-    );
-    let err = Grammar::new(rules, "a").compile().unwrap_err();
-    let msg = format!("{}", err);
-    assert!(msg.contains("indirect left recursion"), "got: {}", msg);
-    assert!(msg.contains("a") && msg.contains("b"), "got: {}", msg);
-}
-
-#[test]
 fn lr_through_nullable_prefix_is_detected() {
     // start <- opt start "+" "n" / "n"
     // opt   <- "x"?

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -636,6 +636,154 @@ fn right_recursive_rule_is_not_marked_lr() {
 }
 
 #[test]
+fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
+    // a <- b "x" / "y"
+    // b <- a "z" / "w"
+    // First-call SCC {a, b}; both rules must be wrapped as LR.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "a".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("b".into()),
+                Pattern::literal("x"),
+            ]),
+            Pattern::literal("y"),
+        ]),
+    );
+    rules.insert(
+        "b".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("a".into()),
+                Pattern::literal("z"),
+            ]),
+            Pattern::literal("w"),
+        ]),
+    );
+    let prog = Grammar::new(rules, "a").compile().unwrap();
+    let lr_bodies = prog
+        .code
+        .iter()
+        .filter(|i| matches!(i, Instruction::LRBody(..)))
+        .count();
+    let lr_tails = prog
+        .code
+        .iter()
+        .filter(|i| matches!(i, Instruction::LRTail(..)))
+        .count();
+    assert_eq!(lr_bodies, 2, "both SCC members must emit LRBody");
+    assert_eq!(lr_tails, 2, "both SCC members must emit LRTail");
+    for ins in &prog.code {
+        assert!(
+            !matches!(ins, Instruction::MemoOpen(..) | Instruction::MemoClose(..)),
+            "indirect-LR rules must not emit MemoOpen/MemoClose: {:?}",
+            ins
+        );
+    }
+}
+
+#[test]
+fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
+    // a <- b "x" / "p"
+    // b <- c "y" / "q"
+    // c <- a "z" / "r"
+    // First-call SCC {a, b, c}; all three rules must be wrapped as LR.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "a".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("b".into()),
+                Pattern::literal("x"),
+            ]),
+            Pattern::literal("p"),
+        ]),
+    );
+    rules.insert(
+        "b".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("c".into()),
+                Pattern::literal("y"),
+            ]),
+            Pattern::literal("q"),
+        ]),
+    );
+    rules.insert(
+        "c".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::NonTerminal("a".into()),
+                Pattern::literal("z"),
+            ]),
+            Pattern::literal("r"),
+        ]),
+    );
+    let prog = Grammar::new(rules, "a").compile().unwrap();
+    let lr_bodies = prog
+        .code
+        .iter()
+        .filter(|i| matches!(i, Instruction::LRBody(..)))
+        .count();
+    let lr_tails = prog
+        .code
+        .iter()
+        .filter(|i| matches!(i, Instruction::LRTail(..)))
+        .count();
+    assert_eq!(lr_bodies, 3, "all three SCC members must emit LRBody");
+    assert_eq!(lr_tails, 3, "all three SCC members must emit LRTail");
+    for ins in &prog.code {
+        assert!(
+            !matches!(ins, Instruction::MemoOpen(..) | Instruction::MemoClose(..)),
+            "indirect-LR rules must not emit MemoOpen/MemoClose: {:?}",
+            ins
+        );
+    }
+}
+
+#[test]
+fn right_recursive_two_rule_grammar_is_not_marked_lr() {
+    // a <- "x" b / "y"
+    // b <- "z" a / "w"
+    // Each call site is preceded by a literal — no first-call edges, so
+    // no SCC and no LR wrapping. Sanity check that the analysis isn't
+    // over-eager about cross-rule recursion.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "a".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::literal("x"),
+                Pattern::NonTerminal("b".into()),
+            ]),
+            Pattern::literal("y"),
+        ]),
+    );
+    rules.insert(
+        "b".into(),
+        Pattern::choice(vec![
+            Pattern::seq(vec![
+                Pattern::literal("z"),
+                Pattern::NonTerminal("a".into()),
+            ]),
+            Pattern::literal("w"),
+        ]),
+    );
+    let prog = Grammar::new(rules, "a").compile().unwrap();
+    let has_lr = prog
+        .code
+        .iter()
+        .any(|i| matches!(i, Instruction::LRBody(..) | Instruction::LRTail(..)));
+    assert!(!has_lr, "non-first-call mutual recursion must not emit LR");
+    let has_memo_open = prog
+        .code
+        .iter()
+        .any(|i| matches!(i, Instruction::MemoOpen(..)));
+    assert!(has_memo_open, "non-LR rules must use MemoOpen");
+}
+
+#[test]
 fn lr_through_nullable_prefix_is_detected() {
     // start <- opt start "+" "n" / "n"
     // opt   <- "x"?

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -1,10 +1,11 @@
-//! End-to-end tests for direct left recursion: grammar source → compile
-//! → run, asserting both parse outcomes and capture forests reflect
-//! left-associative matching. Pairs with `compiler_tests.rs` (which
-//! pins the bytecode skeleton) and `vm_tests.rs` (which pins the
-//! VM-level bytecode semantics on hand-built programs).
+//! End-to-end tests for left recursion (direct and indirect): grammar
+//! source → compile → run, asserting both parse outcomes and capture
+//! forests reflect left-associative matching. Pairs with
+//! `compiler_tests.rs` (which pins the bytecode skeleton) and
+//! `vm_tests.rs` (which pins the VM-level bytecode semantics on
+//! hand-built programs).
 
-use syntax_highlighter::pegc::{self, CompileError};
+use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, CaptureKind, MatchResult, VM};
 
 fn run(src: &str, input: &[u8]) -> MatchResult {
@@ -181,21 +182,6 @@ fn right_recursive_grammar_is_not_marked_lr() {
     let r = run(src, b"1,2,3");
     assert!(r.complete);
     assert_eq!(r.matched, 5);
-}
-
-#[test]
-fn indirect_lr_in_source_returns_compile_error() {
-    let src = r#"
-        a <- b 'x' / 'y'
-        b <- a 'z' / 'w'
-    "#;
-    match pegc::compile(src) {
-        Err(pegc::Error::Compile(CompileError::IndirectLeftRecursion(cycle))) => {
-            assert!(cycle.contains(&"a".to_string()));
-            assert!(cycle.contains(&"b".to_string()));
-        }
-        other => panic!("expected IndirectLeftRecursion, got {:?}", other),
-    }
 }
 
 #[test]

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -185,6 +185,48 @@ fn right_recursive_grammar_is_not_marked_lr() {
 }
 
 #[test]
+fn indirect_lr_cycle_of_2_runs() {
+    // SCC {a, b}; both rules are wrapped as LR. Input "y" matches via
+    // a's base alternative on the first iteration; no growth occurs.
+    let src = r#"
+        a <- b 'x' / 'y'
+        b <- a 'z' / 'w'
+    "#;
+    let r = run(src, b"y");
+    assert!(r.complete);
+    assert_eq!(r.matched, 1);
+}
+
+#[test]
+fn indirect_lr_cycle_of_2_grows_through_chain() {
+    // Same SCC. Input "yzx" exercises one full seed-and-grow round
+    // through the indirect cycle: a's seed grows from {y at sp=1} to
+    // {b'x' at sp=3} where b in turn used a's seed to match "yz".
+    let src = r#"
+        a <- b 'x' / 'y'
+        b <- a 'z' / 'w'
+    "#;
+    let r = run(src, b"yzx");
+    assert!(r.complete);
+    assert_eq!(r.matched, 3);
+}
+
+#[test]
+fn indirect_lr_cycle_of_3_runs() {
+    // Length-3 first-call cycle a → b → c → a; all three rules are
+    // wrapped as LR. Input "p" matches via a's base alt; the test
+    // confirms that cycles longer than 2 compile and run.
+    let src = r#"
+        a <- b 'x' / 'p'
+        b <- c 'y' / 'q'
+        c <- a 'z' / 'r'
+    "#;
+    let r = run(src, b"p");
+    assert!(r.complete);
+    assert_eq!(r.matched, 1);
+}
+
+#[test]
 fn lr_inside_recover_repeat_resyncs_cleanly() {
     // top <- (expr ';')*^ !.
     // expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}


### PR DESCRIPTION
## Summary

Indirect left recursion (`A <- B …; B <- A …`) is now supported via the same bounded-LR mechanism as direct LR. `analyze_left_recursion` (`src/pegc/compiler.rs`) wraps every member of any non-trivial first-call SCC with `LRBody`/`LRTail`; the VM's existing `(memo_id, sp)`-keyed `LFrame` lookup handles cross-rule cycles transparently — no runtime changes.

The now-unreachable `CompileError::IndirectLeftRecursion` variant is removed.

Closes #47.