### PR TITLE
pegc: static partial-match-leniency lint as library function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,8 @@ harness = false
 name = "follow_set"
 path = "benches/follow_set.rs"
 harness = false
+
+[[bench]]
+name = "lint"
+path = "benches/lint.rs"
+harness = false

--- a/benches/lint.rs
+++ b/benches/lint.rs
@@ -1,0 +1,118 @@
+//! Partial-match-leniency lint cost per shipped grammar.
+//!
+//! Measures `pegc::analysis::lint_partial_match` on each bundled
+//! grammar. Output: one JSONL row per grammar `(grammar, rules,
+//! findings, time_us)`.
+//!
+//! Run with `cargo bench --bench lint`. Output written to
+//! `target/bench-results/lint.jsonl` for commit-by-commit comparison.
+//!
+//! Methodology mirrors `benches/follow_set.rs`: `std::time::Instant`,
+//! median-of-`RUNS_PER_CELL`. The lint is a one-shot static pass;
+//! callers run it via the library API, so the absolute cost matters
+//! more than per-rule scaling.
+
+use std::time::Instant;
+
+use syntax_highlighter::pegc;
+use syntax_highlighter::pegc::analysis::lint_partial_match;
+use syntax_highlighter::pegc::Grammar;
+
+#[path = "common.rs"]
+mod common;
+
+use common::{json_f64, json_num, json_str, median, open_jsonl, write_jsonl_row};
+
+const JSON_GRAMMAR: &str = include_str!("../grammars/json.peg");
+const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
+const SQL_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
+const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
+const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
+const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
+const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
+const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
+
+const RUNS_PER_CELL: usize = 11;
+
+struct GrammarCase {
+    name: &'static str,
+    grammar: Grammar,
+}
+
+fn parse_case(name: &str, src: &str) -> Grammar {
+    pegc::parse(src).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+fn measure(grammar: &Grammar, runs: usize) -> (u128, usize, usize) {
+    let mut times = Vec::with_capacity(runs);
+    let mut findings = 0;
+    for _ in 0..runs {
+        let t0 = Instant::now();
+        let f = lint_partial_match(grammar);
+        let dt = t0.elapsed().as_nanos();
+        times.push(dt);
+        findings = f.len();
+    }
+    (median(times), grammar.rules.len(), findings)
+}
+
+fn main() {
+    let cases = [
+        GrammarCase {
+            name: "json",
+            grammar: parse_case("json", JSON_GRAMMAR),
+        },
+        GrammarCase {
+            name: "toml",
+            grammar: parse_case("toml", TOML_GRAMMAR),
+        },
+        GrammarCase {
+            name: "sql",
+            grammar: parse_case("sql", SQL_GRAMMAR),
+        },
+        GrammarCase {
+            name: "rust",
+            grammar: parse_case("rust", RUST_GRAMMAR),
+        },
+        GrammarCase {
+            name: "javascript",
+            grammar: parse_case("javascript", JS_GRAMMAR),
+        },
+        GrammarCase {
+            name: "go",
+            grammar: parse_case("go", GO_GRAMMAR),
+        },
+        GrammarCase {
+            name: "c",
+            grammar: parse_case("c", C_GRAMMAR),
+        },
+        GrammarCase {
+            name: "css",
+            grammar: parse_case("css", CSS_GRAMMAR),
+        },
+    ];
+
+    let mut jsonl = open_jsonl("lint");
+    println!(
+        "{:<12} {:>6} {:>8} {:>12}",
+        "grammar", "rules", "findings", "time(us)"
+    );
+    for case in &cases {
+        let (median_ns, rules, findings) = measure(&case.grammar, RUNS_PER_CELL);
+        let time_us = median_ns as f64 / 1000.0;
+        println!(
+            "{:<12} {:>6} {:>8} {:>12.1}",
+            case.name, rules, findings, time_us
+        );
+        if let Some(w) = jsonl.as_mut() {
+            let row = &[
+                ("bench", json_str("lint")),
+                ("grammar", json_str(case.name)),
+                ("rules", json_num(rules)),
+                ("findings", json_num(findings)),
+                ("time_us", json_f64(time_us)),
+            ];
+            let _ = write_jsonl_row(w, row);
+        }
+    }
+}

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -479,3 +479,499 @@ fn extend_follow(
         }
     }
 }
