### PR TITLE
js: accept reserved words at IdentifierName positions

### DIFF
--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -240,10 +240,13 @@ postfix_op    <- @punctuation{'.'} postfix_selector
 postfix_op_nc <- @punctuation{'.'} postfix_selector
                / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
                / @punctuation{'('} ws call_args? ws @punctuation{')'}
-postfix_selector <- @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}           # x.(type) (only in type switch; accepted here too)
-                  / @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
+postfix_selector <- @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
                   / @function{ident} &(ws @punctuation{'('})
                   / @property{ident}
+# `x.(type)` is intentionally not a postfix here: it is only valid inside
+# a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
+# Letting `postfix_selector` swallow it would leave nothing for the guard
+# to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
 slice_or_index <- expr? ws @punctuation{':'} ws expr? (ws @punctuation{':'} ws expr)?
                / expr
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -23,7 +23,7 @@
 # Recovery: top-level uses `*^` so malformed top-level declarations
 # don't abort the whole file.
 
-go_file       <- ws package_clause ws (import_decl ws)* (top_decl)*^ ws !.
+go_file       <- ws package_clause ws (import_decl ws)* (top_decl ws)*^ !.
 
 # --- Package / imports ----------------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -28,7 +28,7 @@
 # Recovery: top-level uses `*^` so malformed statements don't abort
 # the whole file.
 
-js_file        <- ws (stmt)*^ ws !.
+js_file        <- ws (stmt ws)*^ !.
 
 # --- Statements -------------------------------------------------------
 #

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -73,11 +73,11 @@ import_ns_or_named <- import_namespace / import_named
 import_namespace <- @operator{'*'} ws @keyword{'as'} ws @variable{ident}
 import_named   <- @punctuation{'{'} ws import_specifier_list? ws @punctuation{'}'}
 import_specifier_list <- import_specifier (ws @punctuation{','} ws import_specifier)* (ws @punctuation{','})?
-import_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+import_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident}
                   / @variable{ident}
 
 export_decl    <- @keyword{'export'} ws @keyword{'default'} ws export_default_body
-                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident} ws)? @keyword{'from'} ws string_lit ws opt_semi
+                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident_name} ws)? @keyword{'from'} ws string_lit ws opt_semi
                 / @keyword{'export'} ws export_named
                 / @keyword{'export'} ws fn_decl
                 / @keyword{'export'} ws class_decl
@@ -87,7 +87,7 @@ export_default_body <- fn_decl
                      / expr ws opt_semi
 export_named   <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
 export_specifier_list <- export_specifier (ws @punctuation{','} ws export_specifier)* (ws @punctuation{','})?
-export_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+export_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
@@ -105,10 +105,10 @@ class_method_or_field <- (@keyword{'static'} ws)? (class_method / class_field)
 class_method   <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block ws
                 / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block ws
 method_head    <- computed_prop
-                / @function{ident}
+                / @function{ident_name}
                 / string_lit
                 / number_lit
