### PR TITLE
pegdb: skip trivia rules when picking the recovery-cluster leaf

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -318,4 +318,6 @@ comment       <- @comment{line_comment / block_comment}
 line_comment  <- '//' (!'\n' .)*
 block_comment <- '/*' (!'*/' .)* '*/'
 
+trivia        <- ws
+
 ws            <- (comment / [ \t\r\n])*

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -159,4 +159,6 @@ ident_body    <- [A-Za-z0-9_\-]
 comment       <- @comment{block_comment}
 block_comment <- '/*' (!'*/' .)* '*/'
 
+trivia        <- ws
+
 ws            <- (comment / [ \t\r\n])*

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -394,4 +394,6 @@ comment       <- @comment{line_comment / block_comment}
 line_comment  <- '//' (!'\n' .)*
 block_comment <- '/*' (!'*/' .)* '*/'
 
+trivia        <- ws
+
 ws            <- (comment / [ \t\r\n])*

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -381,4 +381,6 @@ comment        <- @comment{line_comment / block_comment}
 line_comment   <- '//' (!'\n' .)*
 block_comment  <- '/*' (!'*/' .)* '*/'
 
+trivia        <- ws
+
 ws             <- (comment / [ \t\r\n])*

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -36,4 +36,6 @@ false_lit   <- 'false'
 null_lit    <- 'null'
 
 hex         <- [0-9a-fA-F]
+trivia      <- spacing
+
 spacing     <- [ \t\n\r]*

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -478,4 +478,6 @@ line_comment  <- '//' (!'\n' .)*
 # the occasional mismatch is acceptable and keeps the grammar simpler.
 block_comment <- '/*' (!'*/' .)* '*/'
 
+trivia        <- ws
+
 ws            <- (comment / [ \t\r\n])*

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -995,6 +995,8 @@ keyword_word <-
 
 # --- Whitespace & comments -------------------------------------------
 
+trivia        <- ws
+
 ws            <- (comment / [ \t\n\r])*
 comment       <- line_comment / block_comment
 line_comment  <- @comment{'--' (!linebreak .)*}

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -117,6 +117,8 @@ comment       <- @comment{'#' (!linebreak .)*}
 
 # Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
+trivia        <- ws
+
 ws            <- (comment / [ \t\r\n])*
 array_ws      <- ws
 

--- a/src/bin/pegdb.rs
+++ b/src/bin/pegdb.rs
@@ -222,6 +222,7 @@ fn run_explain_recoveries(args: &[String]) -> ExitCode {
     p.set_input(input.into_bytes());
     let kinds = p.capture_kinds();
     let rule_names = p.rule_names();
+    let rule_is_trivia = p.rule_is_trivia();
     let complete = p.is_complete();
     let (matched, captures) = p.captures();
     let diagnostics = p.recovery_diagnostics();
@@ -234,9 +235,12 @@ fn run_explain_recoveries(args: &[String]) -> ExitCode {
     // Cluster by `(rule_stack, label_name)`. Every recovery
     // firing carries a label — labeled catches (`^label`) use the
     // author's identifier; `*^` uses the intern of its
-    // `recovery_kind` string. v1 uses the entire stack as the key;
-    // suffix-clustering is a follow-up. BTreeMap preserves a stable
-    // key order for deterministic output.
+    // `recovery_kind` string. Trailing rule_stack frames marked
+    // trivia (reached from a `trivia <- …` reserved-name root) are
+    // popped before the key is built, so two diagnostics that bottom
+    // out in different trivia merge into one cluster on the deepest
+    // semantic rule. BTreeMap preserves a stable key order for
+    // deterministic output.
     type ClusterKey = (Vec<String>, String);
     let mut clusters: std::collections::BTreeMap<ClusterKey, usize> =
         std::collections::BTreeMap::new();
@@ -244,8 +248,16 @@ fn run_explain_recoveries(args: &[String]) -> ExitCode {
         let Some(reach) = slot else {
             continue;
         };
-        let stack: Vec<String> = reach
-            .rule_stack
+        let mut trimmed_stack = reach.rule_stack.clone();
+        while let Some(last) = trimmed_stack.last() {
+            let idx = last.0 as usize;
+            if rule_is_trivia.get(idx).copied().unwrap_or(false) {
+                trimmed_stack.pop();
+            } else {
+                break;
+            }
+        }
+        let stack: Vec<String> = trimmed_stack
             .iter()
             .filter_map(|id| rule_names.get(id.0 as usize).cloned())
             .collect();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -185,6 +185,14 @@ impl Parser {
         &self.program.label_kinds
     }
 
+    /// Per-rule trivia flags indexed by `MemoId.0` — see
+    /// [`crate::pegvm::Program::rule_is_trivia`]. `pegdb explain-recoveries`
+    /// uses this to drop trailing trivia frames from the rule_stack
+    /// when picking the displayed leaf of a recovery cluster.
+    pub fn rule_is_trivia(&self) -> &[bool] {
+        &self.program.rule_is_trivia
+    }
+
     /// Per-recovery diagnostic records from the most recent parse.
     /// Empty unless the parser was built with
     /// [`Parser::with_track_recovery_diagnostics(true)`]. Aligned with

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -29,6 +29,10 @@
 //!   u16 LE      n = rule_names.len()
 //!   for each name: NUL-terminated UTF-8 bytes
 //!
+//! rule-attribute bits:
+//!   ceil(rule_names.len() / 8) bytes, bit-packed `rule_is_trivia`
+//!   (rule `i`'s bit is bit `i % 8` of byte `i / 8`, LSB-first).
+//!
 //! label-name table:
 //!   u16 LE      n = label_kinds.len()
 //!   for each name: NUL-terminated UTF-8 bytes
@@ -192,9 +196,24 @@ pub fn encode(program: &Program) -> Vec<u8> {
     let mut out = Vec::new();
     write_name_table(&mut out, &program.capture_kinds, "capture");
     write_name_table(&mut out, &program.rule_names, "rule");
+    write_bit_vec(&mut out, &program.rule_is_trivia);
     write_name_table(&mut out, &program.label_kinds, "label");
     write_instructions(&mut out, &program.code);
     out
+}
+
+fn write_bit_vec(out: &mut Vec<u8>, bits: &[bool]) {
+    let nbytes = bits.len().div_ceil(8);
+    for byte_idx in 0..nbytes {
+        let mut byte = 0u8;
+        for bit_idx in 0..8 {
+            let i = byte_idx * 8 + bit_idx;
+            if i < bits.len() && bits[i] {
+                byte |= 1 << bit_idx;
+            }
+        }
+        out.push(byte);
+    }
 }
 
 fn write_name_table(out: &mut Vec<u8>, names: &[String], label: &str) {
@@ -330,6 +349,7 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
     let mut cur = Cursor::new(bytes);
     let capture_kinds = read_name_table(&mut cur, Error::InvalidCaptureName)?;
     let rule_names = read_name_table(&mut cur, Error::InvalidRuleName)?;
+    let rule_is_trivia = read_bit_vec(&mut cur, rule_names.len())?;
     let label_kinds = read_name_table(&mut cur, Error::InvalidLabelName)?;
     let code = read_instructions(&mut cur)?;
     if cur.pos != bytes.len() {
@@ -344,7 +364,23 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
         rule_count,
         rule_names,
         label_kinds,
+        rule_is_trivia,
     })
+}
+
+fn read_bit_vec(cur: &mut Cursor<'_>, n_bits: usize) -> Result<Vec<bool>, Error> {
+    let nbytes = n_bits.div_ceil(8);
+    let mut bits = Vec::with_capacity(n_bits);
+    for _ in 0..nbytes {
+        let byte = cur.read_u8()?;
+        for bit_idx in 0..8 {
+            if bits.len() == n_bits {
+                break;
+            }
+            bits.push((byte >> bit_idx) & 1 == 1);
+        }
+    }
+    Ok(bits)
 }
 
 fn read_name_table(
@@ -686,8 +722,31 @@ mod tests {
             rule_count: 2,
             rule_names: vec!["start".to_string(), "other".to_string()],
             label_kinds: vec!["missing_then".to_string()],
+            rule_is_trivia: vec![false, true],
         };
         assert_roundtrip(&p);
+    }
+
+    #[test]
+    fn bit_vec_round_trips_across_byte_boundary() {
+        // 10 rules so the trivia bitmap spans 2 bytes; alternating
+        // pattern catches any off-by-one in the bit ordering.
+        let bits: Vec<bool> = (0..10).map(|i| i % 2 == 0).collect();
+        let rule_names: Vec<String> = (0..10).map(|i| format!("r{i}")).collect();
+        let p = Program {
+            code: vec![Instruction::End],
+            capture_kinds: vec![],
+            rule_count: 10,
+            rule_names,
+            label_kinds: vec![],
+            rule_is_trivia: bits,
+        };
+        let bytes = encode(&p);
+        let decoded = decode(&bytes).expect("decode succeeds");
+        assert_eq!(
+            decoded.rule_is_trivia, p.rule_is_trivia,
+            "trivia bit-vec mismatch after round-trip"
+        );
     }
 
     // ─── error paths ───────────────────────────────────────────────
@@ -824,6 +883,7 @@ mod tests {
             rule_count: 0,
             rule_names: vec![],
             label_kinds: vec![],
+            rule_is_trivia: vec![],
         };
         assert_roundtrip(&p);
     }
@@ -845,6 +905,7 @@ mod tests {
             rule_count: 99, // intentionally inconsistent with the code
             rule_names: vec![],
             label_kinds: vec![],
+            rule_is_trivia: vec![],
         };
         let bytes = encode(&p);
         let decoded = decode(&bytes).expect("decode succeeds");

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -356,6 +356,38 @@ absorbing the leniency — actually holds is currently a convention
 recorded in adjacent comments and unenforced by the lint; see
 `#113` for the planned tightening.
 
+### Reserved rule names
+
+The compiler treats one rule name specially:
+
+- **`trivia`** — if a grammar defines a rule with this name, every
+  rule transitively reachable from it through the call graph is
+  marked as syntactic trivia (whitespace, comments). Runtime
+  semantics are unchanged; the bit surfaces in
+  `Program::rule_is_trivia` and `pegdb explain-recoveries` pops
+  trailing trivia frames from the rule_stack when picking the
+  displayed leaf of each cluster.
+
+  The cascade is structural — only one annotation per grammar (the
+  `trivia` rule's body lists the entry points), no per-rule keyword,
+  no surface markup. Rules whose body contains a recovery catch
+  (`^lbl`, `^^lbl`, `*^`) are pinned out of the cascade so the
+  catch's diagnostic frame stays visible.
+
+  Indentation-sensitive grammars (`#43`) keep significant-whitespace
+  rules outside the `trivia` subgraph; only ignorable bytes go in.
+
+  ```peg
+  trivia        <- ws
+  ws            <- (comment / [ \t\r\n])*
+  comment       <- @comment{line_comment / block_comment}
+  line_comment  <- '//' (!'\n' .)*
+  block_comment <- '/*' (!'*/' .)* '*/'
+  ```
+
+  Grammars without a `trivia` rule leave all trivia bits false;
+  pegdb's leaf-display still works, it just won't trim.
+
 ### Reserved syntax
 
 `^<non-ident-byte>` is a parse error today and reserved for future

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1277,3 +1277,100 @@ fn lower_inferred_boundary_catch(inner: Pattern, label: String, boundary: Patter
         recovery: Box::new(recovery),
     }
 }
+
+/// The reserved rule name that marks the trivia subgraph's root.
+/// If a grammar defines a rule with this name, the compiler cascades
+/// the trivia bit through every rule transitively reachable from it
+/// (subject to the catch-exclusion below).
+pub(crate) const TRIVIA_ROOT_RULE: &str = "trivia";
+
+/// Compute the per-rule trivia bit. A rule is trivia iff it's
+/// transitively reachable through the call graph from a rule named
+/// [`TRIVIA_ROOT_RULE`], excluding rules whose body contains a recovery
+/// catch (`Pattern::Catch` or `Pattern::InferBoundaryCatch`). The
+/// catch-exclusion preserves diagnostic visibility for catch-bearing
+/// frames in `pegdb explain-recoveries`: the catch is the author's
+/// signal that the rule's frame is load-bearing, and silently trimming
+/// it would hide exactly the rule the catch lives in.
+///
+/// Returns an entry for every rule in `rules`; rules in a grammar with
+/// no `trivia` root all get `false`.
+pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<String, bool> {
+    let mut trivia: HashMap<String, bool> = rules.keys().map(|n| (n.clone(), false)).collect();
+    if !rules.contains_key(TRIVIA_ROOT_RULE) {
+        return trivia;
+    }
+    let pinned: HashSet<String> = rules
+        .iter()
+        .filter(|(_, body)| body_contains_catch(body))
+        .map(|(name, _)| name.clone())
+        .collect();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: Vec<String> = vec![TRIVIA_ROOT_RULE.to_string()];
+    while let Some(rule) = queue.pop() {
+        if !visited.insert(rule.clone()) {
+            continue;
+        }
+        if !pinned.contains(&rule) {
+            trivia.insert(rule.clone(), true);
+        }
+        if let Some(body) = rules.get(&rule) {
+            let mut callees = HashSet::new();
+            collect_non_terminal_refs(body, &mut callees);
+            for callee in callees {
+                if rules.contains_key(&callee) && !visited.contains(&callee) {
+                    queue.push(callee);
+                }
+            }
+        }
+    }
+    trivia
+}
+
+fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
+    match pat {
+        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
+        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
+            for it in items {
+                collect_non_terminal_refs(it, out);
+            }
+        }
+        Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner)
+        | Pattern::Optional(inner)
+        | Pattern::NotPredicate(inner)
+        | Pattern::AndPredicate(inner)
+        | Pattern::Capture(_, inner)
+        | Pattern::Lenient(inner) => collect_non_terminal_refs(inner, out),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            collect_non_terminal_refs(inner, out);
+            collect_non_terminal_refs(recovery, out);
+        }
+        Pattern::InferBoundaryCatch { inner, .. } => collect_non_terminal_refs(inner, out),
+        Pattern::NonTerminal(name) => {
+            out.insert(name.clone());
+        }
+    }
+}
+
+fn body_contains_catch(pat: &Pattern) -> bool {
+    match pat {
+        Pattern::Catch { .. } | Pattern::InferBoundaryCatch { .. } => true,
+        Pattern::Literal(_)
+        | Pattern::CharClass(_)
+        | Pattern::AnyChar
+        | Pattern::NonTerminal(_) => false,
+        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
+            items.iter().any(body_contains_catch)
+        }
+        Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner)
+        | Pattern::Optional(inner)
+        | Pattern::NotPredicate(inner)
+        | Pattern::AndPredicate(inner)
+        | Pattern::Capture(_, inner)
+        | Pattern::Lenient(inner) => body_contains_catch(inner),
+    }
+}

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -310,6 +310,7 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
         rule_count: 0,
         rule_names: Vec::new(),
         label_kinds: c.label_names,
+        rule_is_trivia: Vec::new(),
     }
 }
 
@@ -338,6 +339,12 @@ pub(crate) fn compile_rules(
     // Identify left-recursive rules (direct and indirect).
     let lr_rules = analyze_left_recursion(rules)?;
 
+    // Compute the per-rule trivia bit by cascading from any `trivia <- …`
+    // reserved-name root the grammar defines. Catch-bearing rules are
+    // pinned out of the cascade so their frames stay visible in
+    // `pegdb explain-recoveries`.
+    let trivia_bits = super::analysis::compute_trivia_rules(rules);
+
     let mut c = Compiler::new();
     c.emit(Instruction::Call(Label(0))); // patched below
     c.emit(Instruction::End);
@@ -354,11 +361,13 @@ pub(crate) fn compile_rules(
 
     let mut rule_addrs: HashMap<String, usize> = HashMap::new();
     let mut rule_names: Vec<String> = Vec::new();
+    let mut rule_is_trivia: Vec<bool> = Vec::new();
     let mut rule_count: u32 = 0;
     for name in ordered {
         rule_addrs.insert(name.clone(), c.pos());
         let memo_id = MemoId(rule_count);
         rule_names.push(name.clone());
+        rule_is_trivia.push(trivia_bits.get(name).copied().unwrap_or(false));
         rule_count += 1;
         let kind = if lr_rules.contains(name.as_str()) {
             RuleKind::Lr
@@ -404,6 +413,7 @@ pub(crate) fn compile_rules(
         rule_count: rule_count as usize,
         rule_names,
         label_kinds: c.label_names,
+        rule_is_trivia,
     })
 }
 

--- a/src/pegvm/program.rs
+++ b/src/pegvm/program.rs
@@ -31,4 +31,12 @@ pub struct Program {
     /// recovery firing back to its source name. Empty for grammars
     /// that don't use labeled failures.
     pub label_kinds: Vec<String>,
+    /// Per-rule trivia flags, indexed by `MemoId.0`. `true` when the
+    /// rule is reachable from a `trivia <- …` reserved-name root in
+    /// the grammar; a rule containing a recovery catch is pinned out
+    /// of inference so the catch's frame stays visible. `pegdb
+    /// explain-recoveries` consults this to drop trailing trivia
+    /// frames from the rule_stack when picking the displayed leaf of
+    /// a recovery cluster. Length is exactly `rule_count`.
+    pub rule_is_trivia: Vec<bool>,
 }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1845,6 +1845,92 @@ fn compile_errors_on_uninferable_boundary() {
     );
 }
 
+// ---- Trivia reserved-rule cascade --------------------------------
+
+fn trivia_idx(program: &syntax_highlighter::pegvm::Program, name: &str) -> usize {
+    program
+        .rule_names
+        .iter()
+        .position(|n| n == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "rule `{name}` not indexed; rule_names = {:?}",
+                program.rule_names
+            )
+        })
+}
+
+#[test]
+fn trivia_root_marks_itself_and_no_root_leaves_bits_false() {
+    // Without a `trivia` rule the bits are all false.
+    let no_root = parse("start <- 'x'")
+        .expect("parse")
+        .compile()
+        .expect("compile");
+    assert!(no_root.rule_is_trivia.iter().all(|b| !b));
+
+    // The trivia rule itself gets the bit when present.
+    let with_root = parse("start <- trivia 'x'\ntrivia <- ' '*")
+        .expect("parse")
+        .compile()
+        .expect("compile");
+    assert!(with_root.rule_is_trivia[trivia_idx(&with_root, "trivia")]);
+    assert!(!with_root.rule_is_trivia[trivia_idx(&with_root, "start")]);
+}
+
+#[test]
+fn trivia_cascades_to_transitive_callees() {
+    let program = parse(
+        "start  <- trivia 'x'\n\
+         trivia <- ws\n\
+         ws     <- (comment / ' ')*\n\
+         comment <- '#' (!'\\n' .)*",
+    )
+    .expect("parse")
+    .compile()
+    .expect("compile");
+    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
+    assert!(program.rule_is_trivia[trivia_idx(&program, "ws")]);
+    assert!(program.rule_is_trivia[trivia_idx(&program, "comment")]);
+    assert!(!program.rule_is_trivia[trivia_idx(&program, "start")]);
+}
+
+#[test]
+fn trivia_cascade_skips_catch_bearing_rules() {
+    // `victim` is reached from the trivia subgraph but has a catch
+    // in its body. The cascade pins it out so the catch's frame stays
+    // visible in `pegdb explain-recoveries`.
+    let program = parse(
+        "start  <- trivia 'x'\n\
+         trivia <- (victim / ' ')*\n\
+         victim <- 'a' ^bad 'b'",
+    )
+    .expect("parse")
+    .compile()
+    .expect("compile");
+    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
+    assert!(
+        !program.rule_is_trivia[trivia_idx(&program, "victim")],
+        "rules containing a catch must not cascade to trivia"
+    );
+}
+
+#[test]
+fn trivia_cascade_handles_recursion() {
+    // Trivia subgraph with a self-cycle; fixpoint should terminate
+    // and mark every reachable rule.
+    let program = parse(
+        "start  <- trivia 'x'\n\
+         trivia <- ws\n\
+         ws     <- (ws / ' ')*",
+    )
+    .expect("parse")
+    .compile()
+    .expect("compile");
+    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
+    assert!(program.rule_is_trivia[trivia_idx(&program, "ws")]);
+}
+
 #[test]
 fn all_shipped_grammars_compile_clean() {
     // Load-bearing: every grammar in `grammars/*.peg` must compile

--- a/tests/pegc_tests.rs
+++ b/tests/pegc_tests.rs
@@ -51,12 +51,12 @@ fn stats_json_grammar_emits_expected_record() {
     );
     assert_eq!(
         json_field_str(line, "instructions"),
-        Some("197"),
+        Some("201"),
         "JSON instruction count drifted"
     );
     assert_eq!(
         json_field_str(line, "rules"),
-        Some("16"),
+        Some("17"),
         "JSON rule count drifted"
     );
     let count: usize = json_field_str(line, "capture_kinds_count")

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -387,6 +387,33 @@ fn dump_captures_recovery_span_shares_farthest_reach() {
 // ---------- explain-recoveries ----------
 
 #[test]
+fn explain_recoveries_skips_trivia_when_picking_leaf() {
+    // Shipped grammars define a `trivia <- ws` reserved-name root; the
+    // compiler cascades the trivia bit through `ws → comment →
+    // line_comment / block_comment`, and pegdb explain-recoveries pops
+    // those trailing frames before clustering. The displayed leaf is
+    // the deepest semantic (non-trivia) rule.
+    let (code, stdout, _) = run_stdin(
+        &["explain-recoveries", "-g", "grammars/rust.peg"],
+        b"fn ok() {}\n@@@ garbage @@@\nfn ok2() {}\n",
+    );
+    assert_eq!(code, 0);
+    let trivia_names = ["ws", "spacing", "comment", "line_comment", "block_comment"];
+    for line in stdout.lines() {
+        let leaf = line
+            .split(" — farthest reach ends at ")
+            .nth(1)
+            .and_then(|rest| rest.split(" (label:").next())
+            .map(str::trim)
+            .unwrap_or_else(|| panic!("could not parse leaf from: {line}"));
+        assert!(
+            !trivia_names.contains(&leaf),
+            "displayed leaf must not be a trivia rule, got `{leaf}` in: {line}"
+        );
+    }
+}
+
+#[test]
 fn explain_recoveries_clusters_by_rule_stack() {
     // Multiple `@@@` runs should collapse into a single top-level
     // cluster; non-trivial dive sites (e.g. `g` looking like the start


### PR DESCRIPTION
After PR `#101` added `^label` catches across the shipped grammars, every `pegdb explain-recoveries` cluster line read `farthest reach ends at line_comment` (or `comment` / `ws`) — the deepest reach at recovery time was almost always inside the trivia chain, burying the semantically interesting rule one or two stack frames up.

A grammar that defines a rule named `trivia` opts into a cascade: every rule transitively reachable from it through the call graph is marked as syntactic background, surfaced via `Program::rule_is_trivia` and round-tripped through `pegb`. `pegdb explain-recoveries` pops those trailing frames from the rule_stack before clustering, so the displayed leaf becomes the deepest non-trivia rule and recoveries that bottom out in different trivia merge into one cluster. Each shipped grammar gains a single-line `trivia <- ws` (or `trivia <- spacing` for json) root.

Rules whose body contains a recovery catch are pinned out of the cascade so the catch's diagnostic frame stays visible — the catch is the author's signal that the rule's frame is load-bearing. Indentation-sensitive grammars (`#43`) keep significant-whitespace rules outside the trivia subgraph the same way.

Sanity check on `#102`'s motivating sample:

```
$ pegdb explain-recoveries -g grammars/sqlite.peg <(echo 'SELECT blob.rid IN leaf AS leaf FROM t;')
1 recoveries — farthest reach ends at cmp_tail (label: bad_column)
```

(was `farthest reach ends at line_comment` before.)

Closes #102.
