### PR TITLE
rust: parse Fn-trait paren-sugar in path segments

### DIFF
--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -240,10 +240,13 @@ postfix_op    <- @punctuation{'.'} postfix_selector
 postfix_op_nc <- @punctuation{'.'} postfix_selector
                / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
                / @punctuation{'('} ws call_args? ws @punctuation{')'}
-postfix_selector <- @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}           # x.(type) (only in type switch; accepted here too)
-                  / @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
+postfix_selector <- @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
                   / @function{ident} &(ws @punctuation{'('})
                   / @property{ident}
+# `x.(type)` is intentionally not a postfix here: it is only valid inside
+# a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
+# Letting `postfix_selector` swallow it would leave nothing for the guard
+# to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
 slice_or_index <- expr? ws @punctuation{':'} ws expr? (ws @punctuation{':'} ws expr)?
                / expr
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -23,7 +23,7 @@
 # Recovery: top-level uses `*^` so malformed top-level declarations
 # don't abort the whole file.
 
-go_file       <- ws package_clause ws (import_decl ws)* (top_decl)*^ ws !.
+go_file       <- ws package_clause ws (import_decl ws)* (top_decl ws)*^ !.
 
 # --- Package / imports ----------------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -28,7 +28,7 @@
 # Recovery: top-level uses `*^` so malformed statements don't abort
 # the whole file.
 
-js_file        <- ws (stmt)*^ ws !.
+js_file        <- ws (stmt ws)*^ !.
 
 # --- Statements -------------------------------------------------------
 #

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -73,11 +73,11 @@ import_ns_or_named <- import_namespace / import_named
 import_namespace <- @operator{'*'} ws @keyword{'as'} ws @variable{ident}
 import_named   <- @punctuation{'{'} ws import_specifier_list? ws @punctuation{'}'}
 import_specifier_list <- import_specifier (ws @punctuation{','} ws import_specifier)* (ws @punctuation{','})?
-import_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+import_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident}
                   / @variable{ident}
 
 export_decl    <- @keyword{'export'} ws @keyword{'default'} ws export_default_body
-                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident} ws)? @keyword{'from'} ws string_lit ws opt_semi
+                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident_name} ws)? @keyword{'from'} ws string_lit ws opt_semi
                 / @keyword{'export'} ws export_named
                 / @keyword{'export'} ws fn_decl
                 / @keyword{'export'} ws class_decl
@@ -87,7 +87,7 @@ export_default_body <- fn_decl
                      / expr ws opt_semi
 export_named   <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
 export_specifier_list <- export_specifier (ws @punctuation{','} ws export_specifier)* (ws @punctuation{','})?
-export_specifier <- @variable{ident} ws @keyword{'as'} ws @variable{ident}
+export_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
@@ -105,10 +105,10 @@ class_method_or_field <- (@keyword{'static'} ws)? (class_method / class_field)
 class_method   <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block ws
                 / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block ws
 method_head    <- computed_prop
-                / @function{ident}
+                / @function{ident_name}
                 / string_lit
                 / number_lit