+
+// -- Partial-match-leniency lint -----------------------------------------
+
+/// The kind of lint that produced a [`LintFinding`]. Named even though
+/// v1 has a single variant, so future lints can be added as discriminated
+/// kinds without restructuring the API.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum LintKind {
+    PartialMatchLeniency,
+}
+
+/// One static-lint finding: a rule that can succeed on a prefix of its
+/// expected match, called from a site that does not anchor the boundary.
+///
+/// The fix shape (per PR #101) is a `&(ws <boundary_rule>)` lookahead at
+/// the caller's site; once #103 lands, that lookahead is rewritten into
+/// the boundary-anchored-catch operator.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct LintFinding {
+    pub kind: LintKind,
+    /// The rule whose body has a trailing-nullable position; the lenient one.
+    pub rule: String,
+    /// The rule whose body contains an unanchored call site to [`Self::rule`].
+    pub caller: String,
+}
+
+/// Static lint for the partial-match-leniency antipattern from PR #101.
+///
+/// A rule `R` is flagged at a call site in some rule `R'` when:
+///
+/// 1. R has a non-empty `trailing_first` — there's a tail-position
+///    `Optional` in R's body whose FIRST is non-empty.
+/// 2. Walking outward from the call site through R's call chain, no
+///    "validator" rejects bytes that R's trailing could have consumed.
+///    A validator is either an `AndPredicate` (explicit lookahead anchor)
+///    or a non-nullable consumer whose FIRST is disjoint from
+///    `trailing_first(R)` (would fail if R left wrong bytes).
+///
+/// The reachability analysis differs from a local FIRST/FOLLOW overlap
+/// check: it propagates outward through call sites of R's enclosing
+/// rule, looking for the first hard validator. Only sites where no
+/// validator exists anywhere along the outward chain are flagged.
+///
+/// Findings are returned sorted by `(rule, caller)`.
+pub fn lint_partial_match(grammar: &Grammar) -> Vec<LintFinding> {
+    let nullable = compute_nullable(&grammar.rules);
+
+    let trailing: HashMap<String, FollowSet> = grammar
+        .rules
+        .iter()
+        .map(|(name, body)| (name.clone(), trailing_first(body, &nullable)))
+        .collect();
+
+    let mut findings: Vec<LintFinding> = Vec::new();
+    let mut rule_names: Vec<&String> = grammar.rules.keys().collect();
+    rule_names.sort();
+    let ctx = LintCtx {
+        grammar,
+        nullable: &nullable,
+        trailing: &trailing,
+    };
+    for caller in rule_names {
+        let body = &grammar.rules[caller];
+        let mut cont_stack: Vec<&[Pattern]> = Vec::new();
+        walk_for_call_sites(body, caller, &mut cont_stack, false, &ctx, &mut findings);
+    }
+
+    findings.sort();
+    findings.dedup();
+    findings
+}
+
+/// Immutable shared context for the lint's reachability walk.
+struct LintCtx<'a> {
+    grammar: &'a Grammar,
+    nullable: &'a HashSet<String>,
+    trailing: &'a HashMap<String, FollowSet>,
+}
+
+/// FIRST set of any trailing-Optional position in `pat`.
+///
+/// Restricted to `Optional` (not `Repeat` / `RepeatOne`): operator-chain
+/// Repeats (`expr (binop expr)*`) are intentionally greedy and don't
+/// exhibit the silent-leniency shape from PR #101, where a trailing
+/// `(modifier)?` could fail to match and leave bytes the caller didn't
+/// validate.
+///
+/// - Pattern is `Optional(inner)`: returns FIRST(inner).
+/// - Pattern is a `Sequence`: walks items from the end; for each
+///   trailing nullable item, includes FIRST only if the item is
+///   directly an `Optional` (transparent through `Capture`/`Catch`).
+///   Stops at the first non-nullable item.
+/// - `Capture(_, inner)` / `Catch { inner, .. }`: recurse into inner.
+/// - Otherwise: empty.
+fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
+    let mut out = FollowSet::new();
+    match pat {
+        Pattern::Optional(inner) => {
+            out.extend(pattern_first(inner, nullable));
+        }
+        Pattern::Sequence(items) => {
+            for item in items.iter().rev() {
+                if pattern_nullable(item, nullable) {
+                    if is_trailing_optional_like(item) {
+                        out.extend(pattern_first(item, nullable));
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        Pattern::Capture(_, inner) => {
+            out.extend(trailing_first(inner, nullable));
+        }
+        Pattern::Catch { inner, .. } => {
+            out.extend(trailing_first(inner, nullable));
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Is `pat` an `Optional` (possibly wrapped in transparent `Capture` /
+/// `Catch`)? Used to restrict trailing-nullable detection to the
+/// `(modifier)?` shape from PR #101, excluding `Repeat` operator
+/// chains.
+fn is_trailing_optional_like(pat: &Pattern) -> bool {
+    match pat {
+        Pattern::Optional(_) => true,
+        Pattern::Capture(_, inner) => is_trailing_optional_like(inner),
+        Pattern::Catch { inner, .. } => is_trailing_optional_like(inner),
+        _ => false,
+    }
+}
+
+/// Walk `pat` looking for `NonTerminal` call sites to rules with
+/// non-empty `trailing_first`. Maintains a stack of `continuations` —
+/// each frame is the slice of patterns sibling-after the current
+/// position in some enclosing `Sequence`. At each call site, decide
+/// whether the leniency is contained (validated outward) by examining
+/// the continuation stack and recursively descending into call sites
+/// of the enclosing rule when the stack is exhausted.
+fn walk_for_call_sites<'a>(
+    pat: &'a Pattern,
+    caller: &str,
+    continuations: &mut Vec<&'a [Pattern]>,
+    inside_catch: bool,
+    ctx: &LintCtx<'a>,
+    findings: &mut Vec<LintFinding>,
+) {
+    match pat {
+        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
+        Pattern::NonTerminal(name) => {
+            let Some(t) = ctx.trailing.get(name) else {
+                return;
+            };
+            if t.is_empty() {
+                return;
+            }
+            if !leniency_reaches_unguarded(
+                t,
+                caller,
+                continuations,
+                inside_catch,
+                ctx,
+                &mut HashSet::new(),
+            ) {
+                return;
+            }
+            findings.push(LintFinding {
+                kind: LintKind::PartialMatchLeniency,
+                rule: name.clone(),
+                caller: caller.to_string(),
+            });
+        }
+        Pattern::Sequence(items) => {
+            for i in 0..items.len() {
+                continuations.push(&items[i + 1..]);
+                walk_for_call_sites(
+                    &items[i],
+                    caller,
+                    continuations,
+                    inside_catch,
+                    ctx,
+                    findings,
+                );
+                continuations.pop();
+            }
+        }
+        Pattern::OrderedChoice(alts) => {
+            for alt in alts {
+                walk_for_call_sites(alt, caller, continuations, inside_catch, ctx, findings);
+            }
+        }
+        Pattern::Optional(inner)
+        | Pattern::Capture(_, inner)
+        | Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner) => {
+            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
+        }
+        Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
+            let mut isolated: Vec<&[Pattern]> = Vec::new();
+            walk_for_call_sites(inner, caller, &mut isolated, inside_catch, ctx, findings);
+        }
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            // Inside the Catch's `inner`: leniency that leaks past `inner`
+            // is absorbed by `recovery` (the recovery body fires whenever
+            // the next outer-context matching step fails on the leftover).
+            walk_for_call_sites(inner, caller, continuations, true, ctx, findings);
+            let mut isolated: Vec<&[Pattern]> = Vec::new();
+            walk_for_call_sites(recovery, caller, &mut isolated, false, ctx, findings);
+        }
+    }
+}
+
+/// Returns `true` iff bytes that `target_trailing` could match can reach
+/// an unguarded position from the current continuation stack outward
+/// through call sites of `caller`. "Unguarded" means no `AndPredicate`
+/// anchor and no non-nullable consumer with a FIRST disjoint from
+/// `target_trailing` is encountered along the way.
+fn leniency_reaches_unguarded(
+    target_trailing: &FollowSet,
+    caller: &str,
+    continuations: &[&[Pattern]],
+    inside_catch: bool,
+    ctx: &LintCtx<'_>,
+    visited_callers: &mut HashSet<String>,
+) -> bool {
+    for frame in continuations.iter().rev() {
+        match scan_frame_for_validator(frame, target_trailing, ctx.nullable) {
+            FrameOutcome::Validated => {
+                // A non-Catch validator only saves the call site if we
+                // haven't already passed through a Catch absorber on the
+                // path — a Catch's recovery body would consume the
+                // leniency bytes before a downstream validator fires.
+                if inside_catch {
+                    continue;
+                }
+                return false;
+            }
+            FrameOutcome::Anchored => return false,
+            FrameOutcome::PassedThrough => continue,
+        }
+    }
+
+    if !visited_callers.insert(caller.to_string()) {
+        return true;
+    }
+
+    let mut rule_names: Vec<&String> = ctx.grammar.rules.keys().collect();
+    rule_names.sort();
+
+    if caller == ctx.grammar.start && !target_trailing.contains(&FollowElement::Eof) {
+        visited_callers.remove(caller);
+        return inside_catch;
+    }
+
+    let mut found_call_site = false;
+    for other_rule in rule_names {
+        let body = &ctx.grammar.rules[other_rule];
+        let mut local_findings = false;
+        let mut new_continuations: Vec<&[Pattern]> = Vec::new();
+        let probe = CallsiteProbe {
+            target_caller: caller,
+            target_trailing,
+            in_rule: other_rule,
+        };
+        if find_callsite_unguarded(
+            body,
+            &probe,
+            &mut new_continuations,
+            inside_catch,
+            ctx,
+            visited_callers,
+            &mut local_findings,
+        ) {
+            visited_callers.remove(caller);
+            return true;
+        }
+        found_call_site |= local_findings;
+    }
+    visited_callers.remove(caller);
+
+    if !found_call_site {
+        return inside_catch;
+    }
+
+    false
+}
+
+/// Per-target parameters that don't change as we descend through the
+/// AST in `find_callsite_unguarded`. Bundled to keep the function
+/// signature tight.
+struct CallsiteProbe<'a> {
+    target_caller: &'a str,
+    target_trailing: &'a FollowSet,
+    in_rule: &'a str,
+}
+
+/// Walks the body of `in_rule` searching for occurrences of
+/// `target_caller` (a NonTerminal whose name matches). For each
+/// occurrence, sets the current continuations stack to reflect the
+/// position in `in_rule`'s body and recursively checks whether
+/// `target_trailing` reaches unguarded from there.
+///
+/// Returns `true` if any occurrence is unguarded. Sets
+/// `found_callsite` to true if at least one occurrence exists (so the
+/// caller can distinguish "no call sites at all" from "all call sites
+/// guarded").
+fn find_callsite_unguarded<'a>(
+    pat: &'a Pattern,
+    probe: &CallsiteProbe<'a>,
+    continuations: &mut Vec<&'a [Pattern]>,
+    inside_catch: bool,
+    ctx: &LintCtx<'a>,
+    visited_callers: &mut HashSet<String>,
+    found_callsite: &mut bool,
+) -> bool {
+    match pat {
+        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => false,
+        Pattern::NonTerminal(name) => {
+            if name != probe.target_caller {
+                return false;
+            }
+            *found_callsite = true;
+            leniency_reaches_unguarded(
+                probe.target_trailing,
+                probe.in_rule,
+                continuations,
+                inside_catch,
+                ctx,
+                visited_callers,
+            )
+        }
+        Pattern::Sequence(items) => {
+            for i in 0..items.len() {
+                continuations.push(&items[i + 1..]);
+                let leaked = find_callsite_unguarded(
+                    &items[i],
+                    probe,
+                    continuations,
+                    inside_catch,
+                    ctx,
+                    visited_callers,
+                    found_callsite,
+                );
+                continuations.pop();
+                if leaked {
+                    return true;
+                }
+            }
+            false
+        }
+        Pattern::OrderedChoice(alts) => {
+            for alt in alts {
+                if find_callsite_unguarded(
+                    alt,
+                    probe,
+                    continuations,
+                    inside_catch,
+                    ctx,
+                    visited_callers,
+                    found_callsite,
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+        Pattern::Optional(inner)
+        | Pattern::Capture(_, inner)
+        | Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner) => find_callsite_unguarded(
+            inner,
+            probe,
+            continuations,
+            inside_catch,
+            ctx,
+            visited_callers,
+            found_callsite,
+        ),
+        Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
+            let mut isolated: Vec<&[Pattern]> = Vec::new();
+            find_callsite_unguarded(
+                inner,
+                probe,
+                &mut isolated,
+                inside_catch,
+                ctx,
+                visited_callers,
+                found_callsite,
+            )
+        }
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            if find_callsite_unguarded(
+                inner,
+                probe,
+                continuations,
+                true,
+                ctx,
+                visited_callers,
+                found_callsite,
+            ) {
+                return true;
+            }
+            let mut isolated: Vec<&[Pattern]> = Vec::new();
+            find_callsite_unguarded(
+                recovery,
+                probe,
+                &mut isolated,
+                false,
+                ctx,
+                visited_callers,
+                found_callsite,
+            )
+        }
+    }
+}
+
+enum FrameOutcome {
+    /// A validator was found in this frame: leniency is contained.
+    Validated,
+    /// An `AndPredicate` was found: explicit anchor.
+    Anchored,
+    /// The frame was entirely nullable / overlapping with target — walk
+    /// out further.
+    PassedThrough,
+}
+
+/// Scan one continuation frame (a slice of siblings after the current
+/// position in some Sequence) looking for a hard validator.
+fn scan_frame_for_validator(
+    frame: &[Pattern],
+    target_trailing: &FollowSet,
+    nullable: &HashSet<String>,
+) -> FrameOutcome {
+    for item in frame {
+        if matches!(item, Pattern::AndPredicate(_)) {
+            return FrameOutcome::Anchored;
+        }
+        if let Pattern::NotPredicate(inner) = item {
+            // `!P` succeeds iff P fails. It rejects bytes that match P.
+            // If FIRST(P) contains every element of target_trailing
+            // (target's possible leftover all matches P), then `!P`
+            // unconditionally rejects target's leftover — a validator.
+            // The common case is `!.` (end-of-input assertion), where
+            // FIRST(.) is the full alphabet and any non-empty
+            // target_trailing is subsumed.
+            let inner_first = pattern_first(inner, nullable);
+            if target_trailing
+                .iter()
+                .all(|t| element_subsumed_by(t, &inner_first))
+            {
+                return FrameOutcome::Validated;
+            }
+            // Otherwise it's a zero-width assertion that doesn't help;
+            // keep walking.
+            continue;
+        }
+        if !pattern_nullable(item, nullable) {
+            let item_first = pattern_first(item, nullable);
+            if item_first.is_disjoint(target_trailing) {
+                return FrameOutcome::Validated;
+            }
+            // Non-nullable consumer whose FIRST overlaps with target's
+            // trailing — the consumer doesn't reject what target could
+            // have left. It still consumes, so further siblings are
+            // beyond it; stop walking this frame.
+            return FrameOutcome::PassedThrough;
+        }
+        // Nullable item: walk past it.
+    }
+    FrameOutcome::PassedThrough
+}
+
+/// Returns true iff `elem` is "subsumed" by `set` — every byte that
+/// `elem` can match also can match some element of `set`. Used in
+/// NotPredicate validator analysis.
+///
+/// Conservative: treats `CharClass(full)` as subsuming everything,
+/// `AnyChar` similarly; otherwise checks for exact membership. Rule
+/// references and captures aren't expanded.
+fn element_subsumed_by(elem: &FollowElement, set: &FollowSet) -> bool {
+    let any_char = CharSet::full();
+    if set
+        .iter()
+        .any(|s| matches!(s, FollowElement::CharClass(cs) if *cs == any_char))
+    {
+        return true;
+    }
+    set.contains(elem)
+}

--- a/src/pegc/mod.rs
+++ b/src/pegc/mod.rs
@@ -31,6 +31,7 @@ pub mod compiler;
 pub mod parser;
 pub mod pattern;
 
+pub use analysis::{LintFinding, LintKind};
 pub use compiler::{compile_pattern, CompileError};
 pub use parser::{parse, Grammar, ParseError};
 pub use pattern::Pattern;

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use syntax_highlighter::pegc::analysis::{compute_follow, FollowElement};
+use syntax_highlighter::pegc::analysis::{
+    compute_follow, lint_partial_match, FollowElement, LintFinding, LintKind,
+};
 use syntax_highlighter::pegc::{compile_pattern, parse, Grammar, Pattern};
 use syntax_highlighter::pegvm::{
     Capture, CaptureKind, CharSet, Instruction, Label, LabelId, MatchResult, MemoId, RuleKind, VM,
@@ -1544,3 +1546,170 @@ fn follow_set_real_sqlite_grammar() {
 /// doesn't have a const `from` for arrays in stable Rust without a
 /// `<const N: usize>` import. Defined locally to keep tests readable.
 type BTreeSetOf<T> = std::collections::BTreeSet<T>;
+
+// -- partial-match leniency lint ----------------------------------------
+
+fn finding(rule: &str, caller: &str) -> LintFinding {
+    LintFinding {
+        kind: LintKind::PartialMatchLeniency,
+        rule: rule.into(),
+        caller: caller.into(),
+    }
+}
+
+#[test]
+fn lint_partial_match_trailing_optional_with_eof_validator() {
+    // start <- a; a <- 'x' 'y'?
+    // a is called from the start rule, whose only continuation is Eof.
+    // Eof rejects any non-empty leftover bytes — a validator. No flag.
+    let mut rules = HashMap::new();
+    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::Optional(Box::new(Pattern::literal("y"))),
+        ]),
+    );
+    let g = Grammar::new(rules, "start");
+    assert!(lint_partial_match(&g).is_empty());
+}
+
+#[test]
+fn lint_partial_match_no_trailing_nullable_skipped() {
+    // start <- a; a <- 'x' 'y' — no trailing optional/nullable.
+    let mut rules = HashMap::new();
+    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![Pattern::literal("x"), Pattern::literal("y")]),
+    );
+    let g = Grammar::new(rules, "start");
+    assert!(lint_partial_match(&g).is_empty());
+}
+
+#[test]
+fn lint_partial_match_anchored_via_andpredicate() {
+    // start <- a &'y' 'y'; a <- 'x' 'y'?
+    // The AndPredicate anchors the call to a even though a's trailing
+    // overlaps with what follows.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::seq(vec![
+            Pattern::NonTerminal("a".into()),
+            Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+            Pattern::literal("y"),
+        ]),
+    );
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::Optional(Box::new(Pattern::literal("y"))),
+        ]),
+    );
+    let g = Grammar::new(rules, "start");
+    assert!(
+        lint_partial_match(&g).is_empty(),
+        "AndPredicate should anchor"
+    );
+}
+
+#[test]
+fn lint_partial_match_validated_by_disjoint_consumer() {
+    // start <- a 'z'; a <- 'x' 'y'?
+    // 'z' after a is a non-nullable consumer with FIRST={'z'} disjoint
+    // from a's trailing {'y'}. The consumer validates.
+    let mut rules = HashMap::new();
+    rules.insert(
+        "start".into(),
+        Pattern::seq(vec![
+            Pattern::NonTerminal("a".into()),
+            Pattern::literal("z"),
+        ]),
+    );
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::Optional(Box::new(Pattern::literal("y"))),
+        ]),
+    );
+    let g = Grammar::new(rules, "start");
+    assert!(lint_partial_match(&g).is_empty());
+}
+
+#[test]
+fn lint_partial_match_absorbed_by_outer_catch_flagged() {
+    // start <- (a)*^[;]
+    // a <- 'x' 'y'?
+    // a's leniency at the call site is absorbed by the *^ recovery
+    // wrapper — exactly the PR #101 shape.
+    let mut rules = HashMap::new();
+    let recovery_body = Pattern::Repeat(Box::new(Pattern::seq(vec![
+        Pattern::NotPredicate(Box::new(Pattern::literal(";"))),
+        Pattern::AnyChar,
+    ])));
+    let call_inside_catch = Pattern::Repeat(Box::new(Pattern::Catch {
+        inner: Box::new(Pattern::NonTerminal("a".into())),
+        label: "recovery".into(),
+        recovery: Box::new(recovery_body),
+    }));
+    rules.insert("start".into(), call_inside_catch);
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::Optional(Box::new(Pattern::literal("y"))),
+        ]),
+    );
+    let g = Grammar::new(rules, "start");
+    let findings = lint_partial_match(&g);
+    assert_eq!(findings, vec![finding("a", "start")]);
+}
+
+#[test]
+fn lint_partial_match_real_sqlite_grammar_aliased_expr_anchored() {
+    // The shipped grammar has the PR #101 fix: aliased_expr is anchored
+    // via `&(ws result_column_boundary)` inside result_column. The lint
+    // must not flag aliased_expr → result_column.
+    let source =
+        std::fs::read_to_string("grammars/sqlite.peg").expect("sqlite.peg fixture present");
+    let g = parse(&source).expect("sqlite.peg parses");
+    let findings = lint_partial_match(&g);
+    let bad = findings
+        .iter()
+        .find(|f| f.rule == "aliased_expr" && f.caller == "result_column");
+    assert!(
+        bad.is_none(),
+        "aliased_expr is anchored; should not be flagged"
+    );
+}
+
+#[test]
+fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
+    // Synthesize the pre-PR-#101 shape inline: result_column's body is
+    // just the choice with no anchor. Verify the lint catches the
+    // load-bearing case.
+    let source =
+        std::fs::read_to_string("grammars/sqlite.peg").expect("sqlite.peg fixture present");
+    let mut g = parse(&source).expect("sqlite.peg parses");
+    // Replace result_column's body with an unanchored version.
+    g.rules.insert(
+        "result_column".into(),
+        Pattern::OrderedChoice(vec![
+            Pattern::NonTerminal("table_star".into()),
+            Pattern::Capture("operator".into(), Box::new(Pattern::literal("*"))),
+            Pattern::NonTerminal("aliased_expr".into()),
+        ]),
+    );
+    let findings = lint_partial_match(&g);
+    let hit = findings
+        .iter()
+        .find(|f| f.rule == "aliased_expr" && f.caller == "result_column");
+    assert!(
+        hit.is_some(),
+        "load-bearing PR #101 case must be flagged when anchor is stripped; findings: {findings:?}"
+    );
+}


