### PR TITLE
grammars/javascript: LR-port operator-precedence cascade (#49)

### DIFF
--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -200,24 +200,28 @@ arrow_body     <- block
 
 expr_yield     <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
 
-# Ternary.
-expr_conditional <- expr_bin (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
+# Ternary. Below the ternary, precedence is encoded by direct left
+# recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
+# level — except `expr_pow` (`**`) which stays right-recursive to
+# preserve right-associativity. Each level inlines its operator
+# alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
+# operator vs compound-assign, …) need explicit `!`-lookaheads.
+expr_conditional <- expr_nullish (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
 
-# Binary / logical / bitwise — flattened, precedence not enforced.
-expr_bin       <- expr_unary (ws bin_op ws expr_unary)*
-bin_op         <- @operator{'??'}
-                / @operator{'||'} / @operator{'&&'}
-                / @operator{'==='} / @operator{'!=='}
-                / @operator{'=='} / @operator{'!='}
-                / @operator{'<='} / @operator{'>='}
-                / @operator{'<<'} / @operator{'>>>'} / @operator{'>>'}
-                / @operator{'**'}
-                / @operator{'+'} / @operator{'-'}
-                / @operator{'*'} / @operator{'/'} / @operator{'%'}
-                / @operator{'&'} / @operator{'|'} / @operator{'^'}
-                / @operator{'<'} / @operator{'>'}
-                / @keyword{'instanceof'}
-                / @keyword{'in'}
+expr_nullish   <- expr_nullish ws @operator{'??'} !'=' ws expr_lor / expr_lor
+expr_lor       <- expr_lor ws @operator{'||'} !'=' ws expr_land / expr_land
+expr_land      <- expr_land ws @operator{'&&'} !'=' ws expr_bor / expr_bor
+expr_bor       <- expr_bor ws @operator{'|'} !'|' !'=' ws expr_bxor / expr_bxor
+expr_bxor      <- expr_bxor ws @operator{'^'} !'=' ws expr_band / expr_band
+expr_band      <- expr_band ws @operator{'&'} !'&' !'=' ws expr_eq / expr_eq
+expr_eq        <- expr_eq ws (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) ws expr_rel / expr_rel
+expr_rel       <- expr_rel ws (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) ws expr_shift / expr_shift
+expr_shift     <- expr_shift ws (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') ws expr_add / expr_add
+expr_add       <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
+expr_mul       <- expr_mul ws (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_pow / expr_pow
+
+# Right-associative: stays right-recursive, not LR.
+expr_pow       <- expr_unary ws @operator{'**'} !'=' ws expr_pow / expr_unary
 
 expr_unary     <- (unary_op ws)* expr_postfix
 unary_op       <- @keyword{'typeof'}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -352,6 +352,28 @@ fn ternary_parses() {
 }
 
 #[test]
+fn operator_longest_match_disambiguates_lr_cascade() {
+    // Pins the lookahead-class pitfalls in the LR-cascade port:
+    //   - compound-assign vs same-prefix binary  (`<<=` is one token, not `<<` + `=`)
+    //   - two-char vs one-char relational        (`<<` is shift, not `<` + `<`)
+    //   - logical-vs-bitwise                     (`&&` is land, not `&` + `&`)
+    //   - strict-equality vs equality            (`===` before `==` in the alt)
+    //   - exponent vs multiply                   (`**` is right-assoc pow, not `*` + `*`)
+    let inputs = [
+        "let a = 1; a <<= 2; a >>>= 3; a ??= 4;\n",
+        "if (a < 1 << b) { let c = 1; }\n",
+        "if (a & b && c) { let d = 1; }\n",
+        "if (a === b !== c) { let d = 1; }\n",
+        "let p = 2 ** 3 ** 2;\n",
+    ];
+    for input in &inputs {
+        let (caps, kinds) = assert_complete_full(input);
+        let k = kinds_for(&caps, &kinds);
+        assert!(k.contains(&"operator"), "expected operators in {:?}", input);
+    }
+}
+
+#[test]
 fn labeled_statement_and_break_parse() {
     let (_, _) =
         assert_complete_full("outer: for (let i = 0; i < 10; i++) { if (i === 5) break outer; }\n");


### PR DESCRIPTION
## Summary

Recast the operator-precedence cascade in \`grammars/javascript.peg\` from a flat \`expr_bin\` into a 12-level direct-LR ladder per #49. \`expr_pow\` (\`**\`) stays right-recursive (right-associative). Cross-level operator-prefix ambiguities are guarded by \`!\`-lookaheads inside each level's alternation. New regression test in \`tests/grammar_javascript_tests.rs\` pins five lookahead-class pitfalls.

Stacked on #56 (LR seeds always cache) — without it the 12-level cascade goes O(2^N) on parens-with-comma-list shapes.

## Bench (\`cargo bench --bench memo\`)

```
=== js (post-#56) ===
input    thresh    time(us)  entries    hits     misses
small         0          43      264      73       242
small        32          46      203     165       375
small       128          44      198     165       375
small      4096          44      198     165       375

medium        0        1984    11637    3476     10581
medium       32        2448     9084    8476     17614
medium      128        2549     8950    9540     18729
medium     4096        2509     8911   10094     19337

large         0       36203   136462   38913    126012
large        32       39732   113007   92612    198893
large      128       40217   111810  103348    209012
large     4096       41373   111473  119090    219532

xlarge        0     1810497  1489722  422283   1377082
xlarge       32     1841308  1238417 1011772   2177773
xlarge      128     1845315  1226440 1111938   2270122
xlarge     4096     1862410  1222693 1293230   2390202
```

Time is roughly flat across thresholds (within ~3% on xlarge). \`entries\` decreases monotonically as the threshold climbs; \`hits\` rises because filtered Memo entries weren't producing hits anyway, so hit-rate concentrates on the surviving entries plus the LR seed cache. No performance regression vs. the pre-port flat-iterative shape.

\`DEFAULT_MEMO_THRESHOLD = 128\` does not move.

Refs #49.