-class_field    <- (computed_prop / @property{ident}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
+class_field    <- (computed_prop / @property{ident_name}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
 
 # --- Variable declarations -------------------------------------------
 
@@ -167,7 +167,7 @@ array_pattern_el <- @operator{'...'} pattern
 object_pattern <- @punctuation{'{'} ws object_pattern_list? ws @punctuation{'}'}
 object_pattern_list <- object_pattern_prop (ws @punctuation{','} ws object_pattern_prop)* (ws @punctuation{','})?
 object_pattern_prop <- @operator{'...'} pattern
-                     / (computed_prop / @property{ident}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
+                     / (computed_prop / @property{ident_name}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
                      / @property{ident} (ws @operator{'='} ws expr_no_comma)?
 
 computed_prop  <- @punctuation{'['} ws expr ws @punctuation{']'}
@@ -244,8 +244,8 @@ postfix_op     <- @operator{'++'}
 postfix_after_optional <- call_args
                         / @punctuation{'['} ws expr ws @punctuation{']'}
                         / member_target
-member_target  <- @function{ident} &(ws @punctuation{'('})
-                / @property{ident}
+member_target  <- @function{ident_name} &(ws @punctuation{'('})
+                / @property{ident_name}
 call_args      <- @punctuation{'('} ws arg_list? ws @punctuation{')'}
 arg_list       <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
 arg            <- @operator{'...'} expr_no_comma
@@ -285,7 +285,7 @@ expr_object    <- @punctuation{'{'} ws object_props? ws @punctuation{'}'}
 object_props   <- object_prop (ws @punctuation{','} ws object_prop)* (ws @punctuation{','})?
 object_prop    <- @operator{'...'} expr_no_comma
                 / object_method
-                / (computed_prop / string_lit / number_lit / @property{ident}) ws @punctuation{':'} ws expr_no_comma
+                / (computed_prop / string_lit / number_lit / @property{ident_name}) ws @punctuation{':'} ws expr_no_comma
                 / @property{ident}
 object_method  <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block
                 / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block
@@ -336,6 +336,12 @@ bigint         <- 'n'
 # --- Identifiers / reserved words ------------------------------------
 
 ident          <- !reserved ident_start ident_body*
+# `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
+# `!reserved` guard is dropped so reserved words are accepted. Use at
+# positions where ES allows IdentifierName but not BindingIdentifier
+# (member access after `.` / `?.`, property keys, imported/exported
+# names that aren't local bindings).
+ident_name     <- ident_start ident_body*
 upper_ident    <- !reserved [A-Z] ident_body*
 lower_ident    <- !reserved [a-z_$] ident_body*
 ident_start    <- [A-Za-z_$]

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -441,7 +441,7 @@ num_suffix    <- [a-zA-Z_] [a-zA-Z0-9_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
-lifetime      <- @type{"'" ident_body}
+lifetime      <- @type{"'" ident_body+}
 
 # `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
 # of special meaning for highlighting.

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -78,7 +78,7 @@ fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
 fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
 fn_param      <- attr_outer? self_param
                / attr_outer? fn_param_named
-fn_param_named <- pattern ws @punctuation{':'} ws type_expr
+fn_param_named <- pattern_no_or ws @punctuation{':'} ws type_expr
 self_param    <- ref_marker? ws (@keyword{'mut'} ws)? @keyword{'self'}
                / @keyword{'mut'} ws @keyword{'self'}
                / @keyword{'self'} ws @punctuation{':'} ws type_expr
@@ -215,8 +215,14 @@ generic_arg   <- lifetime
                / literal
 
 # --- Patterns ----------------------------------------------------------
+#
+# `pattern` allows a top-level or-pattern (`A | B`). In positions where
+# the surrounding rule uses `|` as its own delimiter (closure params,
+# fn params), use `pattern_no_or` so the closing `|` isn't eaten by
+# `pattern_or`'s greedy `*`. Mirrors Rust's reference `PatternNoTopAlt`.
 
 pattern       <- pattern_or
+pattern_no_or <- pattern_atom
 pattern_or    <- pattern_atom (ws @punctuation{'|'} ws pattern_atom)*
 pattern_atom  <- pattern_ref
                / pattern_box
@@ -340,7 +346,7 @@ expr_unsafe   <- @keyword{'unsafe'} ws block
 expr_closure  <- (@keyword{'move'} ws)? @punctuation{'|'} ws closure_params? ws @punctuation{'|'}
                  (ws @punctuation{'->'} ws type_expr)? ws expr
 closure_params <- closure_param (ws @punctuation{','} ws closure_param)* (ws @punctuation{','})?
-closure_param <- pattern (ws @punctuation{':'} ws type_expr)?
+closure_param <- pattern_no_or (ws @punctuation{':'} ws type_expr)?
 expr_block    <- block
 expr_async_block <- @keyword{'async'} (ws @keyword{'move'})? ws block
 expr_tuple_or_paren <- @punctuation{'('} ws expr_list? ws @punctuation{')'}

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -198,15 +198,21 @@ type_tuple_or_group <- @punctuation{'('} ws type_list? ws @punctuation{')'}
 type_never    <- @punctuation{'!'}
 
 type_path     <- type_path_seg (@punctuation{'::'} type_path_seg)*
-type_path_seg <- @type{upper_ident} generic_args?
-               / @variable{lower_ident} generic_args?
+type_path_seg <- @type{upper_ident} path_tail?
+               / @variable{lower_ident} path_tail?
                / @keyword{'self'}
                / @keyword{'Self'}
                / @keyword{'super'}
                / @keyword{'crate'}
 
+# Either angle-bracket generics (`Foo<T>`) or paren-sugar for Fn-traits
+# (`Fn(T) -> U`); Rust's reference grammar splits these as
+# `GenericArgs` vs `ParenthesizedGenericArgs`.
+path_tail     <- generic_args
+               / paren_generic_args
 generic_args  <- @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
                / @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
+paren_generic_args <- @punctuation{'('} ws type_list? ws @punctuation{')'} (ws @punctuation{'->'} ws type_expr)?
 generic_arg_list <- generic_arg (ws @punctuation{','} ws generic_arg)* (ws @punctuation{','})?
 generic_arg   <- lifetime
                / type_expr

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -39,6 +39,22 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+/// Collect recovery captures whose text contains anything other than ASCII
+/// whitespace. Trailing-newline recovery is a known pre-existing quirk (see
+/// #71); this filter keeps callers focused on real recovery regressions.
+fn non_ws_recovery_literals<'a>(
+    captures: &[Capture],
+    kinds: &[String],
+    input: &'a str,
+) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "recovery")
+        .map(|c| &input[c.start..c.end])
+        .filter(|s| s.chars().any(|ch| !ch.is_ascii_whitespace()))
+        .collect()
+}
+
 #[test]
 fn grammar_parses_and_compiles() {
     let prog = compile_go();
@@ -149,7 +165,50 @@ fn for_c_style_parses() {
 #[test]
 fn switch_type_switch_parses() {
     let input = "package p\n\nfunc f(x interface{}) {\n\tswitch v := x.(type) {\n\tcase int:\n\t\t_ = v\n\tcase string:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
-    let (_, _) = assert_complete_full(input);
+    let (caps, kinds) = assert_complete_full(input);
+    // Top-level `*^` recovery would let this pass even when the body fails
+    // to parse — explicitly assert the body landed under no recovery and
+    // that the guard produced the expected `switch`, `type`, and `case`
+    // keywords.
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch body should parse cleanly, recovered: {:?}",
+        leaks
+    );
+    let keyword_count = |kw: &str| {
+        caps.iter()
+            .filter(|c| kinds[c.kind.0 as usize] == "keyword")
+            .filter(|c| &input[c.start..c.end] == kw)
+            .count()
+    };
+    assert_eq!(keyword_count("switch"), 1);
+    assert_eq!(keyword_count("type"), 1, "expected `type` inside the guard");
+    assert_eq!(keyword_count("case"), 2);
+}
+
+#[test]
+fn type_switch_with_init_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch y := lookup(); v := y.(type) {\n\tcase int:\n\t\t_ = v\n\tdefault:\n\t\t_ = v\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "type-switch with init clause should parse cleanly, recovered: {:?}",
+        leaks
+    );
+}
+
+#[test]
+fn type_switch_without_assignment_parses() {
+    let input = "package p\n\nfunc f(x interface{}) {\n\tswitch x.(type) {\n\tcase int:\n\tdefault:\n\t}\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let leaks = non_ws_recovery_literals(&caps, &kinds, input);
+    assert!(
+        leaks.is_empty(),
+        "anonymous type-switch should parse cleanly, recovered: {:?}",
+        leaks
+    );
 }
 
 #[test]

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -246,3 +246,17 @@ fn recovery_absorbs_malformed_item() {
         k
     );
 }
+
+#[test]
+fn blank_lines_between_top_decls_emit_no_recovery() {
+    // Regression: file-root `(top_decl)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "package main\n\nfunc a() {}\n\nfunc b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        k
+    );
+}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -329,6 +329,20 @@ fn recovery_absorbs_malformed_item() {
 }
 
 #[test]