### PR DESCRIPTION
PR #101 surfaced a silent correctness bug where `aliased_expr <- expr (ws kw_as ws ident / ws ident)?` succeeded on a prefix of a SQL column expression, leaving `IN leaf AS leaf` for top-level recovery to absorb. Finding the bug took hours of `dump-captures` archaeology; the fix was a one-line `&(ws result_column_boundary)` lookahead in `result_column`. `#104` closes that asymmetry on the static side, so authors don't have to suspect leniency first.

This adds `pegc::analysis::lint_partial_match(&Grammar) -> Vec<LintFinding>` — a reachability analysis that, for each rule with a trailing-Optional, walks the outward call chain looking for a hard validator before reaching an unguarded scope. The load-bearing acceptance criterion lives in `tests/compiler_tests.rs::lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged`: with `result_column`'s anchor stripped (synthesizing the pre-PR-#101 shape), the lint flags `aliased_expr` → `result_column`. With the anchor in place (the shipped grammar), it does not.

The lint is library-only. It is not invoked from `pegc::compile()`. See the commit body for why the original strict-in-compile design was deferred. The substrate is available to downstream tooling (notably the upcoming `#103` boundary-anchored-catch operator), and a future ticket can coordinate grammar cleanup with the new operator and then flip integration.

Part of `#108`'s tracking. Leaves `#104` open since the dynamic-trace half (`#108` step 8) is unchanged.

