### PR TITLE
pegc: optional `:label` suffix on `*^` / `+^` recovery sugar (#100)

### DIFF
--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -83,6 +83,7 @@ point.
 | `p+^` | At-least-once recovery form — desugars to `p (p*^)`. |
 | `p*^[charset]` | Repetition with delimiter-scoped recovery: on inner failure, skip to and consume the next byte in `charset`. |
 | `p+^[charset]` | At-least-once delimiter-scoped recovery — desugars to `p (p*^[charset])`. |
+| `p*^:lbl` / `p*^[charset]:lbl` / `p+^:lbl` / `p+^[charset]:lbl` | Optional `:label` suffix on any of the above, naming the catch scope for `pegdb explain-recoveries` clustering. Default label is `"recovery"`. |
 
 ### Prefix operators
 
@@ -139,6 +140,14 @@ sql_file <- ws (statement)*^ ws !.
 recover on the rest. The recovery capture kind is hard-coded as
 `recovery`.
 
+An optional `:lbl` suffix names the catch scope: `p*^:bad_doc`
+interns label `"bad_doc"` instead of the default `"recovery"`. The
+`:` must touch the preceding `^` and the identifier must touch `:`
+— same tight-binding rule as `^label`. The capture kind is
+unaffected (still `recovery`); only the label changes. `pegdb
+explain-recoveries` clusters by this label, so per-site naming
+lets distinct call sites surface as their own buckets.
+
 **Lowering.** `p*^` is syntactic sugar for a labeled catch wrapped in
 a `Repeat`. The parser produces an AST equivalent to:
 
@@ -184,6 +193,10 @@ The `[charset]` token uses the standard character-class syntax — same
 ranges, escapes, and negation as a top-level `[...]` atom. It must
 touch `^` (no whitespace between them) so the postfix glue isn't
 broken by an intervening atom.
+
+The optional `:lbl` suffix described above applies here too:
+`p*^[;]:bad_stmt` interns label `"bad_stmt"`. The `:` must touch the
+closing `]`.
 
 **EOF semantics.** If the delimiter is missing before EOF, the
 recovery body fails: the catch fails, the outer `*` terminates, and

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -238,7 +238,8 @@ impl<'a> Parser<'a> {
                     if self.peek() == Some(b'^') {
                         self.pos += 1;
                         let charset = self.parse_optional_sync_set()?;
-                        atom = build_recover_repeat(atom, charset);
+                        let label = self.parse_optional_recovery_label()?;
+                        atom = build_recover_repeat(atom, charset, label);
                     } else {
                         atom = Pattern::Repeat(Box::new(atom));
                     }
@@ -248,9 +249,10 @@ impl<'a> Parser<'a> {
                     if self.peek() == Some(b'^') {
                         self.pos += 1;
                         let charset = self.parse_optional_sync_set()?;
+                        let label = self.parse_optional_recovery_label()?;
                         // p+^  ≡  p (p*^)  — at least one inner success required.
                         let head = atom.clone();
-                        atom = Pattern::seq(vec![head, build_recover_repeat(atom, charset)]);
+                        atom = Pattern::seq(vec![head, build_recover_repeat(atom, charset, label)]);
                     } else {
                         atom = Pattern::RepeatOne(Box::new(atom));
                     }
@@ -279,6 +281,30 @@ impl<'a> Parser<'a> {
             Pattern::CharClass(set) => Ok(Some(set)),
             _ => unreachable!("parse_charclass always returns Pattern::CharClass"),
         }
+    }
+
+    /// If the byte following `*^` / `*^[cs]` / `+^` / `+^[cs]` is `:`,
+    /// parse an identifier touching the colon and use it as the catch
+    /// label. The `:` must touch the preceding `^` or `]` (no whitespace),
+    /// and the identifier must touch `:` — same tight-binding rule as
+    /// `parse_catch`'s `^label`. Returns `None` when the next byte isn't
+    /// `:`, in which case the caller falls back to the default
+    /// `"recovery"` label. Bare `_` is rejected as reserved for future
+    /// anonymous-catch syntax, mirroring `parse_catch`.
+    fn parse_optional_recovery_label(&mut self) -> Result<Option<String>, ParseError> {
+        if self.peek() != Some(b':') {
+            return Ok(None);
+        }
+        self.pos += 1;
+        let label = self.parse_ident().map_err(|_| {
+            self.err("expected label identifier immediately after `:` (no whitespace)".into())
+        })?;
+        if label == "_" {
+            return Err(
+                self.err("label name `_` is reserved for future use (anonymous catch)".into())
+            );
+        }
+        Ok(Some(label))
     }
 
     fn parse_atom(&mut self) -> Result<Pattern, ParseError> {
@@ -535,11 +561,11 @@ fn is_atom_start(c: u8) -> bool {
 }
 
 /// Desugar `p*^` and `p*^[cs]` to a labeled-catch loop. Both forms are
-/// `(p ^recovery @recovery{<body>})*` where `<body>` is `.` for the
-/// plain form and `(!cs .)* cs` for the sync-set form. The label and
-/// capture name are both the hardcoded literal `"recovery"`, matching
-/// the `recovery_kind` value the parser used to attach to
-/// `Pattern::RecoverRepeat`.
+/// `(p ^<label> @recovery{<body>})*` where `<body>` is `.` for the
+/// plain form and `(!cs .)* cs` for the sync-set form. The capture
+/// name is always `"recovery"`; the label is the author-supplied
+/// `:lbl` suffix when present and falls back to the literal
+/// `"recovery"` otherwise.
 ///
 /// One implementation, two surface forms — see `parse_postfix`. The
 /// EOF clean-exit behavior of the old `RecoverRepeat` opcode shape
@@ -547,7 +573,11 @@ fn is_atom_start(c: u8) -> bool {
 /// EOF, or `cs` missing before EOF), the failure propagates to the
 /// enclosing `*`'s Backtrack frame and the loop terminates without
 /// consuming further input.
-fn build_recover_repeat(inner: Pattern, charset: Option<CharSet>) -> Pattern {
+fn build_recover_repeat(
+    inner: Pattern,
+    charset: Option<CharSet>,
+    label: Option<String>,
+) -> Pattern {
     let body = match charset {
         None => Pattern::AnyChar,
         Some(cs) => Pattern::Sequence(vec![
@@ -561,7 +591,7 @@ fn build_recover_repeat(inner: Pattern, charset: Option<CharSet>) -> Pattern {
     let recovery = Pattern::Capture("recovery".into(), Box::new(body));
     Pattern::Repeat(Box::new(Pattern::Catch {
         inner: Box::new(inner),
-        label: "recovery".into(),
+        label: label.unwrap_or_else(|| "recovery".into()),
         recovery: Box::new(recovery),
     }))
 }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -912,6 +912,17 @@ fn recover_repeat_emits_choice_commit_skeleton() {
     assert_eq!(prog.label_kinds, vec!["recovery".to_string()]);
 }
 
+#[test]
+fn recover_repeat_labeled_interns_author_label() {
+    // `*^:bad_thing` interns the author-supplied label while leaving
+    // the capture kind at its hardcoded `"recovery"` — the catch
+    // scope is renamed (so pegdb explain-recoveries clusters under
+    // "bad_thing"), but theme styling is unaffected.
+    let prog = syntax_highlighter::pegc::compile("r <- 'a'*^:bad_thing").unwrap();
+    assert_eq!(prog.capture_kinds, vec!["recovery".to_string()]);
+    assert_eq!(prog.label_kinds, vec!["bad_thing".to_string()]);
+}
+
 /// Builds the desugared AST that `p*^[cs]` lowers to: a `Repeat` over
 /// `Catch(inner, "recovery", @recovery{(!cs .)* cs})`. Mirrors
 /// `build_recover_repeat` in `src/pegc/parser.rs`.

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -64,12 +64,22 @@ fn postfix_operators() {
 
 /// Builds the desugared AST that `p*^` lowers to: a `Repeat` over a
 /// `Catch` whose recovery body is the supplied pattern wrapped in a
-/// capture named `recovery`. Mirrors `build_recover_repeat` in
-/// `src/pegc/parser.rs`. Used by the AST-shape assertions below.
+/// capture named `recovery`. The label defaults to `"recovery"` to
+/// match bare `*^`; the `_with_label` variant covers `*^:lbl`.
+/// Mirrors `build_recover_repeat` in `src/pegc/parser.rs`. Used by the
+/// AST-shape assertions below.
 fn desugared_recover_repeat(inner: Pattern, recovery_body: Pattern) -> Pattern {
+    desugared_recover_repeat_with_label(inner, recovery_body, "recovery")
+}
+
+fn desugared_recover_repeat_with_label(
+    inner: Pattern,
+    recovery_body: Pattern,
+    label: &str,
+) -> Pattern {
     Pattern::Repeat(Box::new(Pattern::Catch {
         inner: Box::new(inner),
-        label: "recovery".into(),
+        label: label.into(),
         recovery: Box::new(Pattern::Capture("recovery".into(), Box::new(recovery_body))),
     }))
 }
@@ -165,6 +175,147 @@ fn sync_set_accepts_negated_and_ranges() {
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat(Pattern::literal("x"), recovery_body)
+    );
+}
+
+#[test]
+fn recover_repeat_postfix_star_caret_with_label() {
+    // `p*^:bad` interns label "bad" instead of the default "recovery";
+    // the capture name is unchanged.
+    let g = parse("r <- 'x'*^:bad");
+    assert_eq!(
+        g.rules["r"],
+        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "bad")
+    );
+}
+
+#[test]
+fn recover_repeat_postfix_plus_caret_with_label() {
+    // `p+^:bad` lowers to `p (p*^:bad)` — the label flows through the
+    // tail `*^` only; the head `p` is the unguarded one-iteration prefix.
+    let g = parse("r <- 'x'+^:bad");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "bad"),
+        ])
+    );
+}
+
+#[test]
+fn sync_set_postfix_star_caret_charset_with_label() {
+    // `p*^[;]:bad_stmt` interns label "bad_stmt"; recovery body
+    // (sync-set skip) is unchanged.
+    let semi = CharSet::from_bytes(b";");
+    let g = parse("r <- 'x'*^[;]:bad_stmt");
+    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
+        Pattern::AnyChar,
+    ])));
+    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    assert_eq!(
+        g.rules["r"],
+        desugared_recover_repeat_with_label(Pattern::literal("x"), recovery_body, "bad_stmt")
+    );
+}
+
+#[test]
+fn sync_set_postfix_plus_caret_charset_with_label() {
+    // `p+^[;]:bad_stmt` lowers to `p (p*^[;]:bad_stmt)`.
+    let semi = CharSet::from_bytes(b";");
+    let g = parse("r <- 'x'+^[;]:bad_stmt");
+    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
+        Pattern::AnyChar,
+    ])));
+    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            desugared_recover_repeat_with_label(Pattern::literal("x"), recovery_body, "bad_stmt"),
+        ])
+    );
+}
+
+#[test]
+fn recovery_label_default_is_recovery() {
+    // Back-compat: bare `*^` (no `:label`) lowers to label "recovery"
+    // exactly as before — the helper's default already encodes this,
+    // so the existing tests cover it; this is a self-documenting
+    // sentinel that the default has not drifted.
+    let g = parse("r <- 'x'*^");
+    let Pattern::Repeat(inner) = &g.rules["r"] else {
+        panic!("expected Repeat, got {:?}", g.rules["r"]);
+    };
+    let Pattern::Catch { label, .. } = inner.as_ref() else {
+        panic!("expected Catch inside Repeat, got {:?}", inner);
+    };
+    assert_eq!(label, "recovery");
+}
+
+#[test]
+fn recovery_label_rejects_whitespace_before_colon() {
+    // `*^ :lbl` (whitespace between `^` and `:`) breaks the postfix
+    // glue: the `*^` lowers without a label, the loose `:lbl` isn't a
+    // valid sequence atom, and the parser falls through to the next
+    // rule-start where `:` fails `parse_ident` with "expected
+    // identifier".
+    let err = parse_src("r <- 'x'*^ :lbl").unwrap_err();
+    assert!(
+        err.message.contains("expected identifier"),
+        "expected an identifier-required error at top level, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn recovery_label_rejects_whitespace_after_colon() {
+    // `*^: lbl` — the identifier must touch `:`.
+    let err = parse_src("r <- 'x'*^: lbl").unwrap_err();
+    assert!(
+        err.message.contains("expected label identifier"),
+        "expected a label-identifier error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn recovery_label_rejects_underscore() {
+    // Bare `_` mirrors `^_`'s reservation for future anonymous-catch
+    // syntax.
+    let err = parse_src("r <- 'x'*^:_").unwrap_err();
+    assert!(
+        err.message.contains("reserved"),
+        "expected a reserved-label error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn recovery_label_after_sync_set_requires_no_space_before_colon() {
+    // `*^[;] :lbl` (whitespace between `]` and `:`) breaks the postfix
+    // glue: `*^[;]` lowers without a label, the loose `:lbl` isn't a
+    // valid sequence atom, and the parser falls through to the next
+    // rule-start where `:` fails `parse_ident` with "expected
+    // identifier".
+    let err = parse_src("r <- 'x'*^[;] :lbl").unwrap_err();
+    assert!(
+        err.message.contains("expected identifier"),
+        "expected an identifier-required error at top level, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn recovery_label_accepts_underscore_prefixed_identifier() {
+    // `_foo` (underscore prefix, not bare `_`) stays a valid label,
+    // mirroring `parse_catch`.
+    let g = parse("r <- 'x'*^:_foo");
+    assert_eq!(
+        g.rules["r"],
+        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "_foo")
     );
 }
 
@@ -470,6 +621,23 @@ fn end_to_end_recover_repeat_compile_run() {
     let spans: Vec<(usize, usize)> = r.captures.iter().map(|c| (c.start, c.end)).collect();
     assert_eq!(kinds, vec![kw, recovery, recovery, kw]);
     assert_eq!(spans, vec![(0, 3), (3, 4), (4, 5), (5, 8)]);
+}
+
+#[test]
+fn end_to_end_recover_repeat_with_label_intern() {
+    use syntax_highlighter::pegvm::VM;
+    // `*^:bad_doc` interns the author-supplied label in
+    // `Program::label_kinds`; the runtime behavior is otherwise
+    // identical to the unlabeled form (one recovery capture per
+    // skipped byte, clean exit at EOF). pegdb explain-recoveries
+    // clusters by this label.
+    let g = parse("doc <- @kw{\"foo\"}*^:bad_doc");
+    let prog = g.compile().unwrap();
+    assert_eq!(prog.label_kinds, vec!["bad_doc"]);
+    let r = VM::new(&prog.code, b"fooXXfoo").run();
+    assert!(r.complete);
+    assert_eq!(r.matched, 8);
+    assert_eq!(prog.capture_kinds, vec!["kw", "recovery"]);
 }
 
 #[test]

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -448,6 +448,33 @@ fn explain_recoveries_emits_label_suffix_on_every_cluster() {
 }
 
 #[test]
+fn explain_recoveries_uses_author_supplied_recovery_label() {
+    // `*^:bad_doc` lowers the catch's label slot to the author's name.
+    // The cluster suffix should pick that up — no special-case for the
+    // hardcoded `"recovery"` default.
+    use std::io::Write as _;
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "pegdb_explain_recoveries_label_{}.peg",
+        std::process::id()
+    ));
+    let grammar = b"doc <- 'x'*^:bad_doc\n";
+    let mut f = std::fs::File::create(&path).expect("create temp grammar");
+    f.write_all(grammar).expect("write temp grammar");
+    drop(f);
+    let (code, stdout, _) = run_stdin(
+        &["explain-recoveries", "-g", path.to_str().unwrap()],
+        b"xx@@@xx",
+    );
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("(label: bad_doc)"),
+        "expected the author-supplied label in the cluster output, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn explain_recoveries_reports_no_recoveries_on_clean_input() {
     let (code, stdout, _) = run(&[
         "explain-recoveries",


### PR DESCRIPTION
Adds an optional `:ident` suffix to the recovery sugar so authors can name catch scopes. Today every `*^` / `*^[cs]` / `+^` / `+^[cs]` site shares the hardcoded label `"recovery"`, which collapses every resync into one cluster in `pegdb explain-recoveries` regardless of which call site is firing. After this change `sql_file <- (ws statement stmt_sep?)*^[;]:bad_statement` clusters under `bad_statement` while inner `^bad_column` / `^bad_where` catches keep their own clusters.

Strictly additive: bare sugar keeps the default `"recovery"` label and lowering, so shipped grammars compile unchanged. The `:` must touch the preceding `^` or `]`, and the label identifier must touch `:`, mirroring `parse_catch`'s tight-binding rule. `:_` is reserved for future anonymous-catch syntax, same as `^_`. The capture kind stays `"recovery"` so themes don't need to learn per-grammar names; only the catch label changes.

Verified manually with `pegdb explain-recoveries` on a small `r <- 'x'*^:bad_doc` grammar — the cluster line surfaces `(label: bad_doc)`.

Sets the `:lbl` label-binding spelling convention that #108 calls out as informing #103's surface syntax. No diagnostic change — `pegdb explain-recoveries` already clusters by `(rule_stack, label_name)` via `Program::label_kinds` and treats arbitrary label strings uniformly.

Closes #100.
