### PR TITLE
js: consume inter-stmt whitespace in block and switch_case

### DIFF
--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -134,8 +134,8 @@ while_stmt     <- @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation
 do_while_stmt  <- @keyword{'do'} ws stmt ws @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws opt_semi
 switch_stmt    <- @keyword{'switch'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws
                   @punctuation{'{'} ws switch_case* ws @punctuation{'}'}
-switch_case    <- @keyword{'case'} ws expr ws @punctuation{':'} ws (!switch_case_term stmt)*
-                / @keyword{'default'} ws @punctuation{':'} ws (!switch_case_term stmt)*
+switch_case    <- @keyword{'case'} ws expr ws @punctuation{':'} ws (!switch_case_term stmt ws)*
+                / @keyword{'default'} ws @punctuation{':'} ws (!switch_case_term stmt ws)*
 switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
 try_stmt       <- @keyword{'try'} ws block (ws catch_clause)? (ws finally_clause)?
 catch_clause   <- @keyword{'catch'} (ws @punctuation{'('} ws pattern ws @punctuation{')'})? ws block
@@ -147,7 +147,7 @@ continue_stmt  <- @keyword{'continue'} (ws @variable{ident})? ws opt_semi
 debugger_stmt  <- @keyword{'debugger'} ws opt_semi
 labeled_stmt   <- @variable{ident} ws @punctuation{':'} ws stmt
 block_stmt     <- block
-block          <- @punctuation{'{'} ws stmt* ws @punctuation{'}'}
+block          <- @punctuation{'{'} ws (stmt ws)* @punctuation{'}'}
 
 # --- Function params and patterns -------------------------------------
 

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -378,3 +378,98 @@ fn labeled_statement_and_break_parse() {
     let (_, _) =
         assert_complete_full("outer: for (let i = 0; i < 10; i++) { if (i === 5) break outer; }\n");
 }
+
+// Pins the inter-statement-whitespace handling inside `block` and
+// `switch_case`. Stmts whose syntactic tail is `}` (`if_stmt`,
+// `for_stmt`, `while_stmt`, `block_stmt`, `try_stmt`, …) leave their
+// trailing space unconsumed; the stmt-list rules must consume it
+// between siblings, otherwise the enclosing `block` fails on the
+// next stmt's keyword and the whole `fn_decl` collapses into
+// recovery captures.
+
+fn keyword_literals<'a>(input: &'a str, captures: &[Capture], kinds: &[String]) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "keyword")
+        .map(|c| &input[c.start..c.end])
+        .collect()
+}
+
+#[test]
+fn block_with_if_then_return_keeps_function_keyword() {
+    let input = "function f() { if (true) {} return; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function") && kw.contains(&"if") && kw.contains(&"return"),
+        "expected function/if/return as keywords, got: {:?}",
+        kw
+    );
+}
+
+#[test]
+fn block_with_for_then_return_keeps_function_keyword() {
+    let input = "function f() { for (let i=0;i<1;i++) {} return; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function") && kw.contains(&"for") && kw.contains(&"return"),
+        "expected function/for/return as keywords, got: {:?}",
+        kw
+    );
+}
+
+#[test]
+fn block_with_while_then_return_keeps_function_keyword() {
+    let input = "function f() { while (true) {} return; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function") && kw.contains(&"while") && kw.contains(&"return"),
+        "expected function/while/return as keywords, got: {:?}",
+        kw
+    );
+}
+
+#[test]
+fn block_stmt_then_return_keeps_function_keyword() {
+    let input = "function f() { {} return; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function") && kw.contains(&"return"),
+        "expected function/return as keywords, got: {:?}",
+        kw
+    );
+}
+
+#[test]
+fn switch_case_with_block_tail_stmt_parses() {
+    let input = "function f() { switch (x) { case 1: if (y) {} break; } }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function")
+            && kw.contains(&"switch")
+            && kw.contains(&"case")
+            && kw.contains(&"if")
+            && kw.contains(&"break"),
+        "expected function/switch/case/if/break as keywords, got: {:?}",
+        kw
+    );
+}
+
+#[test]
+fn try_then_return_keeps_function_keyword() {
+    let input = "function f() { try {} catch (e) {} return; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kw = keyword_literals(input, &caps, &kinds);
+    assert!(
+        kw.contains(&"function")
+            && kw.contains(&"try")
+            && kw.contains(&"catch")
+            && kw.contains(&"return"),
+        "expected function/try/catch/return as keywords, got: {:?}",
+        kw
+    );
+}


### PR DESCRIPTION
`function f() { if (true) {} return; }` rendered without `function` highlighted, because the whole `fn_decl` was failing and the top-level `*^` recovery was skipping the leading `f` (visible in `pegdb dump-captures` as a `recovery` capture at byte 0).

Cause: `block` and `switch_case` did not consume whitespace *between* sibling statements. Stmts that end with `ws opt_semi` masked it; stmts whose syntactic tail is `}` (`if_stmt`, `for_stmt`, `while_stmt`, `try_stmt`, `block_stmt`, …) left the inter-stmt space unconsumed, so the next iteration of `stmt*` failed at a whitespace position and the trailing `ws @punctuation{'}'}` then failed on the following stmt's keyword.

The fix mirrors what `grammars/go.peg:121,176-184` already does — wrap each iteration's trailing whitespace into the loop. New tests in `tests/grammar_javascript_tests.rs` pin the original repro plus the analogous `for` / `while` / `try` / nested-block / switch-case-with-block-tail variants. The medium.js bench fixture happens to never put a block-tail stmt before another stmt inside a block, which is why this slipped past the existing suite.
