### PR TITLE
Preserve failed `*^` inner attempt's deepest captures

### DIFF
--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -145,6 +145,13 @@ const TAG_LR_TAIL: u8 = 0x24;
 const TAG_CAPTURE_BEGIN: u8 = 0x30;
 const TAG_CAPTURE_END: u8 = 0x31;
 
+// Per-iteration recovery-scope opcodes for `p*^`. See `Instruction`
+// docs and `src/pegc/compiler.rs` for usage. No payload: all state is
+// on the VM stack.
+const TAG_RECOVER_SCOPE_BEGIN: u8 = 0x40;
+const TAG_RECOVER_TO_SCOPED_MAX: u8 = 0x41;
+const TAG_RECOVER_SCOPE_END: u8 = 0x42;
+
 // `End` is the program-termination sentinel; placing it at the top of the
 // `u8` range (rather than in a grouped sub-range) keeps the
 // "I'm done, no more instructions" tag visually distinct from the
@@ -278,6 +285,9 @@ fn write_instruction(out: &mut Vec<u8>, ins: &Instruction) {
             out.extend_from_slice(&kind.0.to_le_bytes());
         }
         Instruction::CaptureEnd => out.push(TAG_CAPTURE_END),
+        Instruction::RecoverScopeBegin => out.push(TAG_RECOVER_SCOPE_BEGIN),
+        Instruction::RecoverToScopedMax => out.push(TAG_RECOVER_TO_SCOPED_MAX),
+        Instruction::RecoverScopeEnd => out.push(TAG_RECOVER_SCOPE_END),
         Instruction::End => out.push(TAG_END),
     }
 }
@@ -390,6 +400,9 @@ fn read_instruction(cur: &mut Cursor<'_>) -> Result<Instruction, Error> {
             Instruction::CaptureBegin(kind)
         }
         TAG_CAPTURE_END => Instruction::CaptureEnd,
