### PR TITLE
pegc: exact-count quantifier p{n}

### DIFF
--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -23,7 +23,7 @@ array       <- @punctuation{'['} spacing
 
 string      <- '"' string_char* '"'
 string_char <- '\\' ["\\/bfnrt]
-             / '\\' 'u' hex hex hex hex
+             / '\\' 'u' hex{4}
              / [^"\\]
 
 number      <- '-'? int frac? exp?

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -60,7 +60,7 @@ string_body   <- basic_multiline / literal_multiline / basic_string / literal_st
 
 basic_string  <- '"' (basic_char / escape)* '"'
 basic_char    <- !["\\\n\r] .
-escape        <- '\\' (["\\bfnrt] / 'u' hex hex hex hex / 'U' hex hex hex hex hex hex hex hex)
+escape        <- '\\' (["\\bfnrt] / 'u' hex{4} / 'U' hex{8})
 
 basic_multiline <- '"""' multiline_basic_body '"""'
 multiline_basic_body <- .. '"""'
@@ -96,10 +96,10 @@ local_datetime <- date date_time_sep time
 local_date    <- date
 local_time    <- time
 date_time_sep <- 'T' / 't' / ' '
-date          <- \d \d \d \d '-' \d \d '-' \d \d
-time          <- \d \d ':' \d \d ':' \d \d time_frac?
+date          <- \d{4} '-' \d{2} '-' \d{2}
+time          <- \d{2} ':' \d{2} ':' \d{2} time_frac?
 time_frac     <- '.' \d+
-time_offset   <- 'Z' / 'z' / [+\-] \d \d ':' \d \d
+time_offset   <- 'Z' / 'z' / [+\-] \d{2} ':' \d{2}
 
 # --- Arrays (multiline, trailing comma, interior comments allowed) -----
 array         <- @punctuation{'['} array_ws array_body? array_ws @punctuation{']'}

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -42,7 +42,7 @@ the following precedence, tightest-binding first:
 
 ```
 atom       "abc"   [a-z]   .   ident   (...)   @name{...}
-postfix    p*      p+      p?  p*^     p+^     p*^[cs]   p+^[cs]
+postfix    p*      p+      p?      p{n}    p*^     p+^     p*^[cs]   p+^[cs]
 prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
 catch      p1 ^label p2      p1 ^^label B      p1 ^^label
@@ -118,11 +118,29 @@ covers the case in one extra range).
 | `p*` | Greedy, possibly-empty repetition. |
 | `p+` | Greedy, at-least-once repetition. |
 | `p?` | Optional. |
+| `p{n}` | Exactly `n` repetitions, `1 ≤ n ≤ 1024`. Parse-time sugar for `p p … p` (`n` copies). |
 | `p*^` | Repetition with skip-byte error recovery (see below). |
 | `p+^` | At-least-once recovery form — desugars to `p (p*^)`. |
 | `p*^[charset]` | Repetition with delimiter-scoped recovery: on inner failure, skip to and consume the next byte in `charset`. |
 | `p+^[charset]` | At-least-once delimiter-scoped recovery — desugars to `p (p*^[charset])`. |
 | `p*^:lbl` / `p*^[charset]:lbl` / `p+^:lbl` / `p+^[charset]:lbl` | Optional `:label` suffix on any of the above, naming the catch scope for `pegdb explain-recoveries` clustering. Default label is `"recovery"`. |
+
+**Exact-count `p{n}`.** `p{4}` desugars at parse time to four
+copies of `p` concatenated — identical bytecode to writing `p p p p`
+by hand. `n` is a positive decimal integer with `1 ≤ n ≤ 1024`. The
+upper bound is a typo guard; the largest plausible site in the shipped
+corpus is `hex{8}`. The braces are tight — no whitespace inside `{n}`
+or between the atom and `{` — matching the rest of the postfix tier.
+`p{1}` is equivalent to bare `p`; `{0}` is a parse error (write `''`
+if you want the always-succeeding empty pattern). Inside string
+literals, `'p{4}'` is the literal byte sequence `p{4}` — `{n}` is a
+postfix atom-quantifier, not a string escape.
+
+The bounded form `p{n,m}` and lower-bound form `p{n,}` are
+deliberately **not** included: `p{n,}` is strictly redundant with `+`
+(and `{0,}` with `*`), and no shipped grammar has a bounded-range
+need. The `{n,m}` syntax remains an unambiguous future extension slot
+should a real use case appear — see issue #87.
 
 ### Prefix operators
 

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -5,6 +5,12 @@ use super::compiler::{compile_rules, CompileError};
 use super::pattern::Pattern;
 use crate::pegvm::{CharSet, Program};
 
+/// Cap for the `p{n}` exact-count quantifier. Conservative typo guard:
+/// the largest plausible corpus site is `hex{8}`. Above this the parser
+/// rejects with a clear error instead of expanding a malformed grammar
+/// into a pathologically large bytecode block.
+const MAX_REPEAT_COUNT: usize = 1024;
+
 #[derive(Debug, Clone)]
 pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
@@ -362,10 +368,54 @@ impl<'a> Parser<'a> {
                     self.pos += 1;
                     atom = Pattern::Optional(Box::new(atom));
                 }
+                Some(b'{') => {
+                    self.pos += 1;
+                    let n = self.parse_repeat_count()?;
+                    self.expect(b'}')?;
+                    atom = Pattern::seq(vec![atom; n]);
+                }
                 _ => break,
             }
         }
         Ok(atom)
+    }
+
+    /// Parse the body of an exact-count quantifier `{n}`. The opening
+    /// `{` has already been consumed; this reads decimal digits, checks
+    /// `1 ≤ n ≤ MAX_REPEAT_COUNT`, and leaves the cursor at the byte
+    /// following the digits (the closing `}` is consumed by the caller).
+    /// The cap is a typo guard — the largest plausible site in the
+    /// shipped corpus is `hex{8}`.
+    fn parse_repeat_count(&mut self) -> Result<usize, ParseError> {
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if c.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == start {
+            return Err(self.err("expected positive integer in `{n}`".into()));
+        }
+        let digits =
+            std::str::from_utf8(&self.src[start..self.pos]).expect("ASCII digits are valid UTF-8");
+        let n: usize = digits.parse().map_err(|_| {
+            self.err(format!(
+                "repeat count `{}` exceeds maximum {}",
+                digits, MAX_REPEAT_COUNT
+            ))
+        })?;
+        if n == 0 {
+            return Err(self.err("repeat count must be positive (got `{0}`)".into()));
+        }
+        if n > MAX_REPEAT_COUNT {
+            return Err(self.err(format!(
+                "repeat count {} exceeds maximum {}",
+                n, MAX_REPEAT_COUNT
+            )));
+        }
+        Ok(n)
     }
 
     /// If the byte following `*^` / `+^` is `[`, parse a delimiter set

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2003,6 +2003,24 @@ fn backslash_z_matches_eof() {
 }
 
 #[test]
+fn repeat_count_matches_exact_length() {
+    // End-to-end smoke for `p{n}` — verifies the parse-time desugaring
+    // produces the same VM behavior as four hand-written `\d`s.
+    let g = parse("r <- \\d{4} \\z").expect("parse");
+    let prog = g.compile().expect("compile");
+
+    let r = VM::new(&prog.code, b"1234").run();
+    assert!(r.complete, "\\d{{4}} \\z should match exactly four digits");
+    assert_eq!(r.matched, 4);
+
+    let r = VM::new(&prog.code, b"123").run();
+    assert!(!r.complete, "\\d{{4}} should fail on three digits");
+
+    let r = VM::new(&prog.code, b"12345").run();
+    assert!(!r.complete, "\\z should fail when a fifth byte remains");
+}
+
+#[test]
 fn all_shipped_grammars_compile_clean() {
     // Load-bearing: every grammar in `grammars/*.peg` must compile
     // cleanly via `pegc::compile`. Re-introducing partial-match

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -62,6 +62,143 @@ fn postfix_operators() {
     );
 }
 
+#[test]
+fn postfix_repeat_count_single() {
+    // `p{1}` is the bare atom — `Pattern::seq()` unwraps singletons.
+    let g = parse("r <- 'x'{1}");
+    assert_eq!(g.rules["r"], Pattern::literal("x"));
+}
+
+#[test]
+fn postfix_repeat_count_multiple() {
+    let g = parse("r <- 'x'{4}");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            Pattern::literal("x"),
+            Pattern::literal("x"),
+            Pattern::literal("x"),
+        ])
+    );
+}
+
+#[test]
+fn postfix_repeat_count_on_backslash_atom() {
+    let g = parse("r <- \\d{4}");
+    let digit = Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]));
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![digit.clone(), digit.clone(), digit.clone(), digit])
+    );
+}
+
+#[test]
+fn postfix_repeat_count_on_group() {
+    let g = parse("r <- ('a' / 'b'){3}");
+    let choice = Pattern::OrderedChoice(vec![Pattern::literal("a"), Pattern::literal("b")]);
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Sequence(vec![choice.clone(), choice.clone(), choice])
+    );
+}
+
+#[test]
+fn postfix_repeat_count_chains_with_star() {
+    // `p{n}*` parses as `(p{n})*` — the postfix loop applies the `*`
+    // to the already-desugared sequence.
+    let g = parse("r <- 'x'{2}*");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+            Pattern::literal("x"),
+            Pattern::literal("x"),
+        ])))
+    );
+}
+
+#[test]
+fn postfix_repeat_count_at_maximum_accepted() {
+    // Boundary case: 1024 is the cap, must be accepted.
+    let g = parse("r <- 'x'{1024}");
+    match &g.rules["r"] {
+        Pattern::Sequence(items) => assert_eq!(items.len(), 1024),
+        other => panic!("expected Sequence of 1024 items, got: {other:?}"),
+    }
+}
+
+#[test]
+fn postfix_repeat_count_zero_rejected() {
+    let err = parse_src("r <- 'x'{0}").unwrap_err();
+    assert!(
+        err.message.contains("positive"),
+        "expected positive-required message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn postfix_repeat_count_empty_rejected() {
+    let err = parse_src("r <- 'x'{}").unwrap_err();
+    assert!(
+        err.message.contains("expected positive integer"),
+        "expected integer-required message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn postfix_repeat_count_unterminated_rejected() {
+    let err = parse_src("r <- 'x'{4").unwrap_err();
+    assert!(
+        err.message.contains("'}'"),
+        "expected closing-brace message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn postfix_repeat_count_non_decimal_rejected() {
+    // The digit scan stops at `a`, leaving zero digits read — same error
+    // path as `{}`.
+    let err = parse_src("r <- 'x'{a}").unwrap_err();
+    assert!(
+        err.message.contains("expected positive integer"),
+        "expected integer-required message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn postfix_repeat_count_exceeds_maximum_rejected() {
+    let err = parse_src("r <- 'x'{1025}").unwrap_err();
+    assert!(
+        err.message.contains("exceeds maximum 1024"),
+        "expected exceeds-maximum message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn postfix_repeat_count_whitespace_inside_braces_rejected() {
+    // `{n}` is tight, matching the rest of the postfix tier — interior
+    // whitespace makes the digit scan see zero digits.
+    let err = parse_src("r <- 'x'{ 4 }").unwrap_err();
+    assert!(
+        err.message.contains("expected positive integer"),
+        "expected integer-required message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn repeat_count_in_string_literal_is_literal() {
+    // `'p{4}'` is the literal byte sequence `p{4}`, not a quantified
+    // literal — string-literal escapes are not affected by this PR.
+    let g = parse("r <- 'p{4}'");
+    assert_eq!(g.rules["r"], Pattern::literal("p{4}"));
+}
+
 /// Builds the desugared AST that `p*^` lowers to: a `Repeat` over a
 /// `Catch` whose recovery body is the supplied pattern wrapped in a
 /// capture named `recovery`. The label defaults to `"recovery"` to


### PR DESCRIPTION
Closes #87.

Adds a postfix exact-count quantifier `p{n}` to the `pegc` PEG surface — pure parse-time sugar that desugars to `n` copies of `p` concatenated. No new AST variant, no compiler change, no VM change. After this PR the TOML RFC 3339 date / time / time-offset rules and the JSON / TOML `\u`/`\U` escapes read as their declarations rather than as hand-counted atom runs:

```peg
date <- \d{4} '-' \d{2} '-' \d{2}
time <- \d{2} ':' \d{2} ':' \d{2} time_frac?
escape <- '\\' (["\\bfnrt] / 'u' hex{4} / 'U' hex{8})
```

`n` is a positive decimal integer with `1 ≤ n ≤ 1024` (typo guard; largest shipped site is `hex{8}`). The braces are tight, matching the rest of the postfix tier. Inside string literals, `'p{4}'` stays the literal byte sequence `p{4}`. The bounded form `{n,m}` and lower-bound `{n,}` are deliberately deferred — see the surface syntax doc in `src/pegc/README.md` for the full spec and rationale.

`pegc stats` before and after the corpus migration reports identical instruction and rule counts on both `grammars/json.peg` and `grammars/toml.peg`, confirming the desugaring is bytecode-equivalent to the hand-expanded form.