+fn blank_lines_between_top_stmts_emit_no_recovery() {
+    // Regression: file-root `(stmt)*^` used to drop inter-iteration ws,
+    // sending blank-line bytes through the recovery byte-eater. See #71.
+    let input = "function a() {}\n\nfunction b() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        !kv.contains(&"recovery"),
+        "well-formed input should emit no @recovery captures, got: {:?}",
+        kv
+    );
+}
+
+#[test]
 fn method_chain_with_call_parses() {
     let input = "const r = arr.filter(x => x > 0).map(x => x * 2).reduce((a, b) => a + b, 0);\n";
     let (caps, kinds) = assert_complete_full(input);

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -487,3 +487,82 @@ fn try_then_return_keeps_function_keyword() {
         kw
     );
 }
+
+// Regression tests for #73: reserved words must be accepted at
+// IdentifierName positions (member access, property keys, imported
+// /exported names) where ES allows them but rejects only at binding
+// positions.
+
+#[test]
+fn reserved_word_after_dot_parses() {
+    let input = "main().catch(e => log(e));\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for `.catch(...)`: {:?}",
+        k
+    );
+}
+
+#[test]
+fn reserved_word_after_dot_without_call_is_property() {
+    let input = "p.catch;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for `.catch;`: {:?}",
+        k
+    );
+    let catch_pos = input.find("catch").unwrap();
+    let catch_cap = caps.iter().find(|c| c.start == catch_pos).unwrap();
+    assert_eq!(kinds[catch_cap.kind.0 as usize], "property");
+}
+
+#[test]
+fn reserved_word_after_optional_chain_parses() {
+    let input = "obj?.delete; obj?.return(); obj?.['x'];\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "no recovery expected for optional-chain `?.<reserved>`: {:?}",
+        k
+    );
+}
+
+#[test]
+fn reserved_word_as_object_key_parses() {
+    let (_, _) = assert_complete_full("const o = { catch: 1, default: 2, new: 3 };\n");
+}
+
+#[test]
+fn reserved_word_as_object_method_shorthand_parses() {
+    let (_, _) = assert_complete_full("const o = { catch() { return 1; }, default() {} };\n");
+}
+
+#[test]
+fn reserved_word_as_class_method_and_field_parses() {
+    let (_, _) = assert_complete_full("class C { catch() {} default = 1; static return() {} }\n");
+}
+
+#[test]
+fn reserved_word_in_object_destructuring_key_parses() {
+    let (_, _) = assert_complete_full("const { default: d, catch: c } = obj;\n");
+}
+
+#[test]
+fn import_specifier_allows_reserved_imported_name() {
+    let (_, _) = assert_complete_full("import { default as foo, class as Cls } from 'm';\n");
+}
+
+#[test]
+fn export_specifier_allows_reserved_exported_name() {
+    let (_, _) = assert_complete_full("export { foo as default, bar as class };\n");
+}
+
+#[test]
+fn export_star_as_reserved_parses() {
+    let (_, _) = assert_complete_full("export * as default from 'm';\n");
+}

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -167,6 +167,23 @@ fn bitor_still_works_outside_closure_position() {
 }
 
 #[test]
