### PR TITLE
go: fix type-switch guard parsing

### DIFF
--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -240,10 +240,13 @@ postfix_op    <- @punctuation{'.'} postfix_selector
 postfix_op_nc <- @punctuation{'.'} postfix_selector
                / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
                / @punctuation{'('} ws call_args? ws @punctuation{')'}
-postfix_selector <- @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}           # x.(type) (only in type switch; accepted here too)
-                  / @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
+postfix_selector <- @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
                   / @function{ident} &(ws @punctuation{'('})
                   / @property{ident}
+# `x.(type)` is intentionally not a postfix here: it is only valid inside
+# a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
+# Letting `postfix_selector` swallow it would leave nothing for the guard
+# to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
 slice_or_index <- expr? ws @punctuation{':'} ws expr? (ws @punctuation{':'} ws expr)?
                / expr
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -23,7 +23,7 @@
 # Recovery: top-level uses `*^` so malformed top-level declarations
 # don't abort the whole file.
 
-go_file       <- ws package_clause ws (import_decl ws)* (top_decl)*^ ws !.
+go_file       <- ws package_clause ws (import_decl ws)* (top_decl ws)*^ !.
 
 # --- Package / imports ----------------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -28,7 +28,7 @@
 # Recovery: top-level uses `*^` so malformed statements don't abort
 # the whole file.
 
-js_file        <- ws (stmt)*^ ws !.
+js_file        <- ws (stmt ws)*^ !.
 
 # --- Statements -------------------------------------------------------
 #

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -39,6 +39,22 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+/// Collect recovery captures whose text contains anything other than ASCII
+/// whitespace. Trailing-newline recovery is a known pre-existing quirk (see
+/// #71); this filter keeps callers focused on real recovery regressions.
+fn non_ws_recovery_literals<'a>(
+    captures: &[Capture],
+    kinds: &[String],
+    input: &'a str,
+) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "recovery")
+        .map(|c| &input[c.start..c.end])
+        .filter(|s| s.chars().any(|ch| !ch.is_ascii_whitespace()))
+        .collect()
+}
+
 #[test]
 fn grammar_parses_and_compiles() {
     let prog = compile_go();
@@ -149,7 +165,50 @@ fn for_c_style_parses() {
 #[test]
 fn switch_type_switch_parses() {
     let input = "package p\n\nfunc f(x interface{}) {\n\tswitch v := x.(type) {\n\tcase int:\n\t\t_ = v\n\tcase string:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
-    let (_, _) = assert_complete_full(input);
+    let (caps, kinds) = assert_complete_full(input);
+    // Top-level `*^` recovery would let this pass even when the body fails
+    // to parse — explicitly assert the body landed under no recovery and
+    // that the guard produced the expected `switch`, `type`, and `case`
+    // keywords.
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch body should parse cleanly, recovered: {:?}",
+        leaks
+    );
+    let keyword_count = |kw: &str| {
+        caps.iter()
+            .filter(|c| kinds[c.kind.0 as usize] == "keyword")
+            .filter(|c| &input[c.start..c.end] == kw)
+            .count()
+    };
+    assert_eq!(keyword_count("switch"), 1);
+    assert_eq!(keyword_count("type"), 1, "expected `type` inside the guard");
+    assert_eq!(keyword_count("case"), 2);
+}
+
+#[test]
+fn type_switch_with_init_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch y := lookup(); v := y.(type) {\n\tcase int:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch with init clause should parse cleanly, recovered: {:?}",
+        leaks
+    );
+}
+
+#[test]
+fn type_switch_without_assignment_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch x.(type) {\n\tcase int:\n\tdefault:\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "anonymous type-switch should parse cleanly, recovered: {:?}",
+        leaks
+    );
 }
 
 #[test]

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -246,3 +246,17 @@ fn recovery_absorbs_malformed_item() {
         k
     );
 }
+
+#[test]
+fn blank_lines_between_top_decls_emit_no_recovery() {
+    // Regression: file-root `(top_decl)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "package main\n\nfunc a() {}\n\nfunc b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        k
+    );
+}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -329,6 +329,20 @@ fn recovery_absorbs_malformed_item() {
 }
 
 #[test]
+fn blank_lines_between_top_stmts_emit_no_recovery() {
+    // Regression: file-root `(stmt)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "function a() {}\n\nfunction b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        !kv.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        kv
+    );
+}
+
+#[test]
 fn method_chain_with_call_parses() {
     let input = "const r = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);\n";
     let (caps, kinds) = assert_complete_full(input);


### PR DESCRIPTION
Part of the recovery-bug stack #77 → #78 → #79 → #80 → #83 → #84 → #85 (this PR is 2/7). Stack PRs target `main` directly to avoid the cascade-on-merge GitHub does when a PR's base branch is deleted; to see just this PR's diff, [compare against the predecessor branch](https://github.com/stefanobaghino/syntax-highlighter/compare/worktree-issue-71-file-root-ws...fix-issue-72-type-switch).

Fixes #72.

`postfix_selector`'s first alternative matched `(type)`, so when `type_switch_guard` tried to consume `v.(type)` via its lead `expr_no_compound`, the postfix swallowed the whole `.(type)` and left nothing for the guard's mandatory tail. Both `switch_stmt` alternatives then failed and `func_decl` rolled back into the top-level `*^` recovery — every byte of the function body ended up as `recovery`.

The fix removes the `.(type)` alternative from `postfix_selector`. `x.(type)` is only valid inside a type-switch guard, where the `.(type)` tail is matched explicitly by `type_switch_guard`, so dropping the postfix is safe and lets the guard's tail match as designed.

## Test plan

Regression tests strengthen `switch_type_switch_parses` (it previously passed even when the whole body was top-level `*^` recovery, since the rule reaches `End` regardless) and add `type_switch_with_init_parses` plus `type_switch_without_assignment_parses`. A `non_ws_recovery_literals` test helper filters whitespace-only recoveries so the new assertions stay focused on real regressions until #71 is resolved.
