### PR TITLE
c: fix grammar regressions surfaced by medium.c fixture

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -210,7 +210,15 @@ expr_shift    <- expr_shift ws (@operator{'<<'} !'=' / @operator{'>>'} !'=') ws 
 expr_add      <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
 expr_mul      <- expr_mul ws (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_unary / expr_unary
 
-expr_unary    <- (unary_prefix ws)* expr_postfix
+# `sizeof_type` is tried before the generic prefix loop so that
+# `sizeof(struct X)` / `sizeof(union X)` / `sizeof(counter_size_t)`
+# parse: otherwise the prefix loop grabs `sizeof` and the `(...)` has
+# to fit `cast_or_paren`, which only works when the contents also
+# happen to be an `expr_primary` (e.g. `sizeof(int)`). On failure we
+# fall back to the prefix path so `sizeof expr` and `sizeof(expr)`
+# still parse.
+expr_unary    <- sizeof_type
+               / (unary_prefix ws)* expr_postfix
 unary_prefix  <- @operator{'++'} / @operator{'--'}
                / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
                / @operator{'*'} / @operator{'&'}
@@ -232,7 +240,6 @@ expr_primary  <- string_lit
                / char_lit
                / number_lit
                / cast_or_paren
-               / sizeof_type
                / call_ident
                / @type{predef_type_name}
                / @constant{true_lit}

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -11,8 +11,8 @@
 # for a schema-less lexer.
 #
 # Preprocessor lines (`#include`, `#define`, ...) are captured as
-# `@comment` — the directive itself isn't code and needs no
-# tokenization for highlighting.
+# `@keyword` — the directive itself isn't tokenized further, but the
+# whole line stays visually distinct from real comments.
 #
 # Capture kinds used (all present in src/highlight/theme.rs):
 #   keyword, string, number, comment, operator, punctuation, type,
@@ -32,7 +32,7 @@ c_file        <- ws (external_decl)*^ ws !.
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
-pp_line       <- @comment{pp_body}
+pp_line       <- @keyword{pp_body}
 pp_body       <- '#' (pp_cont / !'\n' .)*
 pp_cont       <- '\\' '\n'
                 / '\\' '\r' '\n'

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -82,9 +82,12 @@ predef_type_name <- ('void' / 'char' / 'short' / 'long long' / 'long'
 
 # Heuristic typedef-name: PascalCase or `*_t` tail. If this mismatches
 # an actual declaration, the decl path will fail and we fall back to
-# expression statement.
+# expression statement. The `_t` arm uses the standard PEG non-greedy
+# idiom `(!end_t ident_body)*` because PEG `*` is possessive — a
+# greedy `ident_body*` would swallow the trailing `_t`.
 typedef_name  <- [A-Z] ident_body*
-               / [a-z_] ident_body* '_t' !ident_body
+               / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
+typedef_t_end <- '_t' !ident_body
 
 struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'}) ws
                        (@type{ident})? (ws @punctuation{'{'} ws struct_decl* ws @punctuation{'}'})?

--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -87,8 +87,8 @@ fn hello_world_parses() {
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
     assert!(
-        k.contains(&"comment"),
-        "expected #include as comment: {:?}",
+        !k.contains(&"comment"),
+        "no real comments in input — `#include` should not be tagged as comment: {:?}",
         k
     );
     assert!(k.contains(&"keyword"), "expected keywords: {:?}", k);
@@ -100,7 +100,7 @@ fn preprocessor_directives_parse() {
     let input = "#define FOO 1\n#ifdef FOO\n#include \"x.h\"\n#endif\nint x = 0;\n";
     let (caps, kinds) = assert_complete_full(input);
     let k = kinds_for(&caps, &kinds);
-    assert!(k.contains(&"comment"), "expected PP as comments: {:?}", k);
+    assert!(k.contains(&"keyword"), "expected PP as keywords: {:?}", k);
 }
 
 #[test]

--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -272,6 +272,49 @@ fn t_suffix_typedef_resolves_as_type() {
 }
 
 #[test]
+fn sizeof_struct_type_name_parses() {
+    // Regression: the old `expr_unary` consumed `sizeof` as a unary
+    // prefix, so `sizeof(struct Foo)` then had to parse via
+    // `cast_or_paren` — which fails because `struct Foo` isn't an
+    // `expr_primary`. Fixed by trying `sizeof_type` first in `expr_unary`.
+    let input = "int f(void) { return sizeof(struct Foo); }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(!k.contains(&"recovery"), "no recovery expected: {:?}", k);
+    let sizeof_pos = input.find("sizeof").unwrap();
+    let struct_pos = input.find("struct").unwrap();
+    let foo_pos = input.find("Foo").unwrap();
+    assert_eq!(kind_at_pos(&caps, &kinds, sizeof_pos), Some("keyword"));
+    assert_eq!(kind_at_pos(&caps, &kinds, struct_pos), Some("keyword"));
+    assert_eq!(kind_at_pos(&caps, &kinds, foo_pos), Some("type"));
+}
+
+#[test]
+fn medium_fixture_parses_without_recovery() {
+    let input = include_str!("../benches/fixtures/medium.c");
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "medium.c should parse without recovery, got kinds: {:?}",
+        k
+    );
+    let function_literals: HashSet<&str> = caps
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "function")
+        .map(|c| &input[c.start..c.end])
+        .collect();
+    for name in ["counter_new", "counter_push", "classify", "sum", "main"] {
+        assert!(
+            function_literals.contains(name),
+            "expected `{}` as @function in medium.c captures, got {:?}",
+            name,
+            function_literals
+        );
+    }
+}
+
+#[test]
 fn recovery_absorbs_malformed_item() {
     let input = "int a() {}\n@@@ garbage @@@\nint b() {}\n";
     let (matched, caps, kinds, complete) = run(input);

--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -248,6 +248,29 @@ fn operator_longest_match_disambiguates_lr_cascade() {
     }
 }
 
+fn kind_at_pos<'a>(captures: &[Capture], kinds: &'a [String], pos: usize) -> Option<&'a str> {
+    captures
+        .iter()
+        .find(|c| c.start == pos)
+        .map(|c| kinds[c.kind.0 as usize].as_str())
+}
+
+#[test]
+fn t_suffix_typedef_resolves_as_type() {
+    // Regression: PEG `*` is possessive, so the old
+    // `[a-z_] ident_body* '_t' !ident_body` rule never matched anything
+    // (the greedy `ident_body*` swallowed the trailing `_t`). That caused
+    // identifiers like `counter_size_t` to fail `decl_spec` entirely.
+    let input = "counter_size_t x;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(!k.contains(&"recovery"), "no recovery expected: {:?}", k);
+    let type_pos = input.find("counter_size_t").unwrap();
+    let var_pos = input.find('x').unwrap();
+    assert_eq!(kind_at_pos(&caps, &kinds, type_pos), Some("type"));
+    assert_eq!(kind_at_pos(&caps, &kinds, var_pos), Some("variable"));
+}
+
 #[test]
 fn recovery_absorbs_malformed_item() {
     let input = "int a() {}\n@@@ garbage @@@\nint b() {}\n";

--- a/tests/parse_c_tests.rs
+++ b/tests/parse_c_tests.rs
@@ -50,10 +50,10 @@ fn block_comment_is_comment() {
 }
 
 #[test]
-fn preprocessor_is_comment() {
+fn preprocessor_is_keyword() {
     let input = "#include <stdio.h>\nint x;\n";
     let pos = input.find("#include").unwrap();
-    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("comment"));
+    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("keyword"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes the C grammar issues surfaced by running the demo on `benches/fixtures/medium.c`:

- `#include` / `#define` lines now render as `@keyword` instead of `@comment`, so they read distinctly from real comments.
- `counter_size_t` and other `*_t` typedef-names now resolve as `@type` — the old `[a-z_] ident_body* '_t' !ident_body` rule was dead because PEG `*` is possessive and swallowed the trailing `_t`.
- `sizeof(struct X)` / `sizeof(<typedef-name>)` now parse — `expr_unary` tries `sizeof_type` before the generic prefix loop, which had been grabbing `sizeof` and forcing the contents through `cast_or_paren`.

`benches/fixtures/medium.c` now parses with zero `recovery` captures and all five top-level function definitions are tagged `@function`. Regression tests in `tests/grammar_c_tests.rs` cover each fix plus the medium-fixture round-trip.