+fn closure_with_tuple_destructure_param_parses() {
+    // Regression: `pattern_or`'s greedy `*` used to swallow the closing
+    // `|` of `expr_closure` when the param was an or-eligible
+    // `pattern_atom` (`(_, &n)` here), dropping the body and the rest
+    // of the enclosing item into recovery. `closure_param` now uses
+    // `pattern_no_or` so the delimiter stays free.
+    let input = "fn f() { let top = max_by_key(|(_, &n)| n); }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let kv = kinds_for(&caps, &kinds);
+    assert!(
+        !kv.contains(&"recovery"),
+        "closure with tuple destructuring should not recover: {:?}",
+        kv
+    );
+}
+
+#[test]
 fn method_chain_with_turbofish_parses() {
     let input = "fn f() { v.iter().map(|x| x + 1).collect::<Vec<_>>(); }\n";
     let (_, _) = assert_complete_full(input);

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -253,6 +253,29 @@ fn where_clause_parses() {
 }
 
 #[test]
+fn fn_trait_paren_sugar_parses() {
+    // `Fn(T) -> U` / `FnMut(T)` / `FnOnce(T) -> U` are paren-sugar for
+    // the Fn-trait family — see #82. `type_path_seg`'s tail must accept
+    // both angle-bracket generics and the parenthesized form.
+    for input in [
+        "fn with_each<F: FnMut(i64)>(f: F) {}\n",
+        "fn map_fn<F: Fn(i64) -> i64>(f: F) {}\n",
+        "fn consume<F: FnOnce()>(f: F) {}\n",
+        "fn boxed(f: Box<dyn Fn(i64) -> i64>) {}\n",
+        "fn dual<F: Fn(i64) -> i64 + Send>(f: F) {}\n",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        let recs = recovery_literals(&caps, &kinds, input);
+        assert!(
+            recs.is_empty(),
+            "expected no recovery on `{}` — got {:?}",
+            input.trim_end(),
+            recs
+        );
+    }
+}
+
+#[test]
 fn impl_with_generic_params_parses() {
     let input = "impl<T: Clone> Foo<T> { pub fn new() -> Self { Self { a: T::default() } } }\n";
     let (_, _) = assert_complete_full(input);

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -47,6 +47,14 @@ fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String>
         .collect()
 }
 
+fn recovery_literals<'a>(captures: &[Capture], kinds: &[String], input: &'a str) -> Vec<&'a str> {
+    captures
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "recovery")
+        .map(|c| &input[c.start..c.end])
+        .collect()
+}
+
 #[test]
 fn grammar_parses_and_compiles() {
     let prog = compile_rust();
@@ -206,12 +214,42 @@ fn lifetime_parses_as_type() {
         "lifetime `'a` should be captured as @type: {:?}",
         kv
     );
+    assert!(
+        recovery_literals(&caps, &kinds, input).is_empty(),
+        "no recovery expected for single-char lifetime"
+    );
+}
+
+#[test]
+fn multi_char_lifetime_parses() {
+    // `'static` and other multi-char lifetimes must reach the lifetime
+    // rule's full ident_body sequence — see #81.
+    for input in [
+        "fn k() -> &'static str { \"x\" }\n",
+        "fn k<'lt>(s: &'lt str) -> &'lt str { s }\n",
+        "fn k<'long_name>(x: &'long_name u8) {}\n",
+        "fn f<T>(x: T) where T: Clone + Send + 'static {}\n",
+        "fn f() -> Vec<(i64, &'static str)> { vec![] }\n",
+    ] {
+        let (caps, kinds) = assert_complete_full(input);
+        let recs = recovery_literals(&caps, &kinds, input);
+        assert!(
+            recs.is_empty(),
+            "expected no recovery on `{}` — got {:?}",
+            input.trim_end(),
+            recs
+        );
+    }
 }
 
 #[test]
 fn where_clause_parses() {
     let input = "fn f<T>(x: T) where T: Clone + Send + 'static {}\n";
-    let (_, _) = assert_complete_full(input);
+    let (caps, kinds) = assert_complete_full(input);
+    assert!(
+        recovery_literals(&caps, &kinds, input).is_empty(),
+        "where-clause with `'static` should not recover"
+    );
 }
 
 #[test]

