### PR TITLE
pegc: built-in character-class shortcuts (\d, \s, \h, \R, \z)

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -280,18 +280,18 @@ char_body     <- ('L' / 'u' / 'U')? "'" (char_escape / !"'" .)* "'"
 char_escape   <- '\\' .
 
 number_lit    <- @number{num_body}
-num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? int_suffix?
-               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? int_suffix?
+num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
                / '0b' bin_digits int_suffix?
                / '0' [0-7]* int_suffix?
                / digit_seq '.' digit_seq? exp_part? float_suffix?
                / '.' digit_seq exp_part? float_suffix?
                / digit_seq exp_part float_suffix?
                / digit_seq int_suffix?
-digit_seq     <- [0-9] [0-9']*
-hex_digits    <- [0-9a-fA-F] [0-9a-fA-F']*
+digit_seq     <- \d [\d']*
+hex_digits    <- [\da-fA-F] [\da-fA-F']*
 bin_digits    <- [01] [01']*
-exp_part      <- [eE] [+\-]? [0-9]+
+exp_part      <- [eE] [+\-]? \d+
 int_suffix    <- ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
 float_suffix  <- [fFlL]
 
@@ -299,7 +299,7 @@ float_suffix  <- [fFlL]
 
 ident         <- !reserved ident_start ident_body*
 ident_start   <- [A-Za-z_]
-ident_body    <- [A-Za-z0-9_]
+ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords that must not be matched as identifiers.
 reserved      <- reserved_word !ident_body
@@ -320,4 +320,4 @@ block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 
-ws            <- (comment / [ \t\r\n])*
+ws            <- (comment / \s)*

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -126,16 +126,16 @@ url_body      <- .. ')'
 
 hex_color     <- @constant{hex_body}
 hex_body      <- '#' hex_digit+
-hex_digit     <- [0-9a-fA-F]
+hex_digit     <- [\da-fA-F]
 
 number_with_unit <- @number{num_body}
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
 ~num_body     <- sign? (num_float / num_int) num_unit?
 sign          <- [+\-]
-num_int       <- [0-9]+
-num_float     <- [0-9]* '.' [0-9]+
-                / [0-9]+ '.' [0-9]*
+num_int       <- \d+
+num_float     <- \d* '.' \d+
+                / \d+ '.' \d*
 num_unit      <- '%'
                 / ident
 
@@ -150,7 +150,7 @@ important_flag <- '!important'
 
 ident         <- ident_start ident_body*
 ident_start   <- [A-Za-z_\-]
-ident_body    <- [A-Za-z0-9_\-]
+ident_body    <- [A-Za-z\d_\-]
 
 # --- Whitespace / comments -----------------------------------------
 #
@@ -161,4 +161,4 @@ block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 
-ws            <- (comment / [ \t\r\n])*
+ws            <- (comment / \s)*

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -340,18 +340,18 @@ rune_lit      <- @string{"'" (char_escape / !"'" .)* "'"}
 char_escape   <- '\\' .
 
 number_lit    <- @number{num_body}
-num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? imag?
-               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? [0-9]+)? imag?
+num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? imag?
+               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? imag?
                / '0o' oct_digits imag?
                / '0b' bin_digits imag?
                / digit_seq '.' digit_seq? exp_part? imag?
                / '.' digit_seq exp_part? imag?
                / digit_seq exp_part? imag?
-digit_seq     <- [0-9] ([0-9_])*
-hex_digits    <- [0-9a-fA-F] [0-9a-fA-F_]*
+digit_seq     <- \d ([\d_])*
+hex_digits    <- [\da-fA-F] [\da-fA-F_]*
 oct_digits    <- [0-7] [0-7_]*
 bin_digits    <- [01] [01_]*
-exp_part      <- [eE] [+\-]? [0-9]+
+exp_part      <- [eE] [+\-]? \d+
 imag          <- 'i'
 
 # --- Identifiers / predeclared names ---------------------------------
@@ -360,7 +360,7 @@ ident         <- !reserved ident_start ident_body*
 upper_ident   <- !reserved [A-Z] ident_body*
 lower_ident   <- !reserved [a-z_] ident_body*
 ident_start   <- [A-Za-z_]
-ident_body    <- [A-Za-z0-9_]
+ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords blocking identifier capture.
 reserved      <- reserved_word !ident_body
@@ -396,4 +396,4 @@ block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 
-ws            <- (comment / [ \t\r\n])*
+ws            <- (comment / \s)*

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -339,11 +339,11 @@ num_body       <- '0x' hex_digits bigint?
 decimal_num    <- digit_seq '.' digit_seq? exp_part?
                 / '.' digit_seq exp_part?
                 / digit_seq exp_part?
-digit_seq      <- [0-9] ([0-9_])*
-hex_digits     <- [0-9a-fA-F] [0-9a-fA-F_]*
+digit_seq      <- \d ([\d_])*
+hex_digits     <- [\da-fA-F] [\da-fA-F_]*
 oct_digits     <- [0-7] [0-7_]*
 bin_digits     <- [01] [01_]*
-exp_part       <- [eE] [+\-]? [0-9]+
+exp_part       <- [eE] [+\-]? \d+
 bigint         <- 'n'
 
 # --- Identifiers / reserved words ------------------------------------
@@ -358,7 +358,7 @@ ident_name     <- ident_start ident_body*
 upper_ident    <- !reserved [A-Z] ident_body*
 lower_ident    <- !reserved [a-z_$] ident_body*
 ident_start    <- [A-Za-z_$]
-ident_body     <- [A-Za-z0-9_$]
+ident_body     <- [A-Za-z\d_$]
 
 # Reserved words that must not appear as identifiers. The grammar uses
 # explicit `@keyword{...}` at each call site, so this list only blocks
@@ -383,4 +383,4 @@ block_comment  <- '/*' ..= '*/'
 
 trivia        <- ws
 
-ws             <- (comment / [ \t\r\n])*
+ws             <- (comment / \s)*

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,7 +1,7 @@
 # JSON grammar with highlight annotations.
 # The first rule is the start rule.
 
-json        <- spacing value spacing !.
+json        <- spacing value spacing \z
 
 value       <- @string{string}
              / @number{number}
@@ -27,15 +27,15 @@ string_char <- '\\' ["\\/bfnrt]
              / [^"\\]
 
 number      <- '-'? int frac? exp?
-int         <- '0' / [1-9] [0-9]*
-frac        <- '.' [0-9]+
-exp         <- [eE] [+\-]? [0-9]+
+int         <- '0' / [1-9] \d*
+frac        <- '.' \d+
+exp         <- [eE] [+\-]? \d+
 
 true_lit    <- 'true'
 false_lit   <- 'false'
 null_lit    <- 'null'
 
-hex         <- [0-9a-fA-F]
+hex         <- [\da-fA-F]
 trivia      <- spacing
 
-spacing     <- [ \t\n\r]*
+spacing     <- \s*

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -450,12 +450,12 @@ int_num       <- '0x' hex_digits num_suffix?
                / '0o' oct_digits num_suffix?
                / '0b' bin_digits num_suffix?
                / digit_seq num_suffix?
-digit_seq     <- [0-9] ([0-9_])*
-hex_digits    <- [0-9a-fA-F] [0-9a-fA-F_]*
+digit_seq     <- \d ([\d_])*
+hex_digits    <- [\da-fA-F] [\da-fA-F_]*
 oct_digits    <- [0-7] [0-7_]*
 bin_digits    <- [01] [01_]*
 exp_part      <- [eE] [+\-]? digit_seq
-num_suffix    <- [a-zA-Z_] [a-zA-Z0-9_]*
+num_suffix    <- [a-zA-Z_] [a-zA-Z\d_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
@@ -468,7 +468,7 @@ ident_any     <- @type{upper_ident}
 upper_ident   <- 'r#'? [A-Z] ident_body*
 lower_ident   <- 'r#'? [a-z_] ident_body*
 ident         <- 'r#'? [A-Za-z_] ident_body*
-ident_body    <- [A-Za-z0-9_]
+ident_body    <- [A-Za-z\d_]
 
 # --- Whitespace and comments ------------------------------------------
 
@@ -480,4 +480,4 @@ block_comment <- '/*' ..= '*/'
 
 trivia        <- ws
 
-ws            <- (comment / [ \t\r\n])*
+ws            <- (comment / \s)*

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -54,7 +54,7 @@
 
 # --- Top level --------------------------------------------------------
 
-sql_file   <- (ws statement stmt_sep?)*^[;] ws !.
+sql_file   <- (ws statement stmt_sep?)*^[;] ws \z
 stmt_sep   <- ws @punctuation{';'} ws
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt
@@ -111,7 +111,7 @@ result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{'
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
                         / kw_union / kw_intersect / kw_except
-                        / !.
+                        / \z
 table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
 aliased_expr   <- expr (ws kw_as ws @variable{bare_ident_nonkw}
                       / ws @variable{bare_ident_nonkw})?
@@ -152,7 +152,7 @@ where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
                        / kw_union / kw_intersect / kw_except
-                       / !.
+                       / \z
 group_clause   <- kw_group ws kw_by ws expr (ws @punctuation{','} ws expr)*
 having_clause  <- kw_having ws expr
 
@@ -514,21 +514,21 @@ null_body   <- [nN][uU][lL][lL]
 bool_body   <- [tT][rR][uU][eE] / [fF][aA][lL][sS][eE]
 
 blob_lit    <- @string{blob_body}
-blob_body   <- [xX] "'" [0-9a-fA-F]* "'"
+blob_body   <- [xX] "'" [\da-fA-F]* "'"
 string_lit  <- @string{string_body}
 string_body <- "'" ("''" / !"'" .)* "'"
 
-number_body <- '0x' [0-9a-fA-F]+ !ident_char
+number_body <- '0x' [\da-fA-F]+ !ident_char
              / float_body
              / int_body
-float_body  <- [0-9]+ '.' [0-9]+ ([eE] [+\-]? [0-9]+)?
-             / [0-9]+ [eE] [+\-]? [0-9]+
-int_body    <- [0-9]+
+float_body  <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
+             / \d+ [eE] [+\-]? \d+
+int_body    <- \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.
 bind_param  <- @variable{bind_body}
-bind_body   <- '?' [0-9]*
+bind_body   <- '?' \d*
              / [:@$] ident_start ident_cont*
 
 # --- Identifiers ------------------------------------------------------
@@ -545,8 +545,8 @@ quoted_ident      <- double_quoted_id / backtick_id / bracket_id
 
 bare_raw          <- ident_start ident_cont*
 ident_start       <- [a-zA-Z_]
-ident_cont        <- [a-zA-Z0-9_]
-ident_char        <- [a-zA-Z0-9_]
+ident_cont        <- [a-zA-Z\d_]
+ident_char        <- [a-zA-Z\d_]
 
 double_quoted_id  <- '"' ('""' / !'"' !linebreak .)* '"'
 backtick_id       <- '`' ('``' / !'`' !linebreak .)* '`'
@@ -997,9 +997,9 @@ keyword_word <-
 
 trivia        <- ws
 
-ws            <- (comment / [ \t\n\r])*
+ws            <- (comment / \s)*
 comment       <- line_comment / block_comment
 line_comment  <- @comment{'--' .. linebreak}
 block_comment <- @comment{'/*' block_body '*/'}
 block_body    <- .. '*/'
-linebreak     <- '\r'? '\n'
+linebreak     <- \R

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -15,7 +15,7 @@
 #     kind; revisit when a theme-file is introduced.
 #   - inf / nan are @constant (like true/false), not @number.
 
-toml          <- ws (entry (entry_sep entry)*)? ws !.
+toml          <- ws (entry (entry_sep entry)*)? ws \z
 
 entry         <- array_of_tables_header / table_header / pair
 entry_sep     <- inline_space comment? linebreak ws
@@ -35,7 +35,7 @@ key_path      <- key_seg_type (inline_space @punctuation{'.'} inline_space key_s
 key_seg_prop  <- @property{key_seg_body}
 key_seg_type  <- @type{key_seg_body}
 key_seg_body  <- bare_key / basic_string / literal_string
-bare_key      <- [A-Za-z0-9_\-]+
+bare_key      <- [A-Za-z\d_\-]+
 
 # Values. Order matters: try longer-prefixed / more-specific alternatives
 # first so PEG's first-match semantics pick the right one.
@@ -75,15 +75,15 @@ multiline_literal_body <- .. "'''"
 integer       <- @number{int_body}
 int_body      <- hex_int / oct_int / bin_int / dec_int
 dec_int       <- [+\-]? unsigned_dec
-unsigned_dec  <- '0' / [1-9] ('_'? [0-9])*
+unsigned_dec  <- '0' / [1-9] ('_'? \d)*
 hex_int       <- '0x' hex ('_'? hex)*
 oct_int       <- '0o' [0-7] ('_'? [0-7])*
 bin_int       <- '0b' [01] ('_'? [01])*
 
 float         <- @number{float_body}
 float_body    <- [+\-]? unsigned_dec (frac exp? / exp)
-frac          <- '.' [0-9] ('_'? [0-9])*
-exp           <- [eE] [+\-]? [0-9] ('_'? [0-9])*
+frac          <- '.' \d ('_'? \d)*
+exp           <- [eE] [+\-]? \d ('_'? \d)*
 
 inf_nan       <- [+\-]? ('inf' / 'nan')
 bool_lit      <- 'true' / 'false'
@@ -96,10 +96,10 @@ local_datetime <- date date_time_sep time
 local_date    <- date
 local_time    <- time
 date_time_sep <- 'T' / 't' / ' '
-date          <- [0-9] [0-9] [0-9] [0-9] '-' [0-9] [0-9] '-' [0-9] [0-9]
-time          <- [0-9] [0-9] ':' [0-9] [0-9] ':' [0-9] [0-9] time_frac?
-time_frac     <- '.' [0-9]+
-time_offset   <- 'Z' / 'z' / [+\-] [0-9] [0-9] ':' [0-9] [0-9]
+date          <- \d \d \d \d '-' \d \d '-' \d \d
+time          <- \d \d ':' \d \d ':' \d \d time_frac?
+time_frac     <- '.' \d+
+time_offset   <- 'Z' / 'z' / [+\-] \d \d ':' \d \d
 
 # --- Arrays (multiline, trailing comma, interior comments allowed) -----
 array         <- @punctuation{'['} array_ws array_body? array_ws @punctuation{']'}
@@ -111,15 +111,15 @@ inline_table_body <- inline_pair (inline_space @punctuation{','} inline_space in
 inline_pair   <- key inline_space @punctuation{'='} inline_space value
 
 # --- Whitespace & comments --------------------------------------------
-inline_space  <- [ \t]*
-linebreak     <- '\r'? '\n'
+inline_space  <- \h*
+linebreak     <- \R
 comment       <- @comment{'#' .. linebreak}
 
 # Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
 trivia        <- ws
 
-ws            <- (comment / [ \t\r\n])*
+ws            <- (comment / \s)*
 array_ws      <- ws
 
-hex           <- [0-9a-fA-F]
+hex           <- [\da-fA-F]

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -60,6 +60,7 @@ the whole rule as intentionally lenient — see
 | `"abc"` / `'abc'` | Literal byte sequence. |
 | `[a-z]` / `[^"\\]` | Character class — a set of bytes; leading `^` negates. |
 | `.` | Any single byte (fails only at end of input). |
+| `\d \D \s \S \h \H \R \z` | Built-in character classes — see below. |
 | `ident` | Reference to another rule. |
 | `(...)` | Grouping — any pattern. |
 | `@name{...}` | Named capture — see below. |
@@ -67,6 +68,8 @@ the whole rule as intentionally lenient — see
 **String literals** use either `"..."` or `'...'`. Recognized escapes
 (inside strings and character classes): `\n`, `\r`, `\t`, `\0`, `\\`,
 `\'`, `\"`, `\]`, `\[`, `\-`, `\/`. Unknown escapes are a parse error.
+The backslash-letter atoms below (`\d`, `\R`, etc.) are *not* string
+escapes — `'\d'` keeps the `unknown escape` error.
 
 **Character classes** use the standard `[lo-hi]` range syntax. A `-`
 immediately before the closing `]` is a literal hyphen. Ranges with
@@ -75,6 +78,38 @@ immediately before the closing `]` is a literal hyphen. Ranges with
 The grammar is **byte-oriented** — no UTF-8 decoding happens at any
 stage. `[a-z]` is the ASCII byte range, `.` is one byte, not one code
 point.
+
+### Built-in character classes
+
+Eight regex-style one-letter escapes are atom-level shortcuts for the
+byte sets and idioms that recur across the corpus. ASCII semantics are
+fixed:
+
+| Escape | Equivalent | Notes |
+|---|---|---|
+| `\d` / `\D` | `[0-9]` / `[^0-9]` | Decimal digit and its complement. |
+| `\s` / `\S` | `[ \t\n\r]` / complement | ASCII whitespace and its complement. |
+| `\h` / `\H` | `[ \t]` / complement | Horizontal whitespace and its complement. |
+| `\R` | `'\r\n' / '\n' / '\r'` | Linebreak — CRLF matched atomically. |
+| `\z` | `!.` | End of input (zero-width). |
+
+The six byte-set escapes (`\d`, `\D`, `\s`, `\S`, `\h`, `\H`) are also
+recognized **inside `[...]`** and union into the surrounding class:
+`[\da-fA-F]` is the hex-digit set, `[\d_]` is digit-or-underscore. A
+class shortcut cannot be a range bound — `[\d-z]` is a parse error
+because the shortcut is a set, not a single byte. A leading `^` still
+negates the whole class: `[^\d]` ≡ `\D`.
+
+`\R` and `\z` are atom-only. `\R` matches a multi-byte sequence (CRLF
+atomic) and `\z` is a zero-width assertion — neither has a meaningful
+shape inside `[...]`, and both are rejected with a tailored error
+pointing back at the top-level form.
+
+Deliberately excluded: `\w` / `\W` (word character varies meaningfully
+per language — Rust raw idents, SQL `$`, CSS hyphens), `\v` / `\V`
+(PCRE vertical-whitespace splits `\r\n`; `\R` is the right primitive),
+and any hex-digit shortcut (would collide with `\h`; `[\da-fA-F]`
+covers the case in one extra range).
 
 ### Postfix operators
 

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -443,6 +443,7 @@ impl<'a> Parser<'a> {
                 Ok(Pattern::AnyChar)
             }
             Some(b'@') => self.parse_capture(),
+            Some(b'\\') => self.parse_backslash_atom(),
             Some(c) if is_ident_start(c) => {
                 // Disambiguation against `name <- ...` is handled by at_prefix_start.
                 let name = self.parse_ident()?;
@@ -450,6 +451,49 @@ impl<'a> Parser<'a> {
             }
             Some(c) => Err(self.err(format!("unexpected '{}'", c as char))),
             None => Err(self.err("unexpected end of input".into())),
+        }
+    }
+
+    /// Parse a backslash-letter atom. The eight one-letter escapes are
+    /// the regex-style character-class family:
+    ///
+    /// - `\d` / `\D`: `[0-9]` / its complement.
+    /// - `\s` / `\S`: `[ \t\n\r]` / its complement.
+    /// - `\h` / `\H`: `[ \t]` / its complement.
+    /// - `\R`: ordered choice `'\r\n' / '\n' / '\r'` (CRLF atomic).
+    /// - `\z`: end of input — `!.`.
+    ///
+    /// ASCII-only and byte-oriented, matching the rest of the engine.
+    /// These are *atom-level* escapes; they are not recognized inside
+    /// string literals (`'\d'` keeps today's `unknown escape` error).
+    /// The six byte-set escapes are *also* recognized inside `[...]`
+    /// by `parse_charclass`; `\R` and `\z` are rejected there with a
+    /// pointer back to this form.
+    fn parse_backslash_atom(&mut self) -> Result<Pattern, ParseError> {
+        debug_assert_eq!(self.peek(), Some(b'\\'));
+        self.pos += 1;
+        match self.peek() {
+            Some(c) if class_for_shortcut(c).is_some() => {
+                self.pos += 1;
+                Ok(Pattern::CharClass(class_for_shortcut(c).unwrap()))
+            }
+            Some(b'R') => {
+                self.pos += 1;
+                Ok(Pattern::OrderedChoice(vec![
+                    Pattern::literal("\r\n"),
+                    Pattern::literal("\n"),
+                    Pattern::literal("\r"),
+                ]))
+            }
+            Some(b'z') => {
+                self.pos += 1;
+                Ok(Pattern::NotPredicate(Box::new(Pattern::AnyChar)))
+            }
+            Some(c) => Err(self.err(format!(
+                "unknown atom '\\{}' (valid: \\d \\D \\s \\S \\h \\H \\R \\z)",
+                c as char
+            ))),
+            None => Err(self.err("unterminated escape at top level".into())),
         }
     }
 
@@ -497,6 +541,42 @@ impl<'a> Parser<'a> {
         };
         let mut set = CharSet::empty();
         while self.peek().is_some() && self.peek() != Some(b']') {
+            // Class-shortcut path: `\d`, `\D`, `\s`, `\S`, `\h`, `\H`
+            // expand into the surrounding set instead of contributing
+            // a single byte. `\R` and `\z` don't fit inside `[...]`
+            // (multi-byte / zero-width respectively) — reject with a
+            // pointer back to the top-level form. Other escapes fall
+            // through to the existing per-byte `parse_class_char`.
+            if self.peek() == Some(b'\\') {
+                if let Some(c) = self.peek_at(1) {
+                    if let Some(shortcut) = class_for_shortcut(c) {
+                        self.pos += 2;
+                        // Shortcuts can't form ranges: `[\d-z]` is
+                        // ambiguous (the shortcut is a set, not a
+                        // bound) and rejected explicitly. A trailing
+                        // `-]` is still a literal dash, same as the
+                        // single-byte path.
+                        if self.peek() == Some(b'-') && self.peek_at(1) != Some(b']') {
+                            return Err(self.err(format!(
+                                "character-class range can't start with a shortcut '\\{}' (shortcuts are sets, not bounds)",
+                                c as char
+                            )));
+                        }
+                        set = set.union(&shortcut);
+                        continue;
+                    }
+                    if c == b'R' {
+                        return Err(self.err(
+                            "'\\R' is a multi-byte sequence and can't appear in a character class — use \\R as a standalone atom".into(),
+                        ));
+                    }
+                    if c == b'z' {
+                        return Err(self.err(
+                            "'\\z' is a zero-width assertion and can't appear in a character class — use \\z as a standalone atom".into(),
+                        ));
+                    }
+                }
+            }
             let lo = self.parse_class_char()?;
             // Range form `lo-hi` (but `-` at end is literal; require non-`]` after `-`)
             if self.peek() == Some(b'-') && self.peek_at(1) != Some(b']') {
@@ -684,7 +764,26 @@ fn is_ident_cont(c: u8) -> bool {
 }
 
 fn is_atom_start(c: u8) -> bool {
-    matches!(c, b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&') || is_ident_start(c)
+    matches!(
+        c,
+        b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&' | b'\\'
+    ) || is_ident_start(c)
+}
+
+/// Map a backslash-letter shortcut to its byte set. Returns `None` for
+/// any byte that isn't one of the byte-set shortcuts (`d`, `D`, `s`,
+/// `S`, `h`, `H`). The multi-byte (`R`) and zero-width (`z`) shortcuts
+/// are handled separately by their respective parse arms.
+fn class_for_shortcut(c: u8) -> Option<CharSet> {
+    match c {
+        b'd' => Some(CharSet::from_ranges(&[(b'0', b'9')])),
+        b'D' => Some(CharSet::from_ranges(&[(b'0', b'9')]).negate()),
+        b's' => Some(CharSet::from_bytes(b" \t\n\r")),
+        b'S' => Some(CharSet::from_bytes(b" \t\n\r").negate()),
+        b'h' => Some(CharSet::from_bytes(b" \t")),
+        b'H' => Some(CharSet::from_bytes(b" \t").negate()),
+        _ => None,
+    }
 }
 
 /// Lower `.. S` (skip-until exclusive) to `(!S .)*`. The stop pattern

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1971,6 +1971,38 @@ fn trivia_cascade_handles_recursion() {
 }
 
 #[test]
+fn backslash_cap_r_matches_crlf_atomically() {
+    // `\R` lowers to `'\r\n' / '\n' / '\r'` — CRLF is matched as one
+    // two-byte unit, not two separate line breaks.
+    let g = parse("r <- \\R").expect("parse");
+    let prog = g.compile().expect("compile");
+    let r = VM::new(&prog.code, b"\r\n").run();
+    assert!(r.complete, "\\R should match CRLF");
+    assert_eq!(r.matched, 2, "\\R should consume both CR and LF atomically");
+
+    let r = VM::new(&prog.code, b"\n").run();
+    assert!(r.complete, "\\R should match bare LF");
+    assert_eq!(r.matched, 1);
+
+    let r = VM::new(&prog.code, b"\r").run();
+    assert!(r.complete, "\\R should match bare CR");
+    assert_eq!(r.matched, 1);
+}
+
+#[test]
+fn backslash_z_matches_eof() {
+    // `\z` lowers to `!.` — succeeds at end of input, fails otherwise.
+    let g = parse("r <- \\z").expect("parse");
+    let prog = g.compile().expect("compile");
+    let r = VM::new(&prog.code, b"").run();
+    assert!(r.complete, "\\z should match empty input");
+    assert_eq!(r.matched, 0);
+
+    let r = VM::new(&prog.code, b"x").run();
+    assert!(!r.complete, "\\z should fail when bytes remain");
+}
+
+#[test]
 fn all_shipped_grammars_compile_clean() {
     // Load-bearing: every grammar in `grammars/*.peg` must compile
     // cleanly via `pegc::compile`. Re-introducing partial-match

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -807,6 +807,171 @@ fn dash_in_class_at_end_is_literal() {
 }
 
 #[test]
+fn backslash_d_atom() {
+    let g = parse("r <- \\d");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]))
+    );
+}
+
+#[test]
+fn backslash_d_negated_atom() {
+    let g = parse("r <- \\D");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]).negate())
+    );
+}
+
+#[test]
+fn backslash_s_atom() {
+    let g = parse("r <- \\s");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_bytes(b" \t\n\r"))
+    );
+}
+
+#[test]
+fn backslash_s_negated_atom() {
+    let g = parse("r <- \\S");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_bytes(b" \t\n\r").negate())
+    );
+}
+
+#[test]
+fn backslash_h_atom() {
+    let g = parse("r <- \\h");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_bytes(b" \t"))
+    );
+}
+
+#[test]
+fn backslash_h_negated_atom() {
+    let g = parse("r <- \\H");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_bytes(b" \t").negate())
+    );
+}
+
+#[test]
+fn backslash_cap_r_linebreak_atom() {
+    let g = parse("r <- \\R");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::OrderedChoice(vec![
+            Pattern::literal("\r\n"),
+            Pattern::literal("\n"),
+            Pattern::literal("\r"),
+        ])
+    );
+}
+
+#[test]
+fn backslash_z_atom() {
+    let g = parse("r <- \\z");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::NotPredicate(Box::new(Pattern::AnyChar))
+    );
+}
+
+#[test]
+fn backslash_d_in_class_unions_digits() {
+    let g = parse("r <- [\\d_]");
+    let mut s = CharSet::from_ranges(&[(b'0', b'9')]);
+    s.add(b'_');
+    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+}
+
+#[test]
+fn backslash_d_in_class_with_range_neighbor() {
+    // Mixed class: `[\da-fA-F]` is the hex-digit set.
+    let g = parse("r <- [\\da-fA-F]");
+    let mut s = CharSet::from_ranges(&[(b'0', b'9')]);
+    s.add_range(b'a', b'f');
+    s.add_range(b'A', b'F');
+    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+}
+
+#[test]
+fn backslash_s_in_class_unions_whitespace() {
+    let g = parse("r <- [\\sX]");
+    let mut s = CharSet::from_bytes(b" \t\n\r");
+    s.add(b'X');
+    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+}
+
+#[test]
+fn backslash_d_in_negated_class() {
+    // `[^\d]` is the complement of `\d`, i.e. `\D`.
+    let g = parse("r <- [^\\d]");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]).negate())
+    );
+}
+
+#[test]
+fn backslash_d_in_string_still_errors() {
+    // String literals keep their byte-only escape contract; `\d` is
+    // not a single byte, so it's still an unknown string escape.
+    let err = parse_src("r <- '\\d'").unwrap_err();
+    assert!(
+        err.message.contains("unknown escape"),
+        "expected unknown-escape error in string, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn backslash_cap_r_in_class_rejected() {
+    let err = parse_src("r <- [\\R]").unwrap_err();
+    assert!(
+        err.message.contains("multi-byte") && err.message.contains("\\R"),
+        "expected tailored multi-byte error for \\R in class, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn backslash_z_in_class_rejected() {
+    let err = parse_src("r <- [\\z]").unwrap_err();
+    assert!(
+        err.message.contains("zero-width") && err.message.contains("\\z"),
+        "expected tailored zero-width error for \\z in class, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn backslash_d_range_start_rejected() {
+    // Shortcuts are sets, not bounds — `[\d-z]` is meaningless.
+    let err = parse_src("r <- [\\d-z]").unwrap_err();
+    assert!(
+        err.message.contains("range can't start with a shortcut"),
+        "expected shortcut-in-range error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn unknown_backslash_atom_errors() {
+    let err = parse_src("r <- \\q").unwrap_err();
+    assert!(
+        err.message.contains("unknown atom") && err.message.contains("\\q"),
+        "expected unknown-atom error, got: {}",
+        err.message
+    );
+}
+
+#[test]
 fn end_to_end_grammar_compile_run() {
     use syntax_highlighter::pegvm::VM;
     let g = parse("number <- [0-9]+");


### PR DESCRIPTION
Closes #86.

Adds the regex-style `\d`, `\D`, `\s`, `\S`, `\h`, `\H`, `\R`, `\z` atom-level escapes to the `.peg` surface language. Grammar authors now write `\d+`, `\s*`, `\h*`, `\R`, and `\z` directly instead of re-deriving `[0-9]+`, `[ \t\n\r]*`, `[ \t]*`, `'\r'? '\n'`, and `!.` everywhere. The six byte-set escapes also work inside `[...]` (`[\da-fA-F]` is the hex-digit set); `\R` and `\z` are atom-only and rejected inside classes with a tailored error.

Behavior change worth flagging: `\R` matches a lone `\r` (legacy line ending) in addition to `\n` and `\r\n`, which the previous `'\r'? '\n'` idiom silently dropped — exactly the gap called out in the issue. Bytecode size is unchanged for six grammars; `toml.peg` and `sqlite.peg` each grow by four instructions for this new alternative.

See `src/pegc/README.md` (new *Built-in character classes* subsection) for the surface syntax spec.
