### PR TITLE
pegc: catch-with-recovery operator `inner ^ recovery` (#91)

### DIFF
--- a/src/bin/pegdb.rs
+++ b/src/bin/pegdb.rs
@@ -229,36 +229,45 @@ fn run_explain_recoveries(args: &[String]) -> ExitCode {
     let recovery_kind_idx = kinds.iter().position(|k| k == "recovery");
     let span_aggregates =
         compute_recovery_span_aggregates(captures, diagnostics, recovery_kind_idx);
+    let label_names = p.label_kinds();
 
-    // Cluster by full rule-stack. v1 uses the entire stack as the key;
-    // suffix-clustering is a follow-up. Map preserves insertion order
-    // for stable output across runs.
-    let mut clusters: std::collections::BTreeMap<Vec<String>, usize> =
+    // Cluster by `(rule_stack, label_name)`. Every recovery
+    // firing carries a label — labeled catches (`^label`) use the
+    // author's identifier; `*^` uses the intern of its
+    // `recovery_kind` string. v1 uses the entire stack as the key;
+    // suffix-clustering is a follow-up. BTreeMap preserves a stable
+    // key order for deterministic output.
+    type ClusterKey = (Vec<String>, String);
+    let mut clusters: std::collections::BTreeMap<ClusterKey, usize> =
         std::collections::BTreeMap::new();
     for slot in &span_aggregates {
         let Some(reach) = slot else {
             continue;
         };
-        let key: Vec<String> = reach
+        let stack: Vec<String> = reach
             .rule_stack
             .iter()
             .filter_map(|id| rule_names.get(id.0 as usize).cloned())
             .collect();
-        *clusters.entry(key).or_insert(0) += 1;
+        let label = label_names
+            .get(reach.label.0 as usize)
+            .cloned()
+            .unwrap_or_default();
+        *clusters.entry((stack, label)).or_insert(0) += 1;
     }
 
-    let mut entries: Vec<(Vec<String>, usize)> = clusters.into_iter().collect();
-    // Sort by count descending, then by stack lexicographically for
+    let mut entries: Vec<(ClusterKey, usize)> = clusters.into_iter().collect();
+    // Sort by count descending, then by key lexicographically for
     // determinism on ties.
     entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     let mut out = std::io::stdout().lock();
-    for (stack, count) in &entries {
+    for ((stack, label), count) in &entries {
         let leaf = stack.last().map(String::as_str).unwrap_or("<empty>");
         let _ = writeln!(
             out,
-            "{} recoveries — farthest reach ends at {}",
-            count, leaf
+            "{} recoveries — farthest reach ends at {} (label: {})",
+            count, leaf, label
         );
     }
     if entries.is_empty() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -177,6 +177,14 @@ impl Parser {
         &self.program.rule_names
     }
 
+    /// Label names indexed by `LabelId.0` — see
+    /// [`crate::pegvm::Program::label_kinds`]. Used by diagnostic
+    /// consumers to resolve [`crate::pegvm::RecoveryDiagnostic::label`]
+    /// back to the source `^label` name.
+    pub fn label_kinds(&self) -> &[String] {
+        &self.program.label_kinds
+    }
+
     /// Per-recovery diagnostic records from the most recent parse.
     /// Empty unless the parser was built with
     /// [`Parser::with_track_recovery_diagnostics(true)`]. Aligned with

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -29,6 +29,10 @@
 //!   u16 LE      n = rule_names.len()
 //!   for each name: NUL-terminated UTF-8 bytes
 //!
+//! label-name table:
+//!   u16 LE      n = label_kinds.len()
+//!   for each name: NUL-terminated UTF-8 bytes
+//!
 //! instruction stream:
 //!   u32 LE      k = code.len()
 //!   for each instruction: u8 tag, then variant-specific payload
@@ -50,7 +54,7 @@
 //! is large enough for the load-time allocation to matter — sqlite at
 //! 5,622 instructions decodes in sub-millisecond time.
 
-use crate::pegvm::{CaptureKind, CharSet, Instruction, Label, MemoId, Program, RuleKind};
+use crate::pegvm::{CaptureKind, CharSet, Instruction, Label, LabelId, MemoId, Program, RuleKind};
 
 /// Failure modes for [`decode`]. [`encode`] is infallible for any
 /// well-formed `Program` (`pegc::compile` always produces one).
@@ -71,6 +75,8 @@ pub enum Error {
     InvalidCaptureName(std::str::Utf8Error),
     /// Rule name bytes were not valid UTF-8.
     InvalidRuleName(std::str::Utf8Error),
+    /// Label name bytes were not valid UTF-8.
+    InvalidLabelName(std::str::Utf8Error),
     /// Decoder reached a sensible stopping point but bytes remain in the
     /// buffer — usually means the producer wrote a slightly different
     /// format than the one this decoder reads.
@@ -109,6 +115,7 @@ impl std::fmt::Display for Error {
             }
             Error::InvalidCaptureName(e) => write!(f, "invalid capture name UTF-8: {}", e),
             Error::InvalidRuleName(e) => write!(f, "invalid rule name UTF-8: {}", e),
+            Error::InvalidLabelName(e) => write!(f, "invalid label name UTF-8: {}", e),
             Error::TrailingBytes { remaining } => {
                 write!(f, "{} trailing byte(s) after end of program", remaining)
             }
@@ -185,6 +192,7 @@ pub fn encode(program: &Program) -> Vec<u8> {
     let mut out = Vec::new();
     write_name_table(&mut out, &program.capture_kinds, "capture");
     write_name_table(&mut out, &program.rule_names, "rule");
+    write_name_table(&mut out, &program.label_kinds, "label");
     write_instructions(&mut out, &program.code);
     out
 }
@@ -295,7 +303,10 @@ fn write_instruction(out: &mut Vec<u8>, ins: &Instruction) {
             out.extend_from_slice(&kind.0.to_le_bytes());
         }
         Instruction::CaptureEnd => out.push(TAG_CAPTURE_END),
-        Instruction::RecoverScopeBegin => out.push(TAG_RECOVER_SCOPE_BEGIN),
+        Instruction::RecoverScopeBegin(label) => {
+            out.push(TAG_RECOVER_SCOPE_BEGIN);
+            out.extend_from_slice(&label.0.to_le_bytes());
+        }
         Instruction::RecoverToScopedMax => out.push(TAG_RECOVER_TO_SCOPED_MAX),
         Instruction::RecoverScopeEnd => out.push(TAG_RECOVER_SCOPE_END),
         Instruction::End => out.push(TAG_END),
@@ -319,6 +330,7 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
     let mut cur = Cursor::new(bytes);
     let capture_kinds = read_name_table(&mut cur, Error::InvalidCaptureName)?;
     let rule_names = read_name_table(&mut cur, Error::InvalidRuleName)?;
+    let label_kinds = read_name_table(&mut cur, Error::InvalidLabelName)?;
     let code = read_instructions(&mut cur)?;
     if cur.pos != bytes.len() {
         return Err(Error::TrailingBytes {
@@ -331,6 +343,7 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
         capture_kinds,
         rule_count,
         rule_names,
+        label_kinds,
     })
 }
 
@@ -415,7 +428,10 @@ fn read_instruction(cur: &mut Cursor<'_>) -> Result<Instruction, Error> {
             Instruction::CaptureBegin(kind)
         }
         TAG_CAPTURE_END => Instruction::CaptureEnd,
-        TAG_RECOVER_SCOPE_BEGIN => Instruction::RecoverScopeBegin,
+        TAG_RECOVER_SCOPE_BEGIN => {
+            let label = LabelId(u16::from_le_bytes(cur.read_array::<2>()?));
+            Instruction::RecoverScopeBegin(label)
+        }
         TAG_RECOVER_TO_SCOPED_MAX => Instruction::RecoverToScopedMax,
         TAG_RECOVER_SCOPE_END => Instruction::RecoverScopeEnd,
         TAG_END => Instruction::End,
@@ -613,6 +629,10 @@ mod tests {
             "rule_names mismatch after round-trip"
         );
         assert_eq!(
+            p.label_kinds, p2.label_kinds,
+            "label_kinds mismatch after round-trip"
+        );
+        assert_eq!(
             p.rule_count, p2.rule_count,
             "rule_count mismatch after round-trip (encoder vs derived-on-decode)"
         );
@@ -657,7 +677,7 @@ mod tests {
                 Instruction::LRTail(MemoId(1), Label(43)),
                 Instruction::CaptureBegin(CaptureKind(0)),
                 Instruction::CaptureEnd,
-                Instruction::RecoverScopeBegin,
+                Instruction::RecoverScopeBegin(LabelId(0)),
                 Instruction::RecoverToScopedMax,
                 Instruction::RecoverScopeEnd,
                 Instruction::End,
@@ -665,6 +685,7 @@ mod tests {
             capture_kinds: vec!["alpha".to_string()],
             rule_count: 2,
             rule_names: vec!["start".to_string(), "other".to_string()],
+            label_kinds: vec!["missing_then".to_string()],
         };
         assert_roundtrip(&p);
     }
@@ -705,10 +726,11 @@ mod tests {
 
     #[test]
     fn invalid_opcode_errors() {
-        // Empty capture table + empty rule table + one instruction with a bogus tag.
+        // Empty capture table + empty rule table + empty label table + one instruction with a bogus tag.
         let buf = [
             0x00u8, 0x00, // capture count = 0
             0x00, 0x00, // rule count = 0
+            0x00, 0x00, // label count = 0
             0x01, 0x00, 0x00, 0x00, // instruction count = 1
             0x77, // unknown opcode
         ];
@@ -724,6 +746,8 @@ mod tests {
             0x00, // capture count = 0
             0x00,
             0x00, // rule count = 0
+            0x00,
+            0x00, // label count = 0
             0x01,
             0x00,
             0x00,
@@ -754,6 +778,20 @@ mod tests {
     }
 
     #[test]
+    fn invalid_label_name_utf8_errors() {
+        // Empty capture and rule tables, then label table with one
+        // bad-UTF-8 name.
+        let buf = [
+            0x00u8, 0x00, // capture count = 0
+            0x00, 0x00, // rule count = 0
+            0x01, 0x00, // label count = 1
+            0xFF, 0x00, // bad UTF-8 + NUL
+        ];
+        let err = decode(&buf).unwrap_err();
+        assert!(matches!(err, Error::InvalidLabelName(_)));
+    }
+
+    #[test]
     fn trailing_bytes_errors() {
         let mut bytes = json_program_bytes();
         bytes.push(0x42);
@@ -767,7 +805,9 @@ mod tests {
     #[test]
     fn instruction_count_above_cap_errors() {
         let count = MAX_INSTRUCTION_COUNT + 1;
-        let mut buf = vec![0x00u8, 0x00, 0x00, 0x00]; // empty capture table + empty rule table
+        // empty capture + rule + label tables (6 zero bytes), then a
+        // declared instruction count above the cap.
+        let mut buf = vec![0x00u8; 6];
         buf.extend_from_slice(&count.to_le_bytes());
         let err = decode(&buf).unwrap_err();
         assert!(
@@ -783,6 +823,7 @@ mod tests {
             capture_kinds: vec![],
             rule_count: 0,
             rule_names: vec![],
+            label_kinds: vec![],
         };
         assert_roundtrip(&p);
     }
@@ -803,6 +844,7 @@ mod tests {
             capture_kinds: vec![],
             rule_count: 99, // intentionally inconsistent with the code
             rule_names: vec![],
+            label_kinds: vec![],
         };
         let bytes = encode(&p);
         let decoded = decode(&bytes).expect("decode succeeds");

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -45,6 +45,7 @@ atom       "abc"   [a-z]   .   ident   (...)   @name{...}
 postfix    p*      p+      p?  p*^     p+^
 prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
+catch      p1 ^ p2
 choice     p1 / p2 / p3
 ```
 
@@ -145,6 +146,45 @@ iteration rather than `PartialCommit` — see the invariants section in
 **Empty-match caveat.** If `p` matches the empty string, `p*^` spins
 forever — same hazard as plain `p*`. The compiler does not detect
 this; grammar authors must ensure `p` consumes input on success.
+
+### `inner ^ recovery` — catch with recovery
+
+Tries `inner`; on failure, splices the failed attempt's deepest-reach
+captures back into the live buffer (via `RecoverToScopedMax`) and runs
+`recovery` from that resync point. The recovery branch only fires when
+`inner` fails; on success the catch behaves exactly like its inner.
+
+```peg
+stmt <- (assign / call) ^ @err{ (!';' .)* } ';'
+```
+
+If both branches fail the catch fails to its enclosing backtrack.
+
+Precedence: tighter than `/`, looser than sequence. So `a b ^ c d`
+parses as `(a b) ^ (c d)`, and `a ^ b / c` parses as `(a ^ b) / c`.
+Chained `^` is left-associative: `a ^ b ^ c` ≡ `(a ^ b) ^ c`.
+
+**Difference from `/`.** Ordered choice rewinds `sp` and discards
+inner's partial work before trying the alternative; `^` preserves the
+partial work (the failed attempt's deepest-reach captures and
+position) and runs recovery from there. Subsumes Yacc-style error
+productions:
+
+```peg
+stmt <- alt1 / alt2 / error ';'      # error-production style
+stmt <- (alt1 / alt2) ^ (!';' .)* ';'  # same idea with `^`
+```
+
+**Difference from `*^`.** No loop and no synthetic single-byte
+`recovery` capture — the recovery body is author-written and emits
+whatever captures the author put in it. Wrap recovery in
+`@recovery{...}` (or any other capture name) if you want one. The
+natural two-tier composition is `^` inside a rule for known failure
+points and `*^` outside as the loop-level backstop.
+
+Implementation lives in `Pattern::Catch` (`src/pegc/pattern.rs`) and
+the emission in `src/pegc/compiler.rs`. Reuses the `RecoverScope*`
+opcodes introduced for `*^` — no new VM machinery.
 
 ## Semantics notes
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -45,7 +45,7 @@ atom       "abc"   [a-z]   .   ident   (...)   @name{...}
 postfix    p*      p+      p?  p*^     p+^
 prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
-catch      p1 ^ p2
+catch      p1 ^label p2
 choice     p1 / p2 / p3
 ```
 
@@ -147,7 +147,7 @@ iteration rather than `PartialCommit` — see the invariants section in
 forever — same hazard as plain `p*`. The compiler does not detect
 this; grammar authors must ensure `p` consumes input on success.
 
-### `inner ^ recovery` — catch with recovery
+### `inner ^label recovery` — labeled catch with recovery
 
 Tries `inner`; on failure, splices the failed attempt's deepest-reach
 captures back into the live buffer (via `RecoverToScopedMax`) and runs
@@ -155,36 +155,68 @@ captures back into the live buffer (via `RecoverToScopedMax`) and runs
 `inner` fails; on success the catch behaves exactly like its inner.
 
 ```peg
-stmt <- (assign / call) ^ @err{ (!';' .)* } ';'
+stmt <- (assign / call) ^bad_stmt @err{ (!';' .)* } ';'
 ```
+
+The `label` is mandatory: it tags this scope so `pegdb
+explain-recoveries` can cluster firings — the author's name for "what
+went wrong here." Labels intern into `Program::label_kinds` (a
+separate namespace from `capture_kinds`); `*^` interns its
+`recovery_kind` string as a label the same way, so a `^foo` catch and
+a `*^foo` resync at the same site end up in the same cluster.
+
+The label identifier must touch `^` — no whitespace between them.
+Anything else (`^ lbl`, `^_`, `^!lbl`) is a parse error today and
+reserved for future overlays (anonymous catches, throw atoms — see
+"Reserved syntax" below).
 
 If both branches fail the catch fails to its enclosing backtrack.
 
-Precedence: tighter than `/`, looser than sequence. So `a b ^ c d`
-parses as `(a b) ^ (c d)`, and `a ^ b / c` parses as `(a ^ b) / c`.
-Chained `^` is left-associative: `a ^ b ^ c` ≡ `(a ^ b) ^ c`.
+Precedence: tighter than `/`, looser than sequence. So `a b ^lbl c d`
+parses as `(a b) ^lbl (c d)`, and `a ^lbl b / c` parses as
+`(a ^lbl b) / c`. Chained `^` is left-associative: `a ^l1 b ^l2 c`
+≡ `(a ^l1 b) ^l2 c`.
 
 **Difference from `/`.** Ordered choice rewinds `sp` and discards
-inner's partial work before trying the alternative; `^` preserves the
-partial work (the failed attempt's deepest-reach captures and
+inner's partial work before trying the alternative; `^label` preserves
+the partial work (the failed attempt's deepest-reach captures and
 position) and runs recovery from there. Subsumes Yacc-style error
 productions:
 
 ```peg
-stmt <- alt1 / alt2 / error ';'      # error-production style
-stmt <- (alt1 / alt2) ^ (!';' .)* ';'  # same idea with `^`
+stmt <- alt1 / alt2 / error ';'              # error-production style
+stmt <- (alt1 / alt2) ^bad_stmt (!';' .)* ';'  # same idea with `^`
 ```
 
 **Difference from `*^`.** No loop and no synthetic single-byte
 `recovery` capture — the recovery body is author-written and emits
 whatever captures the author put in it. Wrap recovery in
 `@recovery{...}` (or any other capture name) if you want one. The
-natural two-tier composition is `^` inside a rule for known failure
-points and `*^` outside as the loop-level backstop.
+natural two-tier composition is `^label` inside a rule for known
+failure points and `*^` outside as the loop-level backstop.
 
 Implementation lives in `Pattern::Catch` (`src/pegc/pattern.rs`) and
 the emission in `src/pegc/compiler.rs`. Reuses the `RecoverScope*`
 opcodes introduced for `*^` — no new VM machinery.
+
+### Reserved syntax
+
+`^<non-ident-byte>` is a parse error today and reserved for future
+overlays. Two extensions have been sketched and dropped from the v1
+catch operator pending real-grammar evidence that they're needed:
+
+- **Anonymous catch (`^_` or similar).** A catch with no label.
+  Always emits a placeholder diagnostic. Today's mandatory-label
+  rule keeps `pegdb explain-recoveries` clusters meaningful by
+  forcing every recovery point to be named.
+- **Throw atom (`^!label`).** A zero-byte pattern that always fails
+  with `label`, with Maidl-style cross-rule routing semantics. Useful
+  for compiler frontends that want commitment semantics and
+  targeted "expected X" diagnostics; less load-bearing for syntax
+  highlighters where `*^` covers the common resync case.
+
+If you hit a grammar that needs either, open an issue with the
+concrete use case.
 
 ## Semantics notes
 

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::pattern::Pattern;
-use crate::pegvm::{CaptureKind, Instruction, Label, MemoId, Program, RuleKind};
+use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, RuleKind};
 
 #[derive(Debug)]
 pub enum CompileError {
@@ -33,6 +33,8 @@ struct Compiler {
     pending_calls: Vec<(usize, String)>,
     capture_kinds: HashMap<String, CaptureKind>,
     capture_names: Vec<String>,
+    label_kinds: HashMap<String, LabelId>,
+    label_names: Vec<String>,
 }
 
 impl Compiler {
@@ -42,6 +44,8 @@ impl Compiler {
             pending_calls: Vec::new(),
             capture_kinds: HashMap::new(),
             capture_names: Vec::new(),
+            label_kinds: HashMap::new(),
+            label_names: Vec::new(),
         }
     }
 
@@ -92,6 +96,16 @@ impl Compiler {
         let k = CaptureKind(self.capture_names.len() as u16);
         self.capture_kinds.insert(name.to_string(), k);
         self.capture_names.push(name.to_string());
+        k
+    }
+
+    fn intern_label(&mut self, name: &str) -> LabelId {
+        if let Some(&k) = self.label_kinds.get(name) {
+            return k;
+        }
+        let k = LabelId(self.label_names.len() as u16);
+        self.label_kinds.insert(name.to_string(), k);
+        self.label_names.push(name.to_string());
         k
     }
 
@@ -242,8 +256,9 @@ impl Compiler {
                 // the recovery byte is emitted — see issue #16 and
                 // `StackEntry::RecoverScope` in src/pegvm/vm.rs.
                 let kind = self.intern_capture(recovery_kind);
+                let scope_label = self.intern_label(recovery_kind);
                 let loop_top = self.pos();
-                self.emit(Instruction::RecoverScopeBegin);
+                self.emit(Instruction::RecoverScopeBegin(scope_label));
                 let outer_choice = self.emit(Instruction::Choice(Label(0))); // → rec
                 self.compile_pat(inner);
                 let success_commit = self.emit(Instruction::Commit(Label(0))); // → next_iter
@@ -267,8 +282,12 @@ impl Compiler {
                 self.patch_jump(inner_choice, exit_inner);
                 self.emit(Instruction::RecoverScopeEnd);
             }
-            Pattern::Catch { inner, recovery } => {
-                //              RecoverScopeBegin
+            Pattern::Catch {
+                inner,
+                label,
+                recovery,
+            } => {
+                //              RecoverScopeBegin(label)
                 //              Choice rec
                 //              <inner>
                 //              Commit done            ; pops outer Backtrack
@@ -277,23 +296,24 @@ impl Compiler {
                 //              <recovery>
                 // done:        RecoverScopeEnd
                 //
-                // If `<inner>` succeeds the Commit pops its Backtrack and
-                // jumps to `done:`, where `RecoverScopeEnd` pops the
-                // scope. If `<inner>` fails the VM restores `sp` and
-                // `captures` to the Backtrack's baseline and resumes at
-                // `rec:`; `RecoverToScopedMax` then re-materializes the
-                // failed attempt's deepest-reach captures into the live
-                // buffer before `<recovery>` runs. If `<recovery>` also
-                // fails the fail propagates past the RecoverScope frame
-                // (cleaned up by the `RecoverScope` arm of `fail()` in
-                // src/pegvm/vm.rs) and the whole catch fails to its
-                // enclosing backtrack.
+                // Catches every anonymous failure of `<inner>`. The
+                // `label` is a diagnostic tag threaded into the
+                // `RecoverScope` frame so `RecoverToScopedMax`'s
+                // emitted `RecoveryDiagnostic` carries it; `pegdb
+                // explain-recoveries` clusters firings by it.
                 //
-                // Mirrors the inner half of `RecoverRepeat`'s loop, but
-                // without iteration or a synthetic recovery-byte
-                // capture: the recovery body's captures are whatever
-                // the author wrote.
-                self.emit(Instruction::RecoverScopeBegin);
+                // `RecoverScope` preserves the failed attempt's
+                // deepest-reach captures via `RecoverToScopedMax`
+                // before `<recovery>` runs — the capture-preservation
+                // story from #16.
+                //
+                // If `<recovery>` also fails the fail propagates past
+                // the `RecoverScope` frame (cleaned up by the
+                // `RecoverScope` arm of `fail()` in src/pegvm/vm.rs)
+                // and the whole catch fails to its enclosing
+                // backtrack.
+                let scope_label = self.intern_label(label);
+                self.emit(Instruction::RecoverScopeBegin(scope_label));
                 let outer_choice = self.emit(Instruction::Choice(Label(0))); // → rec
                 self.compile_pat(inner);
                 let success_commit = self.emit(Instruction::Commit(Label(0))); // → done
@@ -327,6 +347,7 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
         capture_kinds: c.capture_names,
         rule_count: 0,
         rule_names: Vec::new(),
+        label_kinds: c.label_names,
     }
 }
 
@@ -420,6 +441,7 @@ pub(crate) fn compile_rules(
         capture_kinds: c.capture_names,
         rule_count: rule_count as usize,
         rule_names,
+        label_kinds: c.label_names,
     })
 }
 
@@ -446,7 +468,9 @@ fn check_refs(
         | Pattern::AndPredicate(inner)
         | Pattern::Capture(_, inner) => check_refs(_rule, inner, rules),
         Pattern::RecoverRepeat { inner, .. } => check_refs(_rule, inner, rules),
-        Pattern::Catch { inner, recovery } => {
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
             check_refs(_rule, inner, rules)?;
             check_refs(_rule, recovery, rules)
         }
@@ -585,7 +609,9 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
         | Pattern::AndPredicate(inner)
         | Pattern::Capture(_, inner) => collect_first_calls(inner, nullable, out),
         Pattern::RecoverRepeat { inner, .. } => collect_first_calls(inner, nullable, out),
-        Pattern::Catch { inner, recovery } => {
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
             // Both branches are reachable at baseline sp: inner
             // unconditionally; recovery whenever inner fails at
             // baseline (i.e. without consuming) — possible regardless

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -267,6 +267,46 @@ impl Compiler {
                 self.patch_jump(inner_choice, exit_inner);
                 self.emit(Instruction::RecoverScopeEnd);
             }
+            Pattern::Catch { inner, recovery } => {
+                //              RecoverScopeBegin
+                //              Choice rec
+                //              <inner>
+                //              Commit done            ; pops outer Backtrack
+                // rec:         RecoverToScopedMax     ; splice failed inner's
+                //                                     ;   deepest-reach captures
+                //              <recovery>
+                // done:        RecoverScopeEnd
+                //
+                // If `<inner>` succeeds the Commit pops its Backtrack and
+                // jumps to `done:`, where `RecoverScopeEnd` pops the
+                // scope. If `<inner>` fails the VM restores `sp` and
+                // `captures` to the Backtrack's baseline and resumes at
+                // `rec:`; `RecoverToScopedMax` then re-materializes the
+                // failed attempt's deepest-reach captures into the live
+                // buffer before `<recovery>` runs. If `<recovery>` also
+                // fails the fail propagates past the RecoverScope frame
+                // (cleaned up by the `RecoverScope` arm of `fail()` in
+                // src/pegvm/vm.rs) and the whole catch fails to its
+                // enclosing backtrack.
+                //
+                // Mirrors the inner half of `RecoverRepeat`'s loop, but
+                // without iteration or a synthetic recovery-byte
+                // capture: the recovery body's captures are whatever
+                // the author wrote.
+                self.emit(Instruction::RecoverScopeBegin);
+                let outer_choice = self.emit(Instruction::Choice(Label(0))); // → rec
+                self.compile_pat(inner);
+                let success_commit = self.emit(Instruction::Commit(Label(0))); // → done
+
+                let rec = self.pos();
+                self.patch_jump(outer_choice, rec);
+                self.emit(Instruction::RecoverToScopedMax);
+                self.compile_pat(recovery);
+
+                let done = self.pos();
+                self.patch_jump(success_commit, done);
+                self.emit(Instruction::RecoverScopeEnd);
+            }
         }
     }
 }
@@ -406,6 +446,10 @@ fn check_refs(
         | Pattern::AndPredicate(inner)
         | Pattern::Capture(_, inner) => check_refs(_rule, inner, rules),
         Pattern::RecoverRepeat { inner, .. } => check_refs(_rule, inner, rules),
+        Pattern::Catch { inner, recovery } => {
+            check_refs(_rule, inner, rules)?;
+            check_refs(_rule, recovery, rules)
+        }
         Pattern::NonTerminal(name) => {
             if rules.contains_key(name) {
                 Ok(())
@@ -493,6 +537,12 @@ fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> bool {
         Pattern::NotPredicate(_) | Pattern::AndPredicate(_) => true,
         Pattern::Capture(_, inner) => pattern_nullable(inner, nullable),
         Pattern::RecoverRepeat { .. } => true,
+        // Catch succeeds-as-inner when inner succeeds, or
+        // succeeds-as-recovery when inner fails. The recovery branch
+        // only runs on inner's failure, so it never contributes a
+        // "matches empty after success" path — nullability follows
+        // inner.
+        Pattern::Catch { inner, .. } => pattern_nullable(inner, nullable),
         Pattern::NonTerminal(name) => nullable.contains(name),
     }
 }
@@ -535,6 +585,16 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
         | Pattern::AndPredicate(inner)
         | Pattern::Capture(_, inner) => collect_first_calls(inner, nullable, out),
         Pattern::RecoverRepeat { inner, .. } => collect_first_calls(inner, nullable, out),
+        Pattern::Catch { inner, recovery } => {
+            // Both branches are reachable at baseline sp: inner
+            // unconditionally; recovery whenever inner fails at
+            // baseline (i.e. without consuming) — possible regardless
+            // of inner's nullability. Recurse into both, like
+            // OrderedChoice, so the LR analysis doesn't miss cycles
+            // routed through a catch's recovery body.
+            collect_first_calls(inner, nullable, out);
+            collect_first_calls(recovery, nullable, out);
+        }
         Pattern::NonTerminal(name) => {
             out.insert(name.clone());
         }

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -91,18 +91,42 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_choice(&mut self) -> Result<Pattern, ParseError> {
-        let mut alts = vec![self.parse_sequence()?];
+        let mut alts = vec![self.parse_catch()?];
         loop {
             self.skip_ws();
             if self.peek() == Some(b'/') {
                 self.pos += 1;
                 self.skip_ws();
-                alts.push(self.parse_sequence()?);
+                alts.push(self.parse_catch()?);
             } else {
                 break;
             }
         }
         Ok(Pattern::choice(alts))
+    }
+
+    /// `inner ^ recovery` — binds tighter than `/`, looser than
+    /// sequence. Left-associative: `a ^ b ^ c` ≡ `(a ^ b) ^ c`. No
+    /// collision with the `*^` / `+^` postfixes — those only fire when
+    /// `^` directly follows `*` / `+` with no whitespace; an `^` at
+    /// infix position is always reached after `parse_postfix` returns.
+    fn parse_catch(&mut self) -> Result<Pattern, ParseError> {
+        let mut lhs = self.parse_sequence()?;
+        loop {
+            self.skip_ws();
+            if self.peek() == Some(b'^') {
+                self.pos += 1;
+                self.skip_ws();
+                let rhs = self.parse_sequence()?;
+                lhs = Pattern::Catch {
+                    inner: Box::new(lhs),
+                    recovery: Box::new(rhs),
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(lhs)
     }
 
     fn parse_sequence(&mut self) -> Result<Pattern, ParseError> {

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -105,21 +105,43 @@ impl<'a> Parser<'a> {
         Ok(Pattern::choice(alts))
     }
 
-    /// `inner ^ recovery` — binds tighter than `/`, looser than
-    /// sequence. Left-associative: `a ^ b ^ c` ≡ `(a ^ b) ^ c`. No
-    /// collision with the `*^` / `+^` postfixes — those only fire when
-    /// `^` directly follows `*` / `+` with no whitespace; an `^` at
-    /// infix position is always reached after `parse_postfix` returns.
+    /// `inner ^label recovery` — labeled catch. Binds tighter than
+    /// `/`, looser than sequence. Left-associative: `a ^l1 b ^l2 c`
+    /// ≡ `(a ^l1 b) ^l2 c`. The label identifier must touch `^` (no
+    /// `^ lbl` with whitespace) so any `^<non-ident-byte>` is reserved
+    /// for future overlays: `^!label` (throw atom), `^_` or similar
+    /// (anonymous catch). See `src/pegc/README.md` for the rationale.
+    ///
+    /// No collision with the `*^` / `+^` postfixes — those only fire
+    /// when `^` directly follows `*` / `+` with no whitespace; an `^`
+    /// at infix position is always reached after `parse_postfix`
+    /// returns.
     fn parse_catch(&mut self) -> Result<Pattern, ParseError> {
         let mut lhs = self.parse_sequence()?;
         loop {
             self.skip_ws();
             if self.peek() == Some(b'^') {
                 self.pos += 1;
+                // Label must touch `^`: no `skip_ws()` here. Anything
+                // other than an ident-start byte is currently a parse
+                // error and reserved for future syntactic slots.
+                let label = self.parse_ident().map_err(|_| {
+                    self.err(
+                        "expected label identifier immediately after `^` (no whitespace); \
+                         anonymous (`^_`) and throw (`^!lbl`) forms are reserved for future use"
+                            .into(),
+                    )
+                })?;
+                if label == "_" {
+                    return Err(self.err(
+                        "label name `_` is reserved for future use (anonymous catch)".into(),
+                    ));
+                }
                 self.skip_ws();
                 let rhs = self.parse_sequence()?;
                 lhs = Pattern::Catch {
                     inner: Box::new(lhs),
+                    label,
                     recovery: Box::new(rhs),
                 };
             } else {
@@ -149,6 +171,12 @@ impl<'a> Parser<'a> {
             None => false,
             Some(b'/') | Some(b')') | Some(b'}') => false,
             Some(b'<') => false, // start of next rule's "<-"
+            // `^` is the catch operator at infix position — leave it
+            // for `parse_catch`. Future overlays (e.g. `^!lbl` throw
+            // atom, `^_` anonymous catch) live in the reserved
+            // `^<non-ident-byte>` slot; when added, this function
+            // grows a one-byte lookahead.
+            Some(b'^') => false,
             Some(c) if is_ident_start(c) => !self.looks_like_rule_def(),
             Some(c) => is_atom_start(c),
         }

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -25,6 +25,16 @@ pub enum Pattern {
         inner: Box<Pattern>,
         recovery_kind: String,
     },
+    /// Try `inner`; on failure, materialize the failed attempt's
+    /// deepest-reach captures (via `RecoverToScopedMax`) and run
+    /// `recovery` from that resync point. Reuses the `RecoverScope`
+    /// machinery from #16, minus the loop wrapper of `RecoverRepeat`.
+    /// If `recovery` also fails, the catch fails to its enclosing
+    /// backtrack.
+    Catch {
+        inner: Box<Pattern>,
+        recovery: Box<Pattern>,
+    },
 }
 
 impl Pattern {

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -31,8 +31,17 @@ pub enum Pattern {
     /// machinery from #16, minus the loop wrapper of `RecoverRepeat`.
     /// If `recovery` also fails, the catch fails to its enclosing
     /// backtrack.
+    ///
+    /// The `label` is mandatory and serves as a diagnostic tag:
+    /// `pegdb explain-recoveries` clusters firings by it so a grammar
+    /// author can see which catch is recovering on which input. It
+    /// has no effect on failure propagation — every catch fires on
+    /// any anonymous failure of `inner`. Future overlays (`^!label`
+    /// throws, `^_` or similar anonymous catch) are reserved
+    /// syntactic slots; see `src/pegc/README.md`.
     Catch {
         inner: Box<Pattern>,
+        label: String,
         recovery: Box<Pattern>,
     },
 }
@@ -55,6 +64,17 @@ impl Pattern {
             items.into_iter().next().unwrap()
         } else {
             Pattern::OrderedChoice(items)
+        }
+    }
+
+    /// Labeled catch — equivalent to `inner ^label recovery` in source.
+    /// The label is a diagnostic tag flowed into `RecoveryDiagnostic` so
+    /// `pegdb explain-recoveries` can cluster firings by it.
+    pub fn catch(inner: Pattern, label: impl Into<String>, recovery: Pattern) -> Pattern {
+        Pattern::Catch {
+            inner: Box::new(inner),
+            label: label.into(),
+            recovery: Box::new(recovery),
         }
     }
 }

--- a/src/pegvm/instruction.rs
+++ b/src/pegvm/instruction.rs
@@ -46,6 +46,18 @@ pub struct CaptureKind(pub u16);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct MemoId(pub u32);
 
+/// Opaque tag identifying a recovery-scope label. Assigned by
+/// `Compiler::intern_label` and threaded through each
+/// `RecoverScopeBegin` instruction. The label is a diagnostic tag
+/// only: it flows into `RecoveryDiagnostic.label` so `pegdb
+/// explain-recoveries` clusters firings by it. The name resolves via
+/// [`crate::pegvm::Program::label_kinds`]. Distinct namespace from
+/// `CaptureKind` so a label and a capture kind with the same name
+/// don't collide.
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
+pub struct LabelId(pub u16);
+
 /// Discriminator on a [`Instruction::RuleEnter`] selecting the post-cache-miss
 /// behavior. The cache-hit prologue is identical for both kinds; only the
 /// miss path differs.
@@ -241,11 +253,17 @@ pub enum Instruction {
 
     /// Push a fresh `RecoverScope` frame capturing the current
     /// `(sp, captures.len())` as the iteration baseline. Emitted at the
-    /// top of every `p*^` iteration so the VM can track the deepest
+    /// top of every `p*^` iteration and at the head of every catch
+    /// (`inner ^label recovery`) so the VM can track the deepest
     /// captures the failed inner attempt produced — see
-    /// `RecoverToScopedMax` and `src/pegc/compiler.rs`'s `RecoverRepeat`
-    /// arm.
-    RecoverScopeBegin,
+    /// `RecoverToScopedMax` and `src/pegc/compiler.rs`.
+    ///
+    /// The `LabelId` tags the scope with the catch's diagnostic label.
+    /// `*^` emits this as the intern of its `recovery_kind` string so
+    /// every `RecoveryDiagnostic` carries a name. Used by `pegdb
+    /// explain-recoveries` to cluster recoveries by label alongside
+    /// rule stack.
+    RecoverScopeBegin(LabelId),
     /// Materialize the topmost `RecoverScope`'s deepest-progress
     /// captures into the live capture buffer past the iteration's
     /// `baseline_capture_len`, and advance `sp` to `scoped_max_sp`.

--- a/src/pegvm/mod.rs
+++ b/src/pegvm/mod.rs
@@ -4,6 +4,6 @@ pub mod program;
 pub mod vm;
 
 pub use incremental::{Edit, MemoCache};
-pub use instruction::{CaptureKind, CharSet, Instruction, Label, MemoId, RuleKind};
+pub use instruction::{CaptureKind, CharSet, Instruction, Label, LabelId, MemoId, RuleKind};
 pub use program::Program;
 pub use vm::{Capture, MatchResult, MemoStats, RecoveryDiagnostic, VM};

--- a/src/pegvm/program.rs
+++ b/src/pegvm/program.rs
@@ -24,4 +24,11 @@ pub struct Program {
     /// and `pegdb explain-recoveries`) to render rule-stack snapshots
     /// back into human-readable names. Length is exactly `rule_count`.
     pub rule_names: Vec<String>,
+    /// Compile-time label names, indexed by `LabelId.0`. Populated by
+    /// [`crate::pegc`] in the order labels are interned (which is
+    /// deterministic given a fixed compile-time pattern walk).
+    /// `pegdb explain-recoveries` resolves the label of a labeled
+    /// recovery firing back to its source name. Empty for grammars
+    /// that don't use labeled failures.
+    pub label_kinds: Vec<String>,
 }

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::instruction::{CaptureKind, Instruction, MemoId, RuleKind};
+use super::instruction::{CaptureKind, Instruction, LabelId, MemoId, RuleKind};
 
 /// One half-open byte span `start..end` tagged with a [`CaptureKind`].
 ///
@@ -114,6 +114,13 @@ enum StackEntry {
         /// would otherwise reject this shape on style grounds.
         #[allow(clippy::box_collection)]
         scoped_max_rule_stack: Option<Box<Vec<MemoId>>>,
+        /// Diagnostic tag for this scope. Set from the
+        /// `RecoverScopeBegin` instruction's payload; flows into the
+        /// `RecoveryDiagnostic` so `pegdb explain-recoveries` can
+        /// cluster firings by label. Has no effect on failure
+        /// propagation — every scope catches anonymous failures
+        /// alike.
+        label: LabelId,
     },
 }
 
@@ -175,6 +182,14 @@ pub struct RecoveryDiagnostic {
     /// during the failed iteration. Indexed values can be resolved to
     /// names via [`crate::pegvm::Program::rule_names`].
     pub rule_stack: Vec<MemoId>,
+    /// Diagnostic label attached to the enclosing `RecoverScope`.
+    /// Resolvable via [`crate::pegvm::Program::label_kinds`]. Set from
+    /// the `RecoverScopeBegin` instruction's payload — every recovery
+    /// firing carries one (labeled catches use the author's label;
+    /// `*^` uses the intern of its `recovery_kind` string). Lets
+    /// `pegdb explain-recoveries` cluster recoveries by
+    /// `(rule_stack, label)`.
+    pub label: LabelId,
 }
 
 /// Diagnostic counters for the memoization cache, exposed via
@@ -540,14 +555,15 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::BackCommit(label) => {
                     self.maybe_snapshot();
                     let entry = self.pop_backtrack();
-                    if let StackEntry::Backtrack {
-                        sp, capture_len, ..
-                    } = entry
-                    {
-                        self.sp = sp;
-                        self.protect_max_captures(capture_len);
-                        self.captures.truncate(capture_len);
-                    }
+                    let (sp, capture_len) = match entry {
+                        StackEntry::Backtrack {
+                            sp, capture_len, ..
+                        } => (sp, capture_len),
+                        _ => unreachable!("pop_backtrack returns only Backtrack frames"),
+                    };
+                    self.sp = sp;
+                    self.protect_max_captures(capture_len);
+                    self.captures.truncate(capture_len);
                     self.ip = label.as_index();
                 }
                 Instruction::FailTwice => {
@@ -922,7 +938,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     self.captures[idx].end = Some(self.sp);
                     self.ip += 1;
                 }
-                Instruction::RecoverScopeBegin => {
+                Instruction::RecoverScopeBegin(label) => {
                     let cur_sp = self.sp;
                     let cur_len = self.captures.len();
                     let scope_idx = self.stack.len();
@@ -942,6 +958,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         scoped_saved_lower: cur_len,
                         scoped_saved_above: Vec::new(),
                         scoped_max_rule_stack: initial_rule_stack,
+                        label: *label,
                     });
                     self.recover_scope_indices.push(scope_idx);
                     self.ip += 1;
@@ -977,6 +994,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         scoped_saved_lower,
                         scoped_saved_above,
                         scoped_max_rule_stack: _,
+                        label,
                     } = &mut self.stack[scope_idx]
                     else {
                         unreachable!("rposition matched RecoverScope")
@@ -985,6 +1003,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     let baseline_capture_len = *baseline_capture_len;
                     let scoped_max_sp = *scoped_max_sp;
                     let scoped_max_captures_len = *scoped_max_captures_len;
+                    let scope_label = *label;
                     debug_assert!(
                         scoped_max_sp >= baseline_sp,
                         "RecoverToScopedMax: scoped_max_sp ({}) retreated below baseline_sp ({})",
@@ -1067,6 +1086,7 @@ impl<'p, 'i> VM<'p, 'i> {
                             capture_index,
                             pos: scoped_max_sp,
                             rule_stack: rule_stack_for_diag,
+                            label: scope_label,
                         });
                     }
 
@@ -1112,6 +1132,9 @@ impl<'p, 'i> VM<'p, 'i> {
         }
     }
 
+    /// Pop the topmost backtrack frame. Used by `Commit`,
+    /// `BackCommit`, and `FailTwice`, all of which consume the frame
+    /// their paired `Choice` pushed.
     fn pop_backtrack(&mut self) -> StackEntry {
         match self.stack.pop() {
             Some(e @ StackEntry::Backtrack { .. }) => e,
@@ -1119,10 +1142,16 @@ impl<'p, 'i> VM<'p, 'i> {
         }
     }
 
+    /// Walks the stack to the nearest `Backtrack`, restoring `(ip, sp,
+    /// captures)` to that frame's snapshot. Pops `Memo`/`LFrame`/`Return`
+    /// frames along the way, caching the rule's failure where applicable.
+    /// Returns `false` if the stack drains without finding a catcher —
+    /// the caller (every dispatch site reaching `fail()`) finalizes the
+    /// parse as a partial match.
     fn fail(&mut self) -> bool {
         self.maybe_snapshot();
         while let Some(entry) = self.stack.pop() {
-            // Explicit match on all three variants — silently dropping a
+            // Explicit match on every variant — silently dropping a
             // `Memo` frame would skip caching its failure and leak
             // re-executions on future hits at the same sp.
             match entry {

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use syntax_highlighter::pegc::{compile_pattern, Grammar, Pattern};
 use syntax_highlighter::pegvm::{
-    Capture, CaptureKind, CharSet, Instruction, Label, MatchResult, MemoId, RuleKind, VM,
+    Capture, CaptureKind, CharSet, Instruction, Label, LabelId, MatchResult, MemoId, RuleKind, VM,
 };
 
 fn run_pattern(pat: &Pattern, input: &[u8]) -> MatchResult {
@@ -464,11 +464,8 @@ fn recover_repeat_inside_called_rule_returns_cleanly() {
     assert_eq!(r.captures, vec![cap(0, 4, 5)]);
 }
 
-fn catch(inner: Pattern, recovery: Pattern) -> Pattern {
-    Pattern::Catch {
-        inner: Box::new(inner),
-        recovery: Box::new(recovery),
-    }
+fn catch(inner: Pattern, label: &str, recovery: Pattern) -> Pattern {
+    Pattern::catch(inner, label, recovery)
 }
 
 #[test]
@@ -477,6 +474,7 @@ fn catch_inner_success_does_not_run_recovery() {
     // Input matches inner cleanly; recovery branch must not fire.
     let p = catch(
         Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        "lbl",
         Pattern::Capture(
             "err".into(),
             Box::new(Pattern::Repeat(Box::new(Pattern::seq(vec![
@@ -501,6 +499,7 @@ fn catch_inner_failure_runs_recovery() {
     // inner = @open{"ab"} fails at sp=0; recovery = @err{.} consumes one byte.
     let p = catch(
         Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        "lbl",
         Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
     );
     let r = run_pattern(&p, b"xy");
@@ -529,6 +528,7 @@ fn catch_preserves_failed_inner_attempt_deepest_captures() {
             Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
             Pattern::literal("b"),
         ]),
+        "lbl",
         Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
     );
     let r = run_pattern(&p, b"ax");
@@ -551,7 +551,7 @@ fn catch_recovery_failure_propagates() {
     // OrderedChoice with a literal fallback to observe the failure
     // visibly via the fallback running.
     let p = Pattern::choice(vec![
-        catch(Pattern::literal("ab"), Pattern::literal("yz")),
+        catch(Pattern::literal("ab"), "lbl", Pattern::literal("yz")),
         Pattern::literal("ax"),
     ]);
     let r = run_pattern(&p, b"ax");
@@ -564,9 +564,9 @@ fn catch_recovery_failure_propagates() {
 
 #[test]
 fn catch_emits_recover_scope_skeleton() {
-    let p = catch(Pattern::literal("a"), Pattern::literal("b"));
+    let p = catch(Pattern::literal("a"), "lbl", Pattern::literal("b"));
     let prog = compile_pattern(&p);
-    // 0:  RecoverScopeBegin
+    // 0:  RecoverScopeBegin(LabelId(0))
     // 1:  Choice rec(4)
     // 2:  Char 'a'                ; <inner>
     // 3:  Commit done(6)          ; pops outer Backtrack
@@ -583,7 +583,7 @@ fn catch_emits_recover_scope_skeleton() {
     assert_eq!(
         prog.code,
         vec![
-            Instruction::RecoverScopeBegin,
+            Instruction::RecoverScopeBegin(LabelId(0)),
             Instruction::Choice(Label(4)),
             Instruction::Char(b'a'),
             Instruction::Commit(Label(6)),
@@ -594,6 +594,7 @@ fn catch_emits_recover_scope_skeleton() {
         ]
     );
     assert_eq!(prog.capture_kinds, Vec::<String>::new());
+    assert_eq!(prog.label_kinds, vec!["lbl".to_string()]);
 }
 
 #[test]
@@ -610,6 +611,7 @@ fn catch_nested_inside_recover_repeat() {
             Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
             Pattern::literal("b"),
         ]),
+        "lbl",
         Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
     );
     let p = recover(inner_catch, "recovery");
@@ -619,6 +621,50 @@ fn catch_nested_inside_recover_repeat() {
         "nested catch inside *^ must complete without panic"
     );
     assert_eq!(r.matched, 7);
+}
+
+#[test]
+fn label_interning_dedups_across_catches() {
+    // Two catches using the same label name share one `LabelId`,
+    // with exactly one entry in `label_kinds`. Confirms
+    // `intern_label` is idempotent.
+    let p = catch(
+        catch(Pattern::literal("a"), "missing", Pattern::literal("x")),
+        "missing",
+        Pattern::literal("y"),
+    );
+    let prog = compile_pattern(&p);
+    let scope_begin_count = prog
+        .code
+        .iter()
+        .filter(|i| matches!(i, Instruction::RecoverScopeBegin(_)))
+        .count();
+    assert_eq!(scope_begin_count, 2);
+    assert_eq!(prog.label_kinds, vec!["missing".to_string()]);
+    for ins in &prog.code {
+        if let Instruction::RecoverScopeBegin(lid) = ins {
+            assert_eq!(lid.0, 0, "both scopes resolve to LabelId(0)");
+        }
+    }
+}
+
+#[test]
+fn label_intern_shared_with_recover_repeat_recovery_kind() {
+    // `*^` interns its `recovery_kind` as a label too, so a catch
+    // using the same string lands on the same `LabelId`. Confirms
+    // the intern is by name, not by emission site — useful so
+    // `pegdb explain-recoveries` can cluster `*^` recoveries and
+    // matching `^lbl` catches under one bucket when the author
+    // chose identical names.
+    let p = Pattern::seq(vec![
+        Pattern::RecoverRepeat {
+            inner: Box::new(Pattern::literal("a")),
+            recovery_kind: "shared".into(),
+        },
+        catch(Pattern::literal("b"), "shared", Pattern::literal("c")),
+    ]);
+    let prog = compile_pattern(&p);
+    assert_eq!(prog.label_kinds, vec!["shared".to_string()]);
 }
 
 #[test]
@@ -840,11 +886,11 @@ fn recover_repeat_emits_choice_commit_skeleton() {
     assert_eq!(
         prog.code,
         vec![
-            Instruction::RecoverScopeBegin, // loop_top
-            Instruction::Choice(Label(4)),  // → rec
-            Instruction::Char(b'a'),        // <inner>
-            Instruction::Commit(Label(10)), // → next_iter
-            Instruction::Choice(Label(12)), // rec: → exit_inner
+            Instruction::RecoverScopeBegin(LabelId(0)), // loop_top
+            Instruction::Choice(Label(4)),              // → rec
+            Instruction::Char(b'a'),                    // <inner>
+            Instruction::Commit(Label(10)),             // → next_iter
+            Instruction::Choice(Label(12)),             // rec: → exit_inner
             Instruction::RecoverToScopedMax,
             Instruction::CaptureBegin(CaptureKind(0)), // recovery
             Instruction::Any(1),

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -464,6 +464,163 @@ fn recover_repeat_inside_called_rule_returns_cleanly() {
     assert_eq!(r.captures, vec![cap(0, 4, 5)]);
 }
 
+fn catch(inner: Pattern, recovery: Pattern) -> Pattern {
+    Pattern::Catch {
+        inner: Box::new(inner),
+        recovery: Box::new(recovery),
+    }
+}
+
+#[test]
+fn catch_inner_success_does_not_run_recovery() {
+    // inner = @open{"ab"}, recovery = @err{(!';' .)*}
+    // Input matches inner cleanly; recovery branch must not fire.
+    let p = catch(
+        Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        Pattern::Capture(
+            "err".into(),
+            Box::new(Pattern::Repeat(Box::new(Pattern::seq(vec![
+                Pattern::NotPredicate(Box::new(Pattern::literal(";"))),
+                Pattern::AnyChar,
+            ])))),
+        ),
+    );
+    let r = run_pattern(&p, b"ab");
+    assert!(r.complete);
+    assert_eq!(r.matched, 2);
+    // Inner enters first → "open" interns to id 0, "err" to id 1.
+    assert_eq!(
+        r.captures,
+        vec![cap(0, 0, 2)],
+        "only the inner's @open capture; recovery's @err must not fire",
+    );
+}
+
+#[test]
+fn catch_inner_failure_runs_recovery() {
+    // inner = @open{"ab"} fails at sp=0; recovery = @err{.} consumes one byte.
+    let p = catch(
+        Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+    );
+    let r = run_pattern(&p, b"xy");
+    assert!(r.complete);
+    assert_eq!(r.matched, 1);
+    assert_eq!(
+        r.captures,
+        vec![cap(1, 0, 1)],
+        "@err captures the single byte the recovery consumed",
+    );
+}
+
+#[test]
+fn catch_preserves_failed_inner_attempt_deepest_captures() {
+    // The whole point of `^` over `/`: when inner fails after partial
+    // progress, the deepest-reach captures from the failed attempt are
+    // re-materialized (via RecoverToScopedMax) and recovery runs from
+    // that resync point — not from baseline sp.
+    //
+    // inner = @open{"a"} "b" — opens an @open over the leading 'a',
+    // then requires 'b' which fails on input "ax". recovery = @err{.}
+    // consumes one byte starting at the failed attempt's deepest sp
+    // (sp=1, after the 'a'), not at baseline (sp=0).
+    let p = catch(
+        Pattern::seq(vec![
+            Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+            Pattern::literal("b"),
+        ]),
+        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+    );
+    let r = run_pattern(&p, b"ax");
+    assert!(r.complete);
+    assert_eq!(r.matched, 2);
+    assert_eq!(
+        r.captures,
+        vec![
+            cap(0, 0, 1), // @open: re-materialized from the failed attempt's deepest reach
+            cap(1, 1, 2), // @err: starts at sp=1 (deepest reach), not at baseline sp=0
+        ],
+        "failed inner's @open survives; recovery's @err starts at scoped_max_sp",
+    );
+}
+
+#[test]
+fn catch_recovery_failure_propagates() {
+    // Both branches fail: inner needs "ab", recovery needs "yz", input
+    // is "ax". The catch as a whole must fail. Wrap it in an outer
+    // OrderedChoice with a literal fallback to observe the failure
+    // visibly via the fallback running.
+    let p = Pattern::choice(vec![
+        catch(Pattern::literal("ab"), Pattern::literal("yz")),
+        Pattern::literal("ax"),
+    ]);
+    let r = run_pattern(&p, b"ax");
+    assert!(r.complete);
+    assert_eq!(
+        r.matched, 2,
+        "catch failed (both branches), so the OrderedChoice fell through to the 'ax' literal",
+    );
+}
+
+#[test]
+fn catch_emits_recover_scope_skeleton() {
+    let p = catch(Pattern::literal("a"), Pattern::literal("b"));
+    let prog = compile_pattern(&p);
+    // 0:  RecoverScopeBegin
+    // 1:  Choice rec(4)
+    // 2:  Char 'a'                ; <inner>
+    // 3:  Commit done(6)          ; pops outer Backtrack
+    // 4:  rec: RecoverToScopedMax
+    // 5:  Char 'b'                ; <recovery>
+    // 6:  done: RecoverScopeEnd
+    // 7:  End
+    //
+    // Smaller than RecoverRepeat's loop: no inner Choice (the recovery
+    // body is author-written; if it fails, the VM's `fail()` cleans up
+    // the RecoverScope frame via the same arm that handles `*^`
+    // escapes — see src/pegvm/vm.rs). No synthetic recovery-byte
+    // capture either.
+    assert_eq!(
+        prog.code,
+        vec![
+            Instruction::RecoverScopeBegin,
+            Instruction::Choice(Label(4)),
+            Instruction::Char(b'a'),
+            Instruction::Commit(Label(6)),
+            Instruction::RecoverToScopedMax,
+            Instruction::Char(b'b'),
+            Instruction::RecoverScopeEnd,
+            Instruction::End,
+        ]
+    );
+    assert_eq!(prog.capture_kinds, Vec::<String>::new());
+}
+
+#[test]
+fn catch_nested_inside_recover_repeat() {
+    // Nested RecoverScope frames: outer `*^` loop wraps a `^` catch.
+    // The catch's frame is pushed and popped each iteration; the
+    // outer's frame stays live across iterations. Regression-tests
+    // that both frames stay balanced under nested capture
+    // re-materialization. Like recover_repeat_nested_loops_do_not_panic
+    // we lock in the operational invariant (no panic, complete parse)
+    // rather than exact capture spans.
+    let inner_catch = catch(
+        Pattern::seq(vec![
+            Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+            Pattern::literal("b"),
+        ]),
+        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+    );
+    let p = recover(inner_catch, "recovery");
+    let r = run_pattern(&p, b"abaxabZ");
+    assert!(
+        r.complete,
+        "nested catch inside *^ must complete without panic"
+    );
+    assert_eq!(r.matched, 7);
+}
+
 #[test]
 fn optional_pattern() {
     let p = Pattern::seq(vec![

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -92,11 +92,12 @@ fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
 
 #[test]
 fn catch_basic_parses_to_pattern_catch() {
-    let g = parse("r <- 'a' ^ 'b'");
+    let g = parse("r <- 'a' ^lbl 'b'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
             inner: Box::new(Pattern::literal("a")),
+            label: "lbl".into(),
             recovery: Box::new(Pattern::literal("b")),
         }
     );
@@ -104,13 +105,14 @@ fn catch_basic_parses_to_pattern_catch() {
 
 #[test]
 fn catch_binds_tighter_than_choice() {
-    // 'a' ^ 'b' / 'c'   ≡   ('a' ^ 'b') / 'c'
-    let g = parse("r <- 'a' ^ 'b' / 'c'");
+    // 'a' ^lbl 'b' / 'c'   ≡   ('a' ^lbl 'b') / 'c'
+    let g = parse("r <- 'a' ^lbl 'b' / 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::OrderedChoice(vec![
             Pattern::Catch {
                 inner: Box::new(Pattern::literal("a")),
+                label: "lbl".into(),
                 recovery: Box::new(Pattern::literal("b")),
             },
             Pattern::literal("c"),
@@ -120,8 +122,8 @@ fn catch_binds_tighter_than_choice() {
 
 #[test]
 fn catch_binds_looser_than_sequence() {
-    // 'a' 'b' ^ 'c' 'd'   ≡   ('a' 'b') ^ ('c' 'd')
-    let g = parse("r <- 'a' 'b' ^ 'c' 'd'");
+    // 'a' 'b' ^lbl 'c' 'd'   ≡   ('a' 'b') ^lbl ('c' 'd')
+    let g = parse("r <- 'a' 'b' ^lbl 'c' 'd'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -129,6 +131,7 @@ fn catch_binds_looser_than_sequence() {
                 Pattern::literal("a"),
                 Pattern::literal("b"),
             ])),
+            label: "lbl".into(),
             recovery: Box::new(Pattern::Sequence(vec![
                 Pattern::literal("c"),
                 Pattern::literal("d"),
@@ -139,15 +142,17 @@ fn catch_binds_looser_than_sequence() {
 
 #[test]
 fn catch_is_left_associative() {
-    // 'a' ^ 'b' ^ 'c'   ≡   ('a' ^ 'b') ^ 'c'
-    let g = parse("r <- 'a' ^ 'b' ^ 'c'");
+    // 'a' ^l1 'b' ^l2 'c'   ≡   ('a' ^l1 'b') ^l2 'c'
+    let g = parse("r <- 'a' ^l1 'b' ^l2 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
             inner: Box::new(Pattern::Catch {
                 inner: Box::new(Pattern::literal("a")),
+                label: "l1".into(),
                 recovery: Box::new(Pattern::literal("b")),
             }),
+            label: "l2".into(),
             recovery: Box::new(Pattern::literal("c")),
         }
     );
@@ -156,10 +161,9 @@ fn catch_is_left_associative() {
 #[test]
 fn catch_does_not_collide_with_star_caret() {
     // `'x'*^` stays as RecoverRepeat (postfix with no whitespace
-    // between `*` and `^`). `'x'* ^ 'y'` is a Catch of Repeat over a
-    // separate recovery branch — the whitespace breaks the `*^`
-    // postfix form.
-    let g = parse("a <- 'x'*^\nb <- 'x'* ^ 'y'");
+    // between `*` and `^`). `'x'* ^lbl 'y'` is a Catch of Repeat over
+    // a separate recovery branch.
+    let g = parse("a <- 'x'*^\nb <- 'x'* ^lbl 'y'");
     assert_eq!(
         g.rules["a"],
         Pattern::RecoverRepeat {
@@ -171,6 +175,7 @@ fn catch_does_not_collide_with_star_caret() {
         g.rules["b"],
         Pattern::Catch {
             inner: Box::new(Pattern::Repeat(Box::new(Pattern::literal("x")))),
+            label: "lbl".into(),
             recovery: Box::new(Pattern::literal("y")),
         }
     );
@@ -178,18 +183,74 @@ fn catch_does_not_collide_with_star_caret() {
 
 #[test]
 fn catch_parens_force_grouping_on_recovery() {
-    // Default `'a' ^ 'b' / 'c'` is `('a' ^ 'b') / 'c'` (catch tighter
-    // than choice); to put a choice in the recovery branch the author
-    // must parenthesize.
-    let g = parse("r <- 'a' ^ ('b' / 'c')");
+    // Default `'a' ^lbl 'b' / 'c'` is `('a' ^lbl 'b') / 'c'` (catch
+    // tighter than choice); to put a choice in the recovery branch
+    // the author must parenthesize.
+    let g = parse("r <- 'a' ^lbl ('b' / 'c')");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
             inner: Box::new(Pattern::literal("a")),
+            label: "lbl".into(),
             recovery: Box::new(Pattern::OrderedChoice(vec![
                 Pattern::literal("b"),
                 Pattern::literal("c"),
             ])),
+        }
+    );
+}
+
+#[test]
+fn catch_label_touches_caret_whitespace_insensitive_on_left() {
+    // `foo ^lbl bar` and `foo^lbl bar` both parse identically — `^`
+    // is whitespace-insensitive on its *left* (same as today's other
+    // infix operators).
+    let with_space = parse("r <- 'a' ^lbl 'b'");
+    let glued = parse("r <- 'a'^lbl 'b'");
+    let expected = Pattern::Catch {
+        inner: Box::new(Pattern::literal("a")),
+        label: "lbl".into(),
+        recovery: Box::new(Pattern::literal("b")),
+    };
+    assert_eq!(with_space.rules["r"], expected);
+    assert_eq!(glued.rules["r"], expected);
+}
+
+#[test]
+fn catch_requires_label_without_whitespace() {
+    // `foo ^ bar` (whitespace between `^` and the label) is rejected
+    // — `^<non-ident-byte>` is a reserved syntactic slot for future
+    // overlays.
+    let err = parse_src("r <- 'a' ^ 'b'").unwrap_err();
+    assert!(
+        err.message.contains("label identifier"),
+        "expected a label-identifier error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn catch_rejects_reserved_underscore_label() {
+    // Bare `_` as a label name is reserved for future use (anonymous
+    // catch).
+    let err = parse_src("r <- 'a' ^_ 'b'").unwrap_err();
+    assert!(
+        err.message.contains("reserved"),
+        "expected a reserved-label error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn catch_accepts_underscore_prefixed_labels() {
+    // `_foo` (underscore prefix, not bare `_`) stays a valid label.
+    let g = parse("r <- 'a' ^_foo 'b'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::literal("a")),
+            label: "_foo".into(),
+            recovery: Box::new(Pattern::literal("b")),
         }
     );
 }
@@ -339,7 +400,9 @@ fn end_to_end_catch_compile_run() {
     // of the statement under an @err capture and consumes the closing
     // semicolon. Input is malformed (no FROM), so the inner fails and
     // the recovery branch fires.
-    let g = parse("stmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^ @err{(!';' .)*} ';'");
+    let g = parse(
+        "stmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^bad_select @err{(!';' .)*} ';'",
+    );
     let prog = g.compile().unwrap();
     let r = VM::new(&prog.code, b"SELECT bogus;").run();
     assert!(

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -91,6 +91,110 @@ fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
 }
 
 #[test]
+fn catch_basic_parses_to_pattern_catch() {
+    let g = parse("r <- 'a' ^ 'b'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::literal("a")),
+            recovery: Box::new(Pattern::literal("b")),
+        }
+    );
+}
+
+#[test]
+fn catch_binds_tighter_than_choice() {
+    // 'a' ^ 'b' / 'c'   ≡   ('a' ^ 'b') / 'c'
+    let g = parse("r <- 'a' ^ 'b' / 'c'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::OrderedChoice(vec![
+            Pattern::Catch {
+                inner: Box::new(Pattern::literal("a")),
+                recovery: Box::new(Pattern::literal("b")),
+            },
+            Pattern::literal("c"),
+        ])
+    );
+}
+
+#[test]
+fn catch_binds_looser_than_sequence() {
+    // 'a' 'b' ^ 'c' 'd'   ≡   ('a' 'b') ^ ('c' 'd')
+    let g = parse("r <- 'a' 'b' ^ 'c' 'd'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::Sequence(vec![
+                Pattern::literal("a"),
+                Pattern::literal("b"),
+            ])),
+            recovery: Box::new(Pattern::Sequence(vec![
+                Pattern::literal("c"),
+                Pattern::literal("d"),
+            ])),
+        }
+    );
+}
+
+#[test]
+fn catch_is_left_associative() {
+    // 'a' ^ 'b' ^ 'c'   ≡   ('a' ^ 'b') ^ 'c'
+    let g = parse("r <- 'a' ^ 'b' ^ 'c'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::Catch {
+                inner: Box::new(Pattern::literal("a")),
+                recovery: Box::new(Pattern::literal("b")),
+            }),
+            recovery: Box::new(Pattern::literal("c")),
+        }
+    );
+}
+
+#[test]
+fn catch_does_not_collide_with_star_caret() {
+    // `'x'*^` stays as RecoverRepeat (postfix with no whitespace
+    // between `*` and `^`). `'x'* ^ 'y'` is a Catch of Repeat over a
+    // separate recovery branch — the whitespace breaks the `*^`
+    // postfix form.
+    let g = parse("a <- 'x'*^\nb <- 'x'* ^ 'y'");
+    assert_eq!(
+        g.rules["a"],
+        Pattern::RecoverRepeat {
+            inner: Box::new(Pattern::literal("x")),
+            recovery_kind: "recovery".into(),
+        }
+    );
+    assert_eq!(
+        g.rules["b"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::Repeat(Box::new(Pattern::literal("x")))),
+            recovery: Box::new(Pattern::literal("y")),
+        }
+    );
+}
+
+#[test]
+fn catch_parens_force_grouping_on_recovery() {
+    // Default `'a' ^ 'b' / 'c'` is `('a' ^ 'b') / 'c'` (catch tighter
+    // than choice); to put a choice in the recovery branch the author
+    // must parenthesize.
+    let g = parse("r <- 'a' ^ ('b' / 'c')");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::literal("a")),
+            recovery: Box::new(Pattern::OrderedChoice(vec![
+                Pattern::literal("b"),
+                Pattern::literal("c"),
+            ])),
+        }
+    );
+}
+
+#[test]
 fn predicate_operators() {
     let g = parse("a <- !'x' .\nb <- &'y' 'y'");
     assert_eq!(
@@ -226,6 +330,32 @@ fn end_to_end_recover_repeat_compile_run() {
     let spans: Vec<(usize, usize)> = r.captures.iter().map(|c| (c.start, c.end)).collect();
     assert_eq!(kinds, vec![1, 0, 0, 1]);
     assert_eq!(spans, vec![(0, 3), (3, 4), (4, 5), (5, 8)]);
+}
+
+#[test]
+fn end_to_end_catch_compile_run() {
+    use syntax_highlighter::pegvm::VM;
+    // Inner is a `SELECT … FROM` sequence; recovery scoops up the rest
+    // of the statement under an @err capture and consumes the closing
+    // semicolon. Input is malformed (no FROM), so the inner fails and
+    // the recovery branch fires.
+    let g = parse("stmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^ @err{(!';' .)*} ';'");
+    let prog = g.compile().unwrap();
+    let r = VM::new(&prog.code, b"SELECT bogus;").run();
+    assert!(
+        r.complete,
+        "catch should let parse complete on malformed input"
+    );
+    assert_eq!(r.matched, 13);
+    // "kw" was interned first by the inner branch's first capture, "err" second.
+    assert_eq!(prog.capture_kinds, vec!["kw", "err"]);
+    let kinds: Vec<u16> = r.captures.iter().map(|c| c.kind.0).collect();
+    let spans: Vec<(usize, usize)> = r.captures.iter().map(|c| (c.start, c.end)).collect();
+    // Failed inner's deepest reach: the @kw{'SELECT'} survives via
+    // RecoverToScopedMax. Recovery then captures the byte range past
+    // "SELECT " up to the `;`.
+    assert_eq!(kinds, vec![0, 1]);
+    assert_eq!(spans, vec![(0, 6), (7, 12)]);
 }
 
 #[test]

--- a/tests/pegb_roundtrip_tests.rs
+++ b/tests/pegb_roundtrip_tests.rs
@@ -33,6 +33,10 @@ fn assert_roundtrip(grammar: &str, sample: &[u8], tag: &str) {
         "{tag}: capture_kinds differ after round-trip"
     );
     assert_eq!(
+        p1.label_kinds, p2.label_kinds,
+        "{tag}: label_kinds differ after round-trip"
+    );
+    assert_eq!(
         p1.rule_count, p2.rule_count,
         "{tag}: rule_count differs after round-trip (encoder vs derived-on-decode)"
     );
@@ -146,4 +150,13 @@ fn sqlite_roundtrips() {
         include_str!("../grammars/sqlite.peg"),
         b"SELECT id, name FROM users WHERE id = 42;\n",
     );
+}
+
+#[test]
+fn labeled_catch_program_round_trips() {
+    // Exercises `RecoverScopeBegin(LabelId)` plus the label-name
+    // table. Input drives the catch through both success and recovery
+    // branches in case any future encoder change depends on runtime
+    // state.
+    assert_grammar("labeled_catch", "r <- 'a' ^lbl 'b'", b"ab");
 }

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -425,6 +425,29 @@ fn explain_recoveries_clusters_by_rule_stack() {
 }
 
 #[test]
+fn explain_recoveries_emits_label_suffix_on_every_cluster() {
+    // After #91, every recovery firing carries a label — `*^` uses
+    // its `recovery_kind` string. The cluster output now includes a
+    // `(label: …)` suffix on every line, where before unlabeled
+    // recoveries had no suffix.
+    let (code, stdout, _) = run_stdin(
+        &["explain-recoveries", "-g", "grammars/rust.peg"],
+        b"fn ok() {}\n@@@ garbage @@@\nfn ok2() {}\n",
+    );
+    assert_eq!(code, 0);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "expected at least one cluster line");
+    for line in &lines {
+        assert!(
+            line.contains("recoveries")
+                && line.contains("farthest reach ends at")
+                && line.contains("(label:"),
+            "unexpected cluster line (missing label suffix): {line}"
+        );
+    }
+}
+
+#[test]
 fn explain_recoveries_reports_no_recoveries_on_clean_input() {
     let (code, stdout, _) = run(&[
         "explain-recoveries",


### PR DESCRIPTION
The catch operator surface is `inner ^label recovery` — the label is mandatory and serves as a diagnostic tag flowed into `RecoveryDiagnostic` so `pegdb explain-recoveries` clusters firings by it. `*^` interns its `recovery_kind` string as a label the same way, so a `^foo` catch and a `*^` configured with `recovery_kind = "foo"` end up in the same cluster.

```peg
stmt <- (assign / call) ^bad_stmt @err{ (!';' .)* } ';'
```

`^<non-ident-byte>` is a parse error today and reserved for future overlays: `^!label` throw atoms (Maidl-style cross-rule routing, the original scope of #98), and `^_` (or similar) anonymous catches. Both are out of scope here pending real-grammar evidence that they're needed; see `src/pegc/README.md`.

Surface (precedence, left-associativity, label-must-touch-`^` rule) and the difference vs `/` and `*^` are documented in [`src/pegc/README.md`](src/pegc/README.md). Catch arm in `compile_pat`, `check_refs`, `pattern_nullable`, and `collect_first_calls` in `src/pegc/compiler.rs`; AST variant in `src/pegc/pattern.rs`; parser layer in `src/pegc/parser.rs`. `pegdb explain-recoveries` cluster key is now `(rule_stack, label)` with the label suffix on every output line.

Closes #91.