<details>
<summary>Lint cost per shipped grammar</summary>

Median-of-11 from `benches/lint.rs`:

| Grammar | Rules | Findings | Median (µs) |
|---|---|---|---|
| `json` | 16 | 0 | 8 |
| `toml` | 59 | 0 | 127 |
| `css` | 55 | 2 | 404 |
| `c` | 111 | 2 | 547 |
| `javascript` | 148 | 20 | 999 |
| `go` | 152 | 15 | 1,360 |
| `rust` | 185 | 12 | 2,972 |
| `sqlite` | 428 | 37 | 8,300 |

</details>

<details>
<summary>Why the lint is library-only rather than fatal in compile</summary>

The originally-planned strict-in-compile design assumed the lint could be precise enough that shipped grammars would pass cleanly after a small hand-anchored cleanup. Reality: a local FIRST/FOLLOW-overlap check overflags on idiomatic patterns (most trailing-optionals share a leading `ws` rule with their caller's FOLLOW); the precise reachability check still flags ~80 sites on shipped grammars, the bulk of which are real partial-matches that are *intentionally* absorbed by outer `*^`-style recovery scopes. Without an intent signal (annotation, configuration), the lint cannot distinguish those from the PR `#101` shape it correctly catches.

Strict-in-compile + no escape valve requires effectively-perfect precision; that bar isn't met. Library-only ships the substrate without forcing a 80-site grammar-engineering pass whose boundary decisions `#103` will then rewrite. The discussion thread on this `#104` PR is the right place to surface this if the precision floor needs revisiting.

</details>
