### PR TITLE
pegc: boundary-anchored catch operator + leniency marker (#103)

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -165,7 +165,8 @@ stmt          <- labeled_stmt
 labeled_stmt  <- @variable{ident} ws @punctuation{':'} ws stmt
                / @keyword{'case'} ws expr_cond ws @punctuation{':'} ws stmt
                / @keyword{'default'} ws @punctuation{':'} ws stmt
-if_stmt       <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
+# Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
+~if_stmt      <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
                  (ws @keyword{'else'} ws stmt)?
 for_stmt      <- @keyword{'for'} ws @punctuation{'('} ws for_init ws expr? ws @punctuation{';'} ws expr? ws @punctuation{')'} ws stmt
 for_init      <- decl
@@ -194,12 +195,14 @@ expr          <- expr_assign (ws @punctuation{','} ws expr_assign)*
 expr_assign   <- expr_unary ws assign_op ws expr_assign
                / expr_cond
 
+
 assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
                / @operator{'='} !'='
 
-expr_cond     <- expr_lor (ws @operator{'?'} ws expr ws @punctuation{':'} ws expr_assign)?
+# Trailing ternary `?` leniency absorbed by top-level `*^`.
+~expr_cond    <- expr_lor (ws @operator{'?'} ws expr ws @punctuation{':'} ws expr_assign)?
 
 expr_lor      <- expr_lor ws @operator{'||'} ws expr_land / expr_land
 expr_land     <- expr_land ws @operator{'&&'} ws expr_bor / expr_bor

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -86,11 +86,12 @@ attr_body      <- (!']' .)*
 block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
 block_body    <- (block_item ws)*
 block_item    <- at_rule
-                / ~declaration   # leniency on the `important? ws (';' / &'}')` tail is absorbed by `block`'s `^block_close`
+                / declaration
                 / rule
                 / @punctuation{';'}
 
-declaration   <- @property{prop_ident} ws @punctuation{':'} ws value_list ws
+# Trailing `important? ws (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
+~declaration  <- @property{prop_ident} ws @punctuation{':'} ws value_list ws
                  important? ws (@punctuation{';'} / &'}')
 important     <- @keyword{'!important'}
 
@@ -127,9 +128,10 @@ hex_color     <- @constant{hex_body}
 hex_body      <- '#' hex_digit+
 hex_digit     <- [0-9a-fA-F]
 
-number_with_unit <- @number{~num_body}  # trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values
+number_with_unit <- @number{num_body}
 
-num_body      <- sign? (num_float / num_int) num_unit?
+# Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
+~num_body     <- sign? (num_float / num_int) num_unit?
 sign          <- [+\-]
 num_int       <- [0-9]+
 num_float     <- [0-9]* '.' [0-9]+

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -86,7 +86,7 @@ attr_body      <- (!']' .)*
 block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
 block_body    <- (block_item ws)*
 block_item    <- at_rule
-                / declaration
+                / ~declaration   # leniency on the `important? ws (';' / &'}')` tail is absorbed by `block`'s `^block_close`
                 / rule
                 / @punctuation{';'}
 
@@ -127,7 +127,8 @@ hex_color     <- @constant{hex_body}
 hex_body      <- '#' hex_digit+
 hex_digit     <- [0-9a-fA-F]
 
-number_with_unit <- @number{num_body}
+number_with_unit <- @number{~num_body}  # trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values
+
 num_body      <- sign? (num_float / num_int) num_unit?
 sign          <- [+\-]
 num_int       <- [0-9]+

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -44,7 +44,9 @@ top_decl      <- decl
                  / func_decl
                  / method_decl
 
-decl          <- @keyword{'var'} ws var_spec_group
+# Every alt below has trailing-optional leniency (opt_semi or block?)
+# absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
+~decl         <- @keyword{'var'} ws var_spec_group
                / @keyword{'var'} ws var_spec ws opt_semi
                / @keyword{'const'} ws const_spec_group
                / @keyword{'const'} ws const_spec ws opt_semi
@@ -57,13 +59,15 @@ var_spec      <- ident_list ws type_expr ws @operator{'='} ws expr_list
                / ident_list ws @operator{'='} ws expr_list
 
 const_spec_group <- @punctuation{'('} ws (const_spec ws opt_semi)* ws @punctuation{')'}
-const_spec    <- const_ident_list (ws type_expr)? (ws @operator{'='} ws expr_list)?
+# Trailing `(= expr)?` absorbed by outer recovery.
+~const_spec   <- const_ident_list (ws type_expr)? (ws @operator{'='} ws expr_list)?
 
 type_spec_group <- @punctuation{'('} ws (type_spec ws opt_semi)* ws @punctuation{')'}
 type_spec     <- @type{ident} ws type_params? ws (@operator{'='})? ws type_expr
 
-func_decl     <- @keyword{'func'} ws @function{ident} type_params? ws fn_signature ws block?
-method_decl   <- @keyword{'func'} ws method_receiver ws @function{ident} ws fn_signature ws block?
+# Trailing `block?` absorbed by `*^` / `^block_close`.
+~func_decl    <- @keyword{'func'} ws @function{ident} type_params? ws fn_signature ws block?
+~method_decl  <- @keyword{'func'} ws method_receiver ws @function{ident} ws fn_signature ws block?
 method_receiver <- @punctuation{'('} ws (@variable{ident} ws)? type_expr ws @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
@@ -75,7 +79,8 @@ type_union    <- type_term (ws @operator{'|'} ws type_term)*
 type_term     <- @operator{'~'} ws type_expr
                / type_expr
 
-fn_signature  <- fn_params (ws fn_result)?
+# Trailing `(ws fn_result)?` absorbed by outer recovery.
+~fn_signature <- fn_params (ws fn_result)?
 fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
 fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
 fn_param      <- ident_list ws (@operator{'...'} ws)? type_expr
@@ -111,12 +116,14 @@ interface_members <- interface_member (ws opt_semi ws interface_member)* (ws opt
 interface_member <- @function{ident} ws fn_signature
                   / type_term
 type_paren    <- @punctuation{'('} ws type_expr ws @punctuation{')'}
-type_name     <- @type{qualified_ident} type_args?
+# Trailing `type_args?` leniency absorbed by outer recovery.
+~type_name    <- @type{qualified_ident} type_args?
 type_args     <- @punctuation{'['} ws type_arg_list ws @punctuation{']'}
 type_arg_list <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation{','})?
 
 # `pkg.Name` or `Name`.
-qualified_ident <- ident (@punctuation{'.'} ident)?
+# Trailing `(.ident)?` leniency absorbed by outer recovery.
+~qualified_ident <- ident (@punctuation{'.'} ident)?
 
 # --- Statements ------------------------------------------------------
 
@@ -160,7 +167,8 @@ assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator
 
 labeled_stmt  <- @variable{ident} ws @punctuation{':'} ws stmt
 
-if_stmt       <- @keyword{'if'} ws (simple_stmt ws @punctuation{';'} ws)? expr_no_compound ws block
+# Trailing `(else (if | block))?` leniency absorbed by outer recovery.
+~if_stmt      <- @keyword{'if'} ws (simple_stmt ws @punctuation{';'} ws)? expr_no_compound ws block
                  (ws @keyword{'else'} ws (if_stmt / block))?
 for_stmt      <- @keyword{'for'} ws for_header? ws block
 for_header    <- for_range
@@ -190,9 +198,10 @@ recv_stmt     <- (ident_list ws (@operator{'='} / @operator{':='}) ws)? expr_no_
 
 go_stmt       <- @keyword{'go'} ws expr
 defer_stmt    <- @keyword{'defer'} ws expr
-return_stmt   <- @keyword{'return'} (ws expr_list)?
-break_stmt    <- @keyword{'break'} (ws @variable{ident})?
-continue_stmt <- @keyword{'continue'} (ws @variable{ident})?
+# Trailing-optional leniency absorbed by outer recovery.
+~return_stmt  <- @keyword{'return'} (ws expr_list)?
+~break_stmt   <- @keyword{'break'} (ws @variable{ident})?
+~continue_stmt <- @keyword{'continue'} (ws @variable{ident})?
 goto_stmt     <- @keyword{'goto'} ws @variable{ident}
 fallthrough_stmt <- @keyword{'fallthrough'}
 
@@ -378,7 +387,8 @@ predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
 
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
 # we accept optional explicit `;` and let `ws` eat whitespace.
-opt_semi      <- (@punctuation{';'} ws)?
+# `~`-marked: ASI absorption is intentional everywhere this is called.
+~opt_semi     <- (@punctuation{';'} ws)?
 
 comment       <- @comment{line_comment / block_comment}
 line_comment  <- '//' (!'\n' .)*

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -59,7 +59,11 @@ stmt           <- import_decl
                 / empty_stmt
                 / expr ws opt_semi
 
-opt_semi       <- (@punctuation{';'} ws)?
+# Definition-level `~` on `~opt_semi` covers every ASI call site; the
+# missing-else / missing-catch / missing-finally leniency on the other
+# `~`-marked stmts below is absorbed by stmt-level `*^` and
+# `block`'s `^block_close` recovery.
+~opt_semi      <- (@punctuation{';'} ws)?
 empty_stmt     <- @punctuation{';'} ws
 
 # --- Imports / exports ------------------------------------------------
@@ -87,7 +91,8 @@ export_decl    <- @keyword{'export'} ws @keyword{'default'} ws export_default_bo
 export_default_body <- fn_decl
                      / class_decl
                      / expr ws opt_semi
-export_named   <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
+# Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
+~export_named  <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
 export_specifier_list <- export_specifier (ws @punctuation{','} ws export_specifier)* (ws @punctuation{','})?
 export_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident_name}
                   / @variable{ident}
@@ -116,11 +121,13 @@ class_field    <- (computed_prop / @property{ident_name}) ws (@operator{'='} ws 
 
 var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) ws var_declarator_list
 var_declarator_list <- var_declarator (ws @punctuation{','} ws var_declarator)*
