### PR TITLE
pegc: add `..` / `..=` / `^^lbl ..= B` skip-until operators

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -315,8 +315,8 @@ reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
 # --- Whitespace / comments ------------------------------------------
 
 comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' (!'\n' .)*
-block_comment <- '/*' (!'*/' .)* '*/'
+line_comment  <- '//' .. '\n'
+block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -143,7 +143,7 @@ designator    <- ws @punctuation{'['} ws expr_cond ws @punctuation{']'}
 
 # --- Statements ------------------------------------------------------
 
-compound_stmt <- @punctuation{'{'} ws ((block_item ws)* @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
+compound_stmt <- @punctuation{'{'} ws ((block_item ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_item    <- pp_line
                / decl
                / stmt

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -77,9 +77,9 @@ class_selector <- '.' ident
 id_selector    <- '#' ident
 pseudo_element <- '::' ident pseudo_args?
 pseudo_class   <- ':' ident pseudo_args?
-pseudo_args    <- '(' (!')' .)* ')'
+pseudo_args    <- '(' ..= ')'
 attr_selector  <- @punctuation{'['} ws attr_body ws @punctuation{']'}
-attr_body      <- (!']' .)*
+attr_body      <- .. ']'
 
 # --- Blocks & declarations ------------------------------------------
 
@@ -120,7 +120,7 @@ fn_arg        <- value_term
 
 # Unquoted `url(...)` arg — bare text till the closing paren.
 url_unquoted  <- @function{'url'} @punctuation{'('} ws @string{url_body} ws @punctuation{')'}
-url_body      <- (!')' .)*
+url_body      <- .. ')'
 
 # --- Literals -------------------------------------------------------
 
@@ -157,7 +157,7 @@ ident_body    <- [A-Za-z0-9_\-]
 # CSS has only block comments.
 
 comment       <- @comment{block_comment}
-block_comment <- '/*' (!'*/' .)* '*/'
+block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -83,7 +83,7 @@ attr_body      <- .. ']'
 
 # --- Blocks & declarations ------------------------------------------
 
-block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
+block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_body    <- (block_item ws)*
 block_item    <- at_rule
                 / declaration

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -332,7 +332,7 @@ nil_lit       <- 'nil' !ident_body
 iota_lit      <- 'iota' !ident_body
 
 string_lit    <- @string{raw_string / interp_string}
-raw_string    <- '`' (!'`' .)* '`'
+raw_string    <- '`' ..= '`'
 interp_string <- '"' (str_escape / !'"' !'\n' .)* '"'
 str_escape    <- '\\' .
 
@@ -391,8 +391,8 @@ predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
 ~opt_semi     <- (@punctuation{';'} ws)?
 
 comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' (!'\n' .)*
-block_comment <- '/*' (!'*/' .)* '*/'
+line_comment  <- '//' .. '\n'
+block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -127,7 +127,7 @@ type_arg_list <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation
 
 # --- Statements ------------------------------------------------------
 
-block         <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
+block         <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 stmt          <- decl ws opt_semi
                / block

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -158,7 +158,7 @@ throw_stmt     <- @keyword{'throw'} ws expr ws opt_semi
 debugger_stmt  <- @keyword{'debugger'} ws opt_semi
 labeled_stmt   <- @variable{ident} ws @punctuation{':'} ws stmt
 block_stmt     <- block
-block          <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
+block          <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -378,8 +378,8 @@ reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
 # --- Whitespace / comments --------------------------------------------
 
 comment        <- @comment{line_comment / block_comment}
-line_comment   <- '//' (!'\n' .)*
-block_comment  <- '/*' (!'*/' .)* '*/'
+line_comment   <- '//' .. '\n'
+block_comment  <- '/*' ..= '*/'
 
 trivia        <- ws
 

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -52,7 +52,7 @@ item          <- attr_outer
 # Attributes and doc-comments at item position.
 attr_outer    <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'} ws
 attr_inner    <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'} ws
-attr_body     <- (!']' .)*
+attr_body     <- .. ']'
 
 # `use foo::bar::{baz, qux as q};`
 use_item      <- @keyword{'use'} ws use_tree ws @punctuation{';'} ws
@@ -437,7 +437,7 @@ raw_string    <- 'r' raw_hashes '"' raw_body_0 '"' raw_hashes
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
 raw_hashes    <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
-raw_body_0    <- (!'"' .)*
+raw_body_0    <- .. '"'
 
 char_lit      <- @string{"'" (char_escape / !"'" .) "'"}
 char_escape   <- '\\' (!'\n' .)
@@ -473,10 +473,10 @@ ident_body    <- [A-Za-z0-9_]
 # --- Whitespace and comments ------------------------------------------
 
 comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' (!'\n' .)*
+line_comment  <- '//' .. '\n'
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-block_comment <- '/*' (!'*/' .)* '*/'
+block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -392,7 +392,7 @@ struct_init_base   <- @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^block_close @recovery{(!'}' .)*} @punctuation{'}'})
+block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_body    <- (stmt)*
 
 stmt          <- let_stmt

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -550,7 +550,7 @@ ident_char        <- [a-zA-Z0-9_]
 
 double_quoted_id  <- '"' ('""' / !'"' !linebreak .)* '"'
 backtick_id       <- '`' ('``' / !'`' !linebreak .)* '`'
-bracket_id        <- '[' (!']' !linebreak .)* ']'
+bracket_id        <- '[' .. (']' / linebreak) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Per-letter character classes give case-insensitive matching without
@@ -999,7 +999,7 @@ trivia        <- ws
 
 ws            <- (comment / [ \t\n\r])*
 comment       <- line_comment / block_comment
-line_comment  <- @comment{'--' (!linebreak .)*}
+line_comment  <- @comment{'--' .. linebreak}
 block_comment <- @comment{'/*' block_body '*/'}
-block_body    <- (!'*/' .)*
+block_body    <- .. '*/'
 linebreak     <- '\r'? '\n'

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -63,13 +63,13 @@ basic_char    <- !["\\\n\r] .
 escape        <- '\\' (["\\bfnrt] / 'u' hex hex hex hex / 'U' hex hex hex hex hex hex hex hex)
 
 basic_multiline <- '"""' multiline_basic_body '"""'
-multiline_basic_body <- (!'"""' .)*
+multiline_basic_body <- .. '"""'
 
 literal_string  <- "'" literal_char* "'"
 literal_char    <- !['\n\r] .
 
 literal_multiline <- "'''" multiline_literal_body "'''"
-multiline_literal_body <- (!"'''" .)*
+multiline_literal_body <- .. "'''"
 
 # --- Numbers -----------------------------------------------------------
 integer       <- @number{int_body}
@@ -113,7 +113,7 @@ inline_pair   <- key inline_space @punctuation{'='} inline_space value
 # --- Whitespace & comments --------------------------------------------
 inline_space  <- [ \t]*
 linebreak     <- '\r'? '\n'
-comment       <- @comment{'#' (!linebreak .)*}
+comment       <- @comment{'#' .. linebreak}
 
 # Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -367,6 +367,51 @@ uses a placeholder `Pattern::InferBoundaryCatch { inner, label }`
 resolved by `analysis::resolve_inferred_boundaries` before bytecode
 emission. No new VM machinery.
 
+### `INNER ^^lbl ..= B` — bracketed-close catch sugar
+
+A variant of the boundary-anchored catch for the case where the
+boundary is consumed *by the catch itself* (and re-captured with its
+own kind), not left for the outer rule. The five `^block_close`
+sites across the C / CSS / Go / JavaScript / Rust grammars are the
+motivating shape: a `block` rule whose happy path ends in
+`@punctuation{'}'}` and whose recovery skips bytes until the next
+`}` and then matches it, with the closing brace tagged as
+`@punctuation` in both paths.
+
+```peg
+INNER ^^lbl ..= B
+# lowers to
+INNER ^lbl @recovery{(!B .)*} B
+```
+
+Two ways it differs from `^^lbl B`:
+
+- **No `&B` lookahead anchor on INNER.** Every corpus site has INNER
+  already ending in `B` (the structural delimiter); adding `&B`
+  would require a second `B` to follow. Authors who need a leniency
+  anchor on a non-self-terminating INNER write it explicitly.
+- **B is consumed inside the recovery, not by the outer rule.** The
+  recovery body is a `Sequence` of `@recovery{(!B .)*}` then `B` —
+  the skip is captured as `recovery`; `B` keeps whatever capture
+  kind its pattern carries, *outside* the `@recovery` wrap.
+
+Worked example (the `block` rule from `grammars/rust.peg`):
+
+```peg
+block <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+```
+
+The catch fires when `block_body ws @punctuation{'}'}` fails (a
+malformed block). The recovery skips up to the next `}` and consumes
+it as `@punctuation` — so themes that style recoveries differently
+still render the closing brace as a brace, not as a recovery span.
+
+The `..=` spelling matches the standalone consuming semantics from
+the `.. S` / `..= S` operators above. The catch position accepts
+only `..=`, not `..` — the catch necessarily consumes its boundary,
+and `^^lbl .. B` would diverge from the standalone `..` non-consuming
+meaning. The parser rejects it with a hint pointing at `..=`.
+
 ### `~name <-` — intentional-leniency marker
 
 The static `lint_partial_match` check flags trailing-nullable rules

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -211,6 +211,40 @@ region. Pick `*^` when "skip what you can't parse" is the right
 default and sync sets when you want recovery anchored to a specific
 delimiter.
 
+### `.. S` and `..= S` — skip until delimiter
+
+The "repeat-until-delimiter" idiom `(!S .)*` recurs across comment
+bodies, multiline strings, attribute payloads, and recovery scopes.
+The two shorthands name the consume-or-not distinction directly:
+
+| Syntax | Meaning | Lowers to |
+|---|---|---|
+| `.. S` | Skip bytes up to (but not including) `S`. The stop is a negative lookahead; `S` is left for the outer rule. | `(!S .)*` |
+| `..= S` | Skip bytes up to and including `S`. The stop is matched and consumed after the skip; its capture kind (if any) is preserved on the trailing consume. | `(!S .)* S` |
+
+The `..=` convention mirrors Rust's inclusive-range operator. Read
+`..` as "up to" and `..=` as "up to and inclusive".
+
+Two worked examples:
+
+```peg
+# Non-consuming: the newline is left for outer whitespace handling.
+line_comment <- '//' .. '\n'
+
+# Consuming: the closing `*/` is part of the comment.
+block_comment <- '/*' ..= '*/'
+```
+
+Both operators are unary today — the LHS of the skip is always `.`
+(any byte). Every site in the shipped corpus follows this shape; a
+binary `p .. S` / `p ..= S` could be added later if structured
+non-`.` bodies surface in a future grammar.
+
+The two dots must be immediately adjacent, and the `=` of `..=`
+must also touch (`. .` and `.. =` parse as separate atoms,
+preserving today's behavior). Whitespace around the operator and
+between the operator and the stop pattern is allowed.
+
 ### `inner ^label recovery` — labeled catch with recovery
 
 Tries `inner`; on failure, splices the failed attempt's deepest-reach

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -407,6 +407,24 @@ impl<'a> Parser<'a> {
             Some(b'"') | Some(b'\'') => self.parse_string(),
             Some(b'[') => self.parse_charclass(),
             Some(b'.') => {
+                // Three-byte lookahead disambiguates the dot family:
+                //   `..=` — skip-until inclusive (consumes the stop)
+                //   `..`  — skip-until exclusive (leaves the stop)
+                //   `.`   — AnyChar (single byte)
+                // The two dots must be immediately adjacent; the `=` of
+                // `..=` must also touch. Whitespace between the dots
+                // would parse as two separate `AnyChar` atoms.
+                if self.peek_at(1) == Some(b'.') {
+                    let inclusive = self.peek_at(2) == Some(b'=');
+                    self.pos += if inclusive { 3 } else { 2 };
+                    self.skip_ws();
+                    let stop = self.parse_prefix()?;
+                    return Ok(if inclusive {
+                        lower_until_inclusive(stop)
+                    } else {
+                        lower_until_exclusive(stop)
+                    });
+                }
                 self.pos += 1;
                 Ok(Pattern::AnyChar)
             }
@@ -645,6 +663,22 @@ fn is_ident_cont(c: u8) -> bool {
 
 fn is_atom_start(c: u8) -> bool {
     matches!(c, b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&') || is_ident_start(c)
+}
+
+/// Lower `.. S` (skip-until exclusive) to `(!S .)*`. The stop pattern
+/// is a negative lookahead; `S` is not consumed.
+fn lower_until_exclusive(stop: Pattern) -> Pattern {
+    Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(stop)),
+        Pattern::AnyChar,
+    ])))
+}
+
+/// Lower `..= S` (skip-until inclusive) to `(!S .)* S`. The stop is
+/// matched and consumed after the skip; its capture kind (if any) is
+/// preserved on the trailing consume.
+fn lower_until_inclusive(stop: Pattern) -> Pattern {
+    Pattern::Sequence(vec![lower_until_exclusive(stop.clone()), stop])
 }
 
 /// Lower `INNER ^^lbl B` to the explicit boundary-anchored catch

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -177,7 +177,21 @@ impl<'a> Parser<'a> {
                 self.pos += 1;
                 let label = self.parse_catch_label("^^")?;
                 self.skip_ws();
-                let catch_pat = if self.at_prefix_start() {
+                let catch_pat = if self.at_until_inclusive_marker() {
+                    // `INNER ^^lbl ..= B` — bracketed-close catch sugar.
+                    self.pos += 3;
+                    self.skip_ws();
+                    let boundary = self.parse_prefix()?;
+                    lower_bracketed_close_catch(lhs, label, boundary)
+                } else if self.peek() == Some(b'.') && self.peek_at(1) == Some(b'.') {
+                    // `INNER ^^lbl .. B` — rejected. The catch necessarily
+                    // consumes B; the non-consuming form has no use here.
+                    return Err(self.err(
+                        "`^^lbl .. B` is not a valid form; the catch consumes its boundary. \
+                         Use `^^lbl ..= B` to skip-and-consume, or `^^lbl B` to leave B for the outer rule"
+                            .into(),
+                    ));
+                } else if self.at_prefix_start() {
                     let boundary = self.parse_prefix()?;
                     lower_boundary_catch(lhs, label, boundary)
                 } else {
@@ -612,6 +626,14 @@ impl<'a> Parser<'a> {
         self.src.get(self.pos + offset).copied()
     }
 
+    /// True iff the next three bytes are `..=` — the bracketed-close
+    /// catch-sugar marker after `^^lbl`. Adjacent-only; whitespace
+    /// between the dots or before the `=` makes them parse as separate
+    /// tokens.
+    fn at_until_inclusive_marker(&self) -> bool {
+        self.peek() == Some(b'.') && self.peek_at(1) == Some(b'.') && self.peek_at(2) == Some(b'=')
+    }
+
     fn expect(&mut self, c: u8) -> Result<(), ParseError> {
         if self.peek() == Some(c) {
             self.pos += 1;
@@ -695,6 +717,33 @@ fn lower_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pat
     let recovery = Pattern::Capture("recovery".into(), Box::new(stop_loop));
     Pattern::Catch {
         inner: Box::new(Pattern::Sequence(vec![inner, lookahead])),
+        label,
+        recovery: Box::new(recovery),
+    }
+}
+
+/// Lower `INNER ^^lbl ..= B` (bracketed-close catch sugar) to:
+/// `Catch { INNER, lbl, Sequence([@recovery{(!B .)*}, B]) }`.
+///
+/// Distinct from `lower_boundary_catch` in two ways: (1) the inner is
+/// *not* anchored with `&B` — every corpus site has `INNER` already
+/// ending in `B`, so the anchor would require another `B` to follow;
+/// (2) the recovery body consumes `B` after the skip, with `B`
+/// captured per its own kind (outside the `@recovery` wrap). This is
+/// the shape the `^block_close` sites across the shipped grammars
+/// need: the closing `}` keeps its `@punctuation` kind in both happy
+/// and recovery paths.
+fn lower_bracketed_close_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
+    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(boundary.clone())),
+        Pattern::AnyChar,
+    ])));
+    let recovery = Pattern::Sequence(vec![
+        Pattern::Capture("recovery".into(), Box::new(stop_loop)),
+        boundary,
+    ]);
+    Pattern::Catch {
+        inner: Box::new(inner),
         label,
         recovery: Box::new(recovery),
     }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1820,6 +1820,45 @@ fn compile_succeeds_with_boundary_catch_anchor() {
 }
 
 #[test]
+fn compile_succeeds_with_bracketed_close_catch_sugar() {
+    // `^^bad ..= '}'` lowers to a `Catch` whose inner is unanchored
+    // and whose recovery is `Seq(@recovery{(!'}' .)*}, '}')`. The
+    // inner ends in `'}'` (a hard terminator), so `lint_partial_match`
+    // sees no trailing-nullable shape and compilation succeeds.
+    let g = parse("start <- ('{' a '}' ^^bad ..= '}')*\na <- 'x'+").expect("parse");
+    g.compile()
+        .expect("compile should succeed with `^^bad ..= '}'` sugar");
+}
+
+#[test]
+fn bracketed_close_catch_runs_recovery_path() {
+    use syntax_highlighter::pegvm::VM;
+    // Tiny grammar shaped like the corpus' `block` rule: opening `{`,
+    // body that requires `'x'`, closing `}` with `^^bad ..= '}'` to
+    // skip to the brace on body failure. Malformed input `{garbage}`
+    // exercises the recovery: skip captures `garbage` and `}` is
+    // captured as `@punctuation`.
+    let g = parse(
+        "start <- @punctuation{'{'} (body @punctuation{'}'} ^^bad ..= @punctuation{'}'})\nbody <- 'x'",
+    )
+    .expect("parse");
+    let prog = g.compile().expect("compile");
+    let r = VM::new(&prog.code, b"{garbage}").run();
+    assert!(r.complete, "recovery should let the parse complete");
+    assert_eq!(r.matched, 9);
+    let kinds: Vec<&str> = r
+        .captures
+        .iter()
+        .map(|c| prog.capture_kinds[c.kind.0 as usize].as_str())
+        .collect();
+    assert_eq!(
+        kinds,
+        vec!["punctuation", "recovery", "punctuation"],
+        "expected open-punct, recovery span, close-punct (NOT recovery)"
+    );
+}
+
+#[test]
 fn compile_error_display_lists_findings() {
     let g = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
     let err = g.compile().expect_err("compile should fail");

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1097,3 +1097,115 @@ fn skip_until_with_capture_stop_exclusive() {
     let stop = Pattern::Capture("comment".into(), Box::new(Pattern::literal("#")));
     assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
 }
+
+/// Builds the desugared AST that `INNER ^^lbl ..= B` lowers to:
+/// `Catch { INNER, lbl, Seq(@recovery{(!B .)*}, B) }`. No `&B`
+/// anchor on the inner. Mirrors `lower_bracketed_close_catch` in
+/// `src/pegc/parser.rs`.
+fn desugared_bracketed_close_catch(inner: Pattern, label: &str, boundary: Pattern) -> Pattern {
+    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(boundary.clone())),
+        Pattern::AnyChar,
+    ])));
+    let recovery = Pattern::Sequence(vec![
+        Pattern::Capture("recovery".into(), Box::new(stop_loop)),
+        boundary,
+    ]);
+    Pattern::Catch {
+        inner: Box::new(inner),
+        label: label.into(),
+        recovery: Box::new(recovery),
+    }
+}
+
+#[test]
+fn bracketed_close_catch_lowers_without_inner_anchor() {
+    let g = parse("r <- 'a' ^^lbl ..= '}'");
+    assert_eq!(
+        g.rules["r"],
+        desugared_bracketed_close_catch(Pattern::literal("a"), "lbl", Pattern::literal("}"))
+    );
+}
+
+#[test]
+fn bracketed_close_catch_with_capture_boundary() {
+    // The boundary's capture kind is preserved on the trailing
+    // consume — `}` is captured as `@punctuation` in both happy and
+    // recovery paths.
+    let g = parse("r <- 'a' ^^lbl ..= @punctuation{'}'}");
+    let boundary = Pattern::Capture("punctuation".into(), Box::new(Pattern::literal("}")));
+    assert_eq!(
+        g.rules["r"],
+        desugared_bracketed_close_catch(Pattern::literal("a"), "lbl", boundary)
+    );
+}
+
+#[test]
+fn bracketed_close_catch_vs_boundary_catch_distinction() {
+    // `^^lbl B`   — anchors INNER with `&B`; recovery is just `@recovery{(!B .)*}` (B left for outer).
+    // `^^lbl ..= B` — no inner anchor; recovery is `Seq(@recovery{(!B .)*}, B)` (B consumed by recovery).
+    let anchored = parse("r <- 'a' ^^lbl '}'").rules["r"].clone();
+    let bracketed = parse("r <- 'a' ^^lbl ..= '}'").rules["r"].clone();
+    match (&anchored, &bracketed) {
+        (
+            Pattern::Catch {
+                inner: i_anch,
+                recovery: r_anch,
+                ..
+            },
+            Pattern::Catch {
+                inner: i_brkt,
+                recovery: r_brkt,
+                ..
+            },
+        ) => {
+            // Anchored inner is a Sequence ending in AndPredicate; bracketed inner is the bare INNER.
+            assert!(
+                matches!(i_anch.as_ref(), Pattern::Sequence(items) if matches!(items.last(), Some(Pattern::AndPredicate(_)))),
+                "anchored form should have &B on inner: {i_anch:?}"
+            );
+            assert_eq!(
+                i_brkt.as_ref(),
+                &Pattern::literal("a"),
+                "bracketed form should NOT anchor inner: {i_brkt:?}"
+            );
+            // Anchored recovery is just the capture; bracketed recovery is Seq(capture, B).
+            assert!(
+                matches!(r_anch.as_ref(), Pattern::Capture(_, _)),
+                "anchored recovery should be a capture, got: {r_anch:?}"
+            );
+            assert!(
+                matches!(r_brkt.as_ref(), Pattern::Sequence(_)),
+                "bracketed recovery should be a Sequence, got: {r_brkt:?}"
+            );
+        }
+        other => panic!("expected two Catch nodes, got: {other:?}"),
+    }
+}
+
+#[test]
+fn bracketed_close_catch_rejects_non_consuming_form() {
+    // `^^lbl .. B` is inconsistent (catch necessarily consumes B); the
+    // parser rejects it with a hint at `..=`.
+    let err = parse_src("r <- 'a' ^^lbl .. '}'").unwrap_err();
+    assert!(
+        err.message.contains("..=") || err.message.contains("consume"),
+        "expected hint about `..=`, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn bracketed_close_catch_does_not_swallow_trailing_atoms() {
+    // The catch sugar consumes its boundary in the recovery; any atoms
+    // after the boundary belong to the enclosing sequence.
+    let g = parse("r <- 'a' ^^lbl ..= '}' 'c'");
+    match &g.rules["r"] {
+        Pattern::Sequence(items) => {
+            assert_eq!(items.len(), 2, "expected Seq(catch, 'c'), got: {items:?}");
+            assert!(matches!(&items[0], Pattern::Catch { .. }));
+            assert_eq!(items[1], Pattern::literal("c"));
+        }
+        other => panic!("expected Sequence, got: {other:?}"),
+    }
+}

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -958,3 +958,142 @@ fn duplicate_rule_errors() {
     let err = parse_src("a <- 'x'\na <- 'y'").unwrap_err();
     assert!(err.message.contains("twice"), "got: {}", err.message);
 }
+
+/// Builds the desugared AST that `.. S` lowers to:
+/// `Repeat(Seq(NotPredicate(S), AnyChar))`. Mirrors
+/// `lower_until_exclusive` in `src/pegc/parser.rs`.
+fn desugared_until_exclusive(stop: Pattern) -> Pattern {
+    Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::NotPredicate(Box::new(stop)),
+        Pattern::AnyChar,
+    ])))
+}
+
+/// Builds the desugared AST that `..= S` lowers to:
+/// `Seq(.. S, S)`. Mirrors `lower_until_inclusive` in
+/// `src/pegc/parser.rs`.
+fn desugared_until_inclusive(stop: Pattern) -> Pattern {
+    Pattern::Sequence(vec![desugared_until_exclusive(stop.clone()), stop])
+}
+
+#[test]
+fn skip_until_exclusive_lowers_to_repeat() {
+    let g = parse("r <- .. 'b'");
+    assert_eq!(
+        g.rules["r"],
+        desugared_until_exclusive(Pattern::literal("b"))
+    );
+}
+
+#[test]
+fn skip_until_inclusive_lowers_with_trailing_consume() {
+    let g = parse("r <- ..= 'b'");
+    assert_eq!(
+        g.rules["r"],
+        desugared_until_inclusive(Pattern::literal("b"))
+    );
+}
+
+#[test]
+fn skip_until_inclusive_vs_exclusive_distinction() {
+    // Same stop pattern; ASTs differ exactly in the trailing consume.
+    let excl = parse("r <- .. 'b'").rules["r"].clone();
+    let incl = parse("r <- ..= 'b'").rules["r"].clone();
+    assert_eq!(incl, Pattern::Sequence(vec![excl, Pattern::literal("b")]));
+}
+
+#[test]
+fn skip_until_inside_sequence() {
+    let g = parse("r <- 'x' .. 'b' 'y'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            desugared_until_exclusive(Pattern::literal("b")),
+            Pattern::literal("y"),
+        ])
+    );
+}
+
+#[test]
+fn skip_until_requires_adjacent_dots() {
+    // `. . 'b'` (space between dots) is three atoms, not `..`.
+    let g = parse("r <- . . 'b'");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::AnyChar,
+            Pattern::AnyChar,
+            Pattern::literal("b"),
+        ])
+    );
+}
+
+#[test]
+fn skip_until_inclusive_requires_adjacent_equals() {
+    // `.. = 'b'` (space between `..` and `=`) is `..` whose stop is
+    // `=`, then `'b'` as a trailing atom. Since `=` isn't a valid
+    // atom-starter, the parse should fail at `=`.
+    let err = parse_src("r <- .. = 'b'").unwrap_err();
+    assert!(
+        err.message.contains("unexpected") || err.message.contains("expected"),
+        "expected parse error on `=`, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn skip_until_whitespace_after_operator_ok() {
+    let a = parse("r <- ..'b'").rules["r"].clone();
+    let b = parse("r <- ..  'b'").rules["r"].clone();
+    assert_eq!(a, b);
+    let c = parse("r <- ..='b'").rules["r"].clone();
+    let d = parse("r <- ..=  'b'").rules["r"].clone();
+    assert_eq!(c, d);
+}
+
+#[test]
+fn skip_until_with_charclass_stop() {
+    let g = parse("r <- .. [;]");
+    let stop = Pattern::CharClass({
+        let mut s = CharSet::empty();
+        s.add(b';');
+        s
+    });
+    assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
+}
+
+#[test]
+fn skip_until_inclusive_with_grouped_stop() {
+    // Mirrors the sqlite `bracket_id` shape: stop is an OrderedChoice.
+    let g = parse("r <- ..= (']' / 'x')");
+    let stop = Pattern::OrderedChoice(vec![Pattern::literal("]"), Pattern::literal("x")]);
+    assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
+}
+
+#[test]
+fn skip_until_requires_right_operand() {
+    let err = parse_src("r <- ..").unwrap_err();
+    assert!(
+        err.message.contains("unexpected") || err.message.contains("expected"),
+        "expected parse error at end of `..`, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn skip_until_inclusive_with_capture_stop() {
+    // The stop pattern's capture survives lowering: the trailing
+    // consume in `..= S` retains the same capture kind so themes
+    // render the consumed delimiter consistently.
+    let g = parse("r <- ..= @punctuation{'}'}");
+    let stop = Pattern::Capture("punctuation".into(), Box::new(Pattern::literal("}")));
+    assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
+}
+
+#[test]
+fn skip_until_with_capture_stop_exclusive() {
+    let g = parse("r <- .. @comment{'#'}");
+    let stop = Pattern::Capture("comment".into(), Box::new(Pattern::literal("#")));
+    assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
+}

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -414,6 +414,25 @@ fn explain_recoveries_skips_trivia_when_picking_leaf() {
 }
 
 #[test]
+fn explain_recoveries_after_block_close_migration_rust() {
+    // Rust's `block` rule uses the new `^^block_close ..= '}'` sugar.
+    // Malformed block body should still surface a `block_close` cluster
+    // through pegdb explain-recoveries, with the recovery span covering
+    // the garbage and the closing `}` consumed as `@punctuation`.
+    let (code, stdout, _) = run_stdin(
+        &["explain-recoveries", "-g", "grammars/rust.peg"],
+        b"fn ok() { @@@ garbage @@@ }\n",
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.contains("label: block_close")),
+        "expected a cluster labeled block_close; got:\n{stdout}"
+    );
+}
+
+#[test]
 fn explain_recoveries_clusters_by_rule_stack() {
     // Multiple `@@@` runs should collapse into a single top-level
     // cluster; non-trivial dive sites (e.g. `g` looking like the start


### PR DESCRIPTION
Ships three new surface-language operators, co-designed so the spelling family is settled once. Closes the long-standing repeat-until idiom shorthand `#89` and supersedes `#107`'s auto-wrap framing with an explicit bracketed-close catch sugar.

## Operators

- `.. S` — skip until `S` (non-consuming). Lowers to `(!S .)*`.
- `..= S` — skip until and including `S` (consuming). Lowers to `(!S .)* S`.
- `INNER ^^lbl ..= B` — bracketed-close catch sugar. Lowers to `Catch { INNER, lbl, Seq(@recovery{(!B .)*}, B) }`. No `&B` anchor on `INNER` (unlike `^^lbl B`); `B` is consumed inside the recovery and keeps its own capture kind, outside the `@recovery` wrap.

The `..` / `..=` distinction mirrors Rust's range-operator convention. The catch position accepts only `..=` (a non-consuming form would diverge from the standalone semantics and has no corpus use); the parser rejects `^^lbl .. B` with a hint at `..=`.

All three lower at parse time — no new AST variants, no resolver/lint/VM changes.

## Corpus migration

Standalone sites partition cleanly: 14 to `..` (line comments, attr bodies, multiline strings, comment bodies, recovery skips), 7 to `..=` (block comments, paren bodies, raw strings). `sqlite.peg`'s `bracket_id` keeps an explicit `']'` consume after `..` to preserve its fail-on-unclosed semantics (the `..=` form would accept a linebreak as the terminator). The five `^block_close` sites across `c`, `css`, `go`, `javascript`, `rust` collapse from the manual three-piece `^block_close @recovery{(!'}' .)*} @punctuation{'}'}` idiom to `^^block_close ..= @punctuation{'}'}`.

See `src/pegc/README.md` for the precedence-table entries, worked examples, and the semantic contrast between `^^lbl B` and `^^lbl ..= B`.

## Why these together

`#89`'s issue comment names recovery-body uses as the corpus-pressure motivator for `..`. `#107`'s discussion of the bracketed-close shape converges on a catch sugar whose recovery body is `..= B`-shaped (skip + consume, with `B` re-captured). Co-designing locks the spelling once.

Closes #89.
Closes #107.
