### PR TITLE
go,js: wrap inter-iteration ws into file-root recovery loops

### DIFF
--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -23,7 +23,7 @@
 # Recovery: top-level uses `*^` so malformed top-level declarations
 # don't abort the whole file.
 
-go_file       <- ws package_clause ws (import_decl ws)* (top_decl)*^ ws !.
+go_file       <- ws package_clause ws (import_decl ws)* (top_decl ws)*^ !.
 
 # --- Package / imports ----------------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -28,7 +28,7 @@
 # Recovery: top-level uses `*^` so malformed statements don't abort
 # the whole file.
 
-js_file        <- ws (stmt)*^ ws !.
+js_file        <- ws (stmt ws)*^ !.
 
 # --- Statements -------------------------------------------------------
 #

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -246,3 +246,17 @@ fn recovery_absorbs_malformed_item() {
         k
     );
 }
+
+#[test]
+fn blank_lines_between_top_decls_emit_no_recovery() {
+    // Regression: file-root `(top_decl)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "package main\n\nfunc a() {}\n\nfunc b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        k
+    );
+}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -329,6 +329,20 @@ fn recovery_absorbs_malformed_item() {
 }
 
 #[test]
+fn blank_lines_between_top_stmts_emit_no_recovery() {
+    // Regression: file-root `(stmt)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "function a() {}\n\nfunction b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        !kv.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        kv
+    );
+}
+
+#[test]
 fn method_chain_with_call_parses() {
     let input = "const r = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);\n";
     let (caps, kinds) = assert_complete_full(input);


### PR DESCRIPTION
Part of the recovery-bug stack #77 → #78 → #79 → #80 → #83 → #84 → #85 (this PR is 1/7; base stays `main`). Merging the stack in order eliminates every grammar bug `pegdb dump-captures` surfaces on `benches/fixtures/**` and lands a CI gate (#85) that keeps the channel at zero.

Closes #71.

Wraps the inter-iteration whitespace into the file-root recovery loops in `grammars/go.peg` and `grammars/javascript.peg`, mirroring the `(stmt ws)*` convention already used by Go's `block` and `*_case` rules. Without `ws` inside the loop body, blank lines between top-level decls fell through to the `*^` byte-eater and emitted recovery captures.

Verified via `pegdb dump-captures` on the issue's minimal Go and JS repros (both now emit 0 recovery captures) and on `benches/fixtures/{small,medium}.{go,js}` (also 0). Remaining recoveries on `large`/`xlarge` come from unrelated partial-parse bugs (e.g. function bodies that don't fully parse, byte-eaten by the same loop) — out of scope here.