+        TAG_RECOVER_SCOPE_BEGIN => Instruction::RecoverScopeBegin,
+        TAG_RECOVER_TO_SCOPED_MAX => Instruction::RecoverToScopedMax,
+        TAG_RECOVER_SCOPE_END => Instruction::RecoverScopeEnd,
         TAG_END => Instruction::End,
         _ => {
             return Err(Error::InvalidOpcode {
@@ -625,6 +638,9 @@ mod tests {
                 Instruction::LRTail(MemoId(1), Label(43)),
                 Instruction::CaptureBegin(CaptureKind(0)),
                 Instruction::CaptureEnd,
+                Instruction::RecoverScopeBegin,
+                Instruction::RecoverToScopedMax,
+                Instruction::RecoverScopeEnd,
                 Instruction::End,
             ],
             capture_kinds: vec!["alpha".to_string()],

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -193,37 +193,79 @@ impl Compiler {
                 inner,
                 recovery_kind,
             } => {
-                // loop_top: Choice rec
-                //           <inner>
-                //           Commit loop_top
-                // rec:      Choice exit       ; Any(1) at EOF exits cleanly
-                //           CaptureBegin <recovery_kind>
-                //           Any(1)
-                //           CaptureEnd
-                //           Commit loop_top
-                // exit:
+                // loop_top:    RecoverScopeBegin
+                //              Choice rec
+                //              <inner>
+                //              Commit next_iter       ; pops outer Backtrack
+                // rec:         Choice exit_inner      ; baseline frame: undoes
+                //                                     ;   materialization on EOF
+                //              RecoverToScopedMax     ; splice deepest-progress captures
+                //              CaptureBegin <recovery_kind>
+                //              Any(1)
+                //              CaptureEnd
+                //              Commit next_iter       ; pops inner Backtrack
+                // next_iter:   RecoverScopeEnd        ; pops RecoverScope
+                //              Jump loop_top
+                // exit_inner:  RecoverScopeEnd        ; EOF exit edge
                 //
-                // Uses fresh Choice/Commit per iteration (not PartialCommit) so
-                // each retry gets a backtrack baseline at the advanced sp; an
-                // in-place PartialCommit on a stale frame would violate the
-                // hazard documented in src/pegvm/README.md invariant 1.
+                // The success and recovery-success edges route through the
+                // shared `next_iter` epilogue: `Commit` first pops the
+                // enclosing `Choice`'s `Backtrack`, then `RecoverScopeEnd`
+                // pops the scope. The EOF-exit edge lands on `exit_inner`
+                // after the inner `Choice`'s `Backtrack` was already
+                // consumed by `fail()`, so a single `RecoverScopeEnd`
+                // suffices there.
+                //
+                // Crucially, the inner `Choice exit_inner` is pushed
+                // *before* `RecoverToScopedMax`. That way the inner
+                // `Backtrack`'s `(sp, capture_len)` capture the
+                // pre-materialization baseline: if `Any(1)` then fails
+                // (the failed attempt's deepest reach was already at
+                // EOF), `fail()` restores the buffer to baseline and the
+                // loop exits cleanly without the materialized captures
+                // being mistakenly accepted as a successful match. (This
+                // matters: the SQLite grammar's `assert_not_clean_parse`
+                // test wedges on inputs like `"SELECT SELECT"` whose
+                // failed top-level statement scans through EOF — without
+                // the undo edge they would be falsely reported as clean
+                // parses.)
+                //
+                // Fresh Choice/Commit per iteration (not PartialCommit) so
+                // each retry's backtrack baseline is at the advanced sp —
+                // see src/pegvm/README.md invariant 1.
+                //
+                // The RecoverScope frame brackets each iteration; every
+                // exit edge is paired with an explicit `RecoverScopeEnd`
+                // so each `RecoverScopeBegin` is brace-matched.
+                // `RecoverToScopedMax` materializes the iteration's
+                // deepest-progress captures into the live buffer before
+                // the recovery byte is emitted — see issue #16 and
+                // `StackEntry::RecoverScope` in src/pegvm/vm.rs.
                 let kind = self.intern_capture(recovery_kind);
                 let loop_top = self.pos();
+                self.emit(Instruction::RecoverScopeBegin);
                 let outer_choice = self.emit(Instruction::Choice(Label(0))); // → rec
                 self.compile_pat(inner);
-                self.emit(Instruction::Commit(pos_to_label(loop_top)));
+                let success_commit = self.emit(Instruction::Commit(Label(0))); // → next_iter
 
                 let rec = self.pos();
                 self.patch_jump(outer_choice, rec);
-
-                let inner_choice = self.emit(Instruction::Choice(Label(0))); // → exit
+                let inner_choice = self.emit(Instruction::Choice(Label(0))); // → exit_inner
+                self.emit(Instruction::RecoverToScopedMax);
                 self.emit(Instruction::CaptureBegin(kind));
                 self.emit(Instruction::Any(1));
                 self.emit(Instruction::CaptureEnd);
-                self.emit(Instruction::Commit(pos_to_label(loop_top)));
+                let recovery_commit = self.emit(Instruction::Commit(Label(0))); // → next_iter
 
-                let exit = self.pos();
-                self.patch_jump(inner_choice, exit);
+                let next_iter = self.pos();
+                self.patch_jump(success_commit, next_iter);
+                self.patch_jump(recovery_commit, next_iter);
+                self.emit(Instruction::RecoverScopeEnd);
+                self.emit(Instruction::Jump(pos_to_label(loop_top)));
+
+                let exit_inner = self.pos();
+                self.patch_jump(inner_choice, exit_inner);
+                self.emit(Instruction::RecoverScopeEnd);
             }
         }
     }

--- a/src/pegvm/instruction.rs
+++ b/src/pegvm/instruction.rs
@@ -239,5 +239,24 @@ pub enum Instruction {
     CaptureBegin(CaptureKind),
     CaptureEnd,
 
+    /// Push a fresh `RecoverScope` frame capturing the current
+    /// `(sp, captures.len())` as the iteration baseline. Emitted at the
+    /// top of every `p*^` iteration so the VM can track the deepest
+    /// captures the failed inner attempt produced — see
+    /// `RecoverToScopedMax` and `src/pegc/compiler.rs`'s `RecoverRepeat`
+    /// arm.
+    RecoverScopeBegin,
+    /// Materialize the topmost `RecoverScope`'s deepest-progress
+    /// captures into the live capture buffer past the iteration's
+    /// `baseline_capture_len`, and advance `sp` to `scoped_max_sp`.
+    /// Emitted at the head of `p*^`'s recovery branch so the following
+    /// `Any(1)` emits a recovery span starting *after* the partially
+    /// matched prefix instead of swallowing it. Does not pop the scope.
+    RecoverToScopedMax,
+    /// Pop the topmost `RecoverScope` frame. Emitted on every edge that
+    /// leaves a `p*^` iteration so each `RecoverScopeBegin` is
+    /// brace-matched.
+    RecoverScopeEnd,
+
     End,
 }

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -210,17 +210,24 @@ pub struct VM<'p, 'i> {
     /// `p < entry.examined_max`, so the bound must reflect lookahead reads
     /// past `end_sp` as well as the consumed span.
     memo_examined: Vec<usize>,
-    /// Count of live `StackEntry::RecoverScope` frames. Incremented by
-    /// `RecoverScopeBegin`, decremented by `RecoverScopeEnd` and the
-    /// `RecoverScope` arm of `fail()`. Lets `maybe_snapshot` and
-    /// `protect_max_captures` short-circuit their stack walks when no
-    /// scope is live — important because both are hot (`maybe_snapshot`
-    /// fires from `fail()`, `BackCommit`, every `RuleEnter` cache hit,
-    /// and `LRTail`'s commit; `protect_max_captures` fires from
-    /// `BackCommit` and every `fail()` that pops a `Backtrack`). Only
-    /// `p*^` patterns ever push a scope, so most grammars and most
-    /// instruction-stream positions see this counter at zero.
-    recover_scope_count: usize,
+    /// Indices into `self.stack` of every live `RecoverScope` frame.
+    /// Pushed by `RecoverScopeBegin`, popped by `RecoverScopeEnd` and
+    /// the `RecoverScope` arm of `fail()`. Lets `maybe_snapshot` and
+    /// `protect_max_captures` visit only scope frames instead of
+    /// iterating the entire backtrack stack — important because both
+    /// helpers are hot (`maybe_snapshot` fires from `fail()`,
+    /// `BackCommit`, every `RuleEnter` cache hit, and `LRTail`'s
+    /// commit; `protect_max_captures` fires from `BackCommit` and
+    /// every `fail()` that pops a `Backtrack`).
+    ///
+    /// In every shipped grammar that uses `*^`, the top-level rule
+    /// wraps the whole document in one — so the outer scope is live
+    /// for the entire parse and the alternative "skip walk when
+    /// no scope is live" guard never trips. The index list scales
+    /// with the number of scopes, not with overall stack depth, so
+    /// the inner walks stay O(scope-depth) (≤ 1 for non-nested `*^`)
+    /// regardless of rule-call nesting.
+    recover_scope_indices: Vec<usize>,
 }
 
 /// A memo-table entry for a rule invocation at a specific input position.
@@ -280,7 +287,7 @@ impl<'p, 'i> VM<'p, 'i> {
             memo_misses: 0,
             memo_threshold: Self::DEFAULT_MEMO_THRESHOLD,
             memo_examined: Vec::new(),
-            recover_scope_count: 0,
+            recover_scope_indices: Vec::new(),
         }
     }
 
@@ -783,6 +790,7 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::RecoverScopeBegin => {
                     let cur_sp = self.sp;
                     let cur_len = self.captures.len();
+                    let scope_idx = self.stack.len();
                     self.stack.push(StackEntry::RecoverScope {
                         baseline_sp: cur_sp,
                         baseline_capture_len: cur_len,
@@ -791,7 +799,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         scoped_saved_lower: cur_len,
                         scoped_saved_above: Vec::new(),
                     });
-                    self.recover_scope_count += 1;
+                    self.recover_scope_indices.push(scope_idx);
                     self.ip += 1;
                 }
                 Instruction::RecoverToScopedMax => {
@@ -881,7 +889,9 @@ impl<'p, 'i> VM<'p, 'i> {
                             other
                         ),
                     }
