### PR TITLE
pegvm: parse-throughput improvements (5.7× on jquery.js)

### DIFF
--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -185,7 +185,7 @@ pub(crate) struct MemoEntry {
     pub(crate) captures: Vec<Capture>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct OpenCapture {
     kind: CaptureKind,
     start: usize,

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -114,19 +114,29 @@ pub struct VM<'p, 'i> {
     stack: Vec<StackEntry>,
     captures: Vec<OpenCapture>,
     max_sp: usize,
-    /// Length of `captures` at the moment `sp` reached `max_sp`. The
-    /// captures themselves live in `captures[..max_captures_len]` until a
-    /// `fail()` or `BackCommit` truncates the vector below that watermark,
-    /// at which point `protect_max_captures` materializes a copy into
-    /// `max_captures_saved`. Deferring the clone makes `maybe_snapshot`
-    /// O(1) instead of O(n) per sp-advance — critical on large inputs
-    /// where the eager-clone variant went quadratic in captures count.
+    /// Length of `captures` at the moment `sp` reached `max_sp` —
+    /// equivalently, the count of captures alive at the
+    /// farthest-failure watermark. Logically these live in
+    /// `captures[..max_captures_len]`, but a truncate may have
+    /// physically dropped some past `saved_lower` into `saved_above`.
+    /// At finalize, the alive-at-max set is reassembled from both.
     max_captures_len: usize,
-    /// Populated lazily the first time a truncate would drop captures
-    /// below `max_captures_len`. `None` means the canonical captures
-    /// still reside in `captures[..max_captures_len]`. Cleared whenever
-    /// `max_sp` advances (the prior snapshot becomes stale).
-    max_captures_saved: Option<Vec<OpenCapture>>,
+    /// Lowest capture index still backed by `self.captures`. Captures
+    /// in `[saved_lower, max_captures_len)` were displaced by a
+    /// truncate-below-watermark and now live in `saved_above`; those
+    /// in `[0, saved_lower)` are still in `captures`. Invariant:
+    /// `captures.len() >= saved_lower`. Reset to `max_captures_len`
+    /// when `max_sp` advances (the prior watermark is stale).
+    saved_lower: usize,
+    /// Captures displaced from the watermark prefix, stored in
+    /// reverse capture-order — i.e. the most recent drop is at the
+    /// back. `saved_above.iter().rev()` walks them in original
+    /// `[saved_lower, max_captures_len)` order. Replaces the old
+    /// "clone the whole prefix on first endangered truncate"
+    /// strategy: each capture is saved at most once per `max_sp`
+    /// epoch, and only the suffix being dropped — never the bulk of
+    /// the watermark prefix that survives every backtrack.
+    saved_above: Vec<OpenCapture>,
     /// Packrat memo table, keyed by `(memo_id, start_sp)`. Populated by
     /// `MemoClose` on success and by `fail()` on failure escape (Commit 5).
     memo: HashMap<(MemoId, usize), MemoEntry>,
@@ -210,7 +220,8 @@ impl<'p, 'i> VM<'p, 'i> {
             captures: Vec::new(),
             max_sp: 0,
             max_captures_len: 0,
-            max_captures_saved: None,
+            saved_lower: 0,
+            saved_above: Vec::new(),
             memo: HashMap::new(),
             memo_hits: 0,
             memo_misses: 0,
@@ -937,18 +948,41 @@ impl<'p, 'i> VM<'p, 'i> {
     fn maybe_snapshot(&mut self) {
         if self.sp > self.max_sp {
             self.max_sp = self.sp;
-            self.max_captures_len = self.captures.len();
-            self.max_captures_saved = None;
+            let len = self.captures.len();
+            self.max_captures_len = len;
+            self.saved_lower = len;
+            self.saved_above.clear();
         }
     }
 
-    /// Called before truncating `captures` to `new_len`. If the truncate
-    /// would drop captures the farthest-failure snapshot still needs,
-    /// copy them aside first. Runs at most once per `max_sp` epoch —
-    /// subsequent truncates below the same watermark are no-ops.
+    /// Called before truncating `captures` to `new_len`. If the
+    /// truncate would drop captures the farthest-failure watermark
+    /// still needs, displace them to `saved_above` first.
+    ///
+    /// Saves only the *suffix* `captures[new_len..saved_lower]` — the
+    /// captures actually being lost from the watermark prefix on this
+    /// step. Subsequent truncates that go shallower in the same epoch
+    /// save their own additional suffix; truncates that don't dip
+    /// below `saved_lower` are no-ops. Across an entire `max_sp`
+    /// epoch each capture is saved at most once, so the total bytes
+    /// displaced stay bounded by `max_captures_len * sizeof(OpenCapture)`
+    /// instead of being multiplied by the number of endangered
+    /// backtracks (which on jquery.js was ~80 k clones × ~750 KB ≈
+    /// 60 GB of memcpy under the prior eager clone-the-whole-prefix
+    /// strategy).
     fn protect_max_captures(&mut self, new_len: usize) {
-        if new_len < self.max_captures_len && self.max_captures_saved.is_none() {
-            self.max_captures_saved = Some(self.captures[..self.max_captures_len].to_vec());
+        if new_len < self.saved_lower {
+            // SAFETY of indexing: `captures.len() >= saved_lower` is
+            // an invariant — see the field doc. So
+            // `captures[new_len..saved_lower]` is in bounds whenever
+            // `new_len < saved_lower`.
+            self.saved_above.extend(
+                self.captures[new_len..self.saved_lower]
+                    .iter()
+                    .rev()
+                    .copied(),
+            );
+            self.saved_lower = new_len;
         }
     }
 
@@ -959,14 +993,13 @@ impl<'p, 'i> VM<'p, 'i> {
             hits: self.memo_hits,
             misses: self.memo_misses,
         };
-        // Materialize the farthest-failure captures exactly once. If a
-        // prior truncate below the watermark forced an early save, take
-        // that; otherwise the canonical captures are still sitting in
-        // `self.captures[..max_captures_len]`.
-        let max_captures = self
-            .max_captures_saved
-            .take()
-            .unwrap_or_else(|| self.captures[..self.max_captures_len].to_vec());
+        // Reassemble the farthest-failure captures: prefix still in
+        // `self.captures` plus suffix displaced into `saved_above`.
+        // `saved_above` is stored in reverse capture-order so
+        // iter().rev() reads it back in the right place.
+        let mut max_captures: Vec<OpenCapture> = Vec::with_capacity(self.max_captures_len);
+        max_captures.extend_from_slice(&self.captures[..self.saved_lower]);
+        max_captures.extend(self.saved_above.iter().rev().copied());
         let result = MatchResult {
             matched: self.max_sp,
             captures: close_captures(max_captures, self.max_sp),

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -24,29 +24,22 @@ pub struct Segment<'a> {
     pub kind: Option<&'a str>,
 }
 
-#[derive(Clone, Copy, Debug)]
-enum EventKind {
-    Begin,
-    End,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct Event {
-    pos: usize,
-    kind: EventKind,
-    cap_idx: usize,
-}
-
 /// Walk `captures` over `input`, invoking `on_segment` for each
-/// active-kind run between event boundaries. Together the segments
+/// active-kind run between capture boundaries. Together the segments
 /// form a contiguous, non-overlapping cover of `0..input.len()` —
 /// the renderer's load-bearing structural property.
 ///
-/// Implementation: build Begin/End events, sort with the tie-breaking
-/// rule that keeps the active-capture stack consistent under PEG
-/// nesting (forest invariant — captures are nested or disjoint, never
-/// overlapping), and emit one segment per non-empty `cursor..ev.pos`
-/// slice. The active kind is the innermost open capture's kind.
+/// Implementation: a single linear sweep over `captures`, which the
+/// VM emits in `CaptureBegin` order — `start`-ascending with parent
+/// before child (see [`pegvm::Capture`](crate::pegvm::Capture)). That
+/// ordering is exactly a pre-order forest traversal, so the active
+/// capture stack can be maintained directly: at each capture, pop
+/// every stack entry whose `end <= c.start` (those have closed before
+/// `c` begins, emitting their tail run as we go), emit any uncovered
+/// gap up to `c.start`, then push `c`. Drain the stack at the end and
+/// emit the trailing unkinded tail past the last capture's end. No
+/// events, no sort — `O(N)` total work, matching the input ordering
+/// the VM already gives us.
 pub fn walk<'a, F>(
     input: &'a str,
     captures: &'a [Capture],
@@ -66,68 +59,58 @@ pub fn walk<'a, F>(
         return;
     }
 
-    let mut events: Vec<Event> = Vec::with_capacity(captures.len() * 2);
-    for (i, c) in captures.iter().enumerate() {
-        events.push(Event {
-            pos: c.start,
-            kind: EventKind::Begin,
-            cap_idx: i,
-        });
-        events.push(Event {
-            pos: c.end,
-            kind: EventKind::End,
-            cap_idx: i,
-        });
-    }
-
-    // Order events at the same position so the stack stays consistent with
-    // properly nested captures:
-    //   - END events come before BEGIN events (a capture that ends here closes
-    //     before a sibling that starts here).
-    //   - For ENDs at the same position, inner captures (higher cap_idx) end first.
-    //   - For BEGINs at the same position, outer captures (lower cap_idx) start first.
-    events.sort_by(|a, b| {
-        a.pos.cmp(&b.pos).then_with(|| match (a.kind, b.kind) {
-            (EventKind::End, EventKind::Begin) => std::cmp::Ordering::Less,
-            (EventKind::Begin, EventKind::End) => std::cmp::Ordering::Greater,
-            (EventKind::End, EventKind::End) => b.cap_idx.cmp(&a.cap_idx),
-            (EventKind::Begin, EventKind::Begin) => a.cap_idx.cmp(&b.cap_idx),
-        })
-    });
-
+    let kind_of = |i: usize| capture_kinds[captures[i].kind.0 as usize].as_str();
     let mut stack: Vec<usize> = Vec::new(); // capture indices, innermost on top
     let mut cursor = 0usize;
 
-    for ev in events {
-        if ev.pos > cursor {
-            let kind = stack
-                .last()
-                .map(|&i| capture_kinds[captures[i].kind.0 as usize].as_str());
+    for (i, c) in captures.iter().enumerate() {
+        // Pop every still-open capture whose span ended at or before
+        // `c.start`. Each pop emits the unwritten tail of the popped
+        // capture under its own kind, so the stack only ever holds
+        // captures that genuinely contain `c`.
+        while let Some(&top) = stack.last() {
+            let top_end = captures[top].end;
+            if top_end > c.start {
+                break;
+            }
+            if cursor < top_end {
+                on_segment(Segment {
+                    range: cursor..top_end,
+                    kind: Some(kind_of(top)),
+                });
+                cursor = top_end;
+            }
+            stack.pop();
+        }
+        // Gap from cursor to c.start, tagged by whatever capture (if
+        // any) is now innermost on the stack. `None` means no parent —
+        // an unkinded gap between sibling captures or before the first.
+        if cursor < c.start {
+            let kind = stack.last().map(|&j| kind_of(j));
             on_segment(Segment {
-                range: cursor..ev.pos,
+                range: cursor..c.start,
                 kind,
             });
-            cursor = ev.pos;
+            cursor = c.start;
         }
-        match ev.kind {
-            EventKind::Begin => stack.push(ev.cap_idx),
-            EventKind::End => {
-                // With proper PEG nesting, the matching capture is on top of the stack.
-                if let Some(top) = stack.last() {
-                    if *top == ev.cap_idx {
-                        stack.pop();
-                    } else if let Some(pos) = stack.iter().rposition(|&i| i == ev.cap_idx) {
-                        // Defensive: search and remove (shouldn't happen for valid grammars).
-                        stack.remove(pos);
-                    }
-                }
-            }
+        stack.push(i);
+    }
+
+    // Drain remaining open captures, innermost first.
+    while let Some(top) = stack.pop() {
+        let end = captures[top].end;
+        if cursor < end {
+            on_segment(Segment {
+                range: cursor..end,
+                kind: Some(kind_of(top)),
+            });
+            cursor = end;
         }
     }
 
-    // Trailing input past the last event — unkinded by definition (no
-    // open capture covers it). For partial parses this is the
-    // unmatched tail; for full parses it is empty.
+    // Trailing input past the last capture — unkinded by definition.
+    // For partial parses this is the unmatched tail; for full parses
+    // it is empty.
     if cursor < len {
         on_segment(Segment {
             range: cursor..len,


### PR DESCRIPTION
Closes the parse-throughput gap with syntect on realistic JS workloads. On a per-process highlight of jquery.js (247 KB, 9 210 lines) wall time goes from 2.04 s on `main` to 359 ms — a 5.7× speedup that puts us at ~1.47× syntect 5.3.0's `syncat` baseline on the same hardware. Before this PR we were at ~8× syntect's wall time on this workload.

## What changed

Three independent levers in `src/pegvm/vm.rs` and `src/walk.rs`, summarised by where the time was actually going:

`OpenCapture` is now `Copy`. All its fields are already `Copy`; the missing derive on the struct was the only thing keeping `Vec`'s memcpy specialisation off the slice clones inside `protect_max_captures`'s `to_vec()` and the related capture-replay paths. ~24 % wall-clock win on its own.

`protect_max_captures` saves only the *suffix* being dropped from the watermark prefix instead of cloning the whole prefix. The previous strategy cloned `captures[..max_captures_len]` on every endangered backtrack — on a successful jquery.js parse that was ~80 k clones × ~750 KB each ≈ 60 GB of `to_vec()` memcpy under the ~50 GB/s memory-bandwidth ceiling, ~1.2 s of pure copying. The new scheme displaces only `captures[new_len..saved_lower]` into a back-to-front buffer; over an `max_sp` epoch each capture is saved at most once, so the cumulative copy traffic drops to ≤ `max_captures_len × sizeof(OpenCapture)` ≈ 40 MB on jquery.js. This is the headline change; ~4.2× on top of the `Copy` win. See the field doc on `VM::saved_lower` / `VM::saved_above`.

`walk` is now a single linear sweep over the captures slice instead of materialising sorted Begin/End events. Captures arrive from the VM in pre-order forest traversal — `start`-ascending, parent before child, see the doc comment on `pegvm::Capture` — so an active-capture stack with the same end-pop semantics gives the same output without the `O(N log N)` sort or the auxiliary event vector. Behaviour-identical (md5 match on the full jquery.js render). Flat on the wall clock here but cleaner code, and fewer moving pieces if anyone investigates the post-VM cost in the future.

## Benchmark results

`hyperfine -N --warmup 3` on M1 Pro, our `target/release/demo`:

| fixture | main | this PR | speedup |
|---|---|---|---|
| `medium.js` (1.8 KB) | 8.3 ms | 8.4 ms | flat — input too small for the prefix bloat to bite |
| `xlarge.js` (138 KB) | 1117 ms | 216 ms | 5.16× |
| `jquery.js` (247 KB) | 2043 ms | 359 ms | 5.69× |

`benches/memo.rs` `xlarge` cells (median-of-11 µs at default threshold 128), captured with `.claude/skills/memo-bench/compare.sh main pegvm-parse-throughput memo`:

| grammar | main | this PR | speedup |
|---|---|---|---|
| `rust/xlarge` | 1 337 942 µs | 189 903 µs | 7.04× |
| `sql/xlarge` | 482 930 µs | 161 973 µs | 2.98× |
| `toml/xlarge` | 13 816 µs | 4 537 µs | 3.05× |
| `json/xlarge` | 13 355 µs | 12 752 µs | 1.05× (flat) |

Speedup scales with how much the grammar backtracks and how large the watermark prefix grows. Rust's operator-precedence cascades are the worst offender on `main`; JSON's roughly-LL grammar barely backtracks, so `protect_max_captures` was barely firing and there was nothing to fix. `large` cells track the same shape at smaller magnitudes; `medium` and `small` are within ±5 % noise.

## Syntect comparison

Trajectory only — workloads aren't apples-to-apples (different grammar maturity, different tokenisation granularity, syntect's regex backend is oniguruma, ours is pure PEG) but the methodology matches and both numbers include per-process startup + asset/grammar load + parse + ANSI render + write to a hyperfine-captured stdout sink:

| | jquery.js wall time | source |
|---|---|---|
| this PR | 359 ± 11 ms | `hyperfine 1.20.0 -N --warmup 3`, 10 runs, M1 Pro |
| `main` | 2043 ± 11 ms | same |
| syntect 5.3.0 `syncat` | 245 ± 3.4 ms | upstream baseline summary, same hardware/flags |

The motivating workload, samply attribution side-quests, the negative-result `vm-chunked-arena` rewrite that came before this much smaller fix turned out to be the right lever, and the suffix-save analysis are written up in `~/.claude/plans/a-combination-of-if-piped-wave.md` for posterity.
