### PR TITLE
grammars/c: LR-port operator-precedence cascade (#49)

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -177,9 +177,13 @@ expr_stmt     <- expr ws @punctuation{';'}
 
 # --- Expressions ----------------------------------------------------
 #
-# Flat precedence: captures the right token sequence for highlighting.
-# Ordered-choice PEG: the first branch wins, so longer operators must
-# come before their prefixes.
+# Precedence is encoded by direct left recursion: each binary level is
+# `expr_LEVEL <- expr_LEVEL OP expr_NEXT / expr_NEXT`. Each level inlines
+# its own operator alternation. Within a level, longer operators come
+# first; cross-level ambiguities (`<` vs `<<=`, `&` vs `&&`, `+` vs
+# `+=`, …) need explicit `!`-lookaheads so a lower-precedence level
+# doesn't eat a fragment of a longer operator that belongs higher up.
+# Assignment (right-associative) and ternary stay outside the LR ladder.
 
 expr          <- expr_assign (ws @punctuation{','} ws expr_assign)*
 expr_assign   <- expr_unary ws assign_op ws expr_assign
@@ -190,17 +194,18 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
                / @operator{'='} !'='
 
-expr_cond     <- expr_binop (ws @operator{'?'} ws expr ws @punctuation{':'} ws expr_assign)?
+expr_cond     <- expr_lor (ws @operator{'?'} ws expr ws @punctuation{':'} ws expr_assign)?
 
-expr_binop    <- expr_unary (ws bin_op ws expr_unary)*
-bin_op        <- @operator{'&&'} / @operator{'||'}
-               / @operator{'=='} / @operator{'!='}
-               / @operator{'<='} / @operator{'>='}
-               / @operator{'<<'} / @operator{'>>'}
-               / @operator{'+'} / @operator{'-'}
-               / @operator{'*'} / @operator{'/'} / @operator{'%'}
-               / @operator{'&'} / @operator{'|'} / @operator{'^'}
-               / @operator{'<'} / @operator{'>'}
+expr_lor      <- expr_lor ws @operator{'||'} ws expr_land / expr_land
+expr_land     <- expr_land ws @operator{'&&'} ws expr_bor / expr_bor
+expr_bor      <- expr_bor ws @operator{'|'} !'|' !'=' ws expr_bxor / expr_bxor
+expr_bxor     <- expr_bxor ws @operator{'^'} !'=' ws expr_band / expr_band
+expr_band     <- expr_band ws @operator{'&'} !'&' !'=' ws expr_eq / expr_eq
+expr_eq       <- expr_eq ws (@operator{'=='} / @operator{'!='}) ws expr_rel / expr_rel
+expr_rel      <- expr_rel ws (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') ws expr_shift / expr_shift
+expr_shift    <- expr_shift ws (@operator{'<<'} !'=' / @operator{'>>'} !'=') ws expr_add / expr_add
+expr_add      <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
+expr_mul      <- expr_mul ws (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_unary / expr_unary
 
 expr_unary    <- (unary_prefix ws)* expr_postfix
 unary_prefix  <- @operator{'++'} / @operator{'--'}

--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -231,6 +231,24 @@ fn designated_initializer_parses() {
 }
 
 #[test]
+fn operator_longest_match_disambiguates_lr_cascade() {
+    // Pins the three lookahead-class pitfalls in the LR-cascade port:
+    //   - compound-assign vs same-prefix binary  (`<<=` is one token, not `<<` + `=`)
+    //   - two-char vs one-char relational        (`<<` is shift, not `<` + `<`)
+    //   - logical-vs-bitwise                     (`&&` is land, not `&` + `&`)
+    let inputs = [
+        "int main(void) { int a = 1; a <<= 2; a >>= 3; a += 4; return a; }\n",
+        "int main(void) { int a = 1, b = 2; if (a < 1 << b) return 1; return 0; }\n",
+        "int main(void) { int a = 1, b = 2, c = 3; if (a & b && c) return 1; return 0; }\n",
+    ];
+    for input in &inputs {
+        let (caps, kinds) = assert_complete_full(input);
+        let k = kinds_for(&caps, &kinds);
+        assert!(k.contains(&"operator"), "expected operators in {:?}", input);
+    }
+}
+
+#[test]
 fn recovery_absorbs_malformed_item() {
     let input = "int a() {}\n@@@ garbage @@@\nint b() {}\n";
     let (matched, caps, kinds, complete) = run(input);


### PR DESCRIPTION
## Summary

Recast the operator-precedence cascade in `grammars/c.peg` from a flat iterative `expr_binop` into a 10-level direct-LR ladder per #49. Cross-level operator-prefix ambiguities are guarded by `!`-lookaheads inside each level's alternation. New regression test in `tests/grammar_c_tests.rs` pins three lookahead-class pitfalls.

Stacked on #56 (LR seeds always cache) — without it the cascade goes O(2^N).

## Bench (`cargo bench --bench memo`)

```
=== c (post-#56) ===
input    thresh    time(us)  entries    hits   misses
small         0          50      387      73      376
small        32          51      306     129      440
small        64          51      303     129      440
small       128          50      303     129      440
small      4096          49      303     129      440

medium        0        2553    14440    3693    13771
medium       32        2490    12477    6235    18858
medium      128        2514    12397    7187    19845
medium     4096        2491    12380    7187    19845

large         0       56250   186586   35912   186200
large        32       57646   176040   32277   217888
large       128       57505   175993   32338   217962
large      4096       56969   175984   32338   217962

xlarge        0     3292752  1796686  349202  1795400
xlarge       32     3340345  1698300  299847  2102668
xlarge      128     3348826  1698073  299908  2102742
xlarge     4096     3311986  1698064  299908  2102742
```

Time is flat across thresholds for every fixture size — the LR-seed always-cache fix from #56 eliminated the cascade re-descent that produced the original 30× regression on `small` at `thresh=128`. `entries` decreases monotonically as the threshold climbs (Memo entries get filtered; LR seeds stay), and `hits`/`misses` stabilise at `thresh ≥ 64`. Net effect: same parse outcome, similar wall time, smaller memo footprint at higher thresholds.

`DEFAULT_MEMO_THRESHOLD = 128` does not move.

Refs #49.