-                    self.recover_scope_count -= 1;
+                    self.recover_scope_indices
+                        .pop()
+                        .expect("RecoverScopeEnd: recover_scope_indices underflow");
                     self.ip += 1;
                 }
                 Instruction::End => {
@@ -977,7 +987,9 @@ impl<'p, 'i> VM<'p, 'i> {
                     // per-iteration watermark is moot. Drop and keep
                     // unwinding — some enclosing Backtrack will catch the
                     // fail and truncate captures accordingly.
-                    self.recover_scope_count -= 1;
+                    self.recover_scope_indices
+                        .pop()
+                        .expect("fail(): recover_scope_indices underflow on RecoverScope");
                 }
                 StackEntry::LFrame {
                     memo_id: _,
@@ -1131,23 +1143,25 @@ impl<'p, 'i> VM<'p, 'i> {
         // iterations — their recovery, if it fires later, must
         // reconstruct from the deepest pool it ever saw.
         //
-        // Guarded by `recover_scope_count` to short-circuit the stack
-        // walk when no scope is live (the common case for grammars that
-        // don't use `*^` at all and for inter-statement positions in
-        // grammars that do).
-        if self.recover_scope_count == 0 {
+        // Iterate `recover_scope_indices` directly so the cost scales
+        // with scope depth (≤ 1 for non-nested `*^`) rather than total
+        // backtrack-stack depth. The empty-iterator path is the common
+        // case for grammars without `*^`, and for those that have it,
+        // visits exactly the scope frames instead of skipping every
+        // Backtrack / Memo / LFrame / Return on the way down.
+        if self.recover_scope_indices.is_empty() {
             return;
         }
         let cur_sp = self.sp;
         let cur_len = self.captures.len();
-        for entry in self.stack.iter_mut() {
+        for &idx in &self.recover_scope_indices {
             if let StackEntry::RecoverScope {
                 scoped_max_sp,
                 scoped_max_captures_len,
                 scoped_saved_lower,
                 scoped_saved_above,
                 ..
-            } = entry
+            } = &mut self.stack[idx]
             {
                 if cur_sp > *scoped_max_sp {
                     *scoped_max_sp = cur_sp;
@@ -1155,6 +1169,8 @@ impl<'p, 'i> VM<'p, 'i> {
                     *scoped_saved_lower = cur_len;
                     scoped_saved_above.clear();
                 }
+            } else {
+                debug_assert!(false, "recover_scope_indices points to non-RecoverScope");
             }
         }
     }
@@ -1194,19 +1210,19 @@ impl<'p, 'i> VM<'p, 'i> {
         // displacing — captures below baseline are the enclosing
         // scope's (or the global epoch's) responsibility.
         //
-        // Same guard as `maybe_snapshot`: skip the stack walk entirely
-        // when no scope is live (every grammar without `*^`, plus all
-        // inter-statement positions in grammars that use it).
-        if self.recover_scope_count == 0 {
+        // Iterate `recover_scope_indices` to keep the cost proportional
+        // to scope depth rather than backtrack-stack depth (same
+        // rationale as `maybe_snapshot`).
+        if self.recover_scope_indices.is_empty() {
             return;
         }
-        for entry in self.stack.iter_mut() {
+        for &idx in &self.recover_scope_indices {
             if let StackEntry::RecoverScope {
                 baseline_capture_len,
                 scoped_saved_lower,
                 scoped_saved_above,
                 ..
-            } = entry
+            } = &mut self.stack[idx]
             {
                 let clamped = new_len.max(*baseline_capture_len);
                 if clamped < *scoped_saved_lower {
@@ -1218,6 +1234,8 @@ impl<'p, 'i> VM<'p, 'i> {
                     );
                     *scoped_saved_lower = clamped;
                 }
+            } else {
+                debug_assert!(false, "recover_scope_indices points to non-RecoverScope");
             }
         }
     }

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -53,6 +53,48 @@ enum StackEntry {
         return_addr: usize,
         seed: Option<LSeed>,
     },
+    /// Per-iteration tracking frame for `p*^` (`Pattern::RecoverRepeat`).
+    /// Pushed by `RecoverScopeBegin` at the top of each iteration and
+    /// popped by `RecoverScopeEnd` on every exit edge. Carries an
+    /// iteration-local analogue of the global `(max_sp, max_captures_len,
+    /// saved_lower, saved_above)` watermark so `RecoverToScopedMax` can
+    /// splice the failed inner attempt's deepest-progress captures back
+    /// into the live buffer before the recovery branch emits its byte.
+    ///
+    /// Without this frame, the outer `Choice` that lowers `*^` truncates
+    /// `captures` to `baseline_capture_len` on failure (issue #16) and
+    /// the partial match emits zero useful highlights.
+    RecoverScope {
+        /// `sp` at the moment the iteration started — the value the
+        /// outer `Choice`'s `Backtrack` will restore on failure of
+        /// `<inner>`.
+        baseline_sp: usize,
+        /// `captures.len()` at the moment the iteration started — the
+        /// value the outer `Choice`'s `Backtrack` will truncate to on
+        /// failure of `<inner>`.
+        baseline_capture_len: usize,
+        /// Deepest input position reached during this iteration of the
+        /// loop. Initialized to `baseline_sp` and bumped by
+        /// `maybe_snapshot` whenever `sp > scoped_max_sp`. Cannot fall
+        /// below the iteration's baseline by construction.
+        scoped_max_sp: usize,
+        /// `captures.len()` at the moment `scoped_max_sp` was last
+        /// advanced. Mirrors the global `max_captures_len` field.
+        scoped_max_captures_len: usize,
+        /// Lowest capture index in `[baseline_capture_len,
+        /// scoped_max_captures_len)` still physically present in
+        /// `self.captures`. Captures in
+        /// `[scoped_saved_lower, scoped_max_captures_len)` were
+        /// displaced into `scoped_saved_above` by a
+        /// truncate-below-watermark. Mirrors the global `saved_lower`,
+        /// scoped to this iteration's watermark.
+        scoped_saved_lower: usize,
+        /// Captures displaced from the per-iteration watermark prefix,
+        /// stored in reverse capture-order. Walked in original order
+        /// via `iter().rev()` by `RecoverToScopedMax`. Mirrors the
+        /// global `saved_above`.
+        scoped_saved_above: Vec<OpenCapture>,
+    },
 }
 
 /// Successful seed of a left-recursive rule's prior iteration: the `sp` the
@@ -726,6 +768,108 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.captures[idx].end = Some(self.sp);
                     self.ip += 1;
                 }
+                Instruction::RecoverScopeBegin => {
+                    let cur_sp = self.sp;
+                    let cur_len = self.captures.len();
+                    self.stack.push(StackEntry::RecoverScope {
+                        baseline_sp: cur_sp,
+                        baseline_capture_len: cur_len,
+                        scoped_max_sp: cur_sp,
+                        scoped_max_captures_len: cur_len,
+                        scoped_saved_lower: cur_len,
+                        scoped_saved_above: Vec::new(),
+                    });
+                    self.ip += 1;
+                }
+                Instruction::RecoverToScopedMax => {
+                    // We arrive here immediately after the outer Choice's
+                    // Backtrack fired: `sp` and `captures.len()` have been
+                    // restored to the iteration's baselines, and the same
+                    // `fail()` call's `protect_max_captures` has pulled
+                    // every live `RecoverScope`'s `scoped_saved_lower` down
+                    // to its `baseline_capture_len` (or lower). For the
+                    // topmost scope that means the entire alive-at-
+                    // `scoped_max_sp` pool is now sitting in
+                    // `scoped_saved_above`, in reverse capture order.
+                    //
+                    // Splice it back into `self.captures` (closing any
+                    // captures still open at `scoped_max_sp`, mirroring
+                    // `close_captures` and `LRTail`'s seed replay), then
+                    // jump `sp` forward to `scoped_max_sp` so the recovery
+                    // branch's `Any(1)` covers only the byte where parsing
+                    // actually broke, not the iteration's whole baseline-
+                    // to-failure span.
+                    let scope_idx = self
+                        .stack
+                        .iter()
+                        .rposition(|e| matches!(e, StackEntry::RecoverScope { .. }))
+                        .expect("RecoverToScopedMax without enclosing RecoverScope");
+                    let StackEntry::RecoverScope {
+                        baseline_sp,
+                        baseline_capture_len,
+                        scoped_max_sp,
+                        scoped_max_captures_len,
+                        scoped_saved_lower,
+                        scoped_saved_above,
+                    } = &mut self.stack[scope_idx]
+                    else {
+                        unreachable!("rposition matched RecoverScope")
+                    };
+                    let baseline_sp = *baseline_sp;
+                    let baseline_capture_len = *baseline_capture_len;
+                    let scoped_max_sp = *scoped_max_sp;
+                    let scoped_max_captures_len = *scoped_max_captures_len;
+                    debug_assert!(
+                        scoped_max_sp >= baseline_sp,
+                        "RecoverToScopedMax: scoped_max_sp ({}) retreated below baseline_sp ({})",
+                        scoped_max_sp,
+                        baseline_sp,
+                    );
+                    debug_assert_eq!(
+                        *scoped_saved_lower, baseline_capture_len,
+                        "RecoverToScopedMax: outer Choice's Backtrack should have driven \
+                         scoped_saved_lower down to baseline_capture_len via protect_max_captures",
+                    );
+                    let displaced = std::mem::take(scoped_saved_above);
+                    // Mark the per-iteration tracking as fully drained.
+                    // Subsequent `maybe_snapshot` calls in this iteration's
+                    // recovery branch will start from the newly-spliced
+                    // length.
+                    *scoped_saved_lower = scoped_max_captures_len;
+
+                    debug_assert_eq!(
+                        self.captures.len(),
+                        baseline_capture_len,
+                        "RecoverToScopedMax: outer Choice's Backtrack should have truncated \
+                         captures to baseline_capture_len",
+                    );
+                    // `displaced` holds the alive-at-scoped-max captures in
+                    // reverse order; iter().rev() restores original order.
+                    // Close any that were still open at scoped_max_sp so
+                    // the next CaptureEnd binds to the recovery span we're
+                    // about to open rather than to a re-materialized
+                    // straggler.
+                    self.captures
+                        .extend(displaced.iter().rev().map(|c| OpenCapture {
+                            kind: c.kind,
+                            start: c.start,
+                            end: Some(c.end.unwrap_or(scoped_max_sp)),
+                        }));
+                    debug_assert_eq!(self.captures.len(), scoped_max_captures_len);
+
+                    self.sp = scoped_max_sp;
+                    self.ip += 1;
+                }
+                Instruction::RecoverScopeEnd => {
+                    match self.stack.pop() {
+                        Some(StackEntry::RecoverScope { .. }) => {}
+                        other => panic!(
+                            "RecoverScopeEnd expected RecoverScope on stack top, got {:?}",
+                            other
+                        ),
+                    }
+                    self.ip += 1;
+                }
                 Instruction::End => {
                     let stats = MemoStats {
                         entries: self.memo.len(),
@@ -808,6 +952,17 @@ impl<'p, 'i> VM<'p, 'i> {
                     // Rule-call frame unwinding past its caller. The caller's
                     // Backtrack (if any) is deeper on the stack and will be
                     // found by continued popping.
+                }
+                StackEntry::RecoverScope { .. } => {
+                    // The outer `Choice` an iteration of `*^` pushes lives
+                    // *above* the `RecoverScope` and catches every fail
+                    // rooted in `<inner>`. Reaching this arm means the fail
+                    // is escaping the whole `*^` (e.g. through a rule body
+                    // called from `<inner>` whose own enclosing Backtrack is
+                    // deeper than the loop). The iteration is gone; its
+                    // per-iteration watermark is moot. Drop and keep
+                    // unwinding — some enclosing Backtrack will catch the
+                    // fail and truncate captures accordingly.
                 }
                 StackEntry::LFrame {
                     memo_id: _,
@@ -953,6 +1108,32 @@ impl<'p, 'i> VM<'p, 'i> {
             self.saved_lower = len;
             self.saved_above.clear();
         }
+        // Each live `RecoverScope` tracks its own per-iteration
+        // watermark in lockstep with the global one. Multiple may be
+        // live at once (nested `*^`); any scope whose `scoped_max_sp`
+        // has been surpassed needs its watermark advanced. Outer scopes
+        // legitimately track sp positions reached *inside* nested
+        // iterations — their recovery, if it fires later, must
+        // reconstruct from the deepest pool it ever saw.
+        let cur_sp = self.sp;
+        let cur_len = self.captures.len();
+        for entry in self.stack.iter_mut() {
+            if let StackEntry::RecoverScope {
+                scoped_max_sp,
+                scoped_max_captures_len,
+                scoped_saved_lower,
+                scoped_saved_above,
+                ..
+            } = entry
+            {
+                if cur_sp > *scoped_max_sp {
+                    *scoped_max_sp = cur_sp;
+                    *scoped_max_captures_len = cur_len;
+                    *scoped_saved_lower = cur_len;
+                    scoped_saved_above.clear();
+                }
+            }
+        }
     }
 
     /// Called before truncating `captures` to `new_len`. If the
@@ -983,6 +1164,31 @@ impl<'p, 'i> VM<'p, 'i> {
                     .copied(),
             );
             self.saved_lower = new_len;
+        }
+        // Mirror the spillover into every live `RecoverScope`. A scope
+        // only owns captures created since its baseline, so each scope
+        // clamps `new_len` at its `baseline_capture_len` before
+        // displacing — captures below baseline are the enclosing
+        // scope's (or the global epoch's) responsibility.
+        for entry in self.stack.iter_mut() {
+            if let StackEntry::RecoverScope {
+                baseline_capture_len,
+                scoped_saved_lower,
+                scoped_saved_above,
+                ..
+            } = entry
+            {
+                let clamped = new_len.max(*baseline_capture_len);
+                if clamped < *scoped_saved_lower {
+                    scoped_saved_above.extend(
+                        self.captures[clamped..*scoped_saved_lower]
+                            .iter()
+                            .rev()
+                            .copied(),
+                    );
+                    *scoped_saved_lower = clamped;
+                }
+            }
         }
     }
 

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -852,11 +852,6 @@ impl<'p, 'i> VM<'p, 'i> {
                          scoped_saved_lower down to baseline_capture_len via protect_max_captures",
                     );
                     let displaced = std::mem::take(scoped_saved_above);
-                    // Mark the per-iteration tracking as fully drained.
-                    // Subsequent `maybe_snapshot` calls in this iteration's
-                    // recovery branch will start from the newly-spliced
-                    // length.
-                    *scoped_saved_lower = scoped_max_captures_len;
 
                     debug_assert_eq!(
                         self.captures.len(),
@@ -866,17 +861,34 @@ impl<'p, 'i> VM<'p, 'i> {
                     );
                     // `displaced` holds the alive-at-scoped-max captures in
                     // reverse order; iter().rev() restores original order.
-                    // Close any that were still open at scoped_max_sp so
-                    // the next CaptureEnd binds to the recovery span we're
-                    // about to open rather than to a re-materialized
-                    // straggler.
+                    // Drop entries with `end.is_none()`: a still-open capture
+                    // at the watermark means the production that opened it
+                    // never reached its `CaptureEnd` before the inner
+                    // attempt stalled. Manufacturing a close at
+                    // `scoped_max_sp` would invent a token boundary the
+                    // grammar never accepted — the "stutter" of phantom
+                    // keyword/comment fragments in the recovery tail.
                     self.captures
-                        .extend(displaced.iter().rev().map(|c| OpenCapture {
-                            kind: c.kind,
-                            start: c.start,
-                            end: Some(c.end.unwrap_or(scoped_max_sp)),
-                        }));
-                    debug_assert_eq!(self.captures.len(), scoped_max_captures_len);
+                        .extend(displaced.iter().rev().filter(|c| c.end.is_some()).cloned());
+                    let spliced_len = self.captures.len();
+                    debug_assert!(spliced_len <= scoped_max_captures_len);
+
+                    // Re-borrow the scope to commit the per-iteration
+                    // floor at the actual spliced length (filtered may be
+                    // shorter than `scoped_max_captures_len`). The
+                    // recovery byte's subsequent `maybe_snapshot` will
+                    // lift them again from here.
+                    if let StackEntry::RecoverScope {
+                        scoped_max_captures_len,
+                        scoped_saved_lower,
+                        ..
+                    } = &mut self.stack[scope_idx]
+                    {
+                        *scoped_max_captures_len = spliced_len;
+                        *scoped_saved_lower = spliced_len;
+                    } else {
+                        unreachable!("scope_idx no longer points at RecoverScope")
+                    }
 
                     self.sp = scoped_max_sp;
                     self.ip += 1;

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -210,6 +210,17 @@ pub struct VM<'p, 'i> {
     /// `p < entry.examined_max`, so the bound must reflect lookahead reads
     /// past `end_sp` as well as the consumed span.
     memo_examined: Vec<usize>,
+    /// Count of live `StackEntry::RecoverScope` frames. Incremented by
+    /// `RecoverScopeBegin`, decremented by `RecoverScopeEnd` and the
+    /// `RecoverScope` arm of `fail()`. Lets `maybe_snapshot` and
+    /// `protect_max_captures` short-circuit their stack walks when no
+    /// scope is live — important because both are hot (`maybe_snapshot`
+    /// fires from `fail()`, `BackCommit`, every `RuleEnter` cache hit,
+    /// and `LRTail`'s commit; `protect_max_captures` fires from
+    /// `BackCommit` and every `fail()` that pops a `Backtrack`). Only
+    /// `p*^` patterns ever push a scope, so most grammars and most
+    /// instruction-stream positions see this counter at zero.
+    recover_scope_count: usize,
 }
 
 /// A memo-table entry for a rule invocation at a specific input position.
@@ -269,6 +280,7 @@ impl<'p, 'i> VM<'p, 'i> {
             memo_misses: 0,
             memo_threshold: Self::DEFAULT_MEMO_THRESHOLD,
             memo_examined: Vec::new(),
+            recover_scope_count: 0,
         }
     }
 
@@ -779,6 +791,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         scoped_saved_lower: cur_len,
                         scoped_saved_above: Vec::new(),
                     });
+                    self.recover_scope_count += 1;
                     self.ip += 1;
                 }
                 Instruction::RecoverToScopedMax => {
@@ -868,6 +881,7 @@ impl<'p, 'i> VM<'p, 'i> {
                             other
                         ),
                     }