-class_field    <- (computed_prop / @property{ident}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
+class_field    <- (computed_prop / @property{ident_name}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
 
 # --- Variable declarations -------------------------------------------
 
@@ -167,7 +167,7 @@ array_pattern_el <- @operator{'...'} pattern
 object_pattern <- @punctuation{'{'} ws object_pattern_list? ws @punctuation{'}'}
 object_pattern_list <- object_pattern_prop (ws @punctuation{','} ws object_pattern_prop)* (ws @punctuation{','})?
 object_pattern_prop <- @operator{'...'} pattern
-                     / (computed_prop / @property{ident}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
+                     / (computed_prop / @property{ident_name}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
                      / @property{ident} (ws @operator{'='} ws expr_no_comma)?
 
 computed_prop  <- @punctuation{'['} ws expr ws @punctuation{']'}
@@ -244,8 +244,8 @@ postfix_op     <- @operator{'++'}
 postfix_after_optional <- call_args
                         / @punctuation{'['} ws expr ws @punctuation{']'}
                         / member_target
-member_target  <- @function{ident} &(ws @punctuation{'('})
-                / @property{ident}
+member_target  <- @function{ident_name} &(ws @punctuation{'('})
+                / @property{ident_name}
 call_args      <- @punctuation{'('} ws arg_list? ws @punctuation{')'}
 arg_list       <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
 arg            <- @operator{'...'} expr_no_comma
@@ -285,7 +285,7 @@ expr_object    <- @punctuation{'{'} ws object_props? ws @punctuation{'}'}
 object_props   <- object_prop (ws @punctuation{','} ws object_prop)* (ws @punctuation{','})?
 object_prop    <- @operator{'...'} expr_no_comma
                 / object_method
-                / (computed_prop / string_lit / number_lit / @property{ident}) ws @punctuation{':'} ws expr_no_comma
+                / (computed_prop / string_lit / number_lit / @property{ident_name}) ws @punctuation{':'} ws expr_no_comma
                 / @property{ident}
 object_method  <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block
                 / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block
@@ -336,6 +336,12 @@ bigint         <- 'n'
 # --- Identifiers / reserved words ------------------------------------
 
 ident          <- !reserved ident_start ident_body*
+# `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
+# `!reserved` guard is dropped so reserved words are accepted. Use at
+# positions where ES allows IdentifierName but not BindingIdentifier
+# (member access after `.` / `?.`, property keys, imported/exported
+# names that aren't local bindings).
+ident_name     <- ident_start ident_body*
 upper_ident    <- !reserved [A-Z] ident_body*
 lower_ident    <- !reserved [a-z_$] ident_body*
 ident_start    <- [A-Za-z_$]

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -39,6 +39,22 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+/// Collect recovery captures whose text contains anything other than ASCII
+/// whitespace. Trailing-newline recovery is a known pre-existing quirk (see
+/// #71); this filter keeps callers focused on real recovery regressions.
+fn non_ws_recovery_literals<'a>(
+    captures: &[Capture],
+    kinds: &[String],
+    input: &'a str,
+) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "recovery")
+        .map(|c| &input[c.start..c.end])
+        .filter(|s| s.chars().any(|ch| !ch.is_ascii_whitespace()))
+        .collect()
+}
+
 #[test]
 fn grammar_parses_and_compiles() {
     let prog = compile_go();
@@ -149,7 +165,50 @@ fn for_c_style_parses() {
 #[test]
 fn switch_type_switch_parses() {
     let input = "package p\n\nfunc f(x interface{}) {\n\tswitch v := x.(type) {\n\tcase int:\n\t\t_ = v\n\tcase string:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
-    let (_, _) = assert_complete_full(input);
+    let (caps, kinds) = assert_complete_full(input);
+    // Top-level `*^` recovery would let this pass even when the body fails
+    // to parse — explicitly assert the body landed under no recovery and
+    // that the guard produced the expected `switch`, `type`, and `case`
+    // keywords.
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch body should parse cleanly, recovered: {:?}",
+        leaks
+    );
+    let keyword_count = |kw: &str| {
+        caps.iter()
+            .filter(|c| kinds[c.kind.0 as usize] == "keyword")
+            .filter(|c| &input[c.start..c.end] == kw)
+            .count()
+    };
+    assert_eq!(keyword_count("switch"), 1);
+    assert_eq!(keyword_count("type"), 1, "expected `type` inside the guard");
+    assert_eq!(keyword_count("case"), 2);
+}
+
+#[test]
+fn type_switch_with_init_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch y := lookup(); v := y.(type) {\n\tcase int:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch with init clause should parse cleanly, recovered: {:?}",
+        leaks
+    );
+}
+
+#[test]
+fn type_switch_without_assignment_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch x.(type) {\n\tcase int:\n\tdefault:\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "anonymous type-switch should parse cleanly, recovered: {:?}",
+        leaks
+    );
 }
 
 #[test]

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -246,3 +246,17 @@ fn recovery_absorbs_malformed_item() {
         k
     );
 }
+
+#[test]
+fn blank_lines_between_top_decls_emit_no_recovery() {
+    // Regression: file-root `(top_decl)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "package main\n\nfunc a() {}\n\nfunc b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        k
+    );
+}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -329,6 +329,20 @@ fn recovery_absorbs_malformed_item() {
 }
 
 #[test]
+fn blank_lines_between_top_stmts_emit_no_recovery() {
+    // Regression: file-root `(stmt)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "function a() {}\n\nfunction b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        !kv.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        kv
+    );
+}
+
+#[test]
 fn method_chain_with_call_parses() {
     let input = "const r = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);\n";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -487,3 +487,82 @@ fn try_then_return_keeps_function_keyword() {
         kw
     );
 }
+
+// Regression tests for #73: reserved words must be accepted at
+// IdentifierName positions (member access, property keys, imported
+// /exported names) where ES allows them but rejects only at binding
+// positions.
+
+#[test]
+fn reserved_word_after_dot_parses() {
+    let input = "main().catch(e => log(e));\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for `.catch(...)`: {:?}",
+        k
+    );
+}
+
+#[test]
+fn reserved_word_after_dot_without_call_is_property() {
+    let input = "p.catch;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for `.catch;`: {:?}",
+        k
+    );
+    let catch_pos = input.find("catch").unwrap();
+    let catch_cap = caps.iter().find(|c| c.start == catch_pos).unwrap();
+    assert_eq!(kinds[catch_cap.kind.0 as usize], "property");
+}
+
+#[test]
+fn reserved_word_after_optional_chain_parses() {
+    let input = "obj?.delete; obj?.return(); obj?.['x'];\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for optional-chain `?.<reserved>`: {:?}",
+        k
+    );
+}
+
+#[test]
+fn reserved_word_as_object_key_parses() {
+    let (_, _) = assert_complete_full("const o = { catch: 1, default: 2, new: 3 };\n");
+}
+
+#[test]
+fn reserved_word_as_object_method_shorthand_parses() {
+    let (_, _) = assert_complete_full("const o = { catch() { return 1; }, default() {} };\n");
+}
+
+#[test]
+fn reserved_word_as_class_method_and_field_parses() {
+    let (_, _) = assert_complete_full("class C { catch() {} default = 1; static return() {} }\n");
+}
+
+#[test]
+fn reserved_word_in_object_destructuring_key_parses() {
+    let (_, _) = assert_complete_full("const { default: d, catch: c } = obj;\n");
+}
+
+#[test]
+fn import_specifier_allows_reserved_imported_name() {
+    let (_, _) = assert_complete_full("import { default as foo, class as Cls } from 'm';\n");
+}
+
+#[test]
+fn export_specifier_allows_reserved_exported_name() {
+    let (_, _) = assert_complete_full("export { foo as default, bar as class };\n");
+}
+
+#[test]
+fn export_star_as_reserved_parses() {
+    let (_, _) = assert_complete_full("export * as default from 'm';\n");
+}

--- a/tests/parse_javascript_tests.rs
+++ b/tests/parse_javascript_tests.rs
@@ -69,3 +69,21 @@ fn null_is_constant() {
     let pos = input.find("null").unwrap();
     assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("constant"));
 }
+
+// #73: reserved words after `.` are IdentifierName, not Identifier —
+// they must capture under the member-access kind rather than fall
+// into recovery.
+
+#[test]
+fn reserved_after_dot_with_call_is_function() {
+    let input = "main().catch(e);\n";
+    let pos = input.find(".catch").unwrap() + 1;
+    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("function"));
+}
+
+#[test]
+fn reserved_after_dot_without_call_is_property() {
+    let input = "p.catch;\n";
+    let pos = input.find("catch").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("property"));
+}


### PR DESCRIPTION
Part of the recovery-bug stack #77 → #78 → #79 → #80 → #83 → #84 → #85 (this PR is 3/7). Stack PRs target `main` directly to avoid the cascade-on-merge GitHub does when a PR's base branch is deleted; to see just this PR's diff, [compare against the predecessor branch](https://github.com/stefanobaghino/syntax-highlighter/compare/fix-issue-72-type-switch...worktree-issue-73-js-reserved-member-access).

Fixes #73. JS reserved words (`catch`, `delete`, `default`, `class`, …) were rejected at IdentifierName positions because `member_target` and friends all delegated to `ident`, which carries an `!reserved` guard. `main().catch(…)` would parse `main()` cleanly, then `.c` would land in `recovery` and `atch` would re-capture as a fresh identifier.

Splits `ident` into two rules in `grammars/javascript.peg`:

- `ident` — BindingIdentifier (keeps `!reserved`)
- `ident_name` — IdentifierName (drops the guard)

Routes `ident_name` through the positions where ES allows reserved words: member access after `.` / `?.`, property keys in object literals / patterns / class bodies, method names, and imported / exported names that aren't local bindings. Binding positions (`var` / `let` / `const` targets, fn params, labels, `import` default / namespace, shorthand props) stay on `ident`.

## Test plan

New regression tests live in `tests/grammar_javascript_tests.rs` (10 cases) and `tests/parse_javascript_tests.rs` (2 cases). Additionally spot-checked `benches/fixtures/large.js:577` (`main().catch(e => console.error(e?.stack ?? e));`) via `pegdb dump-captures`: `catch` now captures as `function`, `?.stack` as `property`, no `recovery` on the line.