-var_declarator <- pattern (ws @operator{'='} ws expr_no_comma)?
+# Trailing `(= expr)?` absorbed by enclosing stmt recovery.
+~var_declarator <- pattern (ws @operator{'='} ws expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
-if_stmt        <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
+# Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
+~if_stmt       <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
                   (ws @keyword{'else'} ws stmt)?
 for_stmt       <- @keyword{'for'} (ws @keyword{'await'})? ws @punctuation{'('} ws for_head ws @punctuation{')'} ws stmt
 for_head       <- for_c_style
@@ -139,13 +146,15 @@ switch_stmt    <- @keyword{'switch'} ws @punctuation{'('} ws expr ws @punctuatio
 switch_case    <- @keyword{'case'} ws expr ws @punctuation{':'} ws (!switch_case_term stmt ws)*
                 / @keyword{'default'} ws @punctuation{':'} ws (!switch_case_term stmt ws)*
 switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
-try_stmt       <- @keyword{'try'} ws block (ws catch_clause)? (ws finally_clause)?
+# Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
+~try_stmt      <- @keyword{'try'} ws block (ws catch_clause)? (ws finally_clause)?
 catch_clause   <- @keyword{'catch'} (ws @punctuation{'('} ws pattern ws @punctuation{')'})? ws block
 finally_clause <- @keyword{'finally'} ws block
 throw_stmt     <- @keyword{'throw'} ws expr ws opt_semi
-return_stmt    <- @keyword{'return'} (ws expr)? ws opt_semi
-break_stmt     <- @keyword{'break'} (ws @variable{ident})? ws opt_semi
-continue_stmt  <- @keyword{'continue'} (ws @variable{ident})? ws opt_semi
+# Trailing `(ws expr)?` leniency on `~return_stmt` absorbed by stmt recovery.
+~return_stmt   <- @keyword{'return'} (ws expr)? ws opt_semi
+~break_stmt    <- @keyword{'break'} (ws @variable{ident})? ws opt_semi
+~continue_stmt <- @keyword{'continue'} (ws @variable{ident})? ws opt_semi
 debugger_stmt  <- @keyword{'debugger'} ws opt_semi
 labeled_stmt   <- @variable{ident} ws @punctuation{':'} ws stmt
 block_stmt     <- block
@@ -200,7 +209,8 @@ arrow_paren_params <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
 arrow_body     <- block
                 / expr_no_comma
 
-expr_yield     <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
+# Trailing `(ws *)? (ws expr_assign)?` absorbed by stmt-level recovery.
+~expr_yield    <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
@@ -208,7 +218,8 @@ expr_yield     <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
 # preserve right-associativity. Each level inlines its operator
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
-expr_conditional <- expr_nullish (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
+# Trailing ternary leniency absorbed by stmt-level recovery.
+~expr_conditional <- expr_nullish (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
 
 expr_nullish   <- expr_nullish ws @operator{'??'} !'=' ws expr_lor / expr_lor
 expr_lor       <- expr_lor ws @operator{'||'} !'=' ws expr_land / expr_land

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -137,7 +137,8 @@ type_alias_item <- vis? ws @keyword{'type'} ws @type{ident} generic_params? ws w
 macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} ws @function{ident} ws brace_block ws
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
-macro_invocation_stmt <- @function{ident} @punctuation{'!'} ws macro_args ws (@punctuation{';'})? ws
+# Trailing `;?` absorbed by `rust_file`'s `*^`.
+~macro_invocation_stmt <- @function{ident} @punctuation{'!'} ws macro_args ws (@punctuation{';'})? ws
 macro_args    <- paren_group
                / brace_block
                / bracket_group
@@ -182,7 +183,8 @@ type_expr     <- type_fn
                / type_never
                / type_path
 
-type_fn       <- (type_fn_qualifier ws)* @keyword{'fn'} ws @punctuation{'('} ws type_list? ws @punctuation{')'}
+# Trailing `(-> type)?` absorbed by enclosing recovery.
+~type_fn      <- (type_fn_qualifier ws)* @keyword{'fn'} ws @punctuation{'('} ws type_list? ws @punctuation{')'}
                  (ws @punctuation{'->'} ws type_expr)?
 type_fn_qualifier <- @keyword{'unsafe'}
                    / @keyword{'extern'} (ws string_lit)?
@@ -212,9 +214,11 @@ type_path_seg <- @type{upper_ident} path_tail?
 # `GenericArgs` vs `ParenthesizedGenericArgs`.
 path_tail     <- generic_args
                / paren_generic_args
+
 generic_args  <- @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
                / @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
-paren_generic_args <- @punctuation{'('} ws type_list? ws @punctuation{')'} (ws @punctuation{'->'} ws type_expr)?
+# Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
+~paren_generic_args <- @punctuation{'('} ws type_list? ws @punctuation{')'} (ws @punctuation{'->'} ws type_expr)?
 generic_arg_list <- generic_arg (ws @punctuation{','} ws generic_arg)* (ws @punctuation{','})?
 generic_arg   <- lifetime
                / type_expr
@@ -246,7 +250,8 @@ pattern_ref   <- @punctuation{'&'} (ws @keyword{'mut'})? ws pattern_atom
 pattern_box   <- @keyword{'box'} ws pattern_atom
 pattern_tuple <- @punctuation{'('} ws pattern_list? ws @punctuation{')'}
 pattern_list  <- pattern (ws @punctuation{','} ws pattern)* (ws @punctuation{','})?
-pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
+# Trailing `::` chain leniency absorbed by outer recovery.
+~pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
                           (ws pattern_struct_body / ws pattern_tuple)?
 pattern_struct_body <- @punctuation{'{'} ws pattern_struct_fields? ws @punctuation{'}'}
 pattern_struct_fields <- pattern_struct_field (ws @punctuation{','} ws pattern_struct_field)* (ws @punctuation{','})?
@@ -258,7 +263,8 @@ pattern_range <- pattern_literal ws (@punctuation{'..='} / @punctuation{'..'}) w
 pattern_literal <- string_lit / char_lit / number_lit / @constant{bool_lit}
 pattern_wild  <- @punctuation{'_'}
 pattern_rest  <- @punctuation{'..'}
-pattern_binding <- (@keyword{'ref'} ws)? (@keyword{'mut'} ws)? @variable{ident}
+# `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
+~pattern_binding <- (@keyword{'ref'} ws)? (@keyword{'mut'} ws)? @variable{ident}
                    (ws @punctuation{'@'} ws pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
@@ -319,7 +325,8 @@ postfix_op    <- @punctuation{'?'}
 postfix_member <- turbofish_method
                 / @function{ident} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
                 / @number{digit_seq}
-turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
+# Trailing `(args)?` absorbed by outer recovery.
+~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
 
 expr_primary  <- literal
                / expr_if
@@ -339,7 +346,8 @@ expr_primary  <- literal
                / expr_macro_or_path
                / expr_keyword
 
-expr_if       <- @keyword{'if'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
+# Trailing `(else (if | block))?` leniency absorbed by `rust_file`'s `*^` and `block`'s `^block_close`.
+~expr_if      <- @keyword{'if'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
                  (ws @keyword{'else'} ws (expr_if / block))?
 expr_match    <- @keyword{'match'} ws expr ws @punctuation{'{'} ws match_arms? ws @punctuation{'}'}
 match_arms    <- match_arm (ws @punctuation{','} ws match_arm)* (ws @punctuation{','})?
@@ -347,9 +355,10 @@ match_arm     <- (attr_outer ws)* pattern (ws @keyword{'if'} ws expr)? ws @punct
 expr_while    <- @keyword{'while'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
 expr_loop     <- (loop_label ws)? @keyword{'loop'} ws block
 expr_for      <- @keyword{'for'} ws pattern ws @keyword{'in'} ws expr ws block
-expr_return   <- @keyword{'return'} (ws expr)?
-expr_break    <- @keyword{'break'} (ws loop_label)? (ws expr)?
-expr_continue <- @keyword{'continue'} (ws loop_label)?
+# Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
+~expr_return  <- @keyword{'return'} (ws expr)?
+~expr_break   <- @keyword{'break'} (ws loop_label)? (ws expr)?
+~expr_continue <- @keyword{'continue'} (ws loop_label)?
 expr_unsafe   <- @keyword{'unsafe'} ws block
 expr_closure  <- (@keyword{'move'} ws)? @punctuation{'|'} ws closure_params? ws @punctuation{'|'}
                  (ws @punctuation{'->'} ws type_expr)? ws expr
@@ -368,7 +377,8 @@ loop_label    <- @punctuation{'\''} @variable{ident} @punctuation{':'}
 
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
-expr_macro_or_path <- path_expr (ws struct_init / @punctuation{'!'} ws macro_args)?
+# Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
+~expr_macro_or_path <- path_expr (ws struct_init / @punctuation{'!'} ws macro_args)?
 path_expr     <- path_seg (@punctuation{'::'} path_seg)*
 path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?
                / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -85,26 +85,28 @@ statement_body  <- select_stmt
 
 # --- SELECT statement -------------------------------------------------
 
-select_stmt    <- with_clause? select_core compound_tail* order_clause? limit_clause?
+# Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
+~select_stmt   <- with_clause? select_core compound_tail* order_clause? limit_clause?
 
 with_clause    <- kw_with (ws kw_recursive)? ws cte_defn (ws @punctuation{','} ws cte_defn)* ws
 cte_defn       <- @type{bare_ident}
                   (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
                   ws kw_as ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
 
-select_core    <- kw_select (ws (kw_distinct / kw_all))? ws result_list
+# Trailing `(window_clause)?` absorbed by `*^[;]`.
+~select_core   <- kw_select (ws (kw_distinct / kw_all))? ws result_list
                   (ws from_clause)? (ws where_clause)? (ws group_clause)? (ws having_clause)?
                   (ws window_clause)?
 
 result_list    <- result_column (ws @punctuation{','} ws result_column)*
 # A column expression that didn't reach a known boundary is treated
-# as malformed: the trailing `&(ws result_column_boundary)` lookahead
-# makes the inner branch fail when, e.g., `blob.rid IN leaf` parses
-# only `blob.rid` and leaves `IN leaf` dangling. The `^bad_column`
-# catch then resyncs by skipping (without consuming) up to the next
-# `,` / `)` / `;` or SELECT-clause keyword.
-result_column  <- ((table_star / @operator{'*'} / aliased_expr) &(ws result_column_boundary))
-                  ^bad_column @recovery{(!result_column_boundary .)*}
+# as malformed. The `^^bad_column (ws result_column_boundary)`
+# operator anchors the inner branch on the boundary (so e.g.
+# `blob.rid IN leaf` fails because `IN` isn't in the boundary set)
+# and synthesizes the recovery body `(!(ws result_column_boundary) .)*`
+# from the same argument.
+result_column  <- (table_star / @operator{'*'} / aliased_expr)
+                  ^^bad_column (ws result_column_boundary)
 result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{';'}
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
@@ -119,11 +121,13 @@ compound_tail  <- ws (kw_union (ws kw_all)? / kw_intersect / kw_except) ws selec
 from_clause    <- kw_from ws table_or_subquery (ws join_clause)*
 table_or_subquery <- @punctuation{'('} ws select_stmt ws @punctuation{')'} (ws table_alias)?
                    / qualified_table_name (ws table_alias)?
-qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
+# Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
+~qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
 table_alias    <- kw_as ws @variable{bare_ident_nonkw}
                 / @variable{bare_ident_nonkw}
 
-join_clause    <- join_op ws table_or_subquery (ws join_constraint)?
+# Trailing `(join_constraint)?` absorbed by `*^[;]`.
+~join_clause   <- join_op ws table_or_subquery (ws join_constraint)?
 join_op        <- @punctuation{','}
                 / kw_natural (ws join_type)? ws kw_join
                 / join_type ws kw_join
@@ -137,14 +141,13 @@ join_constraint<- kw_on ws expr
                 / kw_using ws @punctuation{'('} ws ident_list ws @punctuation{')'}
 ident_list     <- @variable{bare_ident_nonkw} (ws @punctuation{','} ws @variable{bare_ident_nonkw})*
 
-# Like `result_column`, `where_clause` uses a boundary lookahead to
-# turn partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY
-# …` where `NOT IN <ident>` is unsupported) into a `^bad_where`
-# failure. The catch sits *inside* the `kw_where` match so a missing
-# WHERE keyword still fails the rule cleanly (no spurious empty
-# recovery captures on clean SELECTs).
-where_clause   <- kw_where ws ((expr &(ws where_clause_boundary))
-                               ^bad_where @recovery{(!where_clause_boundary .)*})
+# Like `result_column`, `where_clause` uses `^^bad_where` to turn
+# partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY …`
+# where `NOT IN <ident>` is unsupported) into a recoverable failure.
+# The operator sits *inside* the `kw_where` match so a missing WHERE
+# keyword still fails the rule cleanly (no spurious empty recovery
+# captures on clean SELECTs).
+where_clause   <- kw_where ws (expr ^^bad_where (ws where_clause_boundary))
 where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
@@ -154,10 +157,12 @@ group_clause   <- kw_group ws kw_by ws expr (ws @punctuation{','} ws expr)*
 having_clause  <- kw_having ws expr
 
 order_clause   <- ws kw_order ws kw_by ws order_item (ws @punctuation{','} ws order_item)*
-order_item     <- expr (ws (kw_asc / kw_desc))?
+# Trailing `(asc/desc)?` absorbed by `*^[;]`.
+~order_item    <- expr (ws (kw_asc / kw_desc))?
 
-limit_clause   <- ws kw_limit ws expr (ws kw_offset ws expr
-                                     / ws @punctuation{','} ws expr)?
+# Trailing `(offset)?` absorbed by `*^[;]`.
+~limit_clause  <- ws kw_limit ws expr (ws kw_offset ws expr
+                                      / ws @punctuation{','} ws expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
 # Not counted as reserved keywords in SQLite aside from WINDOW and
@@ -200,7 +205,8 @@ frame_exclude  <- kw_no ws kw_others
 # UPSERT's DO UPDATE path and UPDATE (added in a later commit) share
 # `update_set_list`, which is defined here.
 
-insert_stmt    <- with_clause? insert_prefix ws kw_into ws qualified_table_name
+# Trailing `(returning_clause)?` absorbed by `*^[;]`.
+~insert_stmt   <- with_clause? insert_prefix ws kw_into ws qualified_table_name
                   (ws kw_as ws @variable{bare_ident_nonkw})?
                   (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
                   ws insert_source
@@ -243,7 +249,8 @@ returning_clause <- kw_returning ws result_list
 # compiled without SQLITE_ENABLE_UPDATE_DELETE_LIMIT — highlighting
 # should not pretend the syntax doesn't exist.
 
-update_stmt <- with_clause? kw_update (ws kw_or ws conflict_action)? ws
+# Trailing `(returning_clause)?` absorbed by `*^[;]`.
+~update_stmt <- with_clause? kw_update (ws kw_or ws conflict_action)? ws
                qualified_table_name (ws table_alias)?
                ws kw_set ws update_set_list
                (ws from_clause)?
@@ -252,7 +259,7 @@ update_stmt <- with_clause? kw_update (ws kw_or ws conflict_action)? ws
                limit_clause?
                (ws returning_clause)?
 
-delete_stmt <- with_clause? kw_delete ws kw_from ws qualified_table_name (ws table_alias)?
+~delete_stmt <- with_clause? kw_delete ws kw_from ws qualified_table_name (ws table_alias)?
                (ws where_clause)?
                order_clause?
                limit_clause?
@@ -275,13 +282,15 @@ create_table_stmt <- kw_create (ws (kw_temporary / kw_temp))? ws kw_table
                          (ws table_option (ws @punctuation{','} ws table_option)*)?
                        / kw_as ws select_stmt)
 
-column_def     <- @variable{bare_ident_nonkw}
+# Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
+~column_def    <- @variable{bare_ident_nonkw}
                   (ws type_name)?
                   (ws column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
-type_name      <- @type{bare_ident_nonkw} (ws @type{bare_ident_nonkw})*
+# Trailing `(...)?` leniency absorbed by `*^[;]`.
+~type_name     <- @type{bare_ident_nonkw} (ws @type{bare_ident_nonkw})*
                   (ws @punctuation{'('} ws signed_number
                        (ws @punctuation{','} ws signed_number)? ws @punctuation{')'})?
 
@@ -308,7 +317,8 @@ table_constraint_body <-
     / kw_foreign ws kw_key ws @punctuation{'('} ws ident_list ws @punctuation{')'}
           ws foreign_key_clause
 
-foreign_key_clause <- kw_references ws @type{bare_ident_nonkw}
+# Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
+~foreign_key_clause <- kw_references ws @type{bare_ident_nonkw}
                       (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
                       (ws fk_action)*
                       (ws fk_deferrable)?
@@ -318,7 +328,8 @@ fk_action_body <- kw_set ws (kw_null / kw_default)
                 / kw_cascade
                 / kw_restrict
                 / kw_no ws kw_action
-fk_deferrable  <- (kw_not ws)? kw_deferrable (ws kw_initially ws (kw_immediate / kw_deferred))?
+# Trailing `(initially)?` absorbed by `*^[;]`.
+~fk_deferrable <- (kw_not ws)? kw_deferrable (ws kw_initially ws (kw_immediate / kw_deferred))?
 
 conflict_clause <- kw_on ws kw_conflict ws conflict_action
 
@@ -336,7 +347,8 @@ alter_table_stmt <- kw_alter ws kw_table ws qualified_table_name ws (
 
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
-create_index_stmt <- kw_create (ws kw_unique)? ws kw_index
+# Trailing `(where_clause)?` absorbed by `*^[;]`.
+~create_index_stmt <- kw_create (ws kw_unique)? ws kw_index
                      (ws kw_if ws kw_not ws kw_exists)?
                      ws qualified_table_name
                      ws kw_on ws @type{bare_ident_nonkw}
@@ -378,10 +390,12 @@ drop_trigger_stmt <- kw_drop ws kw_trigger (ws kw_if ws kw_exists)? ws qualified
 
 # --- Transactions & savepoints ---------------------------------------
 
-begin_stmt     <- kw_begin (ws (kw_deferred / kw_immediate / kw_exclusive))?
+# Trailing `(transaction-mode)?` absorbed by `*^[;]`.
+~begin_stmt    <- kw_begin (ws (kw_deferred / kw_immediate / kw_exclusive))?
                   (ws kw_transaction)?
-commit_stmt    <- (kw_commit / kw_end) (ws kw_transaction)?
-rollback_stmt  <- kw_rollback (ws kw_transaction)?
+# Trailing `(transaction)?` absorbed by `*^[;]`.
+~commit_stmt   <- (kw_commit / kw_end) (ws kw_transaction)?
+~rollback_stmt <- kw_rollback (ws kw_transaction)?
                   (ws kw_to (ws kw_savepoint)? ws @variable{bare_ident_nonkw})?
 savepoint_stmt <- kw_savepoint ws @variable{bare_ident_nonkw}
 release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
@@ -393,23 +407,27 @@ release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
 # CREATE VIRTUAL TABLE's module name after USING is @function —
 # the module is invoked, not merely referenced.
 
-pragma_stmt     <- kw_pragma ws qualified_table_name
+# Trailing `(value)?` absorbed by `*^[;]`.
+~pragma_stmt    <- kw_pragma ws qualified_table_name
                    (ws @operator{'='} ws pragma_value
                     / ws @punctuation{'('} ws pragma_value ws @punctuation{')'})?
 pragma_value    <- signed_number / string_lit / @variable{bare_ident}
 
-vacuum_stmt     <- kw_vacuum (ws @type{bare_ident_nonkw})? (ws kw_into ws string_lit)?
+# Trailing `(into)?` absorbed by `*^[;]`.
+~vacuum_stmt    <- kw_vacuum (ws @type{bare_ident_nonkw})? (ws kw_into ws string_lit)?
 
 attach_stmt     <- kw_attach (ws kw_database)? ws expr ws kw_as
                    ws @type{bare_ident_nonkw}
 detach_stmt     <- kw_detach (ws kw_database)? ws @type{bare_ident_nonkw}
 
-reindex_stmt    <- kw_reindex (ws qualified_table_name)?
-analyze_stmt    <- kw_analyze (ws qualified_table_name)?
+# Trailing `(target)?` absorbed by `*^[;]`.
+~reindex_stmt   <- kw_reindex (ws qualified_table_name)?
+~analyze_stmt   <- kw_analyze (ws qualified_table_name)?
 
 explain_stmt    <- kw_explain (ws kw_query ws kw_plan)? ws statement_body
 
-create_virtual_table_stmt <-
+# Trailing `(args)?` absorbed by `*^[;]`.
+~create_virtual_table_stmt <-
     kw_create ws kw_virtual ws kw_table
     (ws kw_if ws kw_not ws kw_exists)?
     ws qualified_table_name
@@ -467,7 +485,8 @@ primary     <- literal
 
 paren_primary <- @punctuation{'('} ws (select_stmt / expr) ws @punctuation{')'}
 
-function_call <- @function{bare_ident_nonkw} ws @punctuation{'('} ws func_args? ws @punctuation{')'}
+# Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
+~function_call <- @function{bare_ident_nonkw} ws @punctuation{'('} ws func_args? ws @punctuation{')'}
                  (ws filter_clause)?
                  (ws kw_over ws window_ref)?
 func_args   <- @operator{'*'}

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -43,7 +43,7 @@ the following precedence, tightest-binding first:
 ```
 atom       "abc"   [a-z]   .   ident   (...)   @name{...}
 postfix    p*      p+      p?  p*^     p+^     p*^[cs]   p+^[cs]
-prefix     !p      &p      ~p
+prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
 catch      p1 ^label p2      p1 ^^label B      p1 ^^label
 choice     p1 / p2 / p3
@@ -51,7 +51,7 @@ choice     p1 / p2 / p3
 
 Rule definitions may carry a top-level `~name <-` decorator to mark
 the whole rule as intentionally lenient — see
-[`~p` / `~name <-`](#p--name----intentional-leniency-marker) below.
+[`~name <-`](#name----intentional-leniency-marker) below.
 
 ### Atoms
 
@@ -333,30 +333,28 @@ uses a placeholder `Pattern::InferBoundaryCatch { inner, label }`
 resolved by `analysis::resolve_inferred_boundaries` before bytecode
 emission. No new VM machinery.
 
-### `~p` / `~name <-` — intentional-leniency marker
+### `~name <-` — intentional-leniency marker
 
 The static `lint_partial_match` check flags trailing-nullable rules
 called unanchored — but on shipped grammars almost every flag is a
 "partial-match leniency intentionally absorbed by outer `*^`-style
 recovery" that the static analysis can't statically prove safe. The
-`~` marker is the author's intent signal: "yes, this leniency is
-known, don't flag it." There are two forms:
-
-- **`~name <-`** at the rule definition. Marks every call to `name`
-  as intentional. Use when a rule is intrinsically lenient (e.g.
-  `~opt_semi <- (';' ws)?` — ASI absorption — applies to every
-  caller). Wraps the rule's body in `Pattern::Lenient`.
-- **`~p`** at a single call site, a prefix-tier operator binding
-  tighter than `!` and `&`. Use when only one caller intentionally
-  tolerates the leniency and others should still be flagged.
-
-Both forms compile transparently — `Pattern::Lenient(p)` emits the
-same bytecode as `p`. The wrapping exists only for static analysis.
+`~name <-` marker is the author's intent signal: "yes, this rule's
+leniency is known, don't flag any call to it." Wraps the rule's body
+in `Pattern::Lenient`, which the lint walker treats as an opaque
+barrier and the compiler treats as transparent (emits the inner's
+bytecode unchanged).
 
 ```peg
-~opt_semi <- (@punctuation{';'} ws)?       # definition-level
-stmt <- ~legacy_form / strict_form         # call-site
+~opt_semi <- (@punctuation{';'} ws)?
 ```
+
+The marker must touch the name (no whitespace between `~` and the
+identifier). Whether the runtime invariant the marker assumes —
+typically an outer `*^` / `*^[;]` / `^block_close` recovery scope
+absorbing the leniency — actually holds is currently a convention
+recorded in adjacent comments and unenforced by the lint; see
+`#113` for the planned tightening.
 
 ### Reserved syntax
 
@@ -415,7 +413,7 @@ concrete use case.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
   that doesn't exist, partial-match leniency on a call site that's
   neither anchored (`^^lbl B`) nor explicitly marked intentional
-  (`~p` / `~name <-`), an `^^lbl` whose call-site FOLLOW set is empty
+  (`~name <-`), an `^^lbl` whose call-site FOLLOW set is empty
   so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -43,11 +43,15 @@ the following precedence, tightest-binding first:
 ```
 atom       "abc"   [a-z]   .   ident   (...)   @name{...}
 postfix    p*      p+      p?  p*^     p+^     p*^[cs]   p+^[cs]
-prefix     !p      &p
+prefix     !p      &p      ~p
 sequence   p1 p2 p3          (juxtaposition)
-catch      p1 ^label p2
+catch      p1 ^label p2      p1 ^^label B      p1 ^^label
 choice     p1 / p2 / p3
 ```
+
+Rule definitions may carry a top-level `~name <-` decorator to mark
+the whole rule as intentionally lenient — see
+[`~p` / `~name <-`](#p--name----intentional-leniency-marker) below.
 
 ### Atoms
 
@@ -257,49 +261,102 @@ failure points and `*^` outside as the loop-level backstop.
 
 #### Anchoring catches at boundaries
 
-In practice every catch site in `grammars/sqlite.peg` needed a third
-ingredient: a **boundary lookahead** before the catch fires. PEG's
-prioritized choice and possessive `*` mean rules routinely succeed
-by matching a prefix and leaving the rest as leftover at the outer
-level — invisibly, with no failure. The catch only helps when the
-rule actually *fails*, so the lookahead is what turns a
-partial-match success into a catch-able failure. The recurring
-shape:
+PEG's prioritized choice and possessive `*` mean rules routinely
+succeed by matching a prefix and leaving the rest as leftover at the
+outer level — invisibly, with no failure. The bare `^label` catch
+only helps when the rule actually *fails*, so anchoring the inner
+on a boundary is what turns a partial-match success into a
+catch-able failure. The
+[`INNER ^^lbl B`](#inner-lbl-b---boundary-anchored-catch) operator
+collapses the three concerns (anchor + catch + recovery body) into
+one form. The bare `^label` form below is still useful for catches
+whose recovery isn't a "skip until boundary" loop — see PR `#101`'s
+`^block_close` sites.
+
+### `INNER ^^lbl B` — boundary-anchored catch
+
+The boundary-anchored catch is a syntactic sugar that takes one
+inner pattern and one boundary `B` (any pattern) and lowers to the
+three-piece idiom that recurs across `grammars/sqlite.peg`:
 
 ```peg
-rule <- ((INNER &(ws boundary)) ^lbl @recovery{(!boundary .)*})
-boundary <- <punct alts> / <kw_* alts> / !.
+INNER ^^lbl B
+# lowers to
+(INNER &B) ^lbl @recovery{(!B .)*}
 ```
 
-`result_column` and `where_clause` in `grammars/sqlite.peg` are the
-worked examples. `&(ws boundary)` requires the rule to consume up
-to a known continuation token; `(!boundary .)*` resyncs without
+`&B` requires `INNER` to consume up to a position where `B` matches
+(turning silent prefix-match success into a `^lbl` catch fire);
+`(!B .)*` resyncs by skipping bytes until `B` is reachable without
 consuming it (so the outer rule still sees the structural
-delimiter).
+delimiter). The `@recovery{...}` wrap is part of the lowering — the
+operator owns the capture-kind choice so authors don't have to type
+it.
 
-**Footgun: where the catch goes.** The catch must sit *inside* any
-required prefix the rule needs to commit to. Writing the catch
-around the whole rule body — e.g.
+**FOLLOW-inferred form `INNER ^^lbl`.** Omitting `B` synthesizes the
+boundary from `INNER`'s call-site FOLLOW set at compile time. Use it
+when the call site has a single, unambiguous FOLLOW and you don't
+need leading-`ws` permissiveness in the lookahead; the resolver
+synthesizes a boundary pattern from the rule's FOLLOW elements and
+applies the same lowering. The two `grammars/sqlite.peg` POC sites
+use the explicit form because their boundary rules include `ws` and
+that wouldn't fall out of FOLLOW.
+
+**Scoping footgun.** The operator must sit *inside* any required
+prefix the rule needs to commit to. Writing the operator around the
+whole rule body — e.g.
 
 ```peg
-where_clause <- kw_where ws (expr &(ws boundary)) ^bad_where @recovery{(!boundary .)*}
+where_clause <- kw_where ws expr ^^bad_where (ws boundary)
 ```
 
-— fires the catch even when `kw_where` itself fails (no WHERE
-keyword present): inner fails → catch fires → recovery `(!boundary
-.)*` matches zero bytes and succeeds → every clean `SELECT 1;`
-emits a spurious empty `recovery` capture. Push the catch past the
+— would let the operator fire even when `kw_where` itself fails (no
+WHERE keyword present): inner fails → recovery `(!boundary .)*`
+matches zero bytes and succeeds → every clean `SELECT 1;` emits a
+spurious empty `recovery` capture. Push the operator past the
 unconditional prefix:
 
 ```peg
-where_clause <- kw_where ws ((expr &(ws boundary)) ^bad_where @recovery{(!boundary .)*})
+where_clause <- kw_where ws (expr ^^bad_where (ws boundary))
 ```
 
 so a missing prefix fails the rule cleanly with no catch involved.
 
+**Operator-family discriminator.** The doubled caret `^^` marks the
+boundary-anchored family; the single caret `^lbl recovery` remains
+the bare catch with author-written recovery. Disambiguation is
+positional — a single byte peek after the first `^`.
+
 Implementation lives in `Pattern::Catch` (`src/pegc/pattern.rs`) and
-the emission in `src/pegc/compiler.rs`. Reuses the `RecoverScope*`
-opcodes introduced for `*^` — no new VM machinery.
+the emission in `src/pegc/compiler.rs`. The FOLLOW-inferred form
+uses a placeholder `Pattern::InferBoundaryCatch { inner, label }`
+resolved by `analysis::resolve_inferred_boundaries` before bytecode
+emission. No new VM machinery.
+
+### `~p` / `~name <-` — intentional-leniency marker
+
+The static `lint_partial_match` check flags trailing-nullable rules
+called unanchored — but on shipped grammars almost every flag is a
+"partial-match leniency intentionally absorbed by outer `*^`-style
+recovery" that the static analysis can't statically prove safe. The
+`~` marker is the author's intent signal: "yes, this leniency is
+known, don't flag it." There are two forms:
+
+- **`~name <-`** at the rule definition. Marks every call to `name`
+  as intentional. Use when a rule is intrinsically lenient (e.g.
+  `~opt_semi <- (';' ws)?` — ASI absorption — applies to every
+  caller). Wraps the rule's body in `Pattern::Lenient`.
+- **`~p`** at a single call site, a prefix-tier operator binding
+  tighter than `!` and `&`. Use when only one caller intentionally
+  tolerates the leniency and others should still be flagged.
+
+Both forms compile transparently — `Pattern::Lenient(p)` emits the
+same bytecode as `p`. The wrapping exists only for static analysis.
+
+```peg
+~opt_semi <- (@punctuation{';'} ws)?       # definition-level
+stmt <- ~legacy_form / strict_form         # call-site
+```
 
 ### Reserved syntax
 
@@ -307,15 +364,15 @@ opcodes introduced for `*^` — no new VM machinery.
 overlays. Two extensions have been sketched and dropped from the v1
 catch operator pending real-grammar evidence that they're needed:
 
-- **Anonymous catch (`^_` or similar).** A catch with no label.
+- **Anonymous catch (`^_` / `^^_`).** A catch with no label.
   Always emits a placeholder diagnostic. Today's mandatory-label
   rule keeps `pegdb explain-recoveries` clusters meaningful by
   forcing every recovery point to be named.
-- **Throw atom (`^!label`).** A zero-byte pattern that always fails
-  with `label`, with Maidl-style cross-rule routing semantics. Useful
-  for compiler frontends that want commitment semantics and
-  targeted "expected X" diagnostics; less load-bearing for syntax
-  highlighters where `*^` covers the common resync case.
+- **Throw atom (`^!label` / `^^!label`).** A zero-byte pattern that
+  always fails with `label`, with Maidl-style cross-rule routing
+  semantics. Useful for compiler frontends that want commitment
+  semantics and targeted "expected X" diagnostics; less load-bearing
+  for syntax highlighters where `*^` covers the common resync case.
 
 If you hit a grammar that needs either, open an issue with the
 concrete use case.
@@ -356,7 +413,10 @@ concrete use case.
   character-class range out of order, unknown escape.
 - **`CompileError`** — source is well-formed but semantically invalid.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
-  that doesn't exist.
+  that doesn't exist, partial-match leniency on a call site that's
+  neither anchored (`^^lbl B`) nor explicitly marked intentional
+  (`~p` / `~name <-`), an `^^lbl` whose call-site FOLLOW set is empty
+  so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.
 

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -629,6 +629,9 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         Pattern::Catch { inner, .. } => {
             out.extend(trailing_first(inner, nullable));
         }
+        // Definition-level `~name <-` opts the rule out of being a flag
+        // target: its `trailing_first` is empty regardless of body shape.
+        Pattern::Lenient(_) => {}
         _ => {}
     }
     out
@@ -662,32 +665,9 @@ fn walk_for_call_sites<'a>(
     ctx: &LintCtx<'a>,
     findings: &mut Vec<LintFinding>,
 ) {
-    walk_for_call_sites_impl(
-        pat,
-        caller,
-        continuations,
-        inside_catch,
-        false,
-        ctx,
-        findings,
-    )
-}
-
-fn walk_for_call_sites_impl<'a>(
-    pat: &'a Pattern,
-    caller: &str,
-    continuations: &mut Vec<&'a [Pattern]>,
-    inside_catch: bool,
-    inside_lenient: bool,
-    ctx: &LintCtx<'a>,
-    findings: &mut Vec<LintFinding>,
-) {
     match pat {
         Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
         Pattern::NonTerminal(name) => {
-            if inside_lenient {
-                return;
-            }
             let Some(t) = ctx.trailing.get(name) else {
                 return;
             };
@@ -713,12 +693,11 @@ fn walk_for_call_sites_impl<'a>(
         Pattern::Sequence(items) => {
             for i in 0..items.len() {
                 continuations.push(&items[i + 1..]);
-                walk_for_call_sites_impl(
+                walk_for_call_sites(
                     &items[i],
                     caller,
                     continuations,
                     inside_catch,
-                    inside_lenient,
                     ctx,
                     findings,
                 );
@@ -727,42 +706,18 @@ fn walk_for_call_sites_impl<'a>(
         }
         Pattern::OrderedChoice(alts) => {
             for alt in alts {
-                walk_for_call_sites_impl(
-                    alt,
-                    caller,
-                    continuations,
-                    inside_catch,
-                    inside_lenient,
-                    ctx,
-                    findings,
-                );
+                walk_for_call_sites(alt, caller, continuations, inside_catch, ctx, findings);
             }
         }
         Pattern::Optional(inner)
         | Pattern::Capture(_, inner)
         | Pattern::Repeat(inner)
         | Pattern::RepeatOne(inner) => {
-            walk_for_call_sites_impl(
-                inner,
-                caller,
-                continuations,
-                inside_catch,
-                inside_lenient,
-                ctx,
-                findings,
-            );
+            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
         }
         Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites_impl(
-                inner,
-                caller,
-                &mut isolated,
-                inside_catch,
-                inside_lenient,
-                ctx,
-                findings,
-            );
+            walk_for_call_sites(inner, caller, &mut isolated, inside_catch, ctx, findings);
         }
         Pattern::Catch {
             inner, recovery, ..
@@ -770,41 +725,16 @@ fn walk_for_call_sites_impl<'a>(
             // Inside the Catch's `inner`: leniency that leaks past `inner`
             // is absorbed by `recovery` (the recovery body fires whenever
             // the next outer-context matching step fails on the leftover).
-            walk_for_call_sites_impl(
-                inner,
-                caller,
-                continuations,
-                true,
-                inside_lenient,
-                ctx,
-                findings,
-            );
+            walk_for_call_sites(inner, caller, continuations, true, ctx, findings);
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites_impl(
-                recovery,
-                caller,
-                &mut isolated,
-                false,
-                inside_lenient,
-                ctx,
-                findings,
-            );
+            walk_for_call_sites(recovery, caller, &mut isolated, false, ctx, findings);
         }
-        // Lenient marks the entire wrapped subtree as intentional —
-        // suppress flag emission for any NonTerminal inside. The
-        // propagation walker (`find_callsite_unguarded`) still
-        // descends transparently so deeper rules' leniency reaching
-        // unwrapped sites elsewhere is still detected.
+        // `Lenient` at a rule's body root makes the rule's `trailing_first`
+        // empty — so the rule never appears as a flag target. The walker
+        // still descends transparently to find unrelated unguarded calls
+        // the lenient rule's body may itself contain.
         Pattern::Lenient(inner) => {
-            walk_for_call_sites_impl(
-                inner,
-                caller,
-                continuations,
-                inside_catch,
-                true,
-                ctx,
-                findings,
-            );
+            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
         }
         // The resolver runs before the lint, so the lint should
         // never see an unresolved boundary-anchored catch.

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -662,9 +662,32 @@ fn walk_for_call_sites<'a>(
     ctx: &LintCtx<'a>,
     findings: &mut Vec<LintFinding>,
 ) {
+    walk_for_call_sites_impl(
+        pat,
+        caller,
+        continuations,
+        inside_catch,
+        false,
+        ctx,
+        findings,
+    )
+}
+
+fn walk_for_call_sites_impl<'a>(
+    pat: &'a Pattern,
+    caller: &str,
+    continuations: &mut Vec<&'a [Pattern]>,
+    inside_catch: bool,
+    inside_lenient: bool,
+    ctx: &LintCtx<'a>,
+    findings: &mut Vec<LintFinding>,
+) {
     match pat {
         Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
         Pattern::NonTerminal(name) => {
+            if inside_lenient {
+                return;
+            }
             let Some(t) = ctx.trailing.get(name) else {
                 return;
             };
@@ -690,11 +713,12 @@ fn walk_for_call_sites<'a>(
         Pattern::Sequence(items) => {
             for i in 0..items.len() {
                 continuations.push(&items[i + 1..]);
-                walk_for_call_sites(
+                walk_for_call_sites_impl(
                     &items[i],
                     caller,
                     continuations,
                     inside_catch,
+                    inside_lenient,
                     ctx,
                     findings,
                 );
@@ -703,18 +727,42 @@ fn walk_for_call_sites<'a>(
         }
         Pattern::OrderedChoice(alts) => {
             for alt in alts {
-                walk_for_call_sites(alt, caller, continuations, inside_catch, ctx, findings);
+                walk_for_call_sites_impl(
+                    alt,
+                    caller,
+                    continuations,
+                    inside_catch,
+                    inside_lenient,
+                    ctx,
+                    findings,
+                );
             }
         }
         Pattern::Optional(inner)
         | Pattern::Capture(_, inner)
         | Pattern::Repeat(inner)
         | Pattern::RepeatOne(inner) => {
-            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
+            walk_for_call_sites_impl(
+                inner,
+                caller,
+                continuations,
+                inside_catch,
+                inside_lenient,
+                ctx,
+                findings,
+            );
         }
         Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites(inner, caller, &mut isolated, inside_catch, ctx, findings);
+            walk_for_call_sites_impl(
+                inner,
+                caller,
+                &mut isolated,
+                inside_catch,
+                inside_lenient,
+                ctx,
+                findings,
+            );
         }
         Pattern::Catch {
             inner, recovery, ..
@@ -722,14 +770,42 @@ fn walk_for_call_sites<'a>(
             // Inside the Catch's `inner`: leniency that leaks past `inner`
             // is absorbed by `recovery` (the recovery body fires whenever
             // the next outer-context matching step fails on the leftover).
-            walk_for_call_sites(inner, caller, continuations, true, ctx, findings);
+            walk_for_call_sites_impl(
+                inner,
+                caller,
+                continuations,
+                true,
+                inside_lenient,
+                ctx,
+                findings,
+            );
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites(recovery, caller, &mut isolated, false, ctx, findings);
+            walk_for_call_sites_impl(
+                recovery,
+                caller,
+                &mut isolated,
+                false,
+                inside_lenient,
+                ctx,
+                findings,
+            );
         }
-        // The lenient marker is an explicit author intent signal: the
-        // lint treats the wrapped subtree as opaque and emits no
-        // findings under it.
-        Pattern::Lenient(_) => {}
+        // Lenient marks the entire wrapped subtree as intentional —
+        // suppress flag emission for any NonTerminal inside. The
+        // propagation walker (`find_callsite_unguarded`) still
+        // descends transparently so deeper rules' leniency reaching
+        // unwrapped sites elsewhere is still detected.
+        Pattern::Lenient(inner) => {
+            walk_for_call_sites_impl(
+                inner,
+                caller,
+                continuations,
+                inside_catch,
+                true,
+                ctx,
+                findings,
+            );
+        }
         // The resolver runs before the lint, so the lint should
         // never see an unresolved boundary-anchored catch.
         Pattern::InferBoundaryCatch { .. } => {
@@ -944,9 +1020,19 @@ fn find_callsite_unguarded<'a>(
                 found_callsite,
             )
         }
-        // The lenient marker hides the wrapped subtree from the lint
-        // entirely — call sites inside it don't count.
-        Pattern::Lenient(_) => false,
+        // Propagation walks through the lenient marker transparently;
+        // the marker only suppresses the IMMEDIATE call's flag (handled
+        // in `walk_for_call_sites`), not deeper detection or outward
+        // propagation from nested rules' leniency.
+        Pattern::Lenient(inner) => find_callsite_unguarded(
+            inner,
+            probe,
+            continuations,
+            inside_catch,
+            ctx,
+            visited_callers,
+            found_callsite,
+        ),
         Pattern::InferBoundaryCatch { .. } => {
             unreachable!(
                 "Pattern::InferBoundaryCatch must be resolved by \

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -94,6 +94,13 @@ pub(crate) fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> boo
         // "matches empty after success" path — nullability follows
         // inner.
         Pattern::Catch { inner, .. } => pattern_nullable(inner, nullable),
+        // `~` is runtime-transparent.
+        Pattern::Lenient(inner) => pattern_nullable(inner, nullable),
+        // Pre-resolution placeholder for `^^lbl`. Nullability follows
+        // inner just like `Catch` — the eventual recovery body
+        // `(!B .)*` is always nullable but only contributes on
+        // failure, same shape as `Catch`'s analysis.
+        Pattern::InferBoundaryCatch { inner, .. } => pattern_nullable(inner, nullable),
         Pattern::NonTerminal(name) => nullable.contains(name),
     }
 }
@@ -147,6 +154,12 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
             collect_first_calls(inner, nullable, out);
             collect_first_calls(recovery, nullable, out);
         }
+        Pattern::Lenient(inner) => collect_first_calls(inner, nullable, out),
+        // Pre-resolution placeholder for `^^lbl`. Only the inner can
+        // route a first-call edge — the synthesized recovery
+        // `(!B .)*` has no non-terminals other than B, and the
+        // resolver hasn't picked B yet.
+        Pattern::InferBoundaryCatch { inner, .. } => collect_first_calls(inner, nullable, out),
         Pattern::NonTerminal(name) => {
             out.insert(name.clone());
         }
@@ -336,6 +349,15 @@ fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
             // in FIRST.
             out.extend(pattern_first(inner, nullable));
         }
+        Pattern::Lenient(inner) => {
+            out.extend(pattern_first(inner, nullable));
+        }
+        // Pre-resolution placeholder for `^^lbl`. The eventual recovery
+        // body `(!B .)*` fires only on failure (same as Catch) so it
+        // doesn't appear in FIRST; only the inner does.
+        Pattern::InferBoundaryCatch { inner, .. } => {
+            out.extend(pattern_first(inner, nullable));
+        }
     }
     out
 }
@@ -460,6 +482,17 @@ fn collect_follow(
             // for cross-check).
             collect_follow(inner, nullable, trailing, follow, changed);
             collect_follow(recovery, nullable, trailing, follow, changed);
+        }
+        Pattern::Lenient(inner) => {
+            collect_follow(inner, nullable, trailing, follow, changed);
+        }
+        // Pre-resolution placeholder for `^^lbl`. Treat like `Catch`'s
+        // success arm: inner inherits the catch's trailing. The
+        // synthesized recovery body has no NonTerminal references at
+        // this stage (the resolver hasn't picked B yet), so there's
+        // nothing to propagate into.
+        Pattern::InferBoundaryCatch { inner, .. } => {
+            collect_follow(inner, nullable, trailing, follow, changed);
         }
     }
 }
@@ -693,6 +726,18 @@ fn walk_for_call_sites<'a>(
             let mut isolated: Vec<&[Pattern]> = Vec::new();
             walk_for_call_sites(recovery, caller, &mut isolated, false, ctx, findings);
         }
+        // The lenient marker is an explicit author intent signal: the
+        // lint treats the wrapped subtree as opaque and emits no
+        // findings under it.
+        Pattern::Lenient(_) => {}
+        // The resolver runs before the lint, so the lint should
+        // never see an unresolved boundary-anchored catch.
+        Pattern::InferBoundaryCatch { .. } => {
+            unreachable!(
+                "Pattern::InferBoundaryCatch must be resolved by \
+                 analysis::resolve_inferred_boundaries before lint_partial_match"
+            )
+        }
     }
 }
 
@@ -899,6 +944,15 @@ fn find_callsite_unguarded<'a>(
                 found_callsite,
             )
         }
+        // The lenient marker hides the wrapped subtree from the lint
+        // entirely — call sites inside it don't count.
+        Pattern::Lenient(_) => false,
+        Pattern::InferBoundaryCatch { .. } => {
+            unreachable!(
+                "Pattern::InferBoundaryCatch must be resolved by \
+                 analysis::resolve_inferred_boundaries before lint_partial_match"
+            )
+        }
     }
 }
 
@@ -974,4 +1028,236 @@ fn element_subsumed_by(elem: &FollowElement, set: &FollowSet) -> bool {
         return true;
     }
     set.contains(elem)
+}
+
+// -- FOLLOW-inferred boundary catch resolver -----------------------------
+
+/// Synthesize a boundary pattern from a FOLLOW set. Used by the
+/// `^^lbl` resolver to fill in the boundary argument the author
+/// omitted. The synthesized pattern is an `OrderedChoice` of:
+/// - each literal byte sequence as `Pattern::Literal(bytes)`,
+/// - the union of all character classes as one `Pattern::CharClass(set)`,
+/// - each rule reference as `Pattern::NonTerminal(name)`,
+/// - each capture as `Pattern::Capture(kind, inner)`,
+/// - EOF (if present) as `Pattern::NotPredicate(AnyChar)` (i.e. `!.`).
+///
+/// Single-element synthesis returns the element directly rather than
+/// wrapping in a one-arm `OrderedChoice`.
+pub fn follow_set_to_boundary_pattern(fs: &FollowSet) -> Pattern {
+    let mut alts: Vec<Pattern> = Vec::new();
+    let mut char_union = CharSet::empty();
+    let mut has_char_class = false;
+    for elem in fs {
+        match elem {
+            FollowElement::CharClass(cs) => {
+                char_union = char_union.union(cs);
+                has_char_class = true;
+            }
+            FollowElement::Literal(bytes) => {
+                alts.push(Pattern::Literal(bytes.clone()));
+            }
+            FollowElement::Rule(name) => {
+                alts.push(Pattern::NonTerminal(name.clone()));
+            }
+            FollowElement::Capture { kind, inner } => {
+                alts.push(Pattern::Capture(
+                    kind.clone(),
+                    Box::new(follow_element_inner_to_pattern(inner)),
+                ));
+            }
+            FollowElement::Eof => {
+                alts.push(Pattern::NotPredicate(Box::new(Pattern::AnyChar)));
+            }
+        }
+    }
+    if has_char_class {
+        alts.insert(0, Pattern::CharClass(char_union));
+    }
+    if alts.len() == 1 {
+        alts.into_iter().next().unwrap()
+    } else {
+        Pattern::OrderedChoice(alts)
+    }
+}
+
+fn follow_element_inner_to_pattern(elem: &FollowElement) -> Pattern {
+    match elem {
+        FollowElement::Literal(bytes) => Pattern::Literal(bytes.clone()),
+        FollowElement::CharClass(cs) => Pattern::CharClass(*cs),
+        FollowElement::Rule(name) => Pattern::NonTerminal(name.clone()),
+        FollowElement::Capture { kind, inner } => Pattern::Capture(
+            kind.clone(),
+            Box::new(follow_element_inner_to_pattern(inner)),
+        ),
+        // EOF nested inside a capture would be malformed in practice;
+        // synthesize the same `!.` shape as the top-level case.
+        FollowElement::Eof => Pattern::NotPredicate(Box::new(Pattern::AnyChar)),
+    }
+}
+
+/// Resolve every `Pattern::InferBoundaryCatch` placeholder in `grammar`
+/// to the lowered explicit-form `Catch` shape. Boundary is synthesized
+/// from the placeholder's per-site FOLLOW set; an empty FOLLOW set
+/// returns `CompileError::CannotInferBoundary`.
+///
+/// Runs before `lint_partial_match` and bytecode emission. After this
+/// pass, no `InferBoundaryCatch` remains in the rule bodies.
+pub fn resolve_inferred_boundaries(grammar: &mut Grammar) -> Result<(), CompileError> {
+    let nullable = compute_nullable(&grammar.rules);
+    let follow = compute_follow(grammar);
+    let mut new_rules: HashMap<String, Pattern> = HashMap::with_capacity(grammar.rules.len());
+    for (name, body) in &grammar.rules {
+        let rule_follow = follow.get(name).cloned().unwrap_or_default();
+        let resolved = resolve_in_pattern(body, &rule_follow, &nullable, name)?;
+        new_rules.insert(name.clone(), resolved);
+    }
+    grammar.rules = new_rules;
+    Ok(())
+}
+
+fn resolve_in_pattern(
+    pat: &Pattern,
+    trailing: &FollowSet,
+    nullable: &HashSet<String>,
+    rule_name: &str,
+) -> Result<Pattern, CompileError> {
+    match pat {
+        Pattern::Literal(_)
+        | Pattern::CharClass(_)
+        | Pattern::AnyChar
+        | Pattern::NonTerminal(_) => Ok(pat.clone()),
+        Pattern::Sequence(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for i in 0..items.len() {
+                let sub_trailing = sequence_suffix_trailing(&items[i + 1..], trailing, nullable);
+                out.push(resolve_in_pattern(
+                    &items[i],
+                    &sub_trailing,
+                    nullable,
+                    rule_name,
+                )?);
+            }
+            Ok(Pattern::Sequence(out))
+        }
+        Pattern::OrderedChoice(alts) => {
+            let mut out = Vec::with_capacity(alts.len());
+            for alt in alts {
+                out.push(resolve_in_pattern(alt, trailing, nullable, rule_name)?);
+            }
+            Ok(Pattern::OrderedChoice(out))
+        }
+        Pattern::Repeat(inner) | Pattern::RepeatOne(inner) => {
+            // The inner can iterate; its successor includes FIRST(inner)
+            // plus the outer trailing.
+            let mut sub_trailing = trailing.clone();
+            sub_trailing.extend(pattern_first(inner, nullable));
+            Ok(match pat {
+                Pattern::Repeat(_) => Pattern::Repeat(Box::new(resolve_in_pattern(
+                    inner,
+                    &sub_trailing,
+                    nullable,
+                    rule_name,
+                )?)),
+                Pattern::RepeatOne(_) => Pattern::RepeatOne(Box::new(resolve_in_pattern(
+                    inner,
+                    &sub_trailing,
+                    nullable,
+                    rule_name,
+                )?)),
+                _ => unreachable!(),
+            })
+        }
+        Pattern::Optional(inner) => Ok(Pattern::Optional(Box::new(resolve_in_pattern(
+            inner, trailing, nullable, rule_name,
+        )?))),
+        Pattern::NotPredicate(inner) => Ok(Pattern::NotPredicate(Box::new(resolve_in_pattern(
+            inner,
+            &FollowSet::new(),
+            nullable,
+            rule_name,
+        )?))),
+        Pattern::AndPredicate(inner) => Ok(Pattern::AndPredicate(Box::new(resolve_in_pattern(
+            inner,
+            &FollowSet::new(),
+            nullable,
+            rule_name,
+        )?))),
+        Pattern::Capture(kind, inner) => Ok(Pattern::Capture(
+            kind.clone(),
+            Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+        )),
+        Pattern::Lenient(inner) => Ok(Pattern::Lenient(Box::new(resolve_in_pattern(
+            inner, trailing, nullable, rule_name,
+        )?))),
+        Pattern::Catch {
+            inner,
+            label,
+            recovery,
+        } => {
+            // Success branch: inner inherits the catch's trailing.
+            // Recovery branch: trailing is also the catch's trailing.
+            Ok(Pattern::Catch {
+                inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+                label: label.clone(),
+                recovery: Box::new(resolve_in_pattern(recovery, trailing, nullable, rule_name)?),
+            })
+        }
+        Pattern::InferBoundaryCatch { inner, label } => {
+            if trailing.is_empty() {
+                return Err(CompileError::CannotInferBoundary {
+                    rule: rule_name.into(),
+                    label: label.clone(),
+                });
+            }
+            let boundary = follow_set_to_boundary_pattern(trailing);
+            // Resolve nested catches inside the inner first.
+            let resolved_inner = resolve_in_pattern(inner, trailing, nullable, rule_name)?;
+            Ok(lower_inferred_boundary_catch(
+                resolved_inner,
+                label.clone(),
+                boundary,
+            ))
+        }
+    }
+}
+
+/// FIRST of `items[..]` with `outer_trailing` propagated through if
+/// all items are nullable. Mirrors the Sequence arm of
+/// `collect_follow` but produces a fresh FollowSet rather than
+/// extending one in place.
+fn sequence_suffix_trailing(
+    items: &[Pattern],
+    outer_trailing: &FollowSet,
+    nullable: &HashSet<String>,
+) -> FollowSet {
+    let mut out = FollowSet::new();
+    let mut all_nullable = true;
+    for it in items {
+        out.extend(pattern_first(it, nullable));
+        if !pattern_nullable(it, nullable) {
+            all_nullable = false;
+            break;
+        }
+    }
+    if all_nullable {
+        out.extend(outer_trailing.iter().cloned());
+    }
+    out
+}
+
+/// Mirror of `parser::lower_boundary_catch` for the resolver path.
+/// Builds the same `Catch { Sequence([inner, &B]), label, @recovery{(!B .)*} }`
+/// shape from a synthesized boundary.
+fn lower_inferred_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
+    let lookahead = Pattern::AndPredicate(Box::new(boundary.clone()));
+    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(boundary)),
+        Pattern::AnyChar,
+    ])));
+    let recovery = Pattern::Capture("recovery".into(), Box::new(stop_loop));
+    Pattern::Catch {
+        inner: Box::new(Pattern::Sequence(vec![inner, lookahead])),
+        label,
+        recovery: Box::new(recovery),
+    }
 }

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::analysis::analyze_left_recursion;
+use super::analysis::{analyze_left_recursion, LintFinding};
 use super::pattern::Pattern;
 use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, RuleKind};
 
@@ -8,6 +8,18 @@ use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, Ru
 pub enum CompileError {
     UndefinedRule(String),
     UnknownStartRule(String),
+    /// One or more `^^lbl` catches have no following context to infer
+    /// their boundary from. Emitted by `resolve_inferred_boundaries`.
+    CannotInferBoundary {
+        rule: String,
+        label: String,
+    },
+    /// `lint_partial_match` returned a non-empty result. Each finding
+    /// names a `(rule, caller)` pair where a trailing-nullable rule's
+    /// partial-match leniency reaches an unguarded scope. Anchor with
+    /// `^^lbl B` (or `^^lbl`) when the leniency is a bug, or wrap the
+    /// call site with `~p` when the leniency is intentional.
+    PartialMatchLeniency(Vec<LintFinding>),
 }
 
 impl std::fmt::Display for CompileError {
@@ -15,6 +27,23 @@ impl std::fmt::Display for CompileError {
         match self {
             CompileError::UndefinedRule(name) => write!(f, "undefined rule: {}", name),
             CompileError::UnknownStartRule(name) => write!(f, "unknown start rule: {}", name),
+            CompileError::CannotInferBoundary { rule, label } => write!(
+                f,
+                "cannot infer boundary for `^^{label}` in rule `{rule}`: no following context. \
+                 Either delete the unreachable catch or specify an explicit boundary `^^{label} B`."
+            ),
+            CompileError::PartialMatchLeniency(findings) => {
+                writeln!(f, "partial-match leniency detected:")?;
+                for finding in findings {
+                    writeln!(
+                        f,
+                        "  - rule `{}` is called unanchored by `{}`; its trailing optional \
+                         can succeed on a prefix, leaving bytes the caller does not validate",
+                        finding.rule, finding.caller
+                    )?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -249,6 +278,17 @@ impl Compiler {
                 self.patch_jump(success_commit, done);
                 self.emit(Instruction::RecoverScopeEnd);
             }
+            // Transparent at runtime — the `~` marker affects only
+            // the lint walker. See `Pattern::Lenient` documentation.
+            Pattern::Lenient(inner) => self.compile_pat(inner),
+            // The FOLLOW-inferred resolver must run before bytecode
+            // emission; reaching this arm is a bug.
+            Pattern::InferBoundaryCatch { .. } => {
+                unreachable!(
+                    "Pattern::InferBoundaryCatch must be resolved by \
+                     analysis::resolve_inferred_boundaries before compilation"
+                )
+            }
         }
     }
 }
@@ -388,13 +428,15 @@ fn check_refs(
         | Pattern::Optional(inner)
         | Pattern::NotPredicate(inner)
         | Pattern::AndPredicate(inner)
-        | Pattern::Capture(_, inner) => check_refs(_rule, inner, rules),
+        | Pattern::Capture(_, inner)
+        | Pattern::Lenient(inner) => check_refs(_rule, inner, rules),
         Pattern::Catch {
             inner, recovery, ..
         } => {
             check_refs(_rule, inner, rules)?;
             check_refs(_rule, recovery, rules)
         }
+        Pattern::InferBoundaryCatch { inner, .. } => check_refs(_rule, inner, rules),
         Pattern::NonTerminal(name) => {
             if rules.contains_key(name) {
                 Ok(())

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use super::analysis::resolve_inferred_boundaries;
 use super::compiler::{compile_rules, CompileError};
 use super::pattern::Pattern;
 use crate::pegvm::{CharSet, Program};
@@ -25,8 +26,23 @@ impl Grammar {
     /// [`Program`](crate::pegvm::Program). For one-shot grammar source
     /// → [`Program`] callers, prefer the top-level
     /// [`compile`](super::compile) instead.
+    ///
+    /// Pipeline:
+    /// 1. Resolve `Pattern::InferBoundaryCatch` placeholders (`^^lbl`)
+    ///    via [`resolve_inferred_boundaries`] — synthesizes each
+    ///    boundary from FOLLOW.
+    /// 2. Emit bytecode via `compile_rules`.
+    ///
+    /// The `lint_partial_match` integration that makes findings fatal
+    /// lands as the closing commit of #103, after the per-grammar
+    /// sweep brings shipped-grammar findings to zero.
     pub fn compile(&self) -> Result<Program, CompileError> {
-        compile_rules(&self.rules, &self.start)
+        let mut resolved = Grammar {
+            rules: self.rules.clone(),
+            start: self.start.clone(),
+        };
+        resolve_inferred_boundaries(&mut resolved)?;
+        compile_rules(&resolved.rules, &resolved.start)
     }
 }
 
@@ -105,12 +121,25 @@ impl<'a> Parser<'a> {
         Ok(Pattern::choice(alts))
     }
 
-    /// `inner ^label recovery` — labeled catch. Binds tighter than
-    /// `/`, looser than sequence. Left-associative: `a ^l1 b ^l2 c`
-    /// ≡ `(a ^l1 b) ^l2 c`. The label identifier must touch `^` (no
-    /// `^ lbl` with whitespace) so any `^<non-ident-byte>` is reserved
-    /// for future overlays: `^!label` (throw atom), `^_` or similar
-    /// (anonymous catch). See `src/pegc/README.md` for the rationale.
+    /// Two operators share the catch position, distinguished by a
+    /// single byte after the first `^`:
+    ///
+    /// - `inner ^label recovery` — **bare catch.** Author writes the
+    ///   recovery branch. Left-associative. See `src/pegc/README.md`.
+    /// - `inner ^^label B` / `inner ^^label` — **boundary-anchored
+    ///   catch.** The doubled caret marks a new operator family: the
+    ///   recovery branch is auto-synthesized as `@recovery{(!B .)*}`,
+    ///   and the inner is implicitly anchored with `&B`. The boundary
+    ///   `B` is parsed as one atom-with-prefix-postfix; if absent
+    ///   (no atom-start follows the label), the FOLLOW-inferred form
+    ///   emits `Pattern::InferBoundaryCatch { inner, label }` and the
+    ///   compile-time resolver synthesizes `B` from the call site's
+    ///   FOLLOW set.
+    ///
+    /// The label identifier must touch the discriminator `^` (bare)
+    /// or the second `^` of `^^` (anchored). `^_` / `^^_` are
+    /// reserved for anonymous-catch; `^!lbl` / `^^!lbl` are reserved
+    /// for the throw-atom slot.
     ///
     /// No collision with the `*^` / `+^` postfixes — those only fire
     /// when `^` directly follows `*` / `+` with no whitespace; an `^`
@@ -120,23 +149,41 @@ impl<'a> Parser<'a> {
         let mut lhs = self.parse_sequence()?;
         loop {
             self.skip_ws();
+            if self.peek() != Some(b'^') {
+                break;
+            }
+            self.pos += 1;
+            // Doubled-caret discriminator: a second `^` immediately
+            // after the first marks the boundary-anchored family.
             if self.peek() == Some(b'^') {
                 self.pos += 1;
-                // Label must touch `^`: no `skip_ws()` here. Anything
-                // other than an ident-start byte is currently a parse
-                // error and reserved for future syntactic slots.
-                let label = self.parse_ident().map_err(|_| {
-                    self.err(
-                        "expected label identifier immediately after `^` (no whitespace); \
-                         anonymous (`^_`) and throw (`^!lbl`) forms are reserved for future use"
-                            .into(),
-                    )
-                })?;
-                if label == "_" {
-                    return Err(self.err(
-                        "label name `_` is reserved for future use (anonymous catch)".into(),
-                    ));
+                let label = self.parse_catch_label("^^")?;
+                self.skip_ws();
+                let catch_pat = if self.at_prefix_start() {
+                    let boundary = self.parse_prefix()?;
+                    lower_boundary_catch(lhs, label, boundary)
+                } else {
+                    Pattern::InferBoundaryCatch {
+                        inner: Box::new(lhs),
+                        label,
+                    }
+                };
+                // Trailing sequence atoms after `^^lbl B` (or
+                // `^^lbl` inferred) belong to the enclosing sequence,
+                // not to the catch. `parse_sequence` above already
+                // returned when it hit the first `^`, so absorb the
+                // continuation here and rejoin under a Sequence.
+                let mut items = vec![catch_pat];
+                loop {
+                    self.skip_ws();
+                    if !self.at_prefix_start() {
+                        break;
+                    }
+                    items.push(self.parse_prefix()?);
                 }
+                lhs = Pattern::seq(items);
+            } else {
+                let label = self.parse_catch_label("^")?;
                 self.skip_ws();
                 let rhs = self.parse_sequence()?;
                 lhs = Pattern::Catch {
@@ -144,11 +191,28 @@ impl<'a> Parser<'a> {
                     label,
                     recovery: Box::new(rhs),
                 };
-            } else {
-                break;
             }
         }
         Ok(lhs)
+    }
+
+    /// Parse a catch label that must touch its sigil prefix
+    /// (no whitespace). `sigil` is the literal `^` or `^^` for the
+    /// error message. Reuses the existing `_`-reserved rule and the
+    /// `^!`-reserved-throw-atom rule.
+    fn parse_catch_label(&mut self, sigil: &str) -> Result<String, ParseError> {
+        let label = self.parse_ident().map_err(|_| {
+            self.err(format!(
+                "expected label identifier immediately after `{sigil}` (no whitespace); \
+                 anonymous (`{sigil}_`) and throw (`{sigil}!lbl`) forms are reserved for future use"
+            ))
+        })?;
+        if label == "_" {
+            return Err(
+                self.err("label name `_` is reserved for future use (anonymous catch)".into())
+            );
+        }
+        Ok(label)
     }
 
     fn parse_sequence(&mut self) -> Result<Pattern, ParseError> {
@@ -215,17 +279,57 @@ impl<'a> Parser<'a> {
         match self.peek() {
             Some(b'!') => {
                 self.pos += 1;
-                self.skip_ws();
-                let inner = self.parse_postfix()?;
+                // Recurse into `parse_prefix` so chained prefixes
+                // compose: `!~p` parses as `NotPredicate(Lenient(p))`.
+                // Existing `!atom` shapes are unchanged.
+                let inner = self.parse_prefix_or_postfix_after_predicate()?;
                 Ok(Pattern::NotPredicate(Box::new(inner)))
             }
             Some(b'&') => {
                 self.pos += 1;
-                self.skip_ws();
-                let inner = self.parse_postfix()?;
+                let inner = self.parse_prefix_or_postfix_after_predicate()?;
                 Ok(Pattern::AndPredicate(Box::new(inner)))
             }
+            // `~p` — intentional-leniency marker. `~` must touch the
+            // atom (no whitespace); the wrapper is opaque to the lint
+            // and transparent at runtime. See `src/pegc/README.md`.
+            Some(b'~') => {
+                self.pos += 1;
+                if matches!(
+                    self.peek(),
+                    Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+                ) {
+                    return Err(
+                        self.err("expected pattern immediately after `~` (no whitespace)".into())
+                    );
+                }
+                let inner = self.parse_postfix()?;
+                Ok(Pattern::Lenient(Box::new(inner)))
+            }
             _ => self.parse_postfix(),
+        }
+    }
+
+    /// After `!` / `&` consume their sigil, allow either a single
+    /// `~p` lenient marker or a plain `parse_postfix`. Skipping
+    /// whitespace before the inner is allowed (existing behavior);
+    /// `~` itself enforces its own touching-atom rule.
+    fn parse_prefix_or_postfix_after_predicate(&mut self) -> Result<Pattern, ParseError> {
+        self.skip_ws();
+        if self.peek() == Some(b'~') {
+            self.pos += 1;
+            if matches!(
+                self.peek(),
+                Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+            ) {
+                return Err(
+                    self.err("expected pattern immediately after `~` (no whitespace)".into())
+                );
+            }
+            let inner = self.parse_postfix()?;
+            Ok(Pattern::Lenient(Box::new(inner)))
+        } else {
+            self.parse_postfix()
         }
     }
 
@@ -557,7 +661,29 @@ fn is_ident_cont(c: u8) -> bool {
 }
 
 fn is_atom_start(c: u8) -> bool {
-    matches!(c, b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&') || is_ident_start(c)
+    matches!(
+        c,
+        b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&' | b'~'
+    ) || is_ident_start(c)
+}
+
+/// Lower `INNER ^^lbl B` to the explicit boundary-anchored catch
+/// shape: `Catch { Sequence([INNER, &B]), lbl, @recovery{(!B .)*} }`.
+/// Parse-time lowering — the compiler sees this as a regular `Catch`
+/// with an `AndPredicate` sibling, so the existing lint walker
+/// recognizes it as anchored without a new arm.
+fn lower_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
+    let lookahead = Pattern::AndPredicate(Box::new(boundary.clone()));
+    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(boundary)),
+        Pattern::AnyChar,
+    ])));
+    let recovery = Pattern::Capture("recovery".into(), Box::new(stop_loop));
+    Pattern::Catch {
+        inner: Box::new(Pattern::Sequence(vec![inner, lookahead])),
+        label,
+        recovery: Box::new(recovery),
+    }
 }
 
 /// Desugar `p*^` and `p*^[cs]` to a labeled-catch loop. Both forms are

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -259,45 +259,14 @@ impl<'a> Parser<'a> {
             // `^<non-ident-byte>` slot; when added, this function
             // grows a one-byte lookahead.
             Some(b'^') => false,
-            // `~name <- body` is a definition-level lenient marker for
-            // the NEXT rule, not a call-site `~p` in the current body.
-            // Look past the `~ ident` to see if `<-` follows.
-            Some(b'~') if self.looks_like_lenient_rule_def() => false,
+            // `~` is a definition-level marker on the NEXT rule. There
+            // is no call-site form, so `~` is never a valid in-body
+            // atom-start: fall through and let the sequence terminate
+            // here, letting `parse_grammar` consume `~name <- ...`.
+            Some(b'~') => false,
             Some(c) if is_ident_start(c) => !self.looks_like_rule_def(),
             Some(c) => is_atom_start(c),
         }
-    }
-
-    /// Look past a leading `~` to see if it starts a `~ident <-` rule
-    /// definition. Used by `at_prefix_start` to keep `~` at the
-    /// boundary between rules from being consumed as a call-site
-    /// lenient marker for the previous rule's body.
-    fn looks_like_lenient_rule_def(&self) -> bool {
-        let mut p = self.pos;
-        if p >= self.src.len() || self.src[p] != b'~' {
-            return false;
-        }
-        p += 1;
-        if p >= self.src.len() || !is_ident_start(self.src[p]) {
-            return false;
-        }
-        p += 1;
-        while p < self.src.len() && is_ident_cont(self.src[p]) {
-            p += 1;
-        }
-        loop {
-            while p < self.src.len() && matches!(self.src[p], b' ' | b'\t' | b'\n' | b'\r') {
-                p += 1;
-            }
-            if p < self.src.len() && self.src[p] == b'#' {
-                while p < self.src.len() && self.src[p] != b'\n' {
-                    p += 1;
-                }
-                continue;
-            }
-            break;
-        }
-        p + 1 < self.src.len() && &self.src[p..p + 2] == b"<-"
     }
 
     /// Look ahead from the current position to determine whether what follows is
@@ -333,57 +302,17 @@ impl<'a> Parser<'a> {
         match self.peek() {
             Some(b'!') => {
                 self.pos += 1;
-                // Recurse into `parse_prefix` so chained prefixes
-                // compose: `!~p` parses as `NotPredicate(Lenient(p))`.
-                // Existing `!atom` shapes are unchanged.
-                let inner = self.parse_prefix_or_postfix_after_predicate()?;
+                self.skip_ws();
+                let inner = self.parse_postfix()?;
                 Ok(Pattern::NotPredicate(Box::new(inner)))
             }
             Some(b'&') => {
                 self.pos += 1;
-                let inner = self.parse_prefix_or_postfix_after_predicate()?;
+                self.skip_ws();
+                let inner = self.parse_postfix()?;
                 Ok(Pattern::AndPredicate(Box::new(inner)))
             }
-            // `~p` — intentional-leniency marker. `~` must touch the
-            // atom (no whitespace); the wrapper is opaque to the lint
-            // and transparent at runtime. See `src/pegc/README.md`.
-            Some(b'~') => {
-                self.pos += 1;
-                if matches!(
-                    self.peek(),
-                    Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
-                ) {
-                    return Err(
-                        self.err("expected pattern immediately after `~` (no whitespace)".into())
-                    );
-                }
-                let inner = self.parse_postfix()?;
-                Ok(Pattern::Lenient(Box::new(inner)))
-            }
             _ => self.parse_postfix(),
-        }
-    }
-
-    /// After `!` / `&` consume their sigil, allow either a single
-    /// `~p` lenient marker or a plain `parse_postfix`. Skipping
-    /// whitespace before the inner is allowed (existing behavior);
-    /// `~` itself enforces its own touching-atom rule.
-    fn parse_prefix_or_postfix_after_predicate(&mut self) -> Result<Pattern, ParseError> {
-        self.skip_ws();
-        if self.peek() == Some(b'~') {
-            self.pos += 1;
-            if matches!(
-                self.peek(),
-                Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
-            ) {
-                return Err(
-                    self.err("expected pattern immediately after `~` (no whitespace)".into())
-                );
-            }
-            let inner = self.parse_postfix()?;
-            Ok(Pattern::Lenient(Box::new(inner)))
-        } else {
-            self.parse_postfix()
         }
     }
 
@@ -715,10 +644,7 @@ fn is_ident_cont(c: u8) -> bool {
 }
 
 fn is_atom_start(c: u8) -> bool {
-    matches!(
-        c,
-        b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&' | b'~'
-    ) || is_ident_start(c)
+    matches!(c, b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&') || is_ident_start(c)
 }
 
 /// Lower `INNER ^^lbl B` to the explicit boundary-anchored catch

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::analysis::resolve_inferred_boundaries;
+use super::analysis::{lint_partial_match, resolve_inferred_boundaries};
 use super::compiler::{compile_rules, CompileError};
 use super::pattern::Pattern;
 use crate::pegvm::{CharSet, Program};
@@ -31,17 +31,21 @@ impl Grammar {
     /// 1. Resolve `Pattern::InferBoundaryCatch` placeholders (`^^lbl`)
     ///    via [`resolve_inferred_boundaries`] — synthesizes each
     ///    boundary from FOLLOW.
-    /// 2. Emit bytecode via `compile_rules`.
-    ///
-    /// The `lint_partial_match` integration that makes findings fatal
-    /// lands as the closing commit of #103, after the per-grammar
-    /// sweep brings shipped-grammar findings to zero.
+    /// 2. Run [`lint_partial_match`]; any finding is a fatal
+    ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
+    ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with `~`
+    ///    at the call site or `~name <- body` at the rule definition.
+    /// 3. Emit bytecode via `compile_rules`.
     pub fn compile(&self) -> Result<Program, CompileError> {
         let mut resolved = Grammar {
             rules: self.rules.clone(),
             start: self.start.clone(),
         };
         resolve_inferred_boundaries(&mut resolved)?;
+        let findings = lint_partial_match(&resolved);
+        if !findings.is_empty() {
+            return Err(CompileError::PartialMatchLeniency(findings));
+        }
         compile_rules(&resolved.rules, &resolved.start)
     }
 }
@@ -88,11 +92,25 @@ impl<'a> Parser<'a> {
         let mut rules = HashMap::new();
         let mut order = Vec::new();
         while self.pos < self.src.len() {
+            // Definition-level lenient marker: `~name <- body` declares
+            // that every call to `name` is intentionally lenient and
+            // suppresses `lint_partial_match` findings at every call site
+            // of `name`. The marker touches the name (no whitespace);
+            // the rule's body is wrapped with `Pattern::Lenient` so the
+            // lint walker sees the same shape as a per-call-site `~p`.
+            let mut definition_lenient = false;
+            if self.peek() == Some(b'~') {
+                self.pos += 1;
+                definition_lenient = true;
+            }
             let name = self.parse_ident()?;
             self.skip_ws();
             self.expect_str("<-")?;
             self.skip_ws();
-            let pat = self.parse_choice()?;
+            let mut pat = self.parse_choice()?;
+            if definition_lenient {
+                pat = Pattern::Lenient(Box::new(pat));
+            }
             if rules.insert(name.clone(), pat).is_some() {
                 return Err(self.err(format!("rule '{}' defined twice", name)));
             }
@@ -241,9 +259,45 @@ impl<'a> Parser<'a> {
             // `^<non-ident-byte>` slot; when added, this function
             // grows a one-byte lookahead.
             Some(b'^') => false,
+            // `~name <- body` is a definition-level lenient marker for
+            // the NEXT rule, not a call-site `~p` in the current body.
+            // Look past the `~ ident` to see if `<-` follows.
+            Some(b'~') if self.looks_like_lenient_rule_def() => false,
             Some(c) if is_ident_start(c) => !self.looks_like_rule_def(),
             Some(c) => is_atom_start(c),
         }
+    }
+
+    /// Look past a leading `~` to see if it starts a `~ident <-` rule
+    /// definition. Used by `at_prefix_start` to keep `~` at the
+    /// boundary between rules from being consumed as a call-site
+    /// lenient marker for the previous rule's body.
+    fn looks_like_lenient_rule_def(&self) -> bool {
+        let mut p = self.pos;
+        if p >= self.src.len() || self.src[p] != b'~' {
+            return false;
+        }
+        p += 1;
+        if p >= self.src.len() || !is_ident_start(self.src[p]) {
+            return false;
+        }
+        p += 1;
+        while p < self.src.len() && is_ident_cont(self.src[p]) {
+            p += 1;
+        }
+        loop {
+            while p < self.src.len() && matches!(self.src[p], b' ' | b'\t' | b'\n' | b'\r') {
+                p += 1;
+            }
+            if p < self.src.len() && self.src[p] == b'#' {
+                while p < self.src.len() && self.src[p] != b'\n' {
+                    p += 1;
+                }
+                continue;
+            }
+            break;
+        }
+        p + 1 < self.src.len() && &self.src[p..p + 2] == b"<-"
     }
 
     /// Look ahead from the current position to determine whether what follows is

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -37,6 +37,26 @@ pub enum Pattern {
         label: String,
         recovery: Box<Pattern>,
     },
+    /// Author-local marker that a pattern is intentionally lenient — the
+    /// `lint_partial_match` walker treats this as an opaque barrier and
+    /// does not descend into it for call-site detection. At runtime the
+    /// wrapper is transparent: the compiler emits exactly the inner
+    /// pattern's bytecode. Surface syntax: postfix `~p`.
+    Lenient(Box<Pattern>),
+    /// Boundary-anchored catch with the boundary inferred from the
+    /// call site's FOLLOW set. Placeholder produced at parse time by
+    /// the `^^lbl` surface form; resolved before bytecode emission by
+    /// `analysis::resolve_inferred_boundaries`, which rewrites it to
+    /// the same shape the explicit `^^lbl B` form lowers to (a
+    /// `Catch` whose inner is `Sequence([inner, AndPredicate(B)])`
+    /// and whose recovery is `@recovery{(!B .)*}`).
+    ///
+    /// An `InferBoundaryCatch` should never reach the compiler or any
+    /// downstream analysis — the resolver runs first and replaces it.
+    InferBoundaryCatch {
+        inner: Box<Pattern>,
+        label: String,
+    },
 }
 
 impl Pattern {

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1811,13 +1811,6 @@ fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
 }
 
 #[test]
-fn compile_succeeds_with_call_site_lenient_on_flagged_call() {
-    let g = parse("start <- (~r)*^[;]\nr <- 'x' 'y'?").expect("parse");
-    g.compile()
-        .expect("compile should succeed with call-site `~r`");
-}
-
-#[test]
 fn compile_succeeds_with_boundary_catch_anchor() {
     // `^^bad ';'` lowers to `Catch { Seq(a, &';'), bad, recovery }` —
     // anchoring `a` by lookahead so the lint sees no leniency.

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1724,3 +1724,148 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
         "load-bearing PR #101 case must be flagged when anchor is stripped; findings: {findings:?}"
     );
 }
+
+// ---- Definition-level lenient marker (~rule_name <- body) -----
+
+#[test]
+fn definition_lenient_marker_wraps_rule_body() {
+    // `~rule <- body` parses the body with a top-level `Pattern::Lenient`
+    // wrap, exposing the intent to the lint via the same AST node the
+    // call-site `~p` form produces.
+    let g = parse("~r <- 'a'?").expect("parse");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Lenient(Box::new(Pattern::Optional(Box::new(Pattern::literal("a"))))),
+    );
+}
+
+#[test]
+fn definition_lenient_marker_requires_touching_name() {
+    let err = parse("~ r <- 'a'?").expect_err("space between `~` and name must error");
+    assert!(
+        err.message.contains("expected identifier"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn definition_lenient_suppresses_lint_at_every_call_site() {
+    // Use the Catch-absorbed shape the lint reliably flags: a
+    // top-level `*^[;]` recovery loop calling a trailing-Optional rule.
+    let unmarked = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse unmarked");
+    assert!(
+        lint_partial_match(&unmarked)
+            .iter()
+            .any(|f| f.rule == "r" && f.caller == "start"),
+        "baseline: unmarked grammar should flag r"
+    );
+
+    let marked = parse("start <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse marked");
+    let findings = lint_partial_match(&marked);
+    assert!(
+        !findings.iter().any(|f| f.rule == "r"),
+        "definition-level `~r` should suppress all r-related findings, got: {findings:?}"
+    );
+}
+
+#[test]
+fn definition_lenient_marker_is_runtime_transparent() {
+    // The `~name <-` wrap compiles to the same bytecode as the bare form.
+    let plain = parse("r <- 'x'+")
+        .expect("parse plain")
+        .compile()
+        .expect("compile plain");
+    let marked = parse("~r <- 'x'+")
+        .expect("parse marked")
+        .compile()
+        .expect("compile marked");
+    assert_eq!(plain.code, marked.code);
+}
+
+// ---- Compile-fatal lint integration ---------------------------
+
+#[test]
+fn compile_errors_on_partial_match_leniency() {
+    // `*^[;]` Catch-absorbed shape — the lint reliably flags this.
+    let g = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let err = g.compile().expect_err("compile should fail");
+    match err {
+        syntax_highlighter::pegc::CompileError::PartialMatchLeniency(findings) => {
+            assert!(
+                findings
+                    .iter()
+                    .any(|f| f.rule == "r" && f.caller == "start"),
+                "expected r → start finding, got: {findings:?}"
+            );
+        }
+        other => panic!("expected PartialMatchLeniency, got: {other:?}"),
+    }
+}
+
+#[test]
+fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
+    let g = parse("start <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse");
+    g.compile()
+        .expect("compile should succeed with definition-level `~r`");
+}
+
+#[test]
+fn compile_succeeds_with_call_site_lenient_on_flagged_call() {
+    let g = parse("start <- (~r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    g.compile()
+        .expect("compile should succeed with call-site `~r`");
+}
+
+#[test]
+fn compile_succeeds_with_boundary_catch_anchor() {
+    // `^^bad ';'` lowers to `Catch { Seq(a, &';'), bad, recovery }` —
+    // anchoring `a` by lookahead so the lint sees no leniency.
+    let g = parse("start <- (a ^^bad ';')*\na <- 'x' 'y'?").expect("parse");
+    g.compile()
+        .expect("compile should succeed with `^^bad ';'` anchor");
+}
+
+#[test]
+fn compile_error_display_lists_findings() {
+    let g = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let err = g.compile().expect_err("compile should fail");
+    let msg = format!("{err}");
+    assert!(msg.contains("partial-match leniency"));
+    assert!(msg.contains("`r`"));
+    assert!(msg.contains("`start`"));
+}
+
+#[test]
+fn compile_errors_on_uninferable_boundary() {
+    // The start rule has no FOLLOW context other than EOF — for a
+    // rule with no callers at all, the inferred boundary would be
+    // empty. Construct that case via a non-start unreachable rule.
+    let g = parse("start <- 'x'\norphan <- 'a' ^^bad").expect("parse");
+    let err = g.compile().expect_err("compile should fail");
+    assert!(
+        matches!(
+            err,
+            syntax_highlighter::pegc::CompileError::CannotInferBoundary { .. }
+        ),
+        "expected CannotInferBoundary, got: {err:?}"
+    );
+}
+
+#[test]
+fn all_shipped_grammars_compile_clean() {
+    // Load-bearing: every grammar in `grammars/*.peg` must compile
+    // cleanly via `pegc::compile`. Re-introducing partial-match
+    // leniency without a `~` marker or `^^lbl` anchor breaks this.
+    for entry in std::fs::read_dir("grammars").expect("read grammars dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("peg") {
+            continue;
+        }
+        let src = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("read {path:?}"));
+        let g = parse(&src).unwrap_or_else(|e| panic!("parse {path:?}: {e}"));
+        g.compile()
+            .unwrap_or_else(|e| panic!("compile {path:?}: {e}"));
+    }
+}

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -675,56 +675,13 @@ fn inferred_vs_explicit_no_ambiguity() {
     );
 }
 
-// ---- Lenient marker (`~p`) ------------------------------------
-
-#[test]
-fn lenient_marker_wraps_atom() {
-    let g = parse("r <- 'a' ~b 'c'\nb <- 'x'");
-    assert_eq!(
-        g.rules["r"],
-        Pattern::Sequence(vec![
-            Pattern::literal("a"),
-            Pattern::Lenient(Box::new(Pattern::NonTerminal("b".into()))),
-            Pattern::literal("c"),
-        ]),
-    );
-}
-
-#[test]
-fn lenient_marker_requires_touching_atom() {
-    let err = parse_src("r <- 'a' ~ b\nb <- 'x'").unwrap_err();
-    assert!(
-        err.message.contains("no whitespace"),
-        "expected a touching-atom error, got: {}",
-        err.message
-    );
-}
-
-#[test]
-fn lenient_marker_inside_not_predicate() {
-    let g = parse("r <- !~b 'c'\nb <- 'x'");
-    assert_eq!(
-        g.rules["r"],
-        Pattern::Sequence(vec![
-            Pattern::NotPredicate(Box::new(Pattern::Lenient(Box::new(Pattern::NonTerminal(
-                "b".into()
-            ))))),
-            Pattern::literal("c"),
-        ]),
-    );
-}
-
-#[test]
-fn lenient_marker_carries_through_postfix() {
-    // `~p*` is `Lenient(p)` followed by `*` postfix? No — `~` is at the
-    // prefix tier and wraps a single atom-with-postfix. So `~p*` is
-    // `~(p*)` = `Lenient(Repeat(p))`.
-    let g = parse("r <- ~'a'*");
-    assert_eq!(
-        g.rules["r"],
-        Pattern::Lenient(Box::new(Pattern::Repeat(Box::new(Pattern::literal("a"))))),
-    );
-}
+// ---- Lenient marker (definition-level only) -------------------
+//
+// Definition-level `~name <- body` parsing is verified end-to-end by
+// the `definition_lenient_marker_*` tests in `tests/compiler_tests.rs`.
+// The call-site `~p` form was considered during design and dropped
+// before landing: empirically zero shipped grammars used it after the
+// pivot to definition-level marking.
 
 #[test]
 fn catch_accepts_underscore_prefixed_labels() {
@@ -944,7 +901,7 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
 fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
     let plain = parse("r <- 'x'+").compile().unwrap();
-    let lenient = parse("r <- ~'x'+").compile().unwrap();
+    let lenient = parse("~r <- 'x'+").compile().unwrap();
     assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
     let r = VM::new(&lenient.code, b"xxx").run();
     assert!(r.complete);

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -468,6 +468,264 @@ fn catch_rejects_reserved_underscore_label() {
     );
 }
 
+// ---- Boundary-anchored catch (`^^lbl B` / `^^lbl`) ------------
+
+/// Builds the AST that `INNER ^^lbl B` lowers to: a `Catch` whose
+/// inner is `Sequence([INNER, AndPredicate(B)])` and whose recovery
+/// is `@recovery{(!B .)*}`. Mirrors `lower_boundary_catch` in the
+/// parser.
+fn lowered_boundary_catch(inner: Pattern, label: &str, boundary: Pattern) -> Pattern {
+    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(boundary.clone())),
+        Pattern::AnyChar,
+    ])));
+    Pattern::Catch {
+        inner: Box::new(Pattern::Sequence(vec![
+            inner,
+            Pattern::AndPredicate(Box::new(boundary)),
+        ])),
+        label: label.into(),
+        recovery: Box::new(Pattern::Capture("recovery".into(), Box::new(stop_loop))),
+    }
+}
+
+#[test]
+fn boundary_catch_lowers_to_anchored_catch_with_recovery_loop() {
+    let g = parse("r <- 'a' ^^lbl 'b'");
+    assert_eq!(
+        g.rules["r"],
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
+    );
+}
+
+#[test]
+fn boundary_catch_with_rule_boundary() {
+    let g = parse("r <- 'a' ^^lbl b\nb <- 'x'");
+    assert_eq!(
+        g.rules["r"],
+        lowered_boundary_catch(
+            Pattern::literal("a"),
+            "lbl",
+            Pattern::NonTerminal("b".into())
+        ),
+    );
+}
+
+#[test]
+fn boundary_catch_with_charset_boundary() {
+    let g = parse("r <- 'a' ^^lbl [,;)]");
+    let mut delim = CharSet::empty();
+    delim.add(b',');
+    delim.add(b';');
+    delim.add(b')');
+    assert_eq!(
+        g.rules["r"],
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::CharClass(delim)),
+    );
+}
+
+#[test]
+fn boundary_catch_with_grouped_boundary() {
+    let g = parse("r <- 'a' ^^lbl (b c)\nb <- 'x'\nc <- 'y'");
+    let boundary = Pattern::Sequence(vec![
+        Pattern::NonTerminal("b".into()),
+        Pattern::NonTerminal("c".into()),
+    ]);
+    assert_eq!(
+        g.rules["r"],
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", boundary),
+    );
+}
+
+#[test]
+fn boundary_catch_label_touches_second_caret() {
+    // `^^lbl B` with no whitespace between the carets and the label
+    // is the canonical form; `^^ lbl B` (space) errors with the
+    // "expected label identifier" message.
+    let g = parse("r <- 'a' ^^lbl 'b'");
+    assert_eq!(
+        g.rules["r"],
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
+    );
+    let err = parse_src("r <- 'a' ^^ lbl 'b'").unwrap_err();
+    assert!(
+        err.message.contains("expected label identifier"),
+        "expected a label-identifier error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn boundary_catch_does_not_swallow_trailing_atoms() {
+    // The boundary is one atom-with-prefix-postfix; trailing atoms
+    // belong to the enclosing sequence: `A ^^lbl B C` is `(A ^^lbl B) C`.
+    let g = parse("r <- 'a' ^^lbl 'b' 'c'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
+            Pattern::literal("c"),
+        ]),
+    );
+}
+
+#[test]
+fn bare_catch_with_capture_rhs_still_parses() {
+    // Regression guard: single `^` is bare, `@kind{...}` is the RHS.
+    // The doubled-caret discriminator must not consume `@`.
+    let g = parse("r <- 'a' ^lbl @rec{'b'}");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Catch {
+            inner: Box::new(Pattern::literal("a")),
+            label: "lbl".into(),
+            recovery: Box::new(Pattern::Capture(
+                "rec".into(),
+                Box::new(Pattern::literal("b"))
+            )),
+        },
+    );
+}
+
+#[test]
+fn boundary_catch_rejects_reserved_underscore_label() {
+    let err = parse_src("r <- 'a' ^^_ 'b'").unwrap_err();
+    assert!(
+        err.message.contains("reserved"),
+        "expected reserved-label error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn boundary_catch_rejects_throw_atom_shape() {
+    let err = parse_src("r <- 'a' ^^!lbl 'b'").unwrap_err();
+    assert!(
+        err.message.contains("reserved") || err.message.contains("expected label identifier"),
+        "expected reserved-or-label error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
+    let g = parse("r <- 'a' ^^lbl");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::InferBoundaryCatch {
+            inner: Box::new(Pattern::literal("a")),
+            label: "lbl".into(),
+        },
+    );
+}
+
+#[test]
+fn inferred_catch_before_choice_separator() {
+    let g = parse("r <- 'a' ^^lbl / 'b'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::OrderedChoice(vec![
+            Pattern::InferBoundaryCatch {
+                inner: Box::new(Pattern::literal("a")),
+                label: "lbl".into(),
+            },
+            Pattern::literal("b"),
+        ]),
+    );
+}
+
+#[test]
+fn inferred_catch_before_paren_close() {
+    let g = parse("r <- ('a' ^^lbl) 'c'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::InferBoundaryCatch {
+                inner: Box::new(Pattern::literal("a")),
+                label: "lbl".into(),
+            },
+            Pattern::literal("c"),
+        ]),
+    );
+}
+
+#[test]
+fn inferred_vs_explicit_no_ambiguity() {
+    // Disambiguation is purely by `at_prefix_start`: `^^lbl B C` is
+    // explicit (B is the boundary, C is the trailing sequence atom);
+    // `^^lbl / B` is inferred (`/` is not an atom-start).
+    let explicit = parse("r <- 'a' ^^lbl 'b' 'c'");
+    assert_eq!(
+        explicit.rules["r"],
+        Pattern::Sequence(vec![
+            lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
+            Pattern::literal("c"),
+        ]),
+    );
+    let inferred = parse("r <- 'a' ^^lbl / 'b'");
+    assert_eq!(
+        inferred.rules["r"],
+        Pattern::OrderedChoice(vec![
+            Pattern::InferBoundaryCatch {
+                inner: Box::new(Pattern::literal("a")),
+                label: "lbl".into(),
+            },
+            Pattern::literal("b"),
+        ]),
+    );
+}
+
+// ---- Lenient marker (`~p`) ------------------------------------
+
+#[test]
+fn lenient_marker_wraps_atom() {
+    let g = parse("r <- 'a' ~b 'c'\nb <- 'x'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("a"),
+            Pattern::Lenient(Box::new(Pattern::NonTerminal("b".into()))),
+            Pattern::literal("c"),
+        ]),
+    );
+}
+
+#[test]
+fn lenient_marker_requires_touching_atom() {
+    let err = parse_src("r <- 'a' ~ b\nb <- 'x'").unwrap_err();
+    assert!(
+        err.message.contains("no whitespace"),
+        "expected a touching-atom error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn lenient_marker_inside_not_predicate() {
+    let g = parse("r <- !~b 'c'\nb <- 'x'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::NotPredicate(Box::new(Pattern::Lenient(Box::new(Pattern::NonTerminal(
+                "b".into()
+            ))))),
+            Pattern::literal("c"),
+        ]),
+    );
+}
+
+#[test]
+fn lenient_marker_carries_through_postfix() {
+    // `~p*` is `Lenient(p)` followed by `*` postfix? No — `~` is at the
+    // prefix tier and wraps a single atom-with-postfix. So `~p*` is
+    // `~(p*)` = `Lenient(Repeat(p))`.
+    let g = parse("r <- ~'a'*");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Lenient(Box::new(Pattern::Repeat(Box::new(Pattern::literal("a"))))),
+    );
+}
+
 #[test]
 fn catch_accepts_underscore_prefixed_labels() {
     // `_foo` (underscore prefix, not bare `_`) stays a valid label.
@@ -621,6 +879,76 @@ fn end_to_end_recover_repeat_compile_run() {
     let spans: Vec<(usize, usize)> = r.captures.iter().map(|c| (c.start, c.end)).collect();
     assert_eq!(kinds, vec![kw, recovery, recovery, kw]);
     assert_eq!(spans, vec![(0, 3), (3, 4), (4, 5), (5, 8)]);
+}
+
+#[test]
+fn end_to_end_inferred_catch_matches_explicit_behavior() {
+    // `^^lbl` (FOLLOW-inferred) should produce a program with the
+    // same observable behavior as the explicit `^^lbl B` form when
+    // `B` mirrors the call site's FOLLOW set. Byte-identical
+    // bytecode isn't expected (label numbering shifts), but the
+    // MatchResult on the same input must agree.
+    use syntax_highlighter::pegvm::VM;
+    let inferred = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+        .compile()
+        .unwrap();
+    let explicit = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
+        .compile()
+        .unwrap();
+    for input in [&b"x,x"[..], b"xy,x", b"x"].iter() {
+        let r_inferred = VM::new(&inferred.code, input).run();
+        let r_explicit = VM::new(&explicit.code, input).run();
+        assert_eq!(
+            r_inferred.complete, r_explicit.complete,
+            "completion differs for input {input:?}"
+        );
+        assert_eq!(
+            r_inferred.matched, r_explicit.matched,
+            "matched length differs for input {input:?}"
+        );
+    }
+}
+
+#[test]
+fn end_to_end_inferred_catch_fires_on_partial_match() {
+    use syntax_highlighter::pegvm::VM;
+    // `aliased <- 'x' ^^bad` lowers to a catch that anchors `x` to
+    // FOLLOW(aliased). FOLLOW contains `,` from the call site in
+    // `list`. Input `xy,x` — the first `x` succeeds but the next
+    // byte `y` is not in FOLLOW; the catch fires, recovery skips
+    // `y` until it sees `,`, and parsing resumes with the second `x`.
+    let prog = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+        .compile()
+        .unwrap();
+    let r = VM::new(&prog.code, b"xy,x").run();
+    assert!(r.complete, "catch should let parse complete; got {:?}", r);
+}
+
+#[test]
+fn end_to_end_inferred_catch_clean_input_no_recovery() {
+    use syntax_highlighter::pegvm::VM;
+    let prog = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+        .compile()
+        .unwrap();
+    let r = VM::new(&prog.code, b"x,x").run();
+    assert!(r.complete);
+    let recovery_captures = r
+        .captures
+        .iter()
+        .filter(|c| prog.capture_kinds[c.kind.0 as usize] == "recovery")
+        .count();
+    assert_eq!(recovery_captures, 0, "clean input should emit no recovery");
+}
+
+#[test]
+fn end_to_end_lenient_marker_is_runtime_transparent() {
+    use syntax_highlighter::pegvm::VM;
+    let plain = parse("r <- 'x'+").compile().unwrap();
+    let lenient = parse("r <- ~'x'+").compile().unwrap();
+    assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
+    let r = VM::new(&lenient.code, b"xxx").run();
+    assert!(r.complete);
+    assert_eq!(r.matched, 3);
 }
 
 #[test]


### PR DESCRIPTION
Ships the boundary-anchored catch operator `INNER ^^lbl B` and its FOLLOW-inferred variant `INNER ^^lbl` (from `#108`'s soft-dependency edge on `#105`), plus a per-rule `~name <- body` intentional-leniency marker. Makes `lint_partial_match` fatal in `Grammar::compile()`, closing the leftover compile-integration work from `#104`'s static half. Closes #103. Progresses `#104` (dynamic-trace half stays open per `#108` step 8).

The new operator compresses the three-piece idiom (lookahead + catch + recovery body) that recurred across `grammars/sqlite.peg`'s PR `#101` sites — `result_column` and `where_clause` are converted in place as the worked examples.

The `~` marker is the author's intent signal for sites the lint structurally flags but where the leniency is intentional (absorbed at runtime by an outer `*^` / `^block_close` recovery). On shipped grammars, the lint surfaced 88 candidate sites; after the sweep, all 88 turned out to be intentional and resolved with definition-level `~name <-` on roughly 20 rules. The lint is now fatal in compile, gated by `all_shipped_grammars_compile_clean`.

See `src/pegc/README.md` for the precedence-table entries, the boundary-catch worked example, and the leniency marker. `#113` tracks the follow-up to make the recovery-scope invariant the marker assumes checked rather than convention-recorded.

<details>
<summary>Lint cost after definition-level marking</summary>

Re-running `cargo bench --bench lint` on this branch:

| Grammar | Old (PR `#110`, µs) | New (µs) | Speedup |
|---|---|---|---|
| `json` | 8 | 8.5 | ≈ 1× |
| `toml` | 127 | 124.2 | ≈ 1× |
| `css` | 404 | 444.8 | ≈ 1× |
| `c` | 547 | 475.0 | 1.2× |
| `javascript` | 999 | 115.5 | 8.7× |
| `go` | 1,360 | 91.5 | 14.9× |
| `rust` | 2,972 | 388.7 | 7.6× |
| `sqlite` | 8,300 | 311.6 | 26.6× |

The drop on the larger grammars is a side effect of `Pattern::Lenient` making `trailing_first` empty on the marked rule — the rule never becomes a flag target, so the walker skips every call to it without further work.

</details>

<details>
<summary>The 88 → 0 sweep, by mechanism</summary>

| Mechanism | Sites |
|---|---|
| `^^lbl B` (explicit boundary anchor) | 2 — both pre-existing PR `#101` sites converted from the manual idiom |
| `^^lbl` (FOLLOW-inferred boundary) | 0 on shipped grammars |
| `~name <-` (definition-level lenient) | ~20 rules covering all 88 lint findings |

The lint's primary value on shipped grammars is "force authors to acknowledge that leniency exists" rather than "find new bugs to anchor" — the existing manual anchoring in PR `#101` and the implicit outer-recovery design across the grammar corpus had already absorbed everything the lint structurally identifies.

</details>