+                    self.recover_scope_count -= 1;
                     self.ip += 1;
                 }
                 Instruction::End => {
@@ -963,6 +977,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     // per-iteration watermark is moot. Drop and keep
                     // unwinding — some enclosing Backtrack will catch the
                     // fail and truncate captures accordingly.
+                    self.recover_scope_count -= 1;
                 }
                 StackEntry::LFrame {
                     memo_id: _,
@@ -1115,6 +1130,14 @@ impl<'p, 'i> VM<'p, 'i> {
         // legitimately track sp positions reached *inside* nested
         // iterations — their recovery, if it fires later, must
         // reconstruct from the deepest pool it ever saw.
+        //
+        // Guarded by `recover_scope_count` to short-circuit the stack
+        // walk when no scope is live (the common case for grammars that
+        // don't use `*^` at all and for inter-statement positions in
+        // grammars that do).
+        if self.recover_scope_count == 0 {
+            return;
+        }
         let cur_sp = self.sp;
         let cur_len = self.captures.len();
         for entry in self.stack.iter_mut() {
@@ -1170,6 +1193,13 @@ impl<'p, 'i> VM<'p, 'i> {
         // clamps `new_len` at its `baseline_capture_len` before
         // displacing — captures below baseline are the enclosing
         // scope's (or the global epoch's) responsibility.
+        //
+        // Same guard as `maybe_snapshot`: skip the stack walk entirely
+        // when no scope is live (every grammar without `*^`, plus all
+        // inter-statement positions in grammars that use it).
+        if self.recover_scope_count == 0 {
+            return;
+        }
         for entry in self.stack.iter_mut() {
             if let StackEntry::RecoverScope {
                 baseline_capture_len,

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -242,10 +242,13 @@ fn recover_repeat_mixed_success_and_recovery() {
 }
 
 #[test]
-fn recover_repeat_truncates_failed_inner_attempt_captures() {
+fn recover_repeat_preserves_failed_inner_attempt_deepest_captures() {
     // inner = @open{"a"} "b" — the @open capture opens before the "b"
-    // that may fail. After a failed attempt, that partial @open must NOT
-    // appear in the result; only successful attempts contribute to it.
+    // that may fail. Per issue #16, the deepest-progress captures of a
+    // failed inner attempt are re-materialized by `RecoverToScopedMax`
+    // before the recovery branch fires, and the recovery span covers
+    // only the byte where parsing actually broke (not the iteration's
+    // whole baseline-to-failure window).
     //
     // Kind interning order: RecoverRepeat enters before recursing into
     // inner, so "recovery" interns first (id 0), "open" second (id 1).
@@ -260,11 +263,122 @@ fn recover_repeat_truncates_failed_inner_attempt_captures() {
     assert_eq!(
         r.captures,
         vec![
-            cap(0, 0, 1), // recovery: 'a' (failed inner attempt's @open(0,1) is gone)
-            cap(0, 1, 2), // recovery: 'x'
+            cap(1, 0, 1), // @open: re-materialized from the failed iteration's deepest reach
+            cap(0, 1, 2), // recovery: 'x' (Any(1) consumes from scoped_max_sp=1, not baseline_sp=0)
             cap(1, 2, 3), // @open: the successful 'a' at sp=2
         ],
-        "the failed inner attempt's open capture must not leak into the result",
+        "the failed inner attempt's deepest-progress @open capture survives into the result",
+    );
+}
+
+#[test]
+fn recover_repeat_failed_attempt_reaching_eof_does_not_leak_clean_match() {
+    // inner = @open{"a"} "b" against input "a" — the inner @open opens
+    // at sp=0, then Char 'a' consumes ('sp=1'), then Char 'b' tries at
+    // sp=1 (EOF) and fails. The failed attempt's scoped_max_sp ==
+    // input.len(); RecoverToScopedMax would move sp to EOF, and the
+    // recovery branch's Any(1) would fail. Without the pre-
+    // materialization inner Choice baseline, the materialized
+    // @open(0,1) would leak into the result as a clean match — this
+    // test pins down that the materialization is undone and the parse
+    // reports an incomplete match instead. See the SQLite
+    // assert_not_clean_parse cases (e.g. "SELECT SELECT") for the
+    // grammar-level analogue.
+    let inner = Pattern::seq(vec![
+        Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+        Pattern::literal("b"),
+    ]);
+    let p = recover(inner, "recovery");
+    let r = run_pattern(&p, b"a");
+    // The loop exits cleanly at sp=0, then `compile_pattern` appends
+    // an `End` instruction — so `complete` is true at sp=0.
+    // `matched < input.len()` is what flags the partial parse.
+    assert!(r.matched < 1, "must not advance past failed attempt");
+    assert!(
+        r.captures.is_empty(),
+        "materialized @open must not leak; got {:?}",
+        r.captures
+    );
+}
+
+#[test]
+fn recover_repeat_nested_loops_do_not_panic() {
+    // outer = ((@a{"a"} "X")*^) "Z"  (the outer is itself wrapped in *^)
+    //
+    // Two RecoverScope frames are simultaneously live whenever the
+    // outer iteration is executing its inner `*^`. The
+    // `maybe_snapshot` and `protect_max_captures` walks must handle
+    // both frames without panicking — this regression-tests the
+    // multi-scope spillover logic. Behaviour-level assertions are
+    // deliberately loose: nested `*^` is a corner case, and the
+    // per-scope watermark machinery still has known cosmetic edges
+    // (an inner iteration that undoes via the EOF-Backtrack path may
+    // leave its materialized captures referenced by an outer scope's
+    // `saved_above` — see RecoverToScopedMax in src/pegvm/vm.rs).
+    // What we lock in here is the operational invariant: no panic,
+    // parse runs to completion.
+    let inner = recover(
+        Pattern::seq(vec![
+            Pattern::Capture("a".into(), Box::new(Pattern::literal("a"))),
+            Pattern::literal("X"),
+        ]),
+        "inner_rec",
+    );
+    let outer = recover(
+        Pattern::seq(vec![inner, Pattern::literal("Z")]),
+        "outer_rec",
+    );
+    // Several shapes that exercise different paths through the
+    // double-scope state machine. Every input must reach `End` (i.e.
+    // `complete` is true). The compiler-emitted `End` after the
+    // top-level `*^` always succeeds, so completeness measures only
+    // that the dispatcher didn't panic — sufficient to guard the
+    // multi-scope spillover.
+    for input in [b"".as_slice(), b"aX".as_slice(), b"!".as_slice(), b"aXaXZ"] {
+        let r = run_pattern(&outer, input);
+        assert!(r.complete, "nested *^ panicked or stalled on {:?}", input);
+    }
+}
+
+#[test]
+fn recover_repeat_empty_capture_in_failed_inner_attempt_is_dropped() {
+    // inner = @x{!"x"} "z" — @x opens and closes at the same sp via
+    // the NotPredicate succeeding without consuming. On input "by",
+    // inner fails at "z"; the failed attempt's @x(0,0) sits at the
+    // iteration's baseline sp and is dropped, NOT re-materialized.
+    //
+    // Why dropped: the per-iteration watermark mirrors the global
+    // `max_*` design — `maybe_snapshot` only bumps `scoped_max_*`
+    // when `sp` advances, so a capture that opens and closes without
+    // any byte being consumed doesn't enter the watermark's
+    // `(scoped_max_sp, scoped_max_captures_len)` snapshot. This
+    // matches PEG-failure semantics for the global watermark
+    // (`finalize_partial`) too, where a closed-but-empty capture at
+    // `max_sp` would equally not appear in the partial result.
+    //
+    // The test pins this behaviour explicitly so a future refactor
+    // that tries to "improve" the empty-capture case is forced to
+    // re-baseline this test deliberately.
+    let inner = Pattern::seq(vec![
+        Pattern::Capture(
+            "x".into(),
+            Box::new(Pattern::NotPredicate(Box::new(Pattern::literal("x")))),
+        ),
+        Pattern::literal("z"),
+    ]);
+    let p = recover(inner, "recovery");
+    let r = run_pattern(&p, b"by");
+    assert!(r.complete);
+    assert_eq!(r.matched, 2);
+    // Kind interning order: "recovery" (id 0), "x" (id 1). No @x
+    // captures survive — both iterations produced only empty ones at
+    // their baseline sp, which don't enter the watermark.
+    assert_eq!(
+        r.captures,
+        vec![
+            cap(0, 0, 1), // recovery: 'b'
+            cap(0, 1, 2), // recovery: 'y'
+        ],
     );
 }
 
@@ -480,31 +594,49 @@ fn repeat_emits_partial_commit() {
 fn recover_repeat_emits_choice_commit_skeleton() {
     let p = recover(Pattern::literal("a"), "recovery");
     let prog = compile_pattern(&p);
-    // loop_top: Choice rec
-    //           Char 'a'
-    //           Commit loop_top
-    // rec:      Choice exit
-    //           CaptureBegin recovery
-    //           Any(1)
-    //           CaptureEnd
-    //           Commit loop_top
-    // exit:     End
+    // loop_top:   RecoverScopeBegin
+    //             Choice rec
+    //             Char 'a'
+    //             Commit next_iter           ; pops outer Backtrack
+    // rec:        Choice exit_inner          ; pre-materialization baseline
+    //             RecoverToScopedMax         ; splice & advance sp
+    //             CaptureBegin recovery
+    //             Any(1)
+    //             CaptureEnd
+    //             Commit next_iter           ; pops inner Backtrack
+    // next_iter:  RecoverScopeEnd            ; pops RecoverScope
+    //             Jump loop_top
+    // exit_inner: RecoverScopeEnd            ; EOF exit edge
+    //             End
     //
-    // The recovery loop uses fresh Choice/Commit per iteration (not
+    // Per #16: the RecoverScopeBegin/RecoverScopeEnd pair tracks the
+    // iteration-local farthest-failure watermark; RecoverToScopedMax
+    // splices those captures into the live buffer before the recovery
+    // byte. The inner Choice is pushed *before* RecoverToScopedMax so
+    // its Backtrack captures the pre-materialization baseline — that
+    // way an EOF inside the recovery's Any(1) discards the
+    // materialization instead of leaking a failed attempt's captures
+    // out as a clean parse. Success and recovery-success edges share
+    // the `next_iter` epilogue. Fresh Choice/Commit per iteration (not
     // PartialCommit) so each retry's backtrack baseline is at the
-    // advanced sp. See src/pegvm/README.md invariant 1.
+    // advanced sp — see src/pegvm/README.md invariant 1.
     assert_eq!(
         prog.code,
         vec![
-            Instruction::Choice(Label(3)),             // → rec
-            Instruction::Char(b'a'),                   // <inner>
-            Instruction::Commit(Label(0)),             // → loop_top
-            Instruction::Choice(Label(8)),             // rec: → exit
+            Instruction::RecoverScopeBegin, // loop_top
+            Instruction::Choice(Label(4)),  // → rec
+            Instruction::Char(b'a'),        // <inner>
+            Instruction::Commit(Label(10)), // → next_iter
+            Instruction::Choice(Label(12)), // rec: → exit_inner
+            Instruction::RecoverToScopedMax,
             Instruction::CaptureBegin(CaptureKind(0)), // recovery
             Instruction::Any(1),
             Instruction::CaptureEnd,
-            Instruction::Commit(Label(0)), // → loop_top
-            Instruction::End,              // exit
+            Instruction::Commit(Label(10)), // → next_iter
+            Instruction::RecoverScopeEnd,   // next_iter: pop scope
+            Instruction::Jump(Label(0)),    // → loop_top
+            Instruction::RecoverScopeEnd,   // exit_inner: EOF exit edge
+            Instruction::End,
         ]
     );
     assert_eq!(prog.capture_kinds, vec!["recovery".to_string()]);

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -383,6 +383,43 @@ fn recover_repeat_empty_capture_in_failed_inner_attempt_is_dropped() {
 }
 
 #[test]
+fn recover_repeat_drops_unclosed_capture_from_failed_inner_attempt() {
+    // inner = @kw{ "abc" / "abd" } — the @kw capture opens BEFORE the
+    // alternatives, and neither alternative reaches its CaptureEnd on
+    // input "abx" (both consume "ab" then fail on the third byte).
+    // The failed attempt's `scoped_max_sp` is at sp=2; the open @kw
+    // OpenCapture sits in `scoped_saved_above` with `end: None`.
+    //
+    // Pre-fix, `RecoverToScopedMax` manufactured a close at
+    // `scoped_max_sp`, leaking a phantom `@kw(0,2)="ab"` — the SQLite
+    // dump-captures "stutter" (e.g. `keyword(56,59)="rep"` from
+    // `replace_body` matching half of `repository`). The fix drops
+    // every entry whose `end.is_none()` during the splice: a still-
+    // open capture at the watermark belongs to a production that
+    // didn't complete and must not become a token.
+    let inner = Pattern::Capture(
+        "kw".into(),
+        Box::new(Pattern::choice(vec![
+            Pattern::literal("abc"),
+            Pattern::literal("abd"),
+        ])),
+    );
+    let p = recover(inner, "recovery");
+    let r = run_pattern(&p, b"abx");
+    assert!(r.complete);
+    assert_eq!(r.matched, 3);
+    // Kind interning order: "recovery" (id 0) interns first when
+    // RecoverRepeat is compiled, "kw" (id 1) second. Recovery byte is
+    // 'x' at sp=2 (Any(1) consumes from `scoped_max_sp`, not the
+    // iteration baseline). No @kw capture appears.
+    assert_eq!(
+        r.captures,
+        vec![cap(0, 2, 3)],
+        "an unclosed @kw from a failed inner attempt must not phantom-close at scoped_max_sp"
+    );
+}
+
+#[test]
 fn recover_repeat_inside_called_rule_returns_cleanly() {
     // start <- "PRE" loop
     // loop  <- "a"*^

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -462,6 +462,65 @@ fn non_reserved_words_parse_as_identifiers() {
 }
 
 #[test]
+fn attach_with_unknown_key_clause_keeps_prefix_kinded() {
+    // Issue #16's canonical repro: SQLite doesn't know the
+    // SEE-extension `KEY '...'` clause, so `attach_stmt` fails inside
+    // this line. Before the per-iteration RecoverScope work, the
+    // entire line collapsed into `recovery` because the outer `*^`'s
+    // Backtrack wiped every capture from the failed inner attempt.
+    // With RecoverToScopedMax in place, captures from the failed
+    // attempt's deepest-progress reach survive: at minimum, the
+    // `ATTACH DATABASE` keywords and the `'/path'` literal land as
+    // their proper grammar kinds, not as `recovery`.
+    //
+    // We intentionally test only the load-bearing invariant —
+    // "non-recovery captures appear in the early prefix" — rather
+    // than pinning each surviving token's kind/span. The exact
+    // failure point depends on how `statement`'s alternatives fail,
+    // which can drift as the grammar evolves.
+    let input = "ATTACH DATABASE '/path' AS 'name' KEY '';";
+    let (caps, kinds) = {
+        let (_, caps, kinds, _) = run(input);
+        (caps, kinds)
+    };
+    let recovery_spans = spans_for(&caps, &kinds, "recovery", input);
+    assert!(
+        !recovery_spans.is_empty(),
+        "expected at least one recovery span on this input; got kinds {:?}",
+        kinds_for(&caps, &kinds),
+    );
+    // The `ATTACH DATABASE` keywords sit at the very start. With the
+    // pre-fix behaviour they'd be swallowed by `recovery`. Assert
+    // that *some* non-recovery capture lands in the prefix before
+    // the `'/path'` string ends.
+    let path_close = input.find("' AS").expect("'/path' is in the input") + 1;
+    let non_recovery_in_prefix = caps
+        .iter()
+        .any(|c| kinds[c.kind.0 as usize] != "recovery" && c.start < path_close);
+    assert!(
+        non_recovery_in_prefix,
+        "expected the `ATTACH DATABASE '/path'` prefix to keep its non-recovery \
+         captures (issue #16 regression); got kinds {:?}",
+        kinds_for(&caps, &kinds),
+    );
+    // Recovery should not start before any of the prefix tokens —
+    // specifically, recovery spans must not cover the leading
+    // `ATTACH` keyword (positions 0..6).
+    let attach_end = "ATTACH".len();
+    for cap in &caps {
+        if kinds[cap.kind.0 as usize] == "recovery" {
+            assert!(
+                cap.start >= attach_end,
+                "recovery span at {}..{} = {:?} overlaps the leading ATTACH keyword",
+                cap.start,
+                cap.end,
+                &input[cap.start..cap.end],
+            );
+        }
+    }
+}
+
+#[test]
 fn blatantly_invalid_input_is_not_a_clean_parse() {
     // Two consecutive SELECTs without a separator or expression between
     // them are never valid as a single clean parse — `sql_file`'s

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -518,6 +518,32 @@ fn attach_with_unknown_key_clause_keeps_prefix_kinded() {
             );
         }
     }
+    // Tail-clean check (stutter guard): every capture starting at or
+    // past the closing quote of `'name'` lives inside the unparseable
+    // ` KEY '';` suffix and must be `recovery`. Pre-fix,
+    // `RecoverToScopedMax` phantom-closed every still-open capture in
+    // `scoped_saved_above` at `scoped_max_sp`, producing fragments
+    // like `keyword(56,59)="rep"` (from `replace_body <- [rR][eE][pP]
+    // [lL]…` matching half of `repository` in the original SQLite
+    // repro). With the unclosed-production filter in
+    // `RecoverToScopedMax`, the tail contains only one-byte recovery
+    // spans.
+    let name_close = input.find("' KEY").expect("'name' is in the input") + 1;
+    for cap in &caps {
+        if cap.start >= name_close {
+            let kind = &kinds[cap.kind.0 as usize];
+            assert_eq!(
+                kind,
+                "recovery",
+                "tail capture at {}..{} = {:?} has kind {:?} but only `recovery` \
+                 is allowed past `'name'` (phantom-close regression)",
+                cap.start,
+                cap.end,
+                &input[cap.start..cap.end],
+                kind,
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #16.

Introduces a per-iteration `RecoverScope` analogue of the global farthest-failure watermark, lowered via three new opcodes (`RecoverScopeBegin` / `RecoverToScopedMax` / `RecoverScopeEnd`) emitted by `Pattern::RecoverRepeat` in `src/pegc/compiler.rs`. When the inner `p` of `p*^` fails partway through an iteration, the deepest-progress captures land back in the live capture buffer before the recovery branch consumes its byte; recovery `Any(1)` advances from `scoped_max_sp` rather than the iteration's baseline. Discussion lives next to the `RecoverToScopedMax` handler in `src/pegvm/vm.rs`.

Captures left open at the watermark are dropped rather than phantom-closed at `scoped_max_sp` — a `CaptureBegin` without its matching `CaptureEnd` belongs to a production that didn't complete and must not become a token. (`finalize_partial` has the same shape of defect on the global watermark; tracked separately.)

Behaviour change: `p*^` now preserves the failed inner attempt's deepest captures instead of discarding them. `end_to_end_recover_repeat_compile_run` re-baselined accordingly.

Performance `compare.sh` was last run on the indexed-walk commit (~+14% median memo regression) and has not been re-run since the unclosed-capture filter — happy to re-run before merge.
