### PR TITLE
pegvm: cache converged LR seeds in the packrat memo

### DIFF
--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -82,7 +82,7 @@ Each `Pattern` variant maps to a small fixed sequence of `Instruction`s. The ins
 | Control flow | `Jump`, `Choice`, `Commit`, `PartialCommit`, `BackCommit`, `FailTwice`, `Fail` | Express ordered choice, repetition, and predicates in terms of pushing and popping backtrack records. |
 | Calls | `Call`, `Return` | Invoke a named rule and return from it — the `NonTerminal` variant compiles to `Call(address)`. |
 | Memoization | `MemoOpen`, `MemoClose` | Rule-level packrat cache. The compiler wraps every rule body with a pair; on a hit `MemoOpen` replays cached captures and jumps to the rule's `Return`; on a miss it pushes a `Memo` frame that `MemoClose` commits as a success entry or `fail()` commits as a failure entry. |
-| Left recursion | `LRBody`, `LRTail` | Replace `MemoOpen` / `MemoClose` for rules the compiler detected as directly left-recursive. `LRBody` walks the stack for an in-flight `LFrame` at `(memo_id, sp)`: a hit replays the seed (`None` ⇒ fail, `Some` ⇒ jump to Return), a miss pushes a fresh `LFrame`. `LRTail` is the seed-and-grow controller — growth re-iterates from `start_sp`, no growth commits the seed and falls through. LR rules are not packrat-cached in v1. |
+| Left recursion | `LRBody`, `LRTail` | Replace `MemoOpen` / `MemoClose` for rules the compiler detected as left-recursive. `LRBody` first probes the packrat memo at `(memo_id, sp)` (mirrors `MemoOpen`'s hit path: replay captures, jump to Return on success; `fail()` on cached failure); on a miss it walks the stack for an in-flight `LFrame` (recursive entry replays the seed — `None` ⇒ fail, `Some` ⇒ jump to Return) and pushes a fresh `LFrame` if no match. `LRTail` is the seed-and-grow controller — growth re-iterates from `start_sp`; no growth commits the seed, writes a memo entry whose `examined_max` is the high-water mark across every iteration, and falls through. LR-rule **failure** caching is not yet implemented. |
 | Captures | `CaptureBegin`, `CaptureEnd` | Bracket a matched span with a kind tag so the VM can record it. |
 | Termination | `End` | Mark the end of a successful match. |
 
@@ -200,12 +200,13 @@ return_addr:  Return
 
 The runtime algorithm is **bounded left recursion** (Medeiros, Mascarenhas & Ierusalimschy 2014, §3.2 / §5):
 
+0. **Cache check**: `LRBody` first probes `self.memo.get(&(memo_id, sp))`. A hit replays the cached captures and jumps to `return_addr` (success) or enters `fail()` (failure) — same shape as `MemoOpen`'s hit path. The L-frame walk in step 1/2 is only reached on a cache miss.
 1. **First entry at `sp`**: `LRBody` pushes `StackEntry::LFrame { memo_id, start_sp, capture_start_len, return_addr, seed: None }`. Body executes.
 2. **Recursive entry at the same `sp`**: `LRBody` finds the existing `LFrame` on the stack. `seed: None` ⇒ `fail()`. `seed: Some(end_sp, captures)` ⇒ replay captures, set `sp = end_sp`, jump to `return_addr` so the recursive call appears to return the seed.
-3. **Body succeeds**: `LRTail` decides. Growth (`sp > seed.end_sp`, or first success with `seed: None`) updates the seed and re-iterates from `start_sp`. No growth commits the seed and falls through to `Return`.
-4. **Body fails**: `fail()`'s `LFrame` arm rescues with the prior seed when `seed.is_some()` (returns `true`, resumes at `return_addr`); when `seed.is_none()` it continues unwinding (the LR rule failed without ever growing).
+3. **Body succeeds**: `LRTail` decides. Growth (`sp > seed.end_sp`, or first success with `seed: None`) updates the seed and re-iterates from `start_sp`. No growth commits the seed, writes a memo entry (subject to `memo_threshold`), and falls through to `Return`.
+4. **Body fails**: `fail()`'s `LFrame` arm rescues with the prior seed when `seed.is_some()` (returns `true`, resumes at `return_addr`); when `seed.is_none()` it continues unwinding (the LR rule failed without ever growing). LR-rule failure caching is not yet implemented — symmetric with `fail()`'s `Memo` arm but deferred until profiling motivates it.
 
-The L table is stack-structured and lives only on `self.stack`; nothing is written to `self.memo` for an LR rule in v1. The `memo_examined` watermark is pushed/popped in lockstep with `LFrame`, so an enclosing rule's `examined_max` correctly subsumes positions the LR body looked at.
+The L table is stack-structured and lives on `self.stack`; converged seeds also flow into `self.memo` so subsequent runs (or subsequent calls within the same run) at the same `sp` short-circuit. The `examined_max` recorded with the entry is the value popped from `memo_examined` at `LRTail`'s commit branch — the high-water mark across every iteration of the seed-and-grow loop, since `LRBody`'s miss path pushes one watermark slot at frame entry and only the commit branch (or `fail()`'s `LFrame` arm) pops it. That bound feeds `MemoCache::apply_edit`'s invalidation predicate verbatim.
 
 ## Error types
 

--- a/src/pegvm/incremental.rs
+++ b/src/pegvm/incremental.rs
@@ -41,12 +41,12 @@
 //! working set sizes we care about; a position-indexed structure (e.g.
 //! `BTreeMap<usize, ...>`) is a future optimization if cache size grows.
 //!
-//! Left recursion: the LR table is **transient per run** — `LFrame`s live
-//! on the execution stack only and never enter [`MemoCache`], so this
-//! invalidation pass is unaffected. A future extension that caches
-//! converged LR seeds in the packrat memo would need a separate decision
-//! about what `examined_max` means across iterations of the seed-and-grow
-//! loop; tracked alongside `#40`.
+//! Left recursion: `LFrame`s themselves stay on the execution stack, but
+//! converged LR seeds are written to [`MemoCache`] at `LRTail`'s commit
+//! branch (see `pegvm/README.md` §"Left recursion"). Their `examined_max`
+//! is the high-water mark across every iteration of the seed-and-grow
+//! loop — feeding the same `invalidates()` predicate without special
+//! casing. LR-rule failure caching is not yet implemented.
 
 use std::collections::HashMap;
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -34,8 +34,9 @@ enum StackEntry {
     /// `LRBody` on the first entry at a given `sp`; popped by `LRTail` when
     /// the seed-and-grow loop converges, or by `fail()` (which uses the
     /// `seed` to decide between rescuing the rule with the prior seed or
-    /// continuing to unwind). LR rules are not packrat-cached in v1, so
-    /// nothing is written to `self.memo` when this frame is dropped.
+    /// continuing to unwind). On convergence `LRTail` writes the seed to
+    /// `self.memo` (subject to the threshold filter); failure entries
+    /// for LR rules are not cached yet (#48 scoped to converged seeds).
     LFrame {
         memo_id: MemoId,
         start_sp: usize,
@@ -532,6 +533,38 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.ip += 1;
                 }
                 Instruction::LRBody(memo_id, return_label) => {
+                    // Packrat cache check first — mirrors MemoOpen's hit
+                    // path. A cached entry at this (memo_id, sp) was
+                    // committed by a previous outer invocation that already
+                    // popped its LFrame; a current in-flight LFrame for the
+                    // same key cannot coexist, so the live-stack walk
+                    // below is only reached on a cache miss.
+                    if let Some(entry) = self.memo.get(&(*memo_id, self.sp)) {
+                        self.memo_hits += 1;
+                        let hit_examined = entry.examined_max;
+                        match entry.end_sp {
+                            Some(end_sp) => {
+                                for c in &entry.captures {
+                                    self.captures.push(OpenCapture {
+                                        kind: c.kind,
+                                        start: c.start,
+                                        end: Some(c.end),
+                                    });
+                                }
+                                self.bump_top_memo_examined(hit_examined);
+                                self.sp = end_sp;
+                                self.ip = return_label.0;
+                                self.maybe_snapshot();
+                            }
+                            None => {
+                                self.bump_top_memo_examined(hit_examined);
+                                if !self.fail() {
+                                    return self.finalize_partial();
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     // Walk the stack top-down for an LFrame at the same
                     // (memo_id, sp) — that signals recursive re-entry. For
                     // direct LR the cycle has length 1, so any matching
@@ -655,19 +688,42 @@ impl<'p, 'i> VM<'p, 'i> {
                             .pop()
                             .expect("LRTail: memo_examined underflow");
                         self.bump_top_memo_examined(examined);
-                        // Replay seed captures (if any), restore sp.
+                        // Replay seed captures (if any), restore sp, and
+                        // extract the captures vec for the cache write so
+                        // we don't have to re-clone from the live buffer.
                         self.captures.truncate(capture_start_len);
-                        if let Some(s) = final_seed {
-                            for c in &s.captures {
-                                self.captures.push(OpenCapture {
-                                    kind: c.kind,
-                                    start: c.start,
-                                    end: Some(c.end),
-                                });
+                        let (final_sp, seed_captures) = match final_seed {
+                            Some(s) => {
+                                for c in &s.captures {
+                                    self.captures.push(OpenCapture {
+                                        kind: c.kind,
+                                        start: c.start,
+                                        end: Some(c.end),
+                                    });
+                                }
+                                (s.end_sp, s.captures)
                             }
-                            self.sp = s.end_sp;
-                        } else {
-                            self.sp = start_sp;
+                            None => (start_sp, Vec::new()),
+                        };
+                        self.sp = final_sp;
+                        // Cache the converged seed under the same threshold
+                        // filter MemoClose uses. examined is the high-water
+                        // mark across every iteration of the seed-and-grow
+                        // loop (LRBody pushed one memo_examined slot at
+                        // entry; growth iterations don't pop it, only this
+                        // commit does), so it is the correct invalidation
+                        // bound for MemoCache::apply_edit. Failure caching
+                        // for LR rules is not yet implemented (#48 scoped
+                        // to converged seeds only).
+                        if final_sp - start_sp >= self.memo_threshold {
+                            self.memo.insert(
+                                (*memo_id, start_sp),
+                                MemoEntry {
+                                    end_sp: Some(final_sp),
+                                    examined_max: examined,
+                                    captures: seed_captures,
+                                },
+                            );
                         }
                         self.maybe_snapshot();
                         self.ip += 1;
@@ -779,10 +835,12 @@ impl<'p, 'i> VM<'p, 'i> {
                     return_addr,
                     seed,
                 } => {
-                    // Pop the paired examined watermark. LR rules don't
-                    // packrat-cache in v1, so nothing is written to
-                    // self.memo here — the watermark just needs to flow
-                    // up to the parent rule's frame.
+                    // Pop the paired examined watermark. Successful LR
+                    // converged seeds are cached at LRTail; LR-rule
+                    // failures (this arm with seed=None) are not cached
+                    // yet — symmetric with `fail()`'s `Memo` arm but
+                    // deferred per #48's scoping. The watermark still
+                    // flows up to the parent rule's frame.
                     let examined_max = self
                         .memo_examined
                         .pop()

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -107,6 +107,62 @@ fn empty_cache_behaves_like_fresh_vm() {
     assert_eq!(fresh, seeded);
 }
 
+#[test]
+fn lr_cache_entry_invalidated_by_edit_inside_examined_range() {
+    // The LR cache write at LRTail (#48) records examined_max as the
+    // high-water mark across every iteration. apply_edit's invalidation
+    // predicate (`start_sp < old_end && examined_max > start`) must
+    // therefore drop the entry on any edit that touches what the
+    // seed-and-grow loop looked at.
+    use syntax_highlighter::pegc;
+    use syntax_highlighter::pegvm::Edit;
+    let prog = pegc::compile("expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+
+    let (_, _, mut cache) = VM::new(&prog.code, b"1+2+3")
+        .with_memo_threshold(0)
+        .run_with_cache();
+    let entries_before = cache.len();
+    assert!(
+        entries_before >= 1,
+        "cold LR parse should populate the cache, got {entries_before}"
+    );
+
+    // Replace byte 0 ('1' → '9'). start_sp=0 < old_end=1 and the
+    // entry's examined_max covers byte 0, so the entry must be dropped.
+    cache.apply_edit(Edit::replacement(0, 1, 1));
+    assert!(
+        cache.len() < entries_before,
+        "edit in examined range should invalidate the LR entry (before: {}, after: {})",
+        entries_before,
+        cache.len(),
+    );
+}
+
+#[test]
+fn lr_cache_round_trip_after_edit_matches_fresh_parse() {
+    // End-to-end: cold parse + edit + re-parse via the edited cache
+    // must produce the same MatchResult as a fresh parse of the new
+    // input. This validates that the LR entry's examined_max bound is
+    // correct: too small and a stale entry would be reused; too large
+    // and an irrelevant edit would invalidate too aggressively
+    // (correctness preserved either way, but only the right bound
+    // gives an equivalent fresh-parse result on every edit).
+    use syntax_highlighter::pegc;
+    use syntax_highlighter::pegvm::Edit;
+    let prog = pegc::compile("expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+
+    let (_, _, mut cache) = VM::new(&prog.code, b"1+2+3")
+        .with_memo_threshold(0)
+        .run_with_cache();
+    cache.apply_edit(Edit::replacement(0, 1, 1));
+
+    let (incremental, _, _) = VM::new_with_cache(&prog.code, b"9+2+3", cache)
+        .with_memo_threshold(0)
+        .run_with_cache();
+    let fresh = VM::new(&prog.code, b"9+2+3").with_memo_threshold(0).run();
+    assert_eq!(incremental, fresh);
+}
+
 const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -267,3 +267,38 @@ fn lr_inside_recover_repeat_resyncs_cleanly() {
         "the BAD region must produce recovery captures"
     );
 }
+
+#[test]
+fn cached_lr_seed_matches_uncached_run() {
+    // The new packrat cache for converged LR seeds (#48) must be purely
+    // additive: enabling it (threshold=0) must produce the same
+    // MatchResult as disabling it (threshold=usize::MAX).
+    let src = r#"
+        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let prog = pegc::compile(src).expect("compile");
+    let cached = VM::new(&prog.code, b"1+2+3").with_memo_threshold(0).run();
+    let uncached = VM::new(&prog.code, b"1+2+3")
+        .with_memo_threshold(usize::MAX)
+        .run();
+    assert_eq!(cached, uncached);
+}
+
+#[test]
+fn lr_inside_outer_repetition_matches_uncached_run() {
+    // The LR rule sits under an outer repetition that calls it at
+    // distinct sps; the new cache write at LRTail must not perturb the
+    // surrounding pattern.
+    let src = r#"
+        top  <- (expr ',')* expr
+        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    "#;
+    let prog = pegc::compile(src).expect("compile");
+    let cached = VM::new(&prog.code, b"1+2,3+4,5")
+        .with_memo_threshold(0)
+        .run();
+    let uncached = VM::new(&prog.code, b"1+2,3+4,5")
+        .with_memo_threshold(usize::MAX)
+        .run();
+    assert_eq!(cached, uncached);
+}

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -284,6 +284,51 @@ fn and_predicate_with_memoized_rule() {
     assert!(stats.hits >= 1, "expected a hit, got {}", stats.hits);
 }
 
+/// LR-specific cache write (#48): a converged seed must land in the memo
+/// so a re-parse of the same input at the same sp short-circuits via a
+/// cache hit instead of re-running the seed-and-grow loop.
+#[test]
+fn lr_converged_seed_persists_across_parses() {
+    use syntax_highlighter::pegc;
+    use syntax_highlighter::pegvm::MemoCache;
+    let src = r#"
+        expr <- expr '+' [0-9]+ / [0-9]+
+    "#;
+    let prog = pegc::compile(src).expect("compile");
+    let input = b"1+2+3";
+
+    // Cold parse populates the memo with the LR rule's converged seed.
+    let (cold, cold_stats, memo) = VM::new(&prog.code, input)
+        .with_memo_threshold(0)
+        .run_with_cache();
+    assert!(cold.complete);
+    assert_eq!(cold.matched, 5);
+    assert_eq!(cold_stats.hits, 0, "cold run starts empty");
+    let cold_entries = memo.len();
+    assert!(
+        cold_entries >= 1,
+        "expected ≥1 memo entry after cold LR parse, got {cold_entries}"
+    );
+
+    // Warm parse with the same input: LRBody at sp=0 must hit the cache.
+    let (warm, warm_stats, _) = VM::new_with_cache(&prog.code, input, memo)
+        .with_memo_threshold(0)
+        .run_with_cache();
+    assert_eq!(warm, cold);
+    assert!(
+        warm_stats.hits >= 1,
+        "expected ≥1 cache hit on warm LR parse, got {}",
+        warm_stats.hits
+    );
+
+    // Sanity check: an empty cache reproduces the cold-run misses,
+    // confirming the warm hit came from the seeded cache.
+    let (_, fresh_stats, _) = VM::new_with_cache(&prog.code, input, MemoCache::new())
+        .with_memo_threshold(0)
+        .run_with_cache();
+    assert_eq!(fresh_stats.hits, 0);
+}
+
 /// A grammar that's memoized-by-default produces byte-identical results on
 /// a "happy path" input with no backtracking — the cache has no effect on
 /// correctness, only on work done.


### PR DESCRIPTION
## Summary

LRBody probes `self.memo` before the L-frame walk; LRTail's commit
branch writes the converged seed (subject to `memo_threshold`) with
`examined_max` set to the watermark popped at frame exit. That value
is the high-water mark across every iteration of the seed-and-grow
loop, so `MemoCache::apply_edit`'s invalidation predicate generalizes
to LR entries unchanged. No bytecode or `StackEntry` changes; failure
caching for LR rules is deferred per the issue's scoping.

Closes #48.