--- a/tests/parse_javascript_tests.rs
+++ b/tests/parse_javascript_tests.rs
@@ -69,3 +69,21 @@ fn null_is_constant() {
     let pos = input.find("null").unwrap();
     assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("constant"));
 }
+
+// #73: reserved words after `.` are IdentifierName, not Identifier —
+// they must capture under the member-access kind rather than fall
+// into recovery.
+
+#[test]
+fn reserved_after_dot_with_call_is_function() {
+    let input = "main().catch(e);\n";
+    let pos = input.find(".catch").unwrap() + 1;
+    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("function"));
+}
+
+#[test]
+fn reserved_after_dot_without_call_is_property() {
+    let input = "p.catch;\n";
+    let pos = input.find("catch").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, pos).as_deref(), Some("property"));
+}


### PR DESCRIPTION
Part of the recovery-bug stack #77 → #78 → #79 → #80 → #83 → #84 → #85 (this PR is 6/7). Stack PRs target `main` directly to avoid the cascade-on-merge GitHub does when a PR's base branch is deleted; to see just this PR's diff, [compare against the predecessor branch](https://github.com/stefanobaghino/syntax-highlighter/compare/81-rust-multi-char-lifetimes...82-rust-fn-trait-paren-sugar).

Closes #82.

`type_path_seg`'s tail only accepted angle-bracket generics, so the Fn-trait paren-sugar — `Fn(T) -> U`, `FnMut(T)`, `FnOnce(T) -> U` — failed in every position that uses a path (trait bounds, `dyn` / `impl` traits, where-clauses, `Box<dyn …>`). Introduces a `path_tail` alt that picks between `generic_args` and a new `paren_generic_args` for the paren-sugar form, mirroring Rust's reference split of `GenericArgs` vs `ParenthesizedGenericArgs`.

Together with #81, drops residual recovery counts on every Rust fixture under `benches/fixtures/` to 0 — across all 32 fixtures (8 grammars × 4 sizes) the corpus is now recovery-clean.

## Test plan

New `fn_trait_paren_sugar_parses` in `tests/grammar_rust_tests.rs` covers `FnMut(i64)`, `Fn(i64) -> i64`, `FnOnce()`, `Box<dyn Fn(i64) -> i64>`, and `Fn(i64) -> i64 + Send` (with extra bounds).
