### PR TITLE
ignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.claude/worktrees/


### PR DESCRIPTION
Ignore `.claude/worktrees/`, where the Claude Code harness materialises agent worktrees, so it stops showing up as untracked.
