### PR TITLE
grammars: inline trivial aliases and consolidate ws into trivia

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -30,30 +30,30 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-c_file        <- ws (external_decl)*^ ws !.
+c_file        <- trivia (external_decl)*^ trivia \z
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
 pp_line       <- @keyword{pp_body}
-pp_body       <- '#' (pp_cont / !'\n' .)*
+pp_body       <- '#' (pp_cont / [^\n])*
 pp_cont       <- '\\' '\n'
                 / '\\' '\r' '\n'
 
 # --- External declarations -------------------------------------------
 
-external_decl <- pp_line ws
+external_decl <- pp_line trivia
                / fn_def
                / decl
 
 # Type-specifier + declarator + block.
-fn_def        <- decl_spec_list ws declarator ws (decl ws)* compound_stmt ws
+fn_def        <- decl_spec_list trivia declarator trivia (decl trivia)* compound_stmt trivia
 
 # Declarations end in `;`. Must start with at least one specifier
 # (storage/qualifier/type keyword, `typedef`, `struct`, `union`,
 # `enum`) so we don't accidentally parse `a * b;` as a declaration.
-decl          <- decl_spec_list ws init_declarator_list? ws @punctuation{';'} ws
+decl          <- decl_spec_list trivia init_declarator_list? trivia @punctuation{';'} trivia
 
-decl_spec_list <- decl_spec (ws decl_spec)*
+decl_spec_list <- decl_spec (trivia decl_spec)*
 decl_spec     <- storage_spec
                / type_qualifier
                / type_spec
@@ -91,59 +91,59 @@ typedef_name  <- [A-Z] ident_body*
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
 typedef_t_end <- '_t' !ident_body
 
-struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'}) ws
-                       (@type{ident})? (ws @punctuation{'{'} ws struct_decl* ws @punctuation{'}'})?
-struct_decl   <- decl_spec_list ws struct_declarator_list? ws @punctuation{';'} ws
-               / pp_line ws
-struct_declarator_list <- struct_declarator (ws @punctuation{','} ws struct_declarator)*
-struct_declarator <- struct_field_declarator (ws @punctuation{':'} ws expr_cond)?
-                   / @punctuation{':'} ws expr_cond
-struct_field_declarator <- pointer? ws struct_field_direct
+struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'}) trivia
+                       (@type{ident})? (trivia @punctuation{'{'} trivia struct_decl* trivia @punctuation{'}'})?
+struct_decl   <- decl_spec_list trivia struct_declarator_list? trivia @punctuation{';'} trivia
+               / pp_line trivia
+struct_declarator_list <- struct_declarator (trivia @punctuation{','} trivia struct_declarator)*
+struct_declarator <- struct_field_declarator (trivia @punctuation{':'} trivia expr_cond)?
+                   / @punctuation{':'} trivia expr_cond
+struct_field_declarator <- pointer? trivia struct_field_direct
 struct_field_direct <- @property{ident} struct_field_tail*
-                     / @punctuation{'('} ws struct_field_declarator ws @punctuation{')'} struct_field_tail*
-struct_field_tail <- ws @punctuation{'['} ws (expr / '')? ws @punctuation{']'}
-                   / ws @punctuation{'('} ws param_list? ws @punctuation{')'}
+                     / @punctuation{'('} trivia struct_field_declarator trivia @punctuation{')'} struct_field_tail*
+struct_field_tail <- trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'}
+                   / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'}
 
-enum_spec     <- @keyword{'enum'} ws (@type{ident})?
-                 (ws @punctuation{'{'} ws enum_list? ws @punctuation{'}'})?
-enum_list     <- enum_item (ws @punctuation{','} ws enum_item)* (ws @punctuation{','})?
-enum_item     <- @constant{ident} (ws @operator{'='} ws expr_cond)?
+enum_spec     <- @keyword{'enum'} trivia (@type{ident})?
+                 (trivia @punctuation{'{'} trivia enum_list? trivia @punctuation{'}'})?
+enum_list     <- enum_item (trivia @punctuation{','} trivia enum_item)* (trivia @punctuation{','})?
+enum_item     <- @constant{ident} (trivia @operator{'='} trivia expr_cond)?
 
 # --- Declarators -----------------------------------------------------
 
-init_declarator_list <- init_declarator (ws @punctuation{','} ws init_declarator)*
-init_declarator <- declarator (ws @operator{'='} ws initializer)?
+init_declarator_list <- init_declarator (trivia @punctuation{','} trivia init_declarator)*
+init_declarator <- declarator (trivia @operator{'='} trivia initializer)?
 
-declarator    <- pointer? ws direct_declarator
-pointer       <- (@operator{'*'} (ws type_qualifier)*)+
+declarator    <- pointer? trivia direct_declarator
+pointer       <- (@operator{'*'} (trivia type_qualifier)*)+
 direct_declarator <- simple_declarator direct_declarator_tail*
-simple_declarator <- @function{ident} &(ws @punctuation{'('})
+simple_declarator <- @function{ident} &(trivia @punctuation{'('})
                    / @variable{ident}
-                   / @punctuation{'('} ws declarator ws @punctuation{')'}
-direct_declarator_tail <- ws @punctuation{'['} ws (expr / '')? ws @punctuation{']'}
-                        / ws @punctuation{'('} ws param_list? ws @punctuation{')'}
-                        / ws @punctuation{'('} ws ident_list? ws @punctuation{')'}
+                   / @punctuation{'('} trivia declarator trivia @punctuation{')'}
+direct_declarator_tail <- trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'}
+                        / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'}
+                        / trivia @punctuation{'('} trivia ident_list? trivia @punctuation{')'}
 
-param_list    <- param (ws @punctuation{','} ws param)* (ws @punctuation{','} ws @operator{'...'})?
+param_list    <- param (trivia @punctuation{','} trivia param)* (trivia @punctuation{','} trivia @operator{'...'})?
                / @operator{'...'}
-param         <- decl_spec_list (ws (declarator / abstract_declarator))?
-abstract_declarator <- pointer (ws direct_abstract_declarator)?
+param         <- decl_spec_list (trivia (declarator / abstract_declarator))?
+abstract_declarator <- pointer (trivia direct_abstract_declarator)?
                      / direct_abstract_declarator
-direct_abstract_declarator <- (@punctuation{'('} ws abstract_declarator ws @punctuation{')'} / @punctuation{'['} ws (expr / '')? ws @punctuation{']'})
-                              (ws @punctuation{'['} ws (expr / '')? ws @punctuation{']'} / ws @punctuation{'('} ws param_list? ws @punctuation{')'})*
+direct_abstract_declarator <- (@punctuation{'('} trivia abstract_declarator trivia @punctuation{')'} / @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'})
+                              (trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'} / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'})*
 
-ident_list    <- @variable{ident} (ws @punctuation{','} ws @variable{ident})*
+ident_list    <- @variable{ident} (trivia @punctuation{','} trivia @variable{ident})*
 
-initializer   <- @punctuation{'{'} ws initializer_list? ws @punctuation{','}? ws @punctuation{'}'}
+initializer   <- @punctuation{'{'} trivia initializer_list? trivia @punctuation{','}? trivia @punctuation{'}'}
                / expr_assign
-initializer_list <- designation? initializer (ws @punctuation{','} ws designation? initializer)*
-designation   <- designator+ ws @operator{'='}
-designator    <- ws @punctuation{'['} ws expr_cond ws @punctuation{']'}
-               / ws @punctuation{'.'} @property{ident}
+initializer_list <- designation? initializer (trivia @punctuation{','} trivia designation? initializer)*
+designation   <- designator+ trivia @operator{'='}
+designator    <- trivia @punctuation{'['} trivia expr_cond trivia @punctuation{']'}
+               / trivia @punctuation{'.'} @property{ident}
 
 # --- Statements ------------------------------------------------------
 
-compound_stmt <- @punctuation{'{'} ws ((block_item ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+compound_stmt <- @punctuation{'{'} trivia ((block_item trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_item    <- pp_line
                / decl
                / stmt
@@ -162,24 +162,24 @@ stmt          <- labeled_stmt
                / empty_stmt
                / expr_stmt
 
-labeled_stmt  <- @variable{ident} ws @punctuation{':'} ws stmt
-               / @keyword{'case'} ws expr_cond ws @punctuation{':'} ws stmt
-               / @keyword{'default'} ws @punctuation{':'} ws stmt
+labeled_stmt  <- @variable{ident} trivia @punctuation{':'} trivia stmt
+               / @keyword{'case'} trivia expr_cond trivia @punctuation{':'} trivia stmt
+               / @keyword{'default'} trivia @punctuation{':'} trivia stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt      <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
-                 (ws @keyword{'else'} ws stmt)?
-for_stmt      <- @keyword{'for'} ws @punctuation{'('} ws for_init ws expr? ws @punctuation{';'} ws expr? ws @punctuation{')'} ws stmt
+~if_stmt      <- @keyword{'if'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
+                 (trivia @keyword{'else'} trivia stmt)?
+for_stmt      <- @keyword{'for'} trivia @punctuation{'('} trivia for_init trivia expr? trivia @punctuation{';'} trivia expr? trivia @punctuation{')'} trivia stmt
 for_init      <- decl
-               / expr? ws @punctuation{';'}
-while_stmt    <- @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
-do_while_stmt <- @keyword{'do'} ws stmt ws @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws @punctuation{';'}
-switch_stmt   <- @keyword{'switch'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
-return_stmt   <- @keyword{'return'} (ws expr)? ws @punctuation{';'}
-break_stmt    <- @keyword{'break'} ws @punctuation{';'}
-continue_stmt <- @keyword{'continue'} ws @punctuation{';'}
-goto_stmt     <- @keyword{'goto'} ws @variable{ident} ws @punctuation{';'}
+               / expr? trivia @punctuation{';'}
+while_stmt    <- @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
+do_while_stmt <- @keyword{'do'} trivia stmt trivia @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia @punctuation{';'}
+switch_stmt   <- @keyword{'switch'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
+return_stmt   <- @keyword{'return'} (trivia expr)? trivia @punctuation{';'}
+break_stmt    <- @keyword{'break'} trivia @punctuation{';'}
+continue_stmt <- @keyword{'continue'} trivia @punctuation{';'}
+goto_stmt     <- @keyword{'goto'} trivia @variable{ident} trivia @punctuation{';'}
 empty_stmt    <- @punctuation{';'}
-expr_stmt     <- expr ws @punctuation{';'}
+expr_stmt     <- expr trivia @punctuation{';'}
 
 # --- Expressions ----------------------------------------------------
 #
@@ -191,8 +191,8 @@ expr_stmt     <- expr ws @punctuation{';'}
 # doesn't eat a fragment of a longer operator that belongs higher up.
 # Assignment (right-associative) and ternary stay outside the LR ladder.
 
-expr          <- expr_assign (ws @punctuation{','} ws expr_assign)*
-expr_assign   <- expr_unary ws assign_op ws expr_assign
+expr          <- expr_assign (trivia @punctuation{','} trivia expr_assign)*
+expr_assign   <- expr_unary trivia assign_op trivia expr_assign
                / expr_cond
 
 
@@ -202,18 +202,18 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'='} !'='
 
 # Trailing ternary `?` leniency absorbed by top-level `*^`.
-~expr_cond    <- expr_lor (ws @operator{'?'} ws expr ws @punctuation{':'} ws expr_assign)?
+~expr_cond    <- expr_lor (trivia @operator{'?'} trivia expr trivia @punctuation{':'} trivia expr_assign)?
 
-expr_lor      <- expr_lor ws @operator{'||'} ws expr_land / expr_land
-expr_land     <- expr_land ws @operator{'&&'} ws expr_bor / expr_bor
-expr_bor      <- expr_bor ws @operator{'|'} !'|' !'=' ws expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor ws @operator{'^'} !'=' ws expr_band / expr_band
-expr_band     <- expr_band ws @operator{'&'} !'&' !'=' ws expr_eq / expr_eq
-expr_eq       <- expr_eq ws (@operator{'=='} / @operator{'!='}) ws expr_rel / expr_rel
-expr_rel      <- expr_rel ws (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') ws expr_shift / expr_shift
-expr_shift    <- expr_shift ws (@operator{'<<'} !'=' / @operator{'>>'} !'=') ws expr_add / expr_add
-expr_add      <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
-expr_mul      <- expr_mul ws (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_unary / expr_unary
+expr_lor      <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
+expr_land     <- expr_land trivia @operator{'&&'} trivia expr_bor / expr_bor
+expr_bor      <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
+expr_bxor     <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
+expr_band     <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_eq / expr_eq
+expr_eq       <- expr_eq trivia (@operator{'=='} / @operator{'!='}) trivia expr_rel / expr_rel
+expr_rel      <- expr_rel trivia (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_shift / expr_shift
+expr_shift    <- expr_shift trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
+expr_add      <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
+expr_mul      <- expr_mul trivia (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_unary / expr_unary
 
 # `sizeof_type` is tried before the generic prefix loop so that
 # `sizeof(struct X)` / `sizeof(union X)` / `sizeof(counter_size_t)`
@@ -223,23 +223,23 @@ expr_mul      <- expr_mul ws (@operator{'*'} !'=' / @operator{'/'} !'=' / @opera
 # fall back to the prefix path so `sizeof expr` and `sizeof(expr)`
 # still parse.
 expr_unary    <- sizeof_type
-               / (unary_prefix ws)* expr_postfix
+               / (unary_prefix trivia)* expr_postfix
 unary_prefix  <- @operator{'++'} / @operator{'--'}
                / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
                / @operator{'*'} / @operator{'&'}
-               / @keyword{'sizeof'} &(ws (@punctuation{'('} / ident_start))
+               / @keyword{'sizeof'} &(trivia (@punctuation{'('} / [A-Za-z_]))
                / @keyword{'_Alignof'}
 
-expr_postfix  <- expr_primary (ws postfix_op)*
+expr_postfix  <- expr_primary (trivia postfix_op)*
 postfix_op    <- @operator{'++'} / @operator{'--'}
-               / @punctuation{'('} ws arg_list? ws @punctuation{')'}
-               / @punctuation{'['} ws expr ws @punctuation{']'}
+               / @punctuation{'('} trivia arg_list? trivia @punctuation{')'}
+               / @punctuation{'['} trivia expr trivia @punctuation{']'}
                / @operator{'->'} postfix_member
                / @punctuation{'.'} postfix_member
-postfix_member <- @function{ident} &(ws @punctuation{'('})
+postfix_member <- @function{ident} &(trivia @punctuation{'('})
                 / @property{ident}
 
-arg_list      <- expr_assign (ws @punctuation{','} ws expr_assign)*
+arg_list      <- expr_assign (trivia @punctuation{','} trivia expr_assign)*
 
 expr_primary  <- string_lit
                / char_lit
@@ -247,37 +247,31 @@ expr_primary  <- string_lit
                / cast_or_paren
                / call_ident
                / @type{predef_type_name}
-               / @constant{true_lit}
-               / @constant{false_lit}
-               / @constant{null_lit}
+               / @constant{'true' !ident_body}
+               / @constant{'false' !ident_body}
+               / @constant{'NULL' !ident_body}
                / @variable{ident}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
-sizeof_type   <- @keyword{'sizeof'} ws @punctuation{'('} ws type_name ws @punctuation{')'}
-type_name     <- decl_spec_list (ws abstract_declarator)?
+sizeof_type   <- @keyword{'sizeof'} trivia @punctuation{'('} trivia type_name trivia @punctuation{')'}
+type_name     <- decl_spec_list (trivia abstract_declarator)?
 
 # `(T)expr` vs `(expr)` — try cast first (uses decl_spec which
 # requires a type keyword/qualifier, making the distinction
 # unambiguous for real-world C).
-cast_or_paren <- @punctuation{'('} ws type_name ws @punctuation{')'} ws expr_unary
-               / @punctuation{'('} ws expr ws @punctuation{')'}
+cast_or_paren <- @punctuation{'('} trivia type_name trivia @punctuation{')'} trivia expr_unary
+               / @punctuation{'('} trivia expr trivia @punctuation{')'}
 
-call_ident    <- @function{ident} &(ws @punctuation{'('})
-
-true_lit      <- 'true' !ident_body
-false_lit     <- 'false' !ident_body
-null_lit      <- 'NULL' !ident_body
+call_ident    <- @function{ident} &(trivia @punctuation{'('})
 
 # --- Literals --------------------------------------------------------
 
 string_lit    <- @string{string_pieces}
-string_pieces <- string_piece (ws string_piece)*
-string_piece  <- ('L' / 'u8' / 'u' / 'U')? '"' (str_escape / !'"' !'\n' .)* '"'
-str_escape    <- '\\' .
+string_pieces <- string_piece (trivia string_piece)*
+string_piece  <- ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
 char_lit      <- @string{char_body}
-char_body     <- ('L' / 'u' / 'U')? "'" (char_escape / !"'" .)* "'"
-char_escape   <- '\\' .
+char_body     <- ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
 
 number_lit    <- @number{num_body}
 num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
@@ -297,8 +291,7 @@ float_suffix  <- [fFlL]
 
 # --- Identifiers ----------------------------------------------------
 
-ident         <- !reserved ident_start ident_body*
-ident_start   <- [A-Za-z_]
+ident         <- !reserved [A-Za-z_] ident_body*
 ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords that must not be matched as identifiers.
@@ -314,10 +307,6 @@ reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
 
 # --- Whitespace / comments ------------------------------------------
 
-comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' .. '\n'
-block_comment <- '/*' ..= '*/'
+comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
 
-trivia        <- ws
-
-ws            <- (comment / \s)*
+trivia        <- (comment / \s)*

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -24,26 +24,25 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-css_file      <- ws (statement)*^ ws !.
+css_file      <- trivia (statement)*^ trivia \z
 
 statement     <- at_rule
                 / rule
 
 # --- At-rules --------------------------------------------------------
 
-at_rule       <- at_name ws prelude ws (block / @punctuation{';'}) ws
-at_name       <- @keyword{at_name_body}
-at_name_body  <- '@' ident_body+
+at_rule       <- at_name trivia prelude trivia (block / @punctuation{';'}) trivia
+at_name       <- @keyword{'@' ident_body+}
 
 # Prelude: tokens up to `{` or `;` — sequences of value-like tokens.
-prelude       <- (prelude_token ws)*
+prelude       <- (prelude_token trivia)*
 prelude_token <- string_lit
                 / fn_call
                 / hex_color
                 / number_with_unit
-                / @keyword{important_flag}
+                / @keyword{'!important'}
                 / @type{ident}
-                / @punctuation{'('} ws prelude ws @punctuation{')'}
+                / @punctuation{'('} trivia prelude trivia @punctuation{')'}
                 / @punctuation{','}
                 / @punctuation{':'}
                 / @operator{'='}
@@ -55,53 +54,45 @@ prelude_token <- string_lit
 
 # --- Rules -----------------------------------------------------------
 
-rule          <- selector_list ws block ws
-selector_list <- selector (ws @punctuation{','} ws selector)*
-selector      <- compound_selector (ws combinator_and_next)*
-combinator_and_next <- @operator{'>'} ws compound_selector
-                     / @operator{'+'} ws compound_selector
-                     / @operator{'~'} ws compound_selector
+rule          <- selector_list trivia block trivia
+selector_list <- selector (trivia @punctuation{','} trivia selector)*
+selector      <- compound_selector (trivia combinator_and_next)*
+combinator_and_next <- @operator{'>'} trivia compound_selector
+                     / @operator{'+'} trivia compound_selector
+                     / @operator{'~'} trivia compound_selector
                      / compound_selector
 
-compound_selector <- selector_atom (selector_atom)*
-selector_atom <- @property{class_selector}
-               / @constant{id_selector}
-               / @function{pseudo_element}
-               / @function{pseudo_class}
-               / attr_selector
+compound_selector <- selector_atom+
+selector_atom <- @property{'.' ident}
+               / @constant{'#' ident}
+               / @function{'::' ident pseudo_args?}
+               / @function{':' ident pseudo_args?}
+               / @punctuation{'['} trivia (.. ']') trivia @punctuation{']'}
                / @punctuation{'&'}
                / @punctuation{'*'}
                / @type{ident}
 
-class_selector <- '.' ident
-id_selector    <- '#' ident
-pseudo_element <- '::' ident pseudo_args?
-pseudo_class   <- ':' ident pseudo_args?
 pseudo_args    <- '(' ..= ')'
-attr_selector  <- @punctuation{'['} ws attr_body ws @punctuation{']'}
-attr_body      <- .. ']'
 
 # --- Blocks & declarations ------------------------------------------
 
-block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_body    <- (block_item ws)*
+block         <- @punctuation{'{'} trivia ((block_item trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_item    <- at_rule
                 / declaration
                 / rule
                 / @punctuation{';'}
 
-# Trailing `important? ws (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
-~declaration  <- @property{prop_ident} ws @punctuation{':'} ws value_list ws
-                 important? ws (@punctuation{';'} / &'}')
-important     <- @keyword{'!important'}
+# Trailing `important? trivia (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
+~declaration  <- @property{prop_ident} trivia @punctuation{':'} trivia value_list trivia
+                 @keyword{'!important'}? trivia (@punctuation{';'} / &'}')
 
 prop_ident    <- '--' ident_body+
                 / '-'? ident
 
 # --- Values ---------------------------------------------------------
 
-value_list    <- value_term (ws @punctuation{','} ws value_term)*
-value_term    <- value_factor (ws value_factor)*
+value_list    <- value_term (trivia @punctuation{','} trivia value_term)*
+value_term    <- value_factor (trivia value_factor)*
 value_factor  <- string_lit
                 / fn_call
                 / hex_color
@@ -113,27 +104,20 @@ value_factor  <- string_lit
                 / @operator{'-'}
                 / @operator{'*'}
 
-fn_call       <- @function{fn_name} @punctuation{'('} ws fn_args? ws @punctuation{')'}
-fn_name       <- ident
-fn_args       <- fn_arg (ws @punctuation{','} ws fn_arg)*
-fn_arg        <- value_term
+fn_call       <- @function{ident} @punctuation{'('} trivia fn_args? trivia @punctuation{')'}
+fn_args       <- value_term (trivia @punctuation{','} trivia value_term)*
 
 # Unquoted `url(...)` arg — bare text till the closing paren.
-url_unquoted  <- @function{'url'} @punctuation{'('} ws @string{url_body} ws @punctuation{')'}
-url_body      <- .. ')'
+url_unquoted  <- @function{'url'} @punctuation{'('} trivia @string{.. ')'} trivia @punctuation{')'}
 
 # --- Literals -------------------------------------------------------
 
-hex_color     <- @constant{hex_body}
-hex_body      <- '#' hex_digit+
-hex_digit     <- [\da-fA-F]
+hex_color     <- @constant{'#' [\da-fA-F]+}
 
 number_with_unit <- @number{num_body}
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
-~num_body     <- sign? (num_float / num_int) num_unit?
-sign          <- [+\-]
-num_int       <- \d+
+~num_body     <- [+\-]? (num_float / \d+) num_unit?
 num_float     <- \d* '.' \d+
                 / \d+ '.' \d*
 num_unit      <- '%'
@@ -144,21 +128,15 @@ dq_string     <- '"' (str_escape / !'"' !'\n' .)* '"'
 sq_string     <- "'" (str_escape / !"'" !'\n' .)* "'"
 str_escape    <- '\\' .
 
-important_flag <- '!important'
-
 # --- Identifiers ----------------------------------------------------
 
-ident         <- ident_start ident_body*
-ident_start   <- [A-Za-z_\-]
+ident         <- [A-Za-z_\-] ident_body*
 ident_body    <- [A-Za-z\d_\-]
 
 # --- Whitespace / comments -----------------------------------------
 #
 # CSS has only block comments.
 
-comment       <- @comment{block_comment}
-block_comment <- '/*' ..= '*/'
+comment       <- @comment{'/*' ..= '*/'}
 
-trivia        <- ws
-
-ws            <- (comment / \s)*
+trivia        <- (comment / \s)*

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -25,18 +25,18 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-go_file       <- ws package_clause ws (import_decl ws)* (top_decl ws)*^ !.
+go_file       <- trivia package_clause trivia (import_decl trivia)* (top_decl trivia)*^ \z
 
 # --- Package / imports ----------------------------------------------
 
-package_clause <- @keyword{'package'} ws @variable{ident} ws opt_semi
+package_clause <- @keyword{'package'} trivia @variable{ident} trivia opt_semi
 
-import_decl   <- @keyword{'import'} ws import_spec_group ws opt_semi
-               / @keyword{'import'} ws import_spec ws opt_semi
-import_spec_group <- @punctuation{'('} ws (import_spec ws opt_semi)* ws @punctuation{')'}
+import_decl   <- @keyword{'import'} trivia import_spec_group trivia opt_semi
+               / @keyword{'import'} trivia import_spec trivia opt_semi
+import_spec_group <- @punctuation{'('} trivia (import_spec trivia opt_semi)* trivia @punctuation{')'}
 import_spec   <- import_alias? string_lit
-import_alias  <- @punctuation{'.'} ws
-               / @variable{ident} ws
+import_alias  <- @punctuation{'.'} trivia
+               / @variable{ident} trivia
 
 # --- Top-level declarations -----------------------------------------
 
@@ -46,45 +46,45 @@ top_decl      <- decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl         <- @keyword{'var'} ws var_spec_group
-               / @keyword{'var'} ws var_spec ws opt_semi
-               / @keyword{'const'} ws const_spec_group
-               / @keyword{'const'} ws const_spec ws opt_semi
-               / @keyword{'type'} ws type_spec_group
-               / @keyword{'type'} ws type_spec ws opt_semi
+~decl         <- @keyword{'var'} trivia var_spec_group
+               / @keyword{'var'} trivia var_spec trivia opt_semi
+               / @keyword{'const'} trivia const_spec_group
+               / @keyword{'const'} trivia const_spec trivia opt_semi
+               / @keyword{'type'} trivia type_spec_group
+               / @keyword{'type'} trivia type_spec trivia opt_semi
 
-var_spec_group <- @punctuation{'('} ws (var_spec ws opt_semi)* ws @punctuation{')'}
-var_spec      <- ident_list ws type_expr ws @operator{'='} ws expr_list
-               / ident_list ws type_expr
-               / ident_list ws @operator{'='} ws expr_list
+var_spec_group <- @punctuation{'('} trivia (var_spec trivia opt_semi)* trivia @punctuation{')'}
+var_spec      <- ident_list trivia type_expr trivia @operator{'='} trivia expr_list
+               / ident_list trivia type_expr
+               / ident_list trivia @operator{'='} trivia expr_list
 
-const_spec_group <- @punctuation{'('} ws (const_spec ws opt_semi)* ws @punctuation{')'}
+const_spec_group <- @punctuation{'('} trivia (const_spec trivia opt_semi)* trivia @punctuation{')'}
 # Trailing `(= expr)?` absorbed by outer recovery.
-~const_spec   <- const_ident_list (ws type_expr)? (ws @operator{'='} ws expr_list)?
+~const_spec   <- const_ident_list (trivia type_expr)? (trivia @operator{'='} trivia expr_list)?
 
-type_spec_group <- @punctuation{'('} ws (type_spec ws opt_semi)* ws @punctuation{')'}
-type_spec     <- @type{ident} ws type_params? ws (@operator{'='})? ws type_expr
+type_spec_group <- @punctuation{'('} trivia (type_spec trivia opt_semi)* trivia @punctuation{')'}
+type_spec     <- @type{ident} trivia type_params? trivia (@operator{'='})? trivia type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl    <- @keyword{'func'} ws @function{ident} type_params? ws fn_signature ws block?
-~method_decl  <- @keyword{'func'} ws method_receiver ws @function{ident} ws fn_signature ws block?
-method_receiver <- @punctuation{'('} ws (@variable{ident} ws)? type_expr ws @punctuation{')'}
+~func_decl    <- @keyword{'func'} trivia @function{ident} type_params? trivia fn_signature trivia block?
+~method_decl  <- @keyword{'func'} trivia method_receiver trivia @function{ident} trivia fn_signature trivia block?
+method_receiver <- @punctuation{'('} trivia (@variable{ident} trivia)? type_expr trivia @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
-type_params   <- @punctuation{'['} ws type_param_list ws @punctuation{']'}
-type_param_list <- type_param (ws @punctuation{','} ws type_param)* (ws @punctuation{','})?
-type_param    <- ident_list ws type_constraint
+type_params   <- @punctuation{'['} trivia type_param_list trivia @punctuation{']'}
+type_param_list <- type_param (trivia @punctuation{','} trivia type_param)* (trivia @punctuation{','})?
+type_param    <- ident_list trivia type_constraint
 type_constraint <- type_union
-type_union    <- type_term (ws @operator{'|'} ws type_term)*
-type_term     <- @operator{'~'} ws type_expr
+type_union    <- type_term (trivia @operator{'|'} trivia type_term)*
+type_term     <- @operator{'~'} trivia type_expr
                / type_expr
 
-# Trailing `(ws fn_result)?` absorbed by outer recovery.
-~fn_signature <- fn_params (ws fn_result)?
-fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
-fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
-fn_param      <- ident_list ws (@operator{'...'} ws)? type_expr
-               / (@operator{'...'} ws)? type_expr
+# Trailing `(trivia fn_result)?` absorbed by outer recovery.
+~fn_signature <- fn_params (trivia fn_result)?
+fn_params     <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
+fn_param_list <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
+fn_param      <- ident_list trivia (@operator{'...'} trivia)? type_expr
+               / (@operator{'...'} trivia)? type_expr
 fn_result     <- fn_params
                / type_expr
 
@@ -100,26 +100,26 @@ type_expr     <- type_ptr
                / type_paren
                / type_name
 
-type_ptr      <- @operator{'*'} ws type_expr
-type_slice_or_array <- @punctuation{'['} ws (@operator{'...'} / expr)? ws @punctuation{']'} ws type_expr
-type_map      <- @keyword{'map'} ws @punctuation{'['} ws type_expr ws @punctuation{']'} ws type_expr
-type_chan     <- @operator{'<-'} ws @keyword{'chan'} ws type_expr
-               / @keyword{'chan'} ws @operator{'<-'} ws type_expr
-               / @keyword{'chan'} ws type_expr
-type_func     <- @keyword{'func'} ws fn_signature
-type_struct   <- @keyword{'struct'} ws @punctuation{'{'} ws struct_field_list? ws @punctuation{'}'}
-struct_field_list <- struct_field (ws opt_semi ws struct_field)* (ws opt_semi)?
-struct_field  <- @property{ident} (ws @punctuation{','} ws @property{ident})* ws type_expr (ws string_lit)?
-               / (@operator{'*'} ws)? type_name (ws string_lit)?       # embedded field
-type_interface <- @keyword{'interface'} ws @punctuation{'{'} ws interface_members? ws @punctuation{'}'}
-interface_members <- interface_member (ws opt_semi ws interface_member)* (ws opt_semi)?
-interface_member <- @function{ident} ws fn_signature
+type_ptr      <- @operator{'*'} trivia type_expr
+type_slice_or_array <- @punctuation{'['} trivia (@operator{'...'} / expr)? trivia @punctuation{']'} trivia type_expr
+type_map      <- @keyword{'map'} trivia @punctuation{'['} trivia type_expr trivia @punctuation{']'} trivia type_expr
+type_chan     <- @operator{'<-'} trivia @keyword{'chan'} trivia type_expr
+               / @keyword{'chan'} trivia @operator{'<-'} trivia type_expr
+               / @keyword{'chan'} trivia type_expr
+type_func     <- @keyword{'func'} trivia fn_signature
+type_struct   <- @keyword{'struct'} trivia @punctuation{'{'} trivia struct_field_list? trivia @punctuation{'}'}
+struct_field_list <- struct_field (trivia opt_semi trivia struct_field)* (trivia opt_semi)?
+struct_field  <- @property{ident} (trivia @punctuation{','} trivia @property{ident})* trivia type_expr (trivia string_lit)?
+               / (@operator{'*'} trivia)? type_name (trivia string_lit)?       # embedded field
+type_interface <- @keyword{'interface'} trivia @punctuation{'{'} trivia interface_members? trivia @punctuation{'}'}
+interface_members <- interface_member (trivia opt_semi trivia interface_member)* (trivia opt_semi)?
+interface_member <- @function{ident} trivia fn_signature
                   / type_term
-type_paren    <- @punctuation{'('} ws type_expr ws @punctuation{')'}
+type_paren    <- @punctuation{'('} trivia type_expr trivia @punctuation{')'}
 # Trailing `type_args?` leniency absorbed by outer recovery.
 ~type_name    <- @type{qualified_ident} type_args?
-type_args     <- @punctuation{'['} ws type_arg_list ws @punctuation{']'}
-type_arg_list <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation{','})?
+type_args     <- @punctuation{'['} trivia type_arg_list trivia @punctuation{']'}
+type_arg_list <- type_expr (trivia @punctuation{','} trivia type_expr)* (trivia @punctuation{','})?
 
 # `pkg.Name` or `Name`.
 # Trailing `(.ident)?` leniency absorbed by outer recovery.
@@ -127,9 +127,9 @@ type_arg_list <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation
 
 # --- Statements ------------------------------------------------------
 
-block         <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         <- @punctuation{'{'} trivia ((stmt trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          <- decl ws opt_semi
+stmt          <- decl trivia opt_semi
                / block
                / labeled_stmt
                / if_stmt
@@ -143,10 +143,10 @@ stmt          <- decl ws opt_semi
                / continue_stmt
                / goto_stmt
                / fallthrough_stmt
-               / simple_stmt ws opt_semi
+               / simple_stmt trivia opt_semi
                / empty_stmt
 
-empty_stmt    <- @punctuation{';'} ws
+empty_stmt    <- @punctuation{';'} trivia
 
 simple_stmt   <- send_stmt
                / inc_dec_stmt
@@ -154,10 +154,10 @@ simple_stmt   <- send_stmt
                / short_var_decl
                / expr_stmt
 
-send_stmt     <- expr_no_compound ws @operator{'<-'} ws expr_no_compound
-inc_dec_stmt  <- expr_no_compound ws (@operator{'++'} / @operator{'--'})
-short_var_decl <- ident_list ws @operator{':='} ws expr_list
-assignment    <- expr_no_compound_list ws assign_op ws expr_list
+send_stmt     <- expr_no_compound trivia @operator{'<-'} trivia expr_no_compound
+inc_dec_stmt  <- expr_no_compound trivia (@operator{'++'} / @operator{'--'})
+short_var_decl <- ident_list trivia @operator{':='} trivia expr_list
+assignment    <- expr_no_compound_list trivia assign_op trivia expr_list
 expr_stmt     <- expr_no_compound
 
 assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
@@ -165,44 +165,44 @@ assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator
                / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
                / @operator{'='} !'='
 
-labeled_stmt  <- @variable{ident} ws @punctuation{':'} ws stmt
+labeled_stmt  <- @variable{ident} trivia @punctuation{':'} trivia stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt      <- @keyword{'if'} ws (simple_stmt ws @punctuation{';'} ws)? expr_no_compound ws block
-                 (ws @keyword{'else'} ws (if_stmt / block))?
-for_stmt      <- @keyword{'for'} ws for_header? ws block
+~if_stmt      <- @keyword{'if'} trivia (simple_stmt trivia @punctuation{';'} trivia)? expr_no_compound trivia block
+                 (trivia @keyword{'else'} trivia (if_stmt / block))?
+for_stmt      <- @keyword{'for'} trivia for_header? trivia block
 for_header    <- for_range
                / for_c_style
                / expr_no_compound
-for_range     <- (ident_list ws (@operator{'='} / @operator{':='}) ws)? @keyword{'range'} ws expr_no_compound
-for_c_style   <- simple_stmt? ws @punctuation{';'} ws expr_no_compound? ws @punctuation{';'} ws simple_stmt?
+for_range     <- (ident_list trivia (@operator{'='} / @operator{':='}) trivia)? @keyword{'range'} trivia expr_no_compound
+for_c_style   <- simple_stmt? trivia @punctuation{';'} trivia expr_no_compound? trivia @punctuation{';'} trivia simple_stmt?
 
-switch_stmt   <- @keyword{'switch'} ws type_switch_header ws @punctuation{'{'} ws type_case* ws @punctuation{'}'}
-               / @keyword{'switch'} ws expr_switch_header ws @punctuation{'{'} ws expr_case* ws @punctuation{'}'}
-expr_switch_header <- (simple_stmt ws @punctuation{';'} ws)? expr_no_compound?
+switch_stmt   <- @keyword{'switch'} trivia type_switch_header trivia @punctuation{'{'} trivia type_case* trivia @punctuation{'}'}
+               / @keyword{'switch'} trivia expr_switch_header trivia @punctuation{'{'} trivia expr_case* trivia @punctuation{'}'}
+expr_switch_header <- (simple_stmt trivia @punctuation{';'} trivia)? expr_no_compound?
                / ''
-type_switch_header <- (simple_stmt ws @punctuation{';'} ws)? type_switch_guard
-type_switch_guard  <- (@variable{ident} ws @operator{':='} ws)? expr_no_compound @punctuation{'.'} @punctuation{'('} ws @keyword{'type'} ws @punctuation{')'}
-expr_case     <- @keyword{'case'} ws expr_list ws @punctuation{':'} ws (stmt ws)*
-               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
-type_case     <- @keyword{'case'} ws type_list ws @punctuation{':'} ws (stmt ws)*
-               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
-type_list     <- type_expr (ws @punctuation{','} ws type_expr)*
+type_switch_header <- (simple_stmt trivia @punctuation{';'} trivia)? type_switch_guard
+type_switch_guard  <- (@variable{ident} trivia @operator{':='} trivia)? expr_no_compound @punctuation{'.'} @punctuation{'('} trivia @keyword{'type'} trivia @punctuation{')'}
+expr_case     <- @keyword{'case'} trivia expr_list trivia @punctuation{':'} trivia (stmt trivia)*
+               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
+type_case     <- @keyword{'case'} trivia type_list trivia @punctuation{':'} trivia (stmt trivia)*
+               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
+type_list     <- type_expr (trivia @punctuation{','} trivia type_expr)*
 
-select_stmt   <- @keyword{'select'} ws @punctuation{'{'} ws comm_case* ws @punctuation{'}'}
-comm_case     <- @keyword{'case'} ws comm_clause ws @punctuation{':'} ws (stmt ws)*
-               / @keyword{'default'} ws @punctuation{':'} ws (stmt ws)*
+select_stmt   <- @keyword{'select'} trivia @punctuation{'{'} trivia comm_case* trivia @punctuation{'}'}
+comm_case     <- @keyword{'case'} trivia comm_clause trivia @punctuation{':'} trivia (stmt trivia)*
+               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
 comm_clause   <- send_stmt
                / recv_stmt
-recv_stmt     <- (ident_list ws (@operator{'='} / @operator{':='}) ws)? expr_no_compound
+recv_stmt     <- (ident_list trivia (@operator{'='} / @operator{':='}) trivia)? expr_no_compound
 
-go_stmt       <- @keyword{'go'} ws expr
-defer_stmt    <- @keyword{'defer'} ws expr
+go_stmt       <- @keyword{'go'} trivia expr
+defer_stmt    <- @keyword{'defer'} trivia expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt  <- @keyword{'return'} (ws expr_list)?
-~break_stmt   <- @keyword{'break'} (ws @variable{ident})?
-~continue_stmt <- @keyword{'continue'} (ws @variable{ident})?
-goto_stmt     <- @keyword{'goto'} ws @variable{ident}
+~return_stmt  <- @keyword{'return'} (trivia expr_list)?
+~break_stmt   <- @keyword{'break'} (trivia @variable{ident})?
+~continue_stmt <- @keyword{'continue'} (trivia @variable{ident})?
+goto_stmt     <- @keyword{'goto'} trivia @variable{ident}
 fallthrough_stmt <- @keyword{'fallthrough'}
 
 # --- Expressions -----------------------------------------------------
@@ -223,56 +223,56 @@ fallthrough_stmt <- @keyword{'fallthrough'}
 expr             <- expr_lor
 expr_no_compound <- expr_lor_nc
 
-expr_lor         <- expr_lor ws @operator{'||'} ws expr_land / expr_land
-expr_land        <- expr_land ws @operator{'&&'} ws expr_rel / expr_rel
-expr_rel         <- expr_rel ws (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') ws expr_add / expr_add
-expr_add         <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') ws expr_mul / expr_mul
-expr_mul         <- expr_mul ws (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') ws expr_unary / expr_unary
+expr_lor         <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
+expr_land        <- expr_land trivia @operator{'&&'} trivia expr_rel / expr_rel
+expr_rel         <- expr_rel trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_add / expr_add
+expr_add         <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') trivia expr_mul / expr_mul
+expr_mul         <- expr_mul trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') trivia expr_unary / expr_unary
 
-expr_lor_nc      <- expr_lor_nc ws @operator{'||'} ws expr_land_nc / expr_land_nc
-expr_land_nc     <- expr_land_nc ws @operator{'&&'} ws expr_rel_nc / expr_rel_nc
-expr_rel_nc      <- expr_rel_nc ws (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') ws expr_add_nc / expr_add_nc
-expr_add_nc      <- expr_add_nc ws (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') ws expr_mul_nc / expr_mul_nc
-expr_mul_nc      <- expr_mul_nc ws (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') ws expr_unary_nc / expr_unary_nc
+expr_lor_nc      <- expr_lor_nc trivia @operator{'||'} trivia expr_land_nc / expr_land_nc
+expr_land_nc     <- expr_land_nc trivia @operator{'&&'} trivia expr_rel_nc / expr_rel_nc
+expr_rel_nc      <- expr_rel_nc trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_add_nc / expr_add_nc
+expr_add_nc      <- expr_add_nc trivia (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') trivia expr_mul_nc / expr_mul_nc
+expr_mul_nc      <- expr_mul_nc trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') trivia expr_unary_nc / expr_unary_nc
 
-expr_unary    <- (unary_op ws)* expr_postfix
-expr_unary_nc <- (unary_op ws)* expr_postfix_nc
+expr_unary    <- (unary_op trivia)* expr_postfix
+expr_unary_nc <- (unary_op trivia)* expr_postfix_nc
 unary_op      <- @operator{'!'} / @operator{'+'} / @operator{'-'}
                / @operator{'^'} / @operator{'*'} / @operator{'&'}
                / @operator{'<-'}
 
-expr_postfix  <- expr_primary (ws postfix_op)*
-expr_postfix_nc <- expr_primary_nc (ws postfix_op_nc)*
+expr_postfix  <- expr_primary (trivia postfix_op)*
+expr_postfix_nc <- expr_primary_nc (trivia postfix_op_nc)*
 
 postfix_op    <- @punctuation{'.'} postfix_selector
-               / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
-               / @punctuation{'('} ws call_args? ws @punctuation{')'}
+               / @punctuation{'['} trivia slice_or_index trivia @punctuation{']'}
+               / @punctuation{'('} trivia call_args? trivia @punctuation{')'}
                / composite_body
 postfix_op_nc <- @punctuation{'.'} postfix_selector
-               / @punctuation{'['} ws slice_or_index ws @punctuation{']'}
-               / @punctuation{'('} ws call_args? ws @punctuation{')'}
-postfix_selector <- @punctuation{'('} ws type_expr ws @punctuation{')'}                   # x.(T) type assertion
-                  / @function{ident} &(ws @punctuation{'('})
+               / @punctuation{'['} trivia slice_or_index trivia @punctuation{']'}
+               / @punctuation{'('} trivia call_args? trivia @punctuation{')'}
+postfix_selector <- @punctuation{'('} trivia type_expr trivia @punctuation{')'}                   # x.(T) type assertion
+                  / @function{ident} &(trivia @punctuation{'('})
                   / @property{ident}
 # `x.(type)` is intentionally not a postfix here: it is only valid inside
 # a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
 # Letting `postfix_selector` swallow it would leave nothing for the guard
 # to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
-slice_or_index <- expr? ws @punctuation{':'} ws expr? (ws @punctuation{':'} ws expr)?
+slice_or_index <- expr? trivia @punctuation{':'} trivia expr? (trivia @punctuation{':'} trivia expr)?
                / expr
 
-call_args     <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
-arg           <- expr ws @operator{'...'}
+call_args     <- arg (trivia @punctuation{','} trivia arg)* (trivia @punctuation{','})?
+arg           <- expr trivia @operator{'...'}
                / expr
                / type_expr
 
 # Composite literal body: `{ ... }` after a type expression.
-composite_body <- @punctuation{'{'} ws composite_elems? ws @punctuation{'}'}
-composite_elems <- composite_elem (ws @punctuation{','} ws composite_elem)* (ws @punctuation{','})?
-composite_elem <- composite_key ws @punctuation{':'} ws composite_value
+composite_body <- @punctuation{'{'} trivia composite_elems? trivia @punctuation{'}'}
+composite_elems <- composite_elem (trivia @punctuation{','} trivia composite_elem)* (trivia @punctuation{','})?
+composite_elem <- composite_key trivia @punctuation{':'} trivia composite_value
                / composite_value
 composite_key  <- @property{ident}
-                / @punctuation{'['} ws expr ws @punctuation{']'}
+                / @punctuation{'['} trivia expr trivia @punctuation{']'}
                 / string_lit
                 / number_lit
 composite_value <- composite_body
@@ -286,7 +286,7 @@ expr_primary  <- literal
                / @type{upper_ident}
                / @constant{predeclared_const}
                / @type{predeclared_type}
-               / @function{predeclared_fn} &(ws @punctuation{'('})
+               / @function{predeclared_fn} &(trivia @punctuation{'('})
                / @variable{lower_ident}
                / paren_expr
 expr_primary_nc <- literal
@@ -296,70 +296,65 @@ expr_primary_nc <- literal
                  / @type{upper_ident}
                  / @constant{predeclared_const}
                  / @type{predeclared_type}
-                 / @function{predeclared_fn} &(ws @punctuation{'('})
+                 / @function{predeclared_fn} &(trivia @punctuation{'('})
                  / @variable{lower_ident}
                  / paren_expr
 
-paren_expr    <- @punctuation{'('} ws expr ws @punctuation{')'}
+paren_expr    <- @punctuation{'('} trivia expr trivia @punctuation{')'}
 
 # Composite literal: `T{...}` where T is a named/qualified type.
 composite_lit <- @type{qualified_ident} composite_body
-               / @keyword{'map'} ws @punctuation{'['} ws type_expr ws @punctuation{']'} ws type_expr ws composite_body
-               / @punctuation{'['} ws (@operator{'...'} / expr)? ws @punctuation{']'} ws type_expr ws composite_body
-               / @keyword{'struct'} ws type_struct_body ws composite_body
-type_struct_body <- @punctuation{'{'} ws struct_field_list? ws @punctuation{'}'}
+               / @keyword{'map'} trivia @punctuation{'['} trivia type_expr trivia @punctuation{']'} trivia type_expr trivia composite_body
+               / @punctuation{'['} trivia (@operator{'...'} / expr)? trivia @punctuation{']'} trivia type_expr trivia composite_body
+               / @keyword{'struct'} trivia type_struct_body trivia composite_body
+type_struct_body <- @punctuation{'{'} trivia struct_field_list? trivia @punctuation{'}'}
 
 # Type conversion: `T(x)` where T is a named type — only triggers if
 # immediately followed by `(`.
-type_conv     <- @type{predeclared_type} @punctuation{'('} ws expr ws @punctuation{')'}
+type_conv     <- @type{predeclared_type} @punctuation{'('} trivia expr trivia @punctuation{')'}
 
 # Function literal.
-fn_lit        <- @keyword{'func'} ws fn_signature ws block
+fn_lit        <- @keyword{'func'} trivia fn_signature trivia block
 
-call_ident    <- @function{ident} &(ws @punctuation{'('})
+call_ident    <- @function{ident} &(trivia @punctuation{'('})
 
-ident_list    <- @variable{ident} (ws @punctuation{','} ws @variable{ident})*
-const_ident_list <- @constant{ident} (ws @punctuation{','} ws @constant{ident})*
-expr_list     <- expr (ws @punctuation{','} ws expr)*
-expr_no_compound_list <- expr_no_compound (ws @punctuation{','} ws expr_no_compound)*
+ident_list    <- @variable{ident} (trivia @punctuation{','} trivia @variable{ident})*
+const_ident_list <- @constant{ident} (trivia @punctuation{','} trivia @constant{ident})*
+expr_list     <- expr (trivia @punctuation{','} trivia expr)*
+expr_no_compound_list <- expr_no_compound (trivia @punctuation{','} trivia expr_no_compound)*
 
 # --- Literals -------------------------------------------------------
 
-literal       <- string_lit / number_lit / rune_lit / @constant{bool_lit} / @constant{nil_lit} / @constant{iota_lit}
-
-bool_lit      <- 'true' !ident_body / 'false' !ident_body
-nil_lit       <- 'nil' !ident_body
-iota_lit      <- 'iota' !ident_body
+literal       <- string_lit / number_lit / rune_lit
+               / @constant{'true' !ident_body / 'false' !ident_body}
+               / @constant{'nil' !ident_body}
+               / @constant{'iota' !ident_body}
 
 string_lit    <- @string{raw_string / interp_string}
 raw_string    <- '`' ..= '`'
-interp_string <- '"' (str_escape / !'"' !'\n' .)* '"'
-str_escape    <- '\\' .
+interp_string <- '"' ('\\' . / !'"' !'\n' .)* '"'
 
-rune_lit      <- @string{"'" (char_escape / !"'" .)* "'"}
-char_escape   <- '\\' .
+rune_lit      <- @string{"'" ('\\' . / !"'" .)* "'"}
 
 number_lit    <- @number{num_body}
-num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? imag?
-               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? imag?
-               / '0o' oct_digits imag?
-               / '0b' bin_digits imag?
-               / digit_seq '.' digit_seq? exp_part? imag?
-               / '.' digit_seq exp_part? imag?
-               / digit_seq exp_part? imag?
+num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+               / '0o' oct_digits 'i'?
+               / '0b' bin_digits 'i'?
+               / digit_seq '.' digit_seq? exp_part? 'i'?
+               / '.' digit_seq exp_part? 'i'?
+               / digit_seq exp_part? 'i'?
 digit_seq     <- \d ([\d_])*
 hex_digits    <- [\da-fA-F] [\da-fA-F_]*
 oct_digits    <- [0-7] [0-7_]*
 bin_digits    <- [01] [01_]*
 exp_part      <- [eE] [+\-]? \d+
-imag          <- 'i'
 
 # --- Identifiers / predeclared names ---------------------------------
 
-ident         <- !reserved ident_start ident_body*
+ident         <- !reserved [A-Za-z_] ident_body*
 upper_ident   <- !reserved [A-Z] ident_body*
 lower_ident   <- !reserved [a-z_] ident_body*
-ident_start   <- [A-Za-z_]
 ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords blocking identifier capture.
@@ -386,14 +381,10 @@ predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
 # --- Whitespace / comments / semicolon handling ----------------------
 
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
-# we accept optional explicit `;` and let `ws` eat whitespace.
+# we accept optional explicit `;` and let `trivia` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
-~opt_semi     <- (@punctuation{';'} ws)?
+~opt_semi     <- (@punctuation{';'} trivia)?
 
-comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' .. '\n'
-block_comment <- '/*' ..= '*/'
+comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
 
-trivia        <- ws
-
-ws            <- (comment / \s)*
+trivia        <- (comment / \s)*

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -30,7 +30,7 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-js_file        <- ws (stmt ws)*^ !.
+js_file        <- trivia (stmt trivia)*^ \z
 
 # --- Statements -------------------------------------------------------
 #
@@ -42,7 +42,7 @@ stmt           <- import_decl
                 / export_decl
                 / fn_decl
                 / class_decl
-                / var_decl ws opt_semi
+                / var_decl trivia opt_semi
                 / if_stmt
                 / for_stmt
                 / while_stmt
@@ -57,139 +57,139 @@ stmt           <- import_decl
                 / labeled_stmt
                 / block_stmt
                 / empty_stmt
-                / expr ws opt_semi
+                / expr trivia opt_semi
 
 # Definition-level `~` on `~opt_semi` covers every ASI call site; the
 # missing-else / missing-catch / missing-finally leniency on the other
 # `~`-marked stmts below is absorbed by stmt-level `*^` and
 # `block`'s `^block_close` recovery.
-~opt_semi      <- (@punctuation{';'} ws)?
-empty_stmt     <- @punctuation{';'} ws
+~opt_semi      <- (@punctuation{';'} trivia)?
+empty_stmt     <- @punctuation{';'} trivia
 
 # --- Imports / exports ------------------------------------------------
 
-import_decl    <- @keyword{'import'} ws import_body ws opt_semi
-import_body    <- import_clause ws @keyword{'from'} ws string_lit
+import_decl    <- @keyword{'import'} trivia import_body trivia opt_semi
+import_body    <- import_clause trivia @keyword{'from'} trivia string_lit
                 / string_lit
-import_clause  <- import_default ws @punctuation{','} ws import_ns_or_named
+import_clause  <- import_default trivia @punctuation{','} trivia import_ns_or_named
                 / import_default
                 / import_ns_or_named
 import_default <- @variable{ident}
 import_ns_or_named <- import_namespace / import_named
-import_namespace <- @operator{'*'} ws @keyword{'as'} ws @variable{ident}
-import_named   <- @punctuation{'{'} ws import_specifier_list? ws @punctuation{'}'}
-import_specifier_list <- import_specifier (ws @punctuation{','} ws import_specifier)* (ws @punctuation{','})?
-import_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident}
+import_namespace <- @operator{'*'} trivia @keyword{'as'} trivia @variable{ident}
+import_named   <- @punctuation{'{'} trivia import_specifier_list? trivia @punctuation{'}'}
+import_specifier_list <- import_specifier (trivia @punctuation{','} trivia import_specifier)* (trivia @punctuation{','})?
+import_specifier <- @variable{ident_name} trivia @keyword{'as'} trivia @variable{ident}
                   / @variable{ident}
 
-export_decl    <- @keyword{'export'} ws @keyword{'default'} ws export_default_body
-                / @keyword{'export'} ws @operator{'*'} ws (@keyword{'as'} ws @variable{ident_name} ws)? @keyword{'from'} ws string_lit ws opt_semi
-                / @keyword{'export'} ws export_named
-                / @keyword{'export'} ws fn_decl
-                / @keyword{'export'} ws class_decl
-                / @keyword{'export'} ws var_decl ws opt_semi
+export_decl    <- @keyword{'export'} trivia @keyword{'default'} trivia export_default_body
+                / @keyword{'export'} trivia @operator{'*'} trivia (@keyword{'as'} trivia @variable{ident_name} trivia)? @keyword{'from'} trivia string_lit trivia opt_semi
+                / @keyword{'export'} trivia export_named
+                / @keyword{'export'} trivia fn_decl
+                / @keyword{'export'} trivia class_decl
+                / @keyword{'export'} trivia var_decl trivia opt_semi
 export_default_body <- fn_decl
                      / class_decl
-                     / expr ws opt_semi
+                     / expr trivia opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named  <- @punctuation{'{'} ws export_specifier_list? ws @punctuation{'}'} (ws @keyword{'from'} ws string_lit)? ws opt_semi
-export_specifier_list <- export_specifier (ws @punctuation{','} ws export_specifier)* (ws @punctuation{','})?
-export_specifier <- @variable{ident_name} ws @keyword{'as'} ws @variable{ident_name}
+~export_named  <- @punctuation{'{'} trivia export_specifier_list? trivia @punctuation{'}'} (trivia @keyword{'from'} trivia string_lit)? trivia opt_semi
+export_specifier_list <- export_specifier (trivia @punctuation{','} trivia export_specifier)* (trivia @punctuation{','})?
+export_specifier <- @variable{ident_name} trivia @keyword{'as'} trivia @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
 
-fn_decl        <- @keyword{'async'} ws fn_decl_core
+fn_decl        <- @keyword{'async'} trivia fn_decl_core
                 / fn_decl_core
-fn_decl_core   <- @keyword{'function'} (ws @operator{'*'})? ws @function{ident} ws fn_params ws block
+fn_decl_core   <- @keyword{'function'} (trivia @operator{'*'})? trivia @function{ident} trivia fn_params trivia block
 
-class_decl     <- @keyword{'class'} ws @type{ident} ws class_heritage? ws class_body
-class_heritage <- @keyword{'extends'} ws expr_lhs
-class_body     <- @punctuation{'{'} ws class_member* ws @punctuation{'}'}
-class_member   <- @punctuation{';'} ws
+class_decl     <- @keyword{'class'} trivia @type{ident} trivia class_heritage? trivia class_body
+class_heritage <- @keyword{'extends'} trivia expr_lhs
+class_body     <- @punctuation{'{'} trivia class_member* trivia @punctuation{'}'}
+class_member   <- @punctuation{';'} trivia
                 / class_method_or_field
-class_method_or_field <- (@keyword{'static'} ws)? (class_method / class_field)
-class_method   <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block ws
-                / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block ws
+class_method_or_field <- (@keyword{'static'} trivia)? (class_method / class_field)
+class_method   <- (@keyword{'async'} trivia)? (@operator{'*'} trivia)? method_head trivia fn_params trivia block trivia
+                / (@keyword{'get'} / @keyword{'set'}) trivia method_head trivia fn_params trivia block trivia
 method_head    <- computed_prop
                 / @function{ident_name}
                 / string_lit
                 / number_lit
-class_field    <- (computed_prop / @property{ident_name}) ws (@operator{'='} ws expr_no_comma)? ws opt_semi
+class_field    <- (computed_prop / @property{ident_name}) trivia (@operator{'='} trivia expr_no_comma)? trivia opt_semi
 
 # --- Variable declarations -------------------------------------------
 
-var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) ws var_declarator_list
-var_declarator_list <- var_declarator (ws @punctuation{','} ws var_declarator)*
+var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) trivia var_declarator_list
+var_declarator_list <- var_declarator (trivia @punctuation{','} trivia var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
-~var_declarator <- pattern (ws @operator{'='} ws expr_no_comma)?
+~var_declarator <- pattern (trivia @operator{'='} trivia expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt       <- @keyword{'if'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
-                  (ws @keyword{'else'} ws stmt)?
-for_stmt       <- @keyword{'for'} (ws @keyword{'await'})? ws @punctuation{'('} ws for_head ws @punctuation{')'} ws stmt
+~if_stmt       <- @keyword{'if'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
+                  (trivia @keyword{'else'} trivia stmt)?
+for_stmt       <- @keyword{'for'} (trivia @keyword{'await'})? trivia @punctuation{'('} trivia for_head trivia @punctuation{')'} trivia stmt
 for_head       <- for_c_style
                 / for_in_of
-for_c_style    <- for_init? ws @punctuation{';'} ws expr? ws @punctuation{';'} ws expr?
-for_in_of      <- for_binding ws (@keyword{'in'} / @keyword{'of'}) ws expr
+for_c_style    <- for_init? trivia @punctuation{';'} trivia expr? trivia @punctuation{';'} trivia expr?
+for_in_of      <- for_binding trivia (@keyword{'in'} / @keyword{'of'}) trivia expr
 for_init       <- var_decl
                 / expr
-for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) ws pattern
+for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) trivia pattern
                 / pattern
 
-while_stmt     <- @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws stmt
-do_while_stmt  <- @keyword{'do'} ws stmt ws @keyword{'while'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws opt_semi
-switch_stmt    <- @keyword{'switch'} ws @punctuation{'('} ws expr ws @punctuation{')'} ws
-                  @punctuation{'{'} ws switch_case* ws @punctuation{'}'}
-switch_case    <- @keyword{'case'} ws expr ws @punctuation{':'} ws (!switch_case_term stmt ws)*
-                / @keyword{'default'} ws @punctuation{':'} ws (!switch_case_term stmt ws)*
+while_stmt     <- @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
+do_while_stmt  <- @keyword{'do'} trivia stmt trivia @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia opt_semi
+switch_stmt    <- @keyword{'switch'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia
+                  @punctuation{'{'} trivia switch_case* trivia @punctuation{'}'}
+switch_case    <- @keyword{'case'} trivia expr trivia @punctuation{':'} trivia (!switch_case_term stmt trivia)*
+                / @keyword{'default'} trivia @punctuation{':'} trivia (!switch_case_term stmt trivia)*
 switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt      <- @keyword{'try'} ws block (ws catch_clause)? (ws finally_clause)?
-catch_clause   <- @keyword{'catch'} (ws @punctuation{'('} ws pattern ws @punctuation{')'})? ws block
-finally_clause <- @keyword{'finally'} ws block
-throw_stmt     <- @keyword{'throw'} ws expr ws opt_semi
-# Trailing `(ws expr)?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt   <- @keyword{'return'} (ws expr)? ws opt_semi
-~break_stmt    <- @keyword{'break'} (ws @variable{ident})? ws opt_semi
-~continue_stmt <- @keyword{'continue'} (ws @variable{ident})? ws opt_semi
-debugger_stmt  <- @keyword{'debugger'} ws opt_semi
-labeled_stmt   <- @variable{ident} ws @punctuation{':'} ws stmt
+~try_stmt      <- @keyword{'try'} trivia block (trivia catch_clause)? (trivia finally_clause)?
+catch_clause   <- @keyword{'catch'} (trivia @punctuation{'('} trivia pattern trivia @punctuation{')'})? trivia block
+finally_clause <- @keyword{'finally'} trivia block
+throw_stmt     <- @keyword{'throw'} trivia expr trivia opt_semi
+# Trailing `(trivia expr)?` leniency on `~return_stmt` absorbed by stmt recovery.
+~return_stmt   <- @keyword{'return'} (trivia expr)? trivia opt_semi
+~break_stmt    <- @keyword{'break'} (trivia @variable{ident})? trivia opt_semi
+~continue_stmt <- @keyword{'continue'} (trivia @variable{ident})? trivia opt_semi
+debugger_stmt  <- @keyword{'debugger'} trivia opt_semi
+labeled_stmt   <- @variable{ident} trivia @punctuation{':'} trivia stmt
 block_stmt     <- block
-block          <- @punctuation{'{'} ws ((stmt ws)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block          <- @punctuation{'{'} trivia ((stmt trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------
 
-fn_params      <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
-fn_param_list  <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
+fn_params      <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
+fn_param_list  <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
 fn_param       <- @operator{'...'} pattern
-                / pattern (ws @operator{'='} ws expr_no_comma)?
+                / pattern (trivia @operator{'='} trivia expr_no_comma)?
 
 # --- Destructuring patterns ------------------------------------------
 
 pattern        <- array_pattern / object_pattern / @variable{ident}
-array_pattern  <- @punctuation{'['} ws array_pattern_list? ws @punctuation{']'}
-array_pattern_list <- array_pattern_el (ws @punctuation{','} ws array_pattern_el)* (ws @punctuation{','})?
+array_pattern  <- @punctuation{'['} trivia array_pattern_list? trivia @punctuation{']'}
+array_pattern_list <- array_pattern_el (trivia @punctuation{','} trivia array_pattern_el)* (trivia @punctuation{','})?
 array_pattern_el <- @operator{'...'} pattern
-                  / pattern (ws @operator{'='} ws expr_no_comma)?
+                  / pattern (trivia @operator{'='} trivia expr_no_comma)?
                   / ''
-object_pattern <- @punctuation{'{'} ws object_pattern_list? ws @punctuation{'}'}
-object_pattern_list <- object_pattern_prop (ws @punctuation{','} ws object_pattern_prop)* (ws @punctuation{','})?
+object_pattern <- @punctuation{'{'} trivia object_pattern_list? trivia @punctuation{'}'}
+object_pattern_list <- object_pattern_prop (trivia @punctuation{','} trivia object_pattern_prop)* (trivia @punctuation{','})?
 object_pattern_prop <- @operator{'...'} pattern
-                     / (computed_prop / @property{ident_name}) ws @punctuation{':'} ws pattern (ws @operator{'='} ws expr_no_comma)?
-                     / @property{ident} (ws @operator{'='} ws expr_no_comma)?
+                     / (computed_prop / @property{ident_name}) trivia @punctuation{':'} trivia pattern (trivia @operator{'='} trivia expr_no_comma)?
+                     / @property{ident} (trivia @operator{'='} trivia expr_no_comma)?
 
-computed_prop  <- @punctuation{'['} ws expr ws @punctuation{']'}
+computed_prop  <- @punctuation{'['} trivia expr trivia @punctuation{']'}
 
 # --- Expressions ------------------------------------------------------
 
-expr           <- expr_no_comma (ws @punctuation{','} ws expr_no_comma)*
+expr           <- expr_no_comma (trivia @punctuation{','} trivia expr_no_comma)*
 expr_no_comma  <- expr_assign
 expr_assign    <- expr_arrow
                 / expr_yield
-                / expr_conditional (ws assign_op ws expr_assign)?
+                / expr_conditional (trivia assign_op trivia expr_assign)?
 
 assign_op      <- @operator{'**='}
                 / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
@@ -200,17 +200,17 @@ assign_op      <- @operator{'**='}
 
 # Arrow functions tried first. `async x => ...`, `x => ...`,
 # `(a, b) => ...`, `() => ...`.
-expr_arrow     <- arrow_head ws @operator{'=>'} ws arrow_body
-arrow_head     <- @keyword{'async'} ws arrow_params
+expr_arrow     <- arrow_head trivia @operator{'=>'} trivia arrow_body
+arrow_head     <- @keyword{'async'} trivia arrow_params
                 / arrow_params
 arrow_params   <- @variable{ident}
                 / arrow_paren_params
-arrow_paren_params <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
+arrow_paren_params <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
 arrow_body     <- block
                 / expr_no_comma
 
-# Trailing `(ws *)? (ws expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield    <- @keyword{'yield'} (ws @operator{'*'})? (ws expr_assign)?
+# Trailing `(trivia *)? (trivia expr_assign)?` absorbed by stmt-level recovery.
+~expr_yield    <- @keyword{'yield'} (trivia @operator{'*'})? (trivia expr_assign)?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
@@ -219,24 +219,24 @@ arrow_body     <- block
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
 # Trailing ternary leniency absorbed by stmt-level recovery.
-~expr_conditional <- expr_nullish (ws @operator{'?'} ws expr_no_comma ws @punctuation{':'} ws expr_no_comma)?
+~expr_conditional <- expr_nullish (trivia @operator{'?'} trivia expr_no_comma trivia @punctuation{':'} trivia expr_no_comma)?
 
-expr_nullish   <- expr_nullish ws @operator{'??'} !'=' ws expr_lor / expr_lor
-expr_lor       <- expr_lor ws @operator{'||'} !'=' ws expr_land / expr_land
-expr_land      <- expr_land ws @operator{'&&'} !'=' ws expr_bor / expr_bor
-expr_bor       <- expr_bor ws @operator{'|'} !'|' !'=' ws expr_bxor / expr_bxor
-expr_bxor      <- expr_bxor ws @operator{'^'} !'=' ws expr_band / expr_band
-expr_band      <- expr_band ws @operator{'&'} !'&' !'=' ws expr_eq / expr_eq
-expr_eq        <- expr_eq ws (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) ws expr_rel / expr_rel
-expr_rel       <- expr_rel ws (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) ws expr_shift / expr_shift
-expr_shift     <- expr_shift ws (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') ws expr_add / expr_add
-expr_add       <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
-expr_mul       <- expr_mul ws (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_pow / expr_pow
+expr_nullish   <- expr_nullish trivia @operator{'??'} !'=' trivia expr_lor / expr_lor
+expr_lor       <- expr_lor trivia @operator{'||'} !'=' trivia expr_land / expr_land
+expr_land      <- expr_land trivia @operator{'&&'} !'=' trivia expr_bor / expr_bor
+expr_bor       <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
+expr_bxor      <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
+expr_band      <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_eq / expr_eq
+expr_eq        <- expr_eq trivia (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) trivia expr_rel / expr_rel
+expr_rel       <- expr_rel trivia (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) trivia expr_shift / expr_shift
+expr_shift     <- expr_shift trivia (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
+expr_add       <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
+expr_mul       <- expr_mul trivia (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_pow / expr_pow
 
 # Right-associative: stays right-recursive, not LR.
-expr_pow       <- expr_unary ws @operator{'**'} !'=' ws expr_pow / expr_unary
+expr_pow       <- expr_unary trivia @operator{'**'} !'=' trivia expr_pow / expr_unary
 
-expr_unary     <- (unary_op ws)* expr_postfix
+expr_unary     <- (unary_op trivia)* expr_postfix
 unary_op       <- @keyword{'typeof'}
                 / @keyword{'void'}
                 / @keyword{'delete'}
@@ -246,30 +246,30 @@ unary_op       <- @keyword{'typeof'}
                 / @operator{'!'} / @operator{'~'}
 
 # Postfix: calls, member, optional chain, index, `++`/`--`.
-expr_postfix   <- expr_lhs (ws postfix_op)*
+expr_postfix   <- expr_lhs (trivia postfix_op)*
 postfix_op     <- @operator{'++'}
                 / @operator{'--'}
-                / @operator{'?.'} ws postfix_after_optional
+                / @operator{'?.'} trivia postfix_after_optional
                 / @punctuation{'.'} member_target
-                / @punctuation{'['} ws expr ws @punctuation{']'}
+                / @punctuation{'['} trivia expr trivia @punctuation{']'}
                 / call_args
                 / template_lit
 postfix_after_optional <- call_args
-                        / @punctuation{'['} ws expr ws @punctuation{']'}
+                        / @punctuation{'['} trivia expr trivia @punctuation{']'}
                         / member_target
-member_target  <- @function{ident_name} &(ws @punctuation{'('})
+member_target  <- @function{ident_name} &(trivia @punctuation{'('})
                 / @property{ident_name}
-call_args      <- @punctuation{'('} ws arg_list? ws @punctuation{')'}
-arg_list       <- arg (ws @punctuation{','} ws arg)* (ws @punctuation{','})?
+call_args      <- @punctuation{'('} trivia arg_list? trivia @punctuation{')'}
+arg_list       <- arg (trivia @punctuation{','} trivia arg)* (trivia @punctuation{','})?
 arg            <- @operator{'...'} expr_no_comma
                 / expr_no_comma
 
 expr_lhs       <- expr_new / expr_primary
-expr_new       <- @keyword{'new'} ws expr_new_target
+expr_new       <- @keyword{'new'} trivia expr_new_target
 expr_new_target <- @type{upper_ident} new_tail?
                  / @variable{lower_ident} new_tail?
                  / expr_primary new_tail?
-new_tail       <- (ws postfix_op)+
+new_tail       <- (trivia postfix_op)+
 
 expr_primary   <- literal
                 / expr_this
@@ -283,45 +283,39 @@ expr_primary   <- literal
                 / @type{upper_ident}
                 / @variable{lower_ident}
 
-call_ident     <- @function{ident} &(ws @punctuation{'('})
+call_ident     <- @function{ident} &(trivia @punctuation{'('})
 
 expr_this      <- @keyword{'this'}
 expr_super     <- @keyword{'super'}
-expr_fn        <- (@keyword{'async'} ws)? @keyword{'function'} (ws @operator{'*'})? ws (@function{ident} ws)? fn_params ws block
-expr_class     <- @keyword{'class'} (ws @type{ident})? ws class_heritage? ws class_body
-expr_array     <- @punctuation{'['} ws array_elem_list? ws @punctuation{']'}
-array_elem_list <- array_elem (ws @punctuation{','} ws array_elem)* (ws @punctuation{','})?
+expr_fn        <- (@keyword{'async'} trivia)? @keyword{'function'} (trivia @operator{'*'})? trivia (@function{ident} trivia)? fn_params trivia block
+expr_class     <- @keyword{'class'} (trivia @type{ident})? trivia class_heritage? trivia class_body
+expr_array     <- @punctuation{'['} trivia array_elem_list? trivia @punctuation{']'}
+array_elem_list <- array_elem (trivia @punctuation{','} trivia array_elem)* (trivia @punctuation{','})?
 array_elem     <- @operator{'...'} expr_no_comma
                 / expr_no_comma
                 / ''
-expr_object    <- @punctuation{'{'} ws object_props? ws @punctuation{'}'}
-object_props   <- object_prop (ws @punctuation{','} ws object_prop)* (ws @punctuation{','})?
+expr_object    <- @punctuation{'{'} trivia object_props? trivia @punctuation{'}'}
+object_props   <- object_prop (trivia @punctuation{','} trivia object_prop)* (trivia @punctuation{','})?
 object_prop    <- @operator{'...'} expr_no_comma
                 / object_method
-                / (computed_prop / string_lit / number_lit / @property{ident_name}) ws @punctuation{':'} ws expr_no_comma
+                / (computed_prop / string_lit / number_lit / @property{ident_name}) trivia @punctuation{':'} trivia expr_no_comma
                 / @property{ident}
-object_method  <- (@keyword{'async'} ws)? (@operator{'*'} ws)? method_head ws fn_params ws block
-                / (@keyword{'get'} / @keyword{'set'}) ws method_head ws fn_params ws block
-expr_paren     <- @punctuation{'('} ws expr ws @punctuation{')'}
+object_method  <- (@keyword{'async'} trivia)? (@operator{'*'} trivia)? method_head trivia fn_params trivia block
+                / (@keyword{'get'} / @keyword{'set'}) trivia method_head trivia fn_params trivia block
+expr_paren     <- @punctuation{'('} trivia expr trivia @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 
 literal        <- template_lit
                 / string_lit
                 / number_lit
-                / @constant{bool_lit}
-                / @constant{null_lit}
-                / @constant{undefined_lit}
-
-bool_lit       <- 'true' !ident_body
-                / 'false' !ident_body
-null_lit       <- 'null' !ident_body
-undefined_lit  <- 'undefined' !ident_body
+                / @constant{'true' !ident_body / 'false' !ident_body}
+                / @constant{'null' !ident_body}
+                / @constant{'undefined' !ident_body}
 
 string_lit     <- @string{sq_string / dq_string}
-sq_string      <- "'" (str_escape / !"'" !'\n' .)* "'"
-dq_string      <- '"' (str_escape / !'"' !'\n' .)* '"'
-str_escape     <- '\\' .
+sq_string      <- "'" ('\\' . / !"'" !'\n' .)* "'"
+dq_string      <- '"' ('\\' . / !'"' !'\n' .)* '"'
 
 # Template literals with ${...} interpolation. Chunks outside the
 # interpolations get @string; the interpolation braces stay
@@ -329,13 +323,13 @@ str_escape     <- '\\' .
 template_lit   <- @string{'`'} template_body @string{'`'}
 template_body  <- (template_chunk / template_interp)*
 template_chunk <- @string{('\\' . / !'`' !'${' .)+}
-template_interp <- @punctuation{'${'} ws expr ws @punctuation{'}'}
+template_interp <- @punctuation{'${'} trivia expr trivia @punctuation{'}'}
 
 number_lit     <- @number{num_body}
-num_body       <- '0x' hex_digits bigint?
-                / '0o' oct_digits bigint?
-                / '0b' bin_digits bigint?
-                / decimal_num bigint?
+num_body       <- '0x' hex_digits 'n'?
+                / '0o' oct_digits 'n'?
+                / '0b' bin_digits 'n'?
+                / decimal_num 'n'?
 decimal_num    <- digit_seq '.' digit_seq? exp_part?
                 / '.' digit_seq exp_part?
                 / digit_seq exp_part?
@@ -344,20 +338,18 @@ hex_digits     <- [\da-fA-F] [\da-fA-F_]*
 oct_digits     <- [0-7] [0-7_]*
 bin_digits     <- [01] [01_]*
 exp_part       <- [eE] [+\-]? \d+
-bigint         <- 'n'
 
 # --- Identifiers / reserved words ------------------------------------
 
-ident          <- !reserved ident_start ident_body*
+ident          <- !reserved [A-Za-z_$] ident_body*
 # `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
 # `!reserved` guard is dropped so reserved words are accepted. Use at
 # positions where ES allows IdentifierName but not BindingIdentifier
 # (member access after `.` / `?.`, property keys, imported/exported
 # names that aren't local bindings).
-ident_name     <- ident_start ident_body*
+ident_name     <- [A-Za-z_$] ident_body*
 upper_ident    <- !reserved [A-Z] ident_body*
 lower_ident    <- !reserved [a-z_$] ident_body*
-ident_start    <- [A-Za-z_$]
 ident_body     <- [A-Za-z\d_$]
 
 # Reserved words that must not appear as identifiers. The grammar uses
@@ -377,10 +369,6 @@ reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
 
 # --- Whitespace / comments --------------------------------------------
 
-comment        <- @comment{line_comment / block_comment}
-line_comment   <- '//' .. '\n'
-block_comment  <- '/*' ..= '*/'
+comment        <- @comment{'//' .. '\n' / '/*' ..= '*/'}
 
-trivia        <- ws
-
-ws             <- (comment / \s)*
+trivia         <- (comment / \s)*

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,29 +1,29 @@
 # JSON grammar with highlight annotations.
 # The first rule is the start rule.
 
-json        <- spacing value spacing \z
+json        <- \s* value \s* \z
 
 value       <- @string{string}
              / @number{number}
              / object
              / array
-             / @constant{true_lit}
-             / @constant{false_lit}
-             / @constant{null_lit}
+             / @constant{'true'}
+             / @constant{'false'}
+             / @constant{'null'}
 
-object      <- @punctuation{'{'} spacing
-               (pair (spacing @punctuation{','} spacing pair)*)?
-               spacing @punctuation{'}'}
+object      <- @punctuation{'{'} \s*
+               (pair (\s* @punctuation{','} \s* pair)*)?
+               \s* @punctuation{'}'}
 
-pair        <- @property{string} spacing @punctuation{':'} spacing value
+pair        <- @property{string} \s* @punctuation{':'} \s* value
 
-array       <- @punctuation{'['} spacing
-               (value (spacing @punctuation{','} spacing value)*)?
-               spacing @punctuation{']'}
+array       <- @punctuation{'['} \s*
+               (value (\s* @punctuation{','} \s* value)*)?
+               \s* @punctuation{']'}
 
 string      <- '"' string_char* '"'
 string_char <- '\\' ["\\/bfnrt]
-             / '\\' 'u' hex{4}
+             / '\\' 'u' [\da-fA-F]{4}
              / [^"\\]
 
 number      <- '-'? int frac? exp?
@@ -31,11 +31,4 @@ int         <- '0' / [1-9] \d*
 frac        <- '.' \d+
 exp         <- [eE] [+\-]? \d+
 
-true_lit    <- 'true'
-false_lit   <- 'false'
-null_lit    <- 'null'
-
-hex         <- [\da-fA-F]
-trivia      <- spacing
-
-spacing     <- \s*
+trivia      <- \s*

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -25,7 +25,7 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-rust_file     <- ws (item)*^ ws !.
+rust_file     <- trivia (item)*^ trivia \z
 
 # --- Items -------------------------------------------------------------
 #
@@ -50,17 +50,17 @@ item          <- attr_outer
                / stmt
 
 # Attributes and doc-comments at item position.
-attr_outer    <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'} ws
-attr_inner    <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'} ws
+attr_outer    <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'} trivia
+attr_inner    <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'} trivia
 attr_body     <- .. ']'
 
 # `use foo::bar::{baz, qux as q};`
-use_item      <- @keyword{'use'} ws use_tree ws @punctuation{';'} ws
+use_item      <- @keyword{'use'} trivia use_tree trivia @punctuation{';'} trivia
 use_tree      <- use_path use_tail?
-use_tail      <- ws @keyword{'as'} ws ident_any
+use_tail      <- trivia @keyword{'as'} trivia ident_any
                / @punctuation{'::'} @punctuation{'*'}
-               / @punctuation{'::'} @punctuation{'{'} ws use_tree_list? ws @punctuation{'}'}
-use_tree_list <- use_tree (ws @punctuation{','} ws use_tree)* (ws @punctuation{','})?
+               / @punctuation{'::'} @punctuation{'{'} trivia use_tree_list? trivia @punctuation{'}'}
+use_tree_list <- use_tree (trivia @punctuation{','} trivia use_tree)* (trivia @punctuation{','})?
 use_path      <- use_seg (@punctuation{'::'} use_seg)*
 use_seg       <- @keyword{'self'}
                / @keyword{'super'}
@@ -69,102 +69,102 @@ use_seg       <- @keyword{'self'}
                / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       <- vis? ws fn_qualifiers @keyword{'fn'} ws @function{ident} generic_params? ws
-                 fn_params ws fn_return? ws where_clause? ws (block / @punctuation{';'}) ws
-fn_qualifiers <- (fn_qualifier ws)*
+fn_item       <- vis? trivia fn_qualifiers @keyword{'fn'} trivia @function{ident} generic_params? trivia
+                 fn_params trivia fn_return? trivia where_clause? trivia (block / @punctuation{';'}) trivia
+fn_qualifiers <- (fn_qualifier trivia)*
 fn_qualifier  <- @keyword{'const'}
                / @keyword{'async'}
                / @keyword{'unsafe'}
-               / @keyword{'extern'} (ws string_lit)?
-fn_params     <- @punctuation{'('} ws fn_param_list? ws @punctuation{')'}
-fn_param_list <- fn_param (ws @punctuation{','} ws fn_param)* (ws @punctuation{','})?
+               / @keyword{'extern'} (trivia string_lit)?
+fn_params     <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
+fn_param_list <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
 fn_param      <- attr_outer? self_param
                / attr_outer? fn_param_named
-fn_param_named <- pattern_no_or ws @punctuation{':'} ws type_expr
-self_param    <- ref_marker? ws (@keyword{'mut'} ws)? @keyword{'self'}
-               / @keyword{'mut'} ws @keyword{'self'}
-               / @keyword{'self'} ws @punctuation{':'} ws type_expr
+fn_param_named <- pattern_no_or trivia @punctuation{':'} trivia type_expr
+self_param    <- ref_marker? trivia (@keyword{'mut'} trivia)? @keyword{'self'}
+               / @keyword{'mut'} trivia @keyword{'self'}
+               / @keyword{'self'} trivia @punctuation{':'} trivia type_expr
 ref_marker    <- @punctuation{'&'} lifetime?
-fn_return     <- @punctuation{'->'} ws type_expr
+fn_return     <- @punctuation{'->'} trivia type_expr
 
 # `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
-struct_item   <- vis? ws @keyword{'struct'} ws @type{ident} generic_params? ws
-                 (struct_body_named / struct_body_tuple / @punctuation{';'}) ws
-struct_body_named <- where_clause? ws @punctuation{'{'} ws struct_fields? ws @punctuation{'}'}
-struct_body_tuple <- @punctuation{'('} ws tuple_fields? ws @punctuation{')'} ws where_clause? ws @punctuation{';'}
-struct_fields <- struct_field (ws @punctuation{','} ws struct_field)* (ws @punctuation{','})?
-struct_field  <- (attr_outer ws)* vis? ws @property{ident} ws @punctuation{':'} ws type_expr
-tuple_fields  <- tuple_field (ws @punctuation{','} ws tuple_field)* (ws @punctuation{','})?
-tuple_field   <- (attr_outer ws)* vis? ws type_expr
+struct_item   <- vis? trivia @keyword{'struct'} trivia @type{ident} generic_params? trivia
+                 (struct_body_named / struct_body_tuple / @punctuation{';'}) trivia
+struct_body_named <- where_clause? trivia @punctuation{'{'} trivia struct_fields? trivia @punctuation{'}'}
+struct_body_tuple <- @punctuation{'('} trivia tuple_fields? trivia @punctuation{')'} trivia where_clause? trivia @punctuation{';'}
+struct_fields <- struct_field (trivia @punctuation{','} trivia struct_field)* (trivia @punctuation{','})?
+struct_field  <- (attr_outer trivia)* vis? trivia @property{ident} trivia @punctuation{':'} trivia type_expr
+tuple_fields  <- tuple_field (trivia @punctuation{','} trivia tuple_field)* (trivia @punctuation{','})?
+tuple_field   <- (attr_outer trivia)* vis? trivia type_expr
 
 # `enum E { A, B(T), C { x: T } }`
-enum_item     <- vis? ws @keyword{'enum'} ws @type{ident} generic_params? ws where_clause? ws
-                 @punctuation{'{'} ws enum_variants? ws @punctuation{'}'} ws
-enum_variants <- enum_variant (ws @punctuation{','} ws enum_variant)* (ws @punctuation{','})?
-enum_variant  <- (attr_outer ws)* @type{ident} enum_variant_body?
-enum_variant_body <- ws @punctuation{'('} ws tuple_fields? ws @punctuation{')'}
-                   / ws @punctuation{'{'} ws struct_fields? ws @punctuation{'}'}
-                   / ws @punctuation{'='} ws expr
+enum_item     <- vis? trivia @keyword{'enum'} trivia @type{ident} generic_params? trivia where_clause? trivia
+                 @punctuation{'{'} trivia enum_variants? trivia @punctuation{'}'} trivia
+enum_variants <- enum_variant (trivia @punctuation{','} trivia enum_variant)* (trivia @punctuation{','})?
+enum_variant  <- (attr_outer trivia)* @type{ident} enum_variant_body?
+enum_variant_body <- trivia @punctuation{'('} trivia tuple_fields? trivia @punctuation{')'}
+                   / trivia @punctuation{'{'} trivia struct_fields? trivia @punctuation{'}'}
+                   / trivia @punctuation{'='} trivia expr
 
 # `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
-impl_item     <- @keyword{'impl'} generic_params? ws impl_head ws where_clause? ws
-                 @punctuation{'{'} ws impl_body ws @punctuation{'}'} ws
-impl_head     <- type_expr (ws @keyword{'for'} ws type_expr)?
+impl_item     <- @keyword{'impl'} generic_params? trivia impl_head trivia where_clause? trivia
+                 @punctuation{'{'} trivia impl_body trivia @punctuation{'}'} trivia
+impl_head     <- type_expr (trivia @keyword{'for'} trivia type_expr)?
 impl_body     <- (item)*
 
 # `trait T<U>: Bound { ... }`
-trait_item    <- vis? ws (@keyword{'unsafe'} ws)? @keyword{'trait'} ws @type{ident}
-                 generic_params? trait_bounds? ws where_clause? ws
-                 @punctuation{'{'} ws impl_body ws @punctuation{'}'} ws
-trait_bounds  <- ws @punctuation{':'} ws bound_list
+trait_item    <- vis? trivia (@keyword{'unsafe'} trivia)? @keyword{'trait'} trivia @type{ident}
+                 generic_params? trait_bounds? trivia where_clause? trivia
+                 @punctuation{'{'} trivia impl_body trivia @punctuation{'}'} trivia
+trait_bounds  <- trivia @punctuation{':'} trivia bound_list
 
 # `mod name;` / `mod name { ... }`
-mod_item      <- vis? ws @keyword{'mod'} ws @variable{ident} ws
-                 (@punctuation{';'} / @punctuation{'{'} ws (item)* ws @punctuation{'}'}) ws
+mod_item      <- vis? trivia @keyword{'mod'} trivia @variable{ident} trivia
+                 (@punctuation{';'} / @punctuation{'{'} trivia (item)* trivia @punctuation{'}'}) trivia
 
 # `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
-extern_item   <- @keyword{'extern'} (ws string_lit)? ws @punctuation{'{'} ws (item)* ws @punctuation{'}'} ws
+extern_item   <- @keyword{'extern'} (trivia string_lit)? trivia @punctuation{'{'} trivia (item)* trivia @punctuation{'}'} trivia
 
-const_item    <- vis? ws @keyword{'const'} ws @constant{ident} ws @punctuation{':'} ws type_expr ws
-                 @punctuation{'='} ws expr ws @punctuation{';'} ws
-static_item   <- vis? ws @keyword{'static'} (ws @keyword{'mut'})? ws @constant{ident} ws @punctuation{':'} ws type_expr ws
-                 @punctuation{'='} ws expr ws @punctuation{';'} ws
-type_alias_item <- vis? ws @keyword{'type'} ws @type{ident} generic_params? ws where_clause? ws
-                   @punctuation{'='} ws type_expr ws @punctuation{';'} ws
+const_item    <- vis? trivia @keyword{'const'} trivia @constant{ident} trivia @punctuation{':'} trivia type_expr trivia
+                 @punctuation{'='} trivia expr trivia @punctuation{';'} trivia
+static_item   <- vis? trivia @keyword{'static'} (trivia @keyword{'mut'})? trivia @constant{ident} trivia @punctuation{':'} trivia type_expr trivia
+                 @punctuation{'='} trivia expr trivia @punctuation{';'} trivia
+type_alias_item <- vis? trivia @keyword{'type'} trivia @type{ident} generic_params? trivia where_clause? trivia
+                   @punctuation{'='} trivia type_expr trivia @punctuation{';'} trivia
 
 # `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
 # soup; balance braces.
-macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} ws @function{ident} ws brace_block ws
+macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} trivia @function{ident} trivia brace_block trivia
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
 # Trailing `;?` absorbed by `rust_file`'s `*^`.
-~macro_invocation_stmt <- @function{ident} @punctuation{'!'} ws macro_args ws (@punctuation{';'})? ws
+~macro_invocation_stmt <- @function{ident} @punctuation{'!'} trivia macro_args trivia (@punctuation{';'})? trivia
 macro_args    <- paren_group
                / brace_block
                / bracket_group
 
 # Visibility modifier.
-vis           <- @keyword{'pub'} (ws @punctuation{'('} ws vis_scope ws @punctuation{')'})?
+vis           <- @keyword{'pub'} (trivia @punctuation{'('} trivia vis_scope trivia @punctuation{')'})?
 vis_scope     <- @keyword{'crate'} / @keyword{'self'} / @keyword{'super'}
-               / @keyword{'in'} ws use_path
+               / @keyword{'in'} trivia use_path
 
 # --- Generic parameters and where-clauses ----------------------------
 
-generic_params <- @punctuation{'<'} ws generic_param_list? ws @punctuation{'>'}
-generic_param_list <- generic_param (ws @punctuation{','} ws generic_param)* (ws @punctuation{','})?
+generic_params <- @punctuation{'<'} trivia generic_param_list? trivia @punctuation{'>'}
+generic_param_list <- generic_param (trivia @punctuation{','} trivia generic_param)* (trivia @punctuation{','})?
 generic_param <- lifetime_param
                / type_param
                / const_param
-lifetime_param <- lifetime (ws @punctuation{':'} ws lifetime_bounds)?
-lifetime_bounds <- lifetime (ws @punctuation{'+'} ws lifetime)*
-type_param    <- @type{ident} (ws @punctuation{':'} ws bound_list)? (ws @punctuation{'='} ws type_expr)?
-const_param   <- @keyword{'const'} ws @constant{ident} ws @punctuation{':'} ws type_expr
+lifetime_param <- lifetime (trivia @punctuation{':'} trivia lifetime_bounds)?
+lifetime_bounds <- lifetime (trivia @punctuation{'+'} trivia lifetime)*
+type_param    <- @type{ident} (trivia @punctuation{':'} trivia bound_list)? (trivia @punctuation{'='} trivia type_expr)?
+const_param   <- @keyword{'const'} trivia @constant{ident} trivia @punctuation{':'} trivia type_expr
 
-where_clause  <- @keyword{'where'} ws where_pred (ws @punctuation{','} ws where_pred)* (ws @punctuation{','})?
-where_pred    <- lifetime ws @punctuation{':'} ws lifetime_bounds
-               / type_expr ws @punctuation{':'} ws bound_list
+where_clause  <- @keyword{'where'} trivia where_pred (trivia @punctuation{','} trivia where_pred)* (trivia @punctuation{','})?
+where_pred    <- lifetime trivia @punctuation{':'} trivia lifetime_bounds
+               / type_expr trivia @punctuation{':'} trivia bound_list
 
-bound_list    <- bound (ws @punctuation{'+'} ws bound)*
+bound_list    <- bound (trivia @punctuation{'+'} trivia bound)*
 bound         <- lifetime
                / (@punctuation{'?'})? type_path
 
@@ -184,20 +184,20 @@ type_expr     <- type_fn
                / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn      <- (type_fn_qualifier ws)* @keyword{'fn'} ws @punctuation{'('} ws type_list? ws @punctuation{')'}
-                 (ws @punctuation{'->'} ws type_expr)?
+~type_fn      <- (type_fn_qualifier trivia)* @keyword{'fn'} trivia @punctuation{'('} trivia type_list? trivia @punctuation{')'}
+                 (trivia @punctuation{'->'} trivia type_expr)?
 type_fn_qualifier <- @keyword{'unsafe'}
-                   / @keyword{'extern'} (ws string_lit)?
-type_list     <- type_expr (ws @punctuation{','} ws type_expr)* (ws @punctuation{','})?
+                   / @keyword{'extern'} (trivia string_lit)?
+type_list     <- type_expr (trivia @punctuation{','} trivia type_expr)* (trivia @punctuation{','})?
 
-type_impl     <- @keyword{'impl'} ws bound_list
-type_dyn      <- @keyword{'dyn'} ws bound_list
+type_impl     <- @keyword{'impl'} trivia bound_list
+type_dyn      <- @keyword{'dyn'} trivia bound_list
 
-type_ref      <- @punctuation{'&'} lifetime? ws (@keyword{'mut'} ws)? type_expr
-type_ptr      <- @punctuation{'*'} ws (@keyword{'mut'} / @keyword{'const'}) ws type_expr
+type_ref      <- @punctuation{'&'} lifetime? trivia (@keyword{'mut'} trivia)? type_expr
+type_ptr      <- @punctuation{'*'} trivia (@keyword{'mut'} / @keyword{'const'}) trivia type_expr
 
-type_array_or_slice <- @punctuation{'['} ws type_expr (ws @punctuation{';'} ws expr)? ws @punctuation{']'}
-type_tuple_or_group <- @punctuation{'('} ws type_list? ws @punctuation{')'}
+type_array_or_slice <- @punctuation{'['} trivia type_expr (trivia @punctuation{';'} trivia expr)? trivia @punctuation{']'}
+type_tuple_or_group <- @punctuation{'('} trivia type_list? trivia @punctuation{')'}
 
 type_never    <- @punctuation{'!'}
 
@@ -215,14 +215,14 @@ type_path_seg <- @type{upper_ident} path_tail?
 path_tail     <- generic_args
                / paren_generic_args
 
-generic_args  <- @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
-               / @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'}
+generic_args  <- @punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'}
+               / @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'}
 # Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
-~paren_generic_args <- @punctuation{'('} ws type_list? ws @punctuation{')'} (ws @punctuation{'->'} ws type_expr)?
-generic_arg_list <- generic_arg (ws @punctuation{','} ws generic_arg)* (ws @punctuation{','})?
+~paren_generic_args <- @punctuation{'('} trivia type_list? trivia @punctuation{')'} (trivia @punctuation{'->'} trivia type_expr)?
+generic_arg_list <- generic_arg (trivia @punctuation{','} trivia generic_arg)* (trivia @punctuation{','})?
 generic_arg   <- lifetime
                / type_expr
-               / @constant{ident} ws @punctuation{'='} ws type_expr
+               / @constant{ident} trivia @punctuation{'='} trivia type_expr
                / expr_block
                / literal
 
@@ -235,7 +235,7 @@ generic_arg   <- lifetime
 
 pattern       <- pattern_or
 pattern_no_or <- pattern_atom
-pattern_or    <- pattern_atom (ws @punctuation{'|'} ws pattern_atom)*
+pattern_or    <- pattern_atom (trivia @punctuation{'|'} trivia pattern_atom)*
 pattern_atom  <- pattern_ref
                / pattern_box
                / pattern_tuple
@@ -246,26 +246,26 @@ pattern_atom  <- pattern_ref
                / pattern_wild
                / pattern_rest
                / pattern_binding
-pattern_ref   <- @punctuation{'&'} (ws @keyword{'mut'})? ws pattern_atom
-pattern_box   <- @keyword{'box'} ws pattern_atom
-pattern_tuple <- @punctuation{'('} ws pattern_list? ws @punctuation{')'}
-pattern_list  <- pattern (ws @punctuation{','} ws pattern)* (ws @punctuation{','})?
+pattern_ref   <- @punctuation{'&'} (trivia @keyword{'mut'})? trivia pattern_atom
+pattern_box   <- @keyword{'box'} trivia pattern_atom
+pattern_tuple <- @punctuation{'('} trivia pattern_list? trivia @punctuation{')'}
+pattern_list  <- pattern (trivia @punctuation{','} trivia pattern)* (trivia @punctuation{','})?
 # Trailing `::` chain leniency absorbed by outer recovery.
 ~pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
-                          (ws pattern_struct_body / ws pattern_tuple)?
-pattern_struct_body <- @punctuation{'{'} ws pattern_struct_fields? ws @punctuation{'}'}
-pattern_struct_fields <- pattern_struct_field (ws @punctuation{','} ws pattern_struct_field)* (ws @punctuation{','})?
-pattern_struct_field  <- @property{ident} ws @punctuation{':'} ws pattern
+                          (trivia pattern_struct_body / trivia pattern_tuple)?
+pattern_struct_body <- @punctuation{'{'} trivia pattern_struct_fields? trivia @punctuation{'}'}
+pattern_struct_fields <- pattern_struct_field (trivia @punctuation{','} trivia pattern_struct_field)* (trivia @punctuation{','})?
+pattern_struct_field  <- @property{ident} trivia @punctuation{':'} trivia pattern
                        / @property{ident}
                        / @punctuation{'..'}
-pattern_slice <- @punctuation{'['} ws pattern_list? ws @punctuation{']'}
-pattern_range <- pattern_literal ws (@punctuation{'..='} / @punctuation{'..'}) ws pattern_literal
-pattern_literal <- string_lit / char_lit / number_lit / @constant{bool_lit}
+pattern_slice <- @punctuation{'['} trivia pattern_list? trivia @punctuation{']'}
+pattern_range <- pattern_literal trivia (@punctuation{'..='} / @punctuation{'..'}) trivia pattern_literal
+pattern_literal <- string_lit / char_lit / number_lit / @constant{'true' / 'false'}
 pattern_wild  <- @punctuation{'_'}
 pattern_rest  <- @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding <- (@keyword{'ref'} ws)? (@keyword{'mut'} ws)? @variable{ident}
-                   (ws @punctuation{'@'} ws pattern_atom)?
+~pattern_binding <- (@keyword{'ref'} trivia)? (@keyword{'mut'} trivia)? @variable{ident}
+                   (trivia @punctuation{'@'} trivia pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
 #
@@ -281,7 +281,7 @@ pattern_rest  <- @punctuation{'..'}
 expr          <- expr_assign
 
 # Right-associative: `a = b = c` parses as `a = (b = c)`.
-expr_assign   <- expr_range ws assign_op ws expr_assign / expr_range
+expr_assign   <- expr_range trivia assign_op trivia expr_assign / expr_range
 
 assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'+='}  / @operator{'-='}
@@ -291,42 +291,42 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'='} !'='
 
 # Range: `a..b`, `a..=b`, `..b`, `a..`, `..`. Non-associative.
-expr_range    <- expr_lor (ws (@punctuation{'..='} / @punctuation{'..'}) ws expr_lor?)?
-               / (@punctuation{'..='} / @punctuation{'..'}) ws expr_lor?
+expr_range    <- expr_lor (trivia (@punctuation{'..='} / @punctuation{'..'}) trivia expr_lor?)?
+               / (@punctuation{'..='} / @punctuation{'..'}) trivia expr_lor?
 
-expr_lor      <- expr_lor ws @operator{'||'} ws expr_land / expr_land
-expr_land     <- expr_land ws @operator{'&&'} ws expr_cmp / expr_cmp
-expr_cmp      <- expr_cmp ws (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') ws expr_bor / expr_bor
-expr_bor      <- expr_bor ws @operator{'|'} !'|' !'=' ws expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor ws @operator{'^'} !'=' ws expr_band / expr_band
-expr_band     <- expr_band ws @operator{'&'} !'&' !'=' ws expr_shift / expr_shift
-expr_shift    <- expr_shift ws (@operator{'<<'} !'=' / @operator{'>>'} !'=') ws expr_add / expr_add
-expr_add      <- expr_add ws (@operator{'+'} !'=' / @operator{'-'} !'=') ws expr_mul / expr_mul
-expr_mul      <- expr_mul ws (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') ws expr_as / expr_as
-expr_as       <- expr_as ws @keyword{'as'} ws type_expr_suffix_marker / expr_unary
+expr_lor      <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
+expr_land     <- expr_land trivia @operator{'&&'} trivia expr_cmp / expr_cmp
+expr_cmp      <- expr_cmp trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_bor / expr_bor
+expr_bor      <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
+expr_bxor     <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
+expr_band     <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_shift / expr_shift
+expr_shift    <- expr_shift trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
+expr_add      <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
+expr_mul      <- expr_mul trivia (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_as / expr_as
+expr_as       <- expr_as trivia @keyword{'as'} trivia type_expr_suffix_marker / expr_unary
 
 # A marker rule: when `as` matches, consume the following type. Split
 # from the cascade so the type_expr stays attached.
 type_expr_suffix_marker <- type_expr
 
-expr_unary    <- (unary_op ws)* expr_postfix
-unary_op      <- @operator{'&'} lifetime? (ws @keyword{'mut'})?
+expr_unary    <- (unary_op trivia)* expr_postfix
+unary_op      <- @operator{'&'} lifetime? (trivia @keyword{'mut'})?
                / @operator{'*'}
                / @operator{'-'}
                / @operator{'!'}
 
 # Postfix chain: calls, indexing, field access, try `?`.
-expr_postfix  <- expr_primary (ws postfix_op)*
+expr_postfix  <- expr_primary (trivia postfix_op)*
 postfix_op    <- @punctuation{'?'}
                / @punctuation{'.'} @keyword{'await'}
                / @punctuation{'.'} postfix_member
-               / @punctuation{'('} ws expr_list? ws @punctuation{')'}
-               / @punctuation{'['} ws expr ws @punctuation{']'}
+               / @punctuation{'('} trivia expr_list? trivia @punctuation{')'}
+               / @punctuation{'['} trivia expr trivia @punctuation{']'}
 postfix_member <- turbofish_method
-                / @function{ident} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
+                / @function{ident} (trivia @punctuation{'('} trivia expr_list? trivia @punctuation{')'})?
                 / @number{digit_seq}
 # Trailing `(args)?` absorbed by outer recovery.
-~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'} (ws @punctuation{'('} ws expr_list? ws @punctuation{')'})?
+~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'} (trivia @punctuation{'('} trivia expr_list? trivia @punctuation{')'})?
 
 expr_primary  <- literal
                / expr_if
@@ -347,30 +347,30 @@ expr_primary  <- literal
                / expr_keyword
 
 # Trailing `(else (if | block))?` leniency absorbed by `rust_file`'s `*^` and `block`'s `^block_close`.
-~expr_if      <- @keyword{'if'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
-                 (ws @keyword{'else'} ws (expr_if / block))?
-expr_match    <- @keyword{'match'} ws expr ws @punctuation{'{'} ws match_arms? ws @punctuation{'}'}
-match_arms    <- match_arm (ws @punctuation{','} ws match_arm)* (ws @punctuation{','})?
-match_arm     <- (attr_outer ws)* pattern (ws @keyword{'if'} ws expr)? ws @punctuation{'=>'} ws expr
-expr_while    <- @keyword{'while'} ws (@keyword{'let'} ws pattern ws @operator{'='} ws)? expr ws block
-expr_loop     <- (loop_label ws)? @keyword{'loop'} ws block
-expr_for      <- @keyword{'for'} ws pattern ws @keyword{'in'} ws expr ws block
+~expr_if      <- @keyword{'if'} trivia (@keyword{'let'} trivia pattern trivia @operator{'='} trivia)? expr trivia block
+                 (trivia @keyword{'else'} trivia (expr_if / block))?
+expr_match    <- @keyword{'match'} trivia expr trivia @punctuation{'{'} trivia match_arms? trivia @punctuation{'}'}
+match_arms    <- match_arm (trivia @punctuation{','} trivia match_arm)* (trivia @punctuation{','})?
+match_arm     <- (attr_outer trivia)* pattern (trivia @keyword{'if'} trivia expr)? trivia @punctuation{'=>'} trivia expr
+expr_while    <- @keyword{'while'} trivia (@keyword{'let'} trivia pattern trivia @operator{'='} trivia)? expr trivia block
+expr_loop     <- (loop_label trivia)? @keyword{'loop'} trivia block
+expr_for      <- @keyword{'for'} trivia pattern trivia @keyword{'in'} trivia expr trivia block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return  <- @keyword{'return'} (ws expr)?
-~expr_break   <- @keyword{'break'} (ws loop_label)? (ws expr)?
-~expr_continue <- @keyword{'continue'} (ws loop_label)?
-expr_unsafe   <- @keyword{'unsafe'} ws block
-expr_closure  <- (@keyword{'move'} ws)? @punctuation{'|'} ws closure_params? ws @punctuation{'|'}
-                 (ws @punctuation{'->'} ws type_expr)? ws expr
-closure_params <- closure_param (ws @punctuation{','} ws closure_param)* (ws @punctuation{','})?
-closure_param <- pattern_no_or (ws @punctuation{':'} ws type_expr)?
+~expr_return  <- @keyword{'return'} (trivia expr)?
+~expr_break   <- @keyword{'break'} (trivia loop_label)? (trivia expr)?
+~expr_continue <- @keyword{'continue'} (trivia loop_label)?
+expr_unsafe   <- @keyword{'unsafe'} trivia block
+expr_closure  <- (@keyword{'move'} trivia)? @punctuation{'|'} trivia closure_params? trivia @punctuation{'|'}
+                 (trivia @punctuation{'->'} trivia type_expr)? trivia expr
+closure_params <- closure_param (trivia @punctuation{','} trivia closure_param)* (trivia @punctuation{','})?
+closure_param <- pattern_no_or (trivia @punctuation{':'} trivia type_expr)?
 expr_block    <- block
-expr_async_block <- @keyword{'async'} (ws @keyword{'move'})? ws block
-expr_tuple_or_paren <- @punctuation{'('} ws expr_list? ws @punctuation{')'}
-expr_array    <- @punctuation{'['} ws expr_array_body? ws @punctuation{']'}
-expr_array_body <- expr ws @punctuation{';'} ws expr
-                 / expr (ws @punctuation{','} ws expr)* (ws @punctuation{','})?
-expr_list     <- expr (ws @punctuation{','} ws expr)* (ws @punctuation{','})?
+expr_async_block <- @keyword{'async'} (trivia @keyword{'move'})? trivia block
+expr_tuple_or_paren <- @punctuation{'('} trivia expr_list? trivia @punctuation{')'}
+expr_array    <- @punctuation{'['} trivia expr_array_body? trivia @punctuation{']'}
+expr_array_body <- expr trivia @punctuation{';'} trivia expr
+                 / expr (trivia @punctuation{','} trivia expr)* (trivia @punctuation{','})?
+expr_list     <- expr (trivia @punctuation{','} trivia expr)* (trivia @punctuation{','})?
 expr_keyword  <- @keyword{'self'} / @keyword{'Self'} / @keyword{'super'} / @keyword{'crate'}
 
 loop_label    <- @punctuation{'\''} @variable{ident} @punctuation{':'}
@@ -378,29 +378,29 @@ loop_label    <- @punctuation{'\''} @variable{ident} @punctuation{':'}
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
 # Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
-~expr_macro_or_path <- path_expr (ws struct_init / @punctuation{'!'} ws macro_args)?
+~expr_macro_or_path <- path_expr (trivia struct_init / @punctuation{'!'} trivia macro_args)?
 path_expr     <- path_seg (@punctuation{'::'} path_seg)*
-path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?
-               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} ws generic_arg_list? ws @punctuation{'>'})?
+path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'})?
+               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'})?
 
-struct_init   <- @punctuation{'{'} ws struct_init_fields? ws @punctuation{'}'}
-struct_init_fields <- struct_init_field (ws @punctuation{','} ws struct_init_field)* (ws @punctuation{','} ws struct_init_base?)?
+struct_init   <- @punctuation{'{'} trivia struct_init_fields? trivia @punctuation{'}'}
+struct_init_fields <- struct_init_field (trivia @punctuation{','} trivia struct_init_field)* (trivia @punctuation{','} trivia struct_init_base?)?
 struct_init_field  <- @punctuation{'..'} expr
-                    / @property{ident} ws @punctuation{':'} ws expr
+                    / @property{ident} trivia @punctuation{':'} trivia expr
                     / @property{ident}
 struct_init_base   <- @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         <- @punctuation{'{'} trivia (block_body trivia @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_body    <- (stmt)*
 
 stmt          <- let_stmt
-               / expr ws @punctuation{';'} ws
-               / expr ws                                    # trailing expression (block-valued)
+               / expr trivia @punctuation{';'} trivia
+               / expr trivia                                    # trailing expression (block-valued)
 
-let_stmt      <- @keyword{'let'} ws pattern (ws @punctuation{':'} ws type_expr)?
-                 (ws @punctuation{'='} ws expr)? (ws @keyword{'else'} ws block)? ws @punctuation{';'} ws
+let_stmt      <- @keyword{'let'} trivia pattern (trivia @punctuation{':'} trivia type_expr)?
+                 (trivia @punctuation{'='} trivia expr)? (trivia @keyword{'else'} trivia block)? trivia @punctuation{';'} trivia
 
 # --- Balanced-bracket helpers (used for macro bodies) -----------------
 #
@@ -423,24 +423,20 @@ balanced_atom <- brace_block
 
 # --- Literals ----------------------------------------------------------
 
-literal       <- string_lit / char_lit / number_lit / @constant{bool_lit}
-bool_lit      <- 'true' / 'false'
+literal       <- string_lit / char_lit / number_lit / @constant{'true' / 'false'}
 
 # Raw strings first (longer prefix), then regular.
 string_lit    <- @string{raw_string / byte_string / regular_string}
-regular_string <- '"' (str_escape / !'"' .)* '"'
-str_escape    <- '\\' (!'\n' .)
-byte_string   <- 'b' '"' (str_escape / !'"' .)* '"'
-raw_string    <- 'r' raw_hashes '"' raw_body_0 '"' raw_hashes
-               / 'br' raw_hashes '"' raw_body_0 '"' raw_hashes
+regular_string <- '"' ('\\' (!'\n' .) / !'"' .)* '"'
+byte_string   <- 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
+raw_string    <- 'r' raw_hashes '"' (.. '"') '"' raw_hashes
+               / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
 # Consume matching hash fences; the body is "up to the closing delim".
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
 raw_hashes    <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
-raw_body_0    <- .. '"'
 
-char_lit      <- @string{"'" (char_escape / !"'" .) "'"}
-char_escape   <- '\\' (!'\n' .)
+char_lit      <- @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
 
 number_lit    <- @number{num_body}
 num_body      <- float_num / int_num
@@ -472,12 +468,8 @@ ident_body    <- [A-Za-z\d_]
 
 # --- Whitespace and comments ------------------------------------------
 
-comment       <- @comment{line_comment / block_comment}
-line_comment  <- '//' .. '\n'
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-block_comment <- '/*' ..= '*/'
+comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
 
-trivia        <- ws
-
-ws            <- (comment / \s)*
+trivia        <- (comment / \s)*

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -54,8 +54,8 @@
 
 # --- Top level --------------------------------------------------------
 
-sql_file   <- (ws statement stmt_sep?)*^[;] ws \z
-stmt_sep   <- ws @punctuation{';'} ws
+sql_file   <- (trivia statement stmt_sep?)*^[;] trivia \z
+stmt_sep   <- trivia @punctuation{';'} trivia
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt
                  / insert_stmt
@@ -88,58 +88,58 @@ statement_body  <- select_stmt
 # Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
 ~select_stmt   <- with_clause? select_core compound_tail* order_clause? limit_clause?
 
-with_clause    <- kw_with (ws kw_recursive)? ws cte_defn (ws @punctuation{','} ws cte_defn)* ws
+with_clause    <- kw_with (trivia kw_recursive)? trivia cte_defn (trivia @punctuation{','} trivia cte_defn)* trivia
 cte_defn       <- @type{bare_ident}
-                  (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
-                  ws kw_as ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
+                  (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
+                  trivia kw_as trivia @punctuation{'('} trivia select_stmt trivia @punctuation{')'}
 
 # Trailing `(window_clause)?` absorbed by `*^[;]`.
-~select_core   <- kw_select (ws (kw_distinct / kw_all))? ws result_list
-                  (ws from_clause)? (ws where_clause)? (ws group_clause)? (ws having_clause)?
-                  (ws window_clause)?
+~select_core   <- kw_select (trivia (kw_distinct / kw_all))? trivia result_list
+                  (trivia from_clause)? (trivia where_clause)? (trivia group_clause)? (trivia having_clause)?
+                  (trivia window_clause)?
 
-result_list    <- result_column (ws @punctuation{','} ws result_column)*
+result_list    <- result_column (trivia @punctuation{','} trivia result_column)*
 # A column expression that didn't reach a known boundary is treated
-# as malformed. The `^^bad_column (ws result_column_boundary)`
+# as malformed. The `^^bad_column (trivia result_column_boundary)`
 # operator anchors the inner branch on the boundary (so e.g.
 # `blob.rid IN leaf` fails because `IN` isn't in the boundary set)
-# and synthesizes the recovery body `(!(ws result_column_boundary) .)*`
+# and synthesizes the recovery body `(!(trivia result_column_boundary) .)*`
 # from the same argument.
 result_column  <- (table_star / @operator{'*'} / aliased_expr)
-                  ^^bad_column (ws result_column_boundary)
+                  ^^bad_column (trivia result_column_boundary)
 result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{';'}
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
                         / kw_union / kw_intersect / kw_except
                         / \z
 table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
-aliased_expr   <- expr (ws kw_as ws @variable{bare_ident_nonkw}
-                      / ws @variable{bare_ident_nonkw})?
+aliased_expr   <- expr (trivia kw_as trivia @variable{bare_ident_nonkw}
+                      / trivia @variable{bare_ident_nonkw})?
 
-compound_tail  <- ws (kw_union (ws kw_all)? / kw_intersect / kw_except) ws select_core
+compound_tail  <- trivia (kw_union (trivia kw_all)? / kw_intersect / kw_except) trivia select_core
 
-from_clause    <- kw_from ws table_or_subquery (ws join_clause)*
-table_or_subquery <- @punctuation{'('} ws select_stmt ws @punctuation{')'} (ws table_alias)?
-                   / qualified_table_name (ws table_alias)?
+from_clause    <- kw_from trivia table_or_subquery (trivia join_clause)*
+table_or_subquery <- @punctuation{'('} trivia select_stmt trivia @punctuation{')'} (trivia table_alias)?
+                   / qualified_table_name (trivia table_alias)?
 # Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
 ~qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
-table_alias    <- kw_as ws @variable{bare_ident_nonkw}
+table_alias    <- kw_as trivia @variable{bare_ident_nonkw}
                 / @variable{bare_ident_nonkw}
 
 # Trailing `(join_constraint)?` absorbed by `*^[;]`.
-~join_clause   <- join_op ws table_or_subquery (ws join_constraint)?
+~join_clause   <- join_op trivia table_or_subquery (trivia join_constraint)?
 join_op        <- @punctuation{','}
-                / kw_natural (ws join_type)? ws kw_join
-                / join_type ws kw_join
+                / kw_natural (trivia join_type)? trivia kw_join
+                / join_type trivia kw_join
                 / kw_join
-join_type      <- kw_left (ws kw_outer)?
-                / kw_right (ws kw_outer)?
-                / kw_full (ws kw_outer)?
+join_type      <- kw_left (trivia kw_outer)?
+                / kw_right (trivia kw_outer)?
+                / kw_full (trivia kw_outer)?
                 / kw_inner
                 / kw_cross
-join_constraint<- kw_on ws expr
-                / kw_using ws @punctuation{'('} ws ident_list ws @punctuation{')'}
-ident_list     <- @variable{bare_ident_nonkw} (ws @punctuation{','} ws @variable{bare_ident_nonkw})*
+join_constraint<- kw_on trivia expr
+                / kw_using trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'}
+ident_list     <- @variable{bare_ident_nonkw} (trivia @punctuation{','} trivia @variable{bare_ident_nonkw})*
 
 # Like `result_column`, `where_clause` uses `^^bad_where` to turn
 # partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY …`
@@ -147,22 +147,22 @@ ident_list     <- @variable{bare_ident_nonkw} (ws @punctuation{','} ws @variable
 # The operator sits *inside* the `kw_where` match so a missing WHERE
 # keyword still fails the rule cleanly (no spurious empty recovery
 # captures on clean SELECTs).
-where_clause   <- kw_where ws (expr ^^bad_where (ws where_clause_boundary))
+where_clause   <- kw_where trivia (expr ^^bad_where (trivia where_clause_boundary))
 where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
                        / kw_union / kw_intersect / kw_except
                        / \z
-group_clause   <- kw_group ws kw_by ws expr (ws @punctuation{','} ws expr)*
-having_clause  <- kw_having ws expr
+group_clause   <- kw_group trivia kw_by trivia expr (trivia @punctuation{','} trivia expr)*
+having_clause  <- kw_having trivia expr
 
-order_clause   <- ws kw_order ws kw_by ws order_item (ws @punctuation{','} ws order_item)*
+order_clause   <- trivia kw_order trivia kw_by trivia order_item (trivia @punctuation{','} trivia order_item)*
 # Trailing `(asc/desc)?` absorbed by `*^[;]`.
-~order_item    <- expr (ws (kw_asc / kw_desc))?
+~order_item    <- expr (trivia (kw_asc / kw_desc))?
 
 # Trailing `(offset)?` absorbed by `*^[;]`.
-~limit_clause  <- ws kw_limit ws expr (ws kw_offset ws expr
-                                      / ws @punctuation{','} ws expr)?
+~limit_clause  <- trivia kw_limit trivia expr (trivia kw_offset trivia expr
+                                      / trivia @punctuation{','} trivia expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
 # Not counted as reserved keywords in SQLite aside from WINDOW and
@@ -171,33 +171,33 @@ order_clause   <- ws kw_order ws kw_by ws order_item (ws @punctuation{','} ws or
 # are matched positionally here, so existing SELECTs that use any of
 # those as identifiers keep working.
 
-window_clause  <- kw_window ws named_window (ws @punctuation{','} ws named_window)*
-named_window   <- @variable{bare_ident_nonkw} ws kw_as ws window_defn
+window_clause  <- kw_window trivia named_window (trivia @punctuation{','} trivia named_window)*
+named_window   <- @variable{bare_ident_nonkw} trivia kw_as trivia window_defn
 
-filter_clause  <- kw_filter ws @punctuation{'('} ws kw_where ws expr ws @punctuation{')'}
+filter_clause  <- kw_filter trivia @punctuation{'('} trivia kw_where trivia expr trivia @punctuation{')'}
 
-window_defn    <- @punctuation{'('} ws
-                      (!window_section_keyword @variable{bare_ident_nonkw} ws)?
-                      (kw_partition ws kw_by ws expr (ws @punctuation{','} ws expr)* ws)?
-                      (window_order_body ws)?
-                      (frame_spec ws)? @punctuation{')'}
+window_defn    <- @punctuation{'('} trivia
+                      (!window_section_keyword @variable{bare_ident_nonkw} trivia)?
+                      (kw_partition trivia kw_by trivia expr (trivia @punctuation{','} trivia expr)* trivia)?
+                      (window_order_body trivia)?
+                      (frame_spec trivia)? @punctuation{')'}
 # Guard the optional base-window-name slot against consuming a keyword
 # that actually starts the next positional section (PARTITION / ORDER /
 # RANGE / ROWS / GROUPS). Without the lookahead, PEG would eat
 # `PARTITION` as a bare identifier and then fail on the partition clause.
 window_section_keyword <- kw_partition / kw_order / kw_range / kw_rows / kw_groups
-window_order_body <- kw_order ws kw_by ws order_item (ws @punctuation{','} ws order_item)*
+window_order_body <- kw_order trivia kw_by trivia order_item (trivia @punctuation{','} trivia order_item)*
 window_ref     <- window_defn / @variable{bare_ident_nonkw}
 
-frame_spec     <- (kw_range / kw_rows / kw_groups) ws
-                  (kw_between ws frame_bound ws kw_and ws frame_bound
+frame_spec     <- (kw_range / kw_rows / kw_groups) trivia
+                  (kw_between trivia frame_bound trivia kw_and trivia frame_bound
                    / frame_bound)
-                  (ws kw_exclude ws frame_exclude)?
-frame_bound    <- kw_unbounded ws (kw_preceding / kw_following)
-                / kw_current ws kw_row
-                / expr ws (kw_preceding / kw_following)
-frame_exclude  <- kw_no ws kw_others
-                / kw_current ws kw_row
+                  (trivia kw_exclude trivia frame_exclude)?
+frame_bound    <- kw_unbounded trivia (kw_preceding / kw_following)
+                / kw_current trivia kw_row
+                / expr trivia (kw_preceding / kw_following)
+frame_exclude  <- kw_no trivia kw_others
+                / kw_current trivia kw_row
                 / kw_group
                 / kw_ties
 
@@ -206,42 +206,42 @@ frame_exclude  <- kw_no ws kw_others
 # `update_set_list`, which is defined here.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~insert_stmt   <- with_clause? insert_prefix ws kw_into ws qualified_table_name
-                  (ws kw_as ws @variable{bare_ident_nonkw})?
-                  (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
-                  ws insert_source
-                  (ws upsert_clause)*
-                  (ws returning_clause)?
+~insert_stmt   <- with_clause? insert_prefix trivia kw_into trivia qualified_table_name
+                  (trivia kw_as trivia @variable{bare_ident_nonkw})?
+                  (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
+                  trivia insert_source
+                  (trivia upsert_clause)*
+                  (trivia returning_clause)?
 
-insert_prefix  <- kw_insert (ws kw_or ws conflict_action)?
+insert_prefix  <- kw_insert (trivia kw_or trivia conflict_action)?
                 / kw_replace
 
-insert_source  <- kw_default ws kw_values
-                / kw_values ws values_row (ws @punctuation{','} ws values_row)*
+insert_source  <- kw_default trivia kw_values
+                / kw_values trivia values_row (trivia @punctuation{','} trivia values_row)*
                 / select_stmt
-values_row     <- @punctuation{'('} ws expr (ws @punctuation{','} ws expr)* ws @punctuation{')'}
+values_row     <- @punctuation{'('} trivia expr (trivia @punctuation{','} trivia expr)* trivia @punctuation{')'}
 
 conflict_action <- kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
 
-upsert_clause  <- kw_on ws kw_conflict
-                  (ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'} (ws where_clause)?)?
-                  ws kw_do ws (kw_nothing
-                             / kw_update ws kw_set ws update_set_list (ws where_clause)?)
+upsert_clause  <- kw_on trivia kw_conflict
+                  (trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'} (trivia where_clause)?)?
+                  trivia kw_do trivia (kw_nothing
+                             / kw_update trivia kw_set trivia update_set_list (trivia where_clause)?)
 
-indexed_col_list <- indexed_col (ws @punctuation{','} ws indexed_col)*
-indexed_col      <- expr (ws kw_collate ws @type{bare_ident})? (ws (kw_asc / kw_desc))?
+indexed_col_list <- indexed_col (trivia @punctuation{','} trivia indexed_col)*
+indexed_col      <- expr (trivia kw_collate trivia @type{bare_ident})? (trivia (kw_asc / kw_desc))?
 
-update_set_list <- update_set_item (ws @punctuation{','} ws update_set_item)*
-update_set_item <- @variable{bare_ident_nonkw} ws @operator{'='} ws expr
-                 / @punctuation{'('} ws ident_list ws @punctuation{')'} ws @operator{'='} ws row_value
+update_set_list <- update_set_item (trivia @punctuation{','} trivia update_set_item)*
+update_set_item <- @variable{bare_ident_nonkw} trivia @operator{'='} trivia expr
+                 / @punctuation{'('} trivia ident_list trivia @punctuation{')'} trivia @operator{'='} trivia row_value
 # RHS of a column-tuple assignment: parens-wrapped row-value (literal
 # list or sub-select) or a single expression that yields a row.
-row_value        <- @punctuation{'('} ws
-                    (select_stmt / expr (ws @punctuation{','} ws expr)*)
-                    ws @punctuation{')'}
+row_value        <- @punctuation{'('} trivia
+                    (select_stmt / expr (trivia @punctuation{','} trivia expr)*)
+                    trivia @punctuation{')'}
                   / expr
 
-returning_clause <- kw_returning ws result_list
+returning_clause <- kw_returning trivia result_list
 
 # --- DML: UPDATE, DELETE ---------------------------------------------
 # UPDATE FROM and DELETE reuse `from_clause` and `where_clause` from
@@ -250,20 +250,20 @@ returning_clause <- kw_returning ws result_list
 # should not pretend the syntax doesn't exist.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~update_stmt <- with_clause? kw_update (ws kw_or ws conflict_action)? ws
-               qualified_table_name (ws table_alias)?
-               ws kw_set ws update_set_list
-               (ws from_clause)?
-               (ws where_clause)?
+~update_stmt <- with_clause? kw_update (trivia kw_or trivia conflict_action)? trivia
+               qualified_table_name (trivia table_alias)?
+               trivia kw_set trivia update_set_list
+               (trivia from_clause)?
+               (trivia where_clause)?
                order_clause?
                limit_clause?
-               (ws returning_clause)?
+               (trivia returning_clause)?
 
-~delete_stmt <- with_clause? kw_delete ws kw_from ws qualified_table_name (ws table_alias)?
-               (ws where_clause)?
+~delete_stmt <- with_clause? kw_delete trivia kw_from trivia qualified_table_name (trivia table_alias)?
+               (trivia where_clause)?
                order_clause?
                limit_clause?
-               (ws returning_clause)?
+               (trivia returning_clause)?
 
 # --- DDL: CREATE / DROP / ALTER TABLE --------------------------------
 # Interleaves column_def with table_constraint because SQLite does
@@ -272,133 +272,133 @@ returning_clause <- kw_returning ws result_list
 # requires a non-keyword leading identifier, while table_constraint
 # starts with CONSTRAINT, PRIMARY, UNIQUE, CHECK, or FOREIGN.
 
-create_table_stmt <- kw_create (ws (kw_temporary / kw_temp))? ws kw_table
-                     (ws kw_if ws kw_not ws kw_exists)?
-                     ws qualified_table_name
-                     ws (@punctuation{'('} ws
+create_table_stmt <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_table
+                     (trivia kw_if trivia kw_not trivia kw_exists)?
+                     trivia qualified_table_name
+                     trivia (@punctuation{'('} trivia
                              (column_def / table_constraint)
-                             (ws @punctuation{','} ws (column_def / table_constraint))*
-                         ws @punctuation{')'}
-                         (ws table_option (ws @punctuation{','} ws table_option)*)?
-                       / kw_as ws select_stmt)
+                             (trivia @punctuation{','} trivia (column_def / table_constraint))*
+                         trivia @punctuation{')'}
+                         (trivia table_option (trivia @punctuation{','} trivia table_option)*)?
+                       / kw_as trivia select_stmt)
 
 # Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
 ~column_def    <- @variable{bare_ident_nonkw}
-                  (ws type_name)?
-                  (ws column_constraint)*
+                  (trivia type_name)?
+                  (trivia column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
 # Trailing `(...)?` leniency absorbed by `*^[;]`.
-~type_name     <- @type{bare_ident_nonkw} (ws @type{bare_ident_nonkw})*
-                  (ws @punctuation{'('} ws signed_number
-                       (ws @punctuation{','} ws signed_number)? ws @punctuation{')'})?
+~type_name     <- @type{bare_ident_nonkw} (trivia @type{bare_ident_nonkw})*
+                  (trivia @punctuation{'('} trivia signed_number
+                       (trivia @punctuation{','} trivia signed_number)? trivia @punctuation{')'})?
 
-signed_number  <- (@operator{'-'} / @operator{'+'})? ws @number{number_body}
+signed_number  <- (@operator{'-'} / @operator{'+'})? trivia @number{number_body}
 
-column_constraint      <- (kw_constraint ws @variable{bare_ident_nonkw} ws)? column_constraint_body
+column_constraint      <- (kw_constraint trivia @variable{bare_ident_nonkw} trivia)? column_constraint_body
 column_constraint_body <-
-      kw_primary ws kw_key (ws (kw_asc / kw_desc))? (ws conflict_clause)? (ws kw_autoincrement)?
-    / (kw_not ws)? kw_null (ws conflict_clause)?
-    / kw_unique (ws conflict_clause)?
-    / kw_check ws @punctuation{'('} ws expr ws @punctuation{')'}
-    / kw_default ws (signed_number / literal / @punctuation{'('} ws expr ws @punctuation{')'})
-    / kw_collate ws @type{bare_ident}
+      kw_primary trivia kw_key (trivia (kw_asc / kw_desc))? (trivia conflict_clause)? (trivia kw_autoincrement)?
+    / (kw_not trivia)? kw_null (trivia conflict_clause)?
+    / kw_unique (trivia conflict_clause)?
+    / kw_check trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
+    / kw_default trivia (signed_number / literal / @punctuation{'('} trivia expr trivia @punctuation{')'})
+    / kw_collate trivia @type{bare_ident}
     / foreign_key_clause
-    / (kw_generated ws kw_always ws)? kw_as ws @punctuation{'('} ws expr ws @punctuation{')'}
-      (ws (kw_stored / kw_virtual))?
+    / (kw_generated trivia kw_always trivia)? kw_as trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
+      (trivia (kw_stored / kw_virtual))?
 
-table_constraint      <- (kw_constraint ws @variable{bare_ident_nonkw} ws)? table_constraint_body
+table_constraint      <- (kw_constraint trivia @variable{bare_ident_nonkw} trivia)? table_constraint_body
 table_constraint_body <-
-      (kw_primary ws kw_key / kw_unique)
-          ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'}
-          (ws conflict_clause)?
-    / kw_check ws @punctuation{'('} ws expr ws @punctuation{')'}
-    / kw_foreign ws kw_key ws @punctuation{'('} ws ident_list ws @punctuation{')'}
-          ws foreign_key_clause
+      (kw_primary trivia kw_key / kw_unique)
+          trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'}
+          (trivia conflict_clause)?
+    / kw_check trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
+    / kw_foreign trivia kw_key trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'}
+          trivia foreign_key_clause
 
 # Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
-~foreign_key_clause <- kw_references ws @type{bare_ident_nonkw}
-                      (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
-                      (ws fk_action)*
-                      (ws fk_deferrable)?
-fk_action      <- kw_on ws (kw_delete / kw_update) ws fk_action_body
-                / kw_match ws @variable{bare_ident_nonkw}
-fk_action_body <- kw_set ws (kw_null / kw_default)
+~foreign_key_clause <- kw_references trivia @type{bare_ident_nonkw}
+                      (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
+                      (trivia fk_action)*
+                      (trivia fk_deferrable)?
+fk_action      <- kw_on trivia (kw_delete / kw_update) trivia fk_action_body
+                / kw_match trivia @variable{bare_ident_nonkw}
+fk_action_body <- kw_set trivia (kw_null / kw_default)
                 / kw_cascade
                 / kw_restrict
-                / kw_no ws kw_action
+                / kw_no trivia kw_action
 # Trailing `(initially)?` absorbed by `*^[;]`.
-~fk_deferrable <- (kw_not ws)? kw_deferrable (ws kw_initially ws (kw_immediate / kw_deferred))?
+~fk_deferrable <- (kw_not trivia)? kw_deferrable (trivia kw_initially trivia (kw_immediate / kw_deferred))?
 
-conflict_clause <- kw_on ws kw_conflict ws conflict_action
+conflict_clause <- kw_on trivia kw_conflict trivia conflict_action
 
-table_option   <- kw_without ws kw_rowid / kw_strict
+table_option   <- kw_without trivia kw_rowid / kw_strict
 
-drop_table_stmt <- kw_drop ws kw_table (ws kw_if ws kw_exists)? ws qualified_table_name
+drop_table_stmt <- kw_drop trivia kw_table (trivia kw_if trivia kw_exists)? trivia qualified_table_name
 
-alter_table_stmt <- kw_alter ws kw_table ws qualified_table_name ws (
-      kw_rename ws kw_to ws @type{bare_ident_nonkw}
-    / kw_rename (ws kw_column)? ws @variable{bare_ident_nonkw}
-        ws kw_to ws @variable{bare_ident_nonkw}
-    / kw_add (ws kw_column)? ws column_def
-    / kw_drop (ws kw_column)? ws @variable{bare_ident_nonkw}
+alter_table_stmt <- kw_alter trivia kw_table trivia qualified_table_name trivia (
+      kw_rename trivia kw_to trivia @type{bare_ident_nonkw}
+    / kw_rename (trivia kw_column)? trivia @variable{bare_ident_nonkw}
+        trivia kw_to trivia @variable{bare_ident_nonkw}
+    / kw_add (trivia kw_column)? trivia column_def
+    / kw_drop (trivia kw_column)? trivia @variable{bare_ident_nonkw}
   )
 
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
 # Trailing `(where_clause)?` absorbed by `*^[;]`.
-~create_index_stmt <- kw_create (ws kw_unique)? ws kw_index
-                     (ws kw_if ws kw_not ws kw_exists)?
-                     ws qualified_table_name
-                     ws kw_on ws @type{bare_ident_nonkw}
-                     ws @punctuation{'('} ws indexed_col_list ws @punctuation{')'}
-                     (ws where_clause)?
+~create_index_stmt <- kw_create (trivia kw_unique)? trivia kw_index
+                     (trivia kw_if trivia kw_not trivia kw_exists)?
+                     trivia qualified_table_name
+                     trivia kw_on trivia @type{bare_ident_nonkw}
+                     trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'}
+                     (trivia where_clause)?
 
-drop_index_stmt   <- kw_drop ws kw_index (ws kw_if ws kw_exists)? ws qualified_table_name
+drop_index_stmt   <- kw_drop trivia kw_index (trivia kw_if trivia kw_exists)? trivia qualified_table_name
 
-create_view_stmt  <- kw_create (ws (kw_temporary / kw_temp))? ws kw_view
-                     (ws kw_if ws kw_not ws kw_exists)?
-                     ws qualified_table_name
-                     (ws @punctuation{'('} ws ident_list ws @punctuation{')'})?
-                     ws kw_as ws select_stmt
+create_view_stmt  <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_view
+                     (trivia kw_if trivia kw_not trivia kw_exists)?
+                     trivia qualified_table_name
+                     (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
+                     trivia kw_as trivia select_stmt
 
-drop_view_stmt    <- kw_drop ws kw_view (ws kw_if ws kw_exists)? ws qualified_table_name
+drop_view_stmt    <- kw_drop trivia kw_view (trivia kw_if trivia kw_exists)? trivia qualified_table_name
 
 # --- DDL: CREATE / DROP TRIGGER --------------------------------------
 # Trigger bodies are `;`-separated sequences of DML/SELECT wrapped in
 # BEGIN...END. The inner `;` is mandatory after each body statement,
 # which keeps the nesting disjoint from sql_file's top-level stmt_sep.
 
-create_trigger_stmt <- kw_create (ws (kw_temporary / kw_temp))? ws kw_trigger
-                       (ws kw_if ws kw_not ws kw_exists)?
-                       ws qualified_table_name
-                       (ws (kw_before / kw_after / kw_instead ws kw_of))?
-                       ws trigger_event
-                       ws kw_on ws @type{bare_ident_nonkw}
-                       (ws kw_for ws kw_each ws kw_row)?
-                       (ws kw_when ws expr)?
-                       ws kw_begin
-                       ws (trigger_body_stmt ws @punctuation{';'} ws)+
+create_trigger_stmt <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_trigger
+                       (trivia kw_if trivia kw_not trivia kw_exists)?
+                       trivia qualified_table_name
+                       (trivia (kw_before / kw_after / kw_instead trivia kw_of))?
+                       trivia trigger_event
+                       trivia kw_on trivia @type{bare_ident_nonkw}
+                       (trivia kw_for trivia kw_each trivia kw_row)?
+                       (trivia kw_when trivia expr)?
+                       trivia kw_begin
+                       trivia (trigger_body_stmt trivia @punctuation{';'} trivia)+
                        kw_end
 trigger_event     <- kw_delete
                    / kw_insert
-                   / kw_update (ws kw_of ws ident_list)?
+                   / kw_update (trivia kw_of trivia ident_list)?
 trigger_body_stmt <- insert_stmt / update_stmt / delete_stmt / select_stmt
 
-drop_trigger_stmt <- kw_drop ws kw_trigger (ws kw_if ws kw_exists)? ws qualified_table_name
+drop_trigger_stmt <- kw_drop trivia kw_trigger (trivia kw_if trivia kw_exists)? trivia qualified_table_name
 
 # --- Transactions & savepoints ---------------------------------------
 
 # Trailing `(transaction-mode)?` absorbed by `*^[;]`.
-~begin_stmt    <- kw_begin (ws (kw_deferred / kw_immediate / kw_exclusive))?
-                  (ws kw_transaction)?
+~begin_stmt    <- kw_begin (trivia (kw_deferred / kw_immediate / kw_exclusive))?
+                  (trivia kw_transaction)?
 # Trailing `(transaction)?` absorbed by `*^[;]`.
-~commit_stmt   <- (kw_commit / kw_end) (ws kw_transaction)?
-~rollback_stmt <- kw_rollback (ws kw_transaction)?
-                  (ws kw_to (ws kw_savepoint)? ws @variable{bare_ident_nonkw})?
-savepoint_stmt <- kw_savepoint ws @variable{bare_ident_nonkw}
-release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
+~commit_stmt   <- (kw_commit / kw_end) (trivia kw_transaction)?
+~rollback_stmt <- kw_rollback (trivia kw_transaction)?
+                  (trivia kw_to (trivia kw_savepoint)? trivia @variable{bare_ident_nonkw})?
+savepoint_stmt <- kw_savepoint trivia @variable{bare_ident_nonkw}
+release_stmt   <- kw_release (trivia kw_savepoint)? trivia @variable{bare_ident_nonkw}
 
 # --- PRAGMA, admin statements, EXPLAIN, CREATE VIRTUAL TABLE ---------
 # EXPLAIN wraps statement_body rather than statement, so
@@ -408,32 +408,32 @@ release_stmt   <- kw_release (ws kw_savepoint)? ws @variable{bare_ident_nonkw}
 # the module is invoked, not merely referenced.
 
 # Trailing `(value)?` absorbed by `*^[;]`.
-~pragma_stmt    <- kw_pragma ws qualified_table_name
-                   (ws @operator{'='} ws pragma_value
-                    / ws @punctuation{'('} ws pragma_value ws @punctuation{')'})?
+~pragma_stmt    <- kw_pragma trivia qualified_table_name
+                   (trivia @operator{'='} trivia pragma_value
+                    / trivia @punctuation{'('} trivia pragma_value trivia @punctuation{')'})?
 pragma_value    <- signed_number / string_lit / @variable{bare_ident}
 
 # Trailing `(into)?` absorbed by `*^[;]`.
-~vacuum_stmt    <- kw_vacuum (ws @type{bare_ident_nonkw})? (ws kw_into ws string_lit)?
+~vacuum_stmt    <- kw_vacuum (trivia @type{bare_ident_nonkw})? (trivia kw_into trivia string_lit)?
 
-attach_stmt     <- kw_attach (ws kw_database)? ws expr ws kw_as
-                   ws @type{bare_ident_nonkw}
-detach_stmt     <- kw_detach (ws kw_database)? ws @type{bare_ident_nonkw}
+attach_stmt     <- kw_attach (trivia kw_database)? trivia expr trivia kw_as
+                   trivia @type{bare_ident_nonkw}
+detach_stmt     <- kw_detach (trivia kw_database)? trivia @type{bare_ident_nonkw}
 
 # Trailing `(target)?` absorbed by `*^[;]`.
-~reindex_stmt   <- kw_reindex (ws qualified_table_name)?
-~analyze_stmt   <- kw_analyze (ws qualified_table_name)?
+~reindex_stmt   <- kw_reindex (trivia qualified_table_name)?
+~analyze_stmt   <- kw_analyze (trivia qualified_table_name)?
 
-explain_stmt    <- kw_explain (ws kw_query ws kw_plan)? ws statement_body
+explain_stmt    <- kw_explain (trivia kw_query trivia kw_plan)? trivia statement_body
 
 # Trailing `(args)?` absorbed by `*^[;]`.
 ~create_virtual_table_stmt <-
-    kw_create ws kw_virtual ws kw_table
-    (ws kw_if ws kw_not ws kw_exists)?
-    ws qualified_table_name
-    ws kw_using ws @function{bare_ident_nonkw}
-    (ws @punctuation{'('} ws vtab_args? ws @punctuation{')'})?
-vtab_args       <- vtab_arg (ws @punctuation{','} ws vtab_arg)*
+    kw_create trivia kw_virtual trivia kw_table
+    (trivia kw_if trivia kw_not trivia kw_exists)?
+    trivia qualified_table_name
+    trivia kw_using trivia @function{bare_ident_nonkw}
+    (trivia @punctuation{'('} trivia vtab_args? trivia @punctuation{')'})?
+vtab_args       <- vtab_arg (trivia @punctuation{','} trivia vtab_arg)*
 # Module args are deliberately permissive — fts5/rtree/etc have
 # module-specific mini-grammars that are not worth modelling.
 vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
@@ -444,30 +444,30 @@ vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
 # operator. No shared-prefix issues between levels.
 
 expr        <- or_expr
-or_expr     <- and_expr (ws kw_or ws and_expr)*
-and_expr    <- not_expr (ws kw_and ws not_expr)*
-not_expr    <- kw_not ws not_expr / cmp_expr
+or_expr     <- and_expr (trivia kw_or trivia and_expr)*
+and_expr    <- not_expr (trivia kw_and trivia not_expr)*
+not_expr    <- kw_not trivia not_expr / cmp_expr
 cmp_expr    <- bit_expr cmp_tail*
-cmp_tail    <- ws kw_is ws (kw_not ws)? bit_expr
-             / ws (kw_not ws)? kw_between ws bit_expr ws kw_and ws bit_expr
-             / ws (kw_not ws)? kw_in ws @punctuation{'('} ws in_args? ws @punctuation{')'}
-             / ws (kw_not ws)? kw_like ws bit_expr (ws kw_escape ws bit_expr)?
-             / ws (kw_not ws)? kw_glob ws bit_expr
-             / ws (kw_not ws)? kw_match ws bit_expr
-             / ws (kw_not ws)? kw_regexp ws bit_expr
-             / ws cmp_op ws bit_expr
-in_args     <- select_stmt / expr (ws @punctuation{','} ws expr)*
+cmp_tail    <- trivia kw_is trivia (kw_not trivia)? bit_expr
+             / trivia (kw_not trivia)? kw_between trivia bit_expr trivia kw_and trivia bit_expr
+             / trivia (kw_not trivia)? kw_in trivia @punctuation{'('} trivia in_args? trivia @punctuation{')'}
+             / trivia (kw_not trivia)? kw_like trivia bit_expr (trivia kw_escape trivia bit_expr)?
+             / trivia (kw_not trivia)? kw_glob trivia bit_expr
+             / trivia (kw_not trivia)? kw_match trivia bit_expr
+             / trivia (kw_not trivia)? kw_regexp trivia bit_expr
+             / trivia cmp_op trivia bit_expr
+in_args     <- select_stmt / expr (trivia @punctuation{','} trivia expr)*
 cmp_op      <- @operator{'=='} / @operator{'<='} / @operator{'>='}
              / @operator{'!='} / @operator{'<>'} / @operator{'='}
              / @operator{'<'} / @operator{'>'}
-bit_expr    <- add_expr (ws bit_op ws add_expr)*
+bit_expr    <- add_expr (trivia bit_op trivia add_expr)*
 bit_op      <- @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
-add_expr    <- mul_expr (ws add_op ws mul_expr)*
+add_expr    <- mul_expr (trivia add_op trivia mul_expr)*
 add_op      <- @operator{'+'} / @operator{'-'}
-mul_expr    <- concat_expr (ws mul_op ws concat_expr)*
+mul_expr    <- concat_expr (trivia mul_op trivia concat_expr)*
 mul_op      <- @operator{'*'} / @operator{'/'} / @operator{'%'}
-concat_expr <- unary_expr (ws @operator{'||'} ws unary_expr)*
-unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) ws unary_expr
+concat_expr <- unary_expr (trivia @operator{'||'} trivia unary_expr)*
+unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) trivia unary_expr
              / primary
 
 # Shared-prefix hotspots: function_call / qualified_column_ref /
@@ -483,24 +483,24 @@ primary     <- literal
              / column_ref_bare
              / bind_param
 
-paren_primary <- @punctuation{'('} ws (select_stmt / expr) ws @punctuation{')'}
+paren_primary <- @punctuation{'('} trivia (select_stmt / expr) trivia @punctuation{')'}
 
 # Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
-~function_call <- @function{bare_ident_nonkw} ws @punctuation{'('} ws func_args? ws @punctuation{')'}
-                 (ws filter_clause)?
-                 (ws kw_over ws window_ref)?
+~function_call <- @function{bare_ident_nonkw} trivia @punctuation{'('} trivia func_args? trivia @punctuation{')'}
+                 (trivia filter_clause)?
+                 (trivia kw_over trivia window_ref)?
 func_args   <- @operator{'*'}
-             / (kw_distinct ws)? expr (ws @punctuation{','} ws expr)*
+             / (kw_distinct trivia)? expr (trivia @punctuation{','} trivia expr)*
 
 qualified_column_ref <- @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
 column_ref_bare      <- @variable{bare_ident_nonkw}
 
-case_expr   <- kw_case (ws expr)? (ws when_clause)+ (ws kw_else ws expr)? ws kw_end
-when_clause <- kw_when ws expr ws kw_then ws expr
+case_expr   <- kw_case (trivia expr)? (trivia when_clause)+ (trivia kw_else trivia expr)? trivia kw_end
+when_clause <- kw_when trivia expr trivia kw_then trivia expr
 
-cast_expr   <- kw_cast ws @punctuation{'('} ws expr ws kw_as ws @type{bare_ident} ws @punctuation{')'}
+cast_expr   <- kw_cast trivia @punctuation{'('} trivia expr trivia kw_as trivia @type{bare_ident} trivia @punctuation{')'}
 
-exists_expr <- kw_exists ws @punctuation{'('} ws select_stmt ws @punctuation{')'}
+exists_expr <- kw_exists trivia @punctuation{'('} trivia select_stmt trivia @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 # Order matters: blob before string (X' prefix consumed first); number
@@ -548,9 +548,9 @@ ident_start       <- [a-zA-Z_]
 ident_cont        <- [a-zA-Z\d_]
 ident_char        <- [a-zA-Z\d_]
 
-double_quoted_id  <- '"' ('""' / !'"' !linebreak .)* '"'
-backtick_id       <- '`' ('``' / !'`' !linebreak .)* '`'
-bracket_id        <- '[' .. (']' / linebreak) ']'
+double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
+backtick_id       <- '`' ('``' / !'`' !\R .)* '`'
+bracket_id        <- '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Per-letter character classes give case-insensitive matching without
@@ -995,11 +995,6 @@ keyword_word <-
 
 # --- Whitespace & comments -------------------------------------------
 
-trivia        <- ws
+comment       <- @comment{'--' .. \R / '/*' ..= '*/'}
 
-ws            <- (comment / \s)*
-comment       <- line_comment / block_comment
-line_comment  <- @comment{'--' .. linebreak}
-block_comment <- @comment{'/*' block_body '*/'}
-block_body    <- .. '*/'
-linebreak     <- \R
+trivia        <- (comment / \s)*

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -15,10 +15,10 @@
 #     kind; revisit when a theme-file is introduced.
 #   - inf / nan are @constant (like true/false), not @number.
 
-toml          <- ws (entry (entry_sep entry)*)? ws \z
+toml          <- trivia (entry (entry_sep entry)*)? trivia \z
 
 entry         <- array_of_tables_header / table_header / pair
-entry_sep     <- inline_space comment? linebreak ws
+entry_sep     <- inline_space comment? \R trivia
 
 # Key-value pair: LHS key as @property, RHS value.
 pair          <- key inline_space @punctuation{'='} inline_space value
@@ -43,67 +43,51 @@ bare_key      <- [A-Za-z\d_\-]+
 #   - inf_nan before number (share the optional sign)
 #   - float before integer (both start with digits; float distinguished
 #     by the frac/exp tail)
-value         <- string_val
-               / @constant{inf_nan}
-               / datetime
-               / float
-               / integer
-               / @constant{bool_lit}
+value         <- @string{basic_multiline / literal_multiline / basic_string / literal_string}
+               / @constant{[+\-]? ('inf' / 'nan')}
+               / @number{full_datetime / local_datetime / local_date / local_time}
+               / @number{[+\-]? unsigned_dec (frac exp? / exp)}
+               / @number{hex_int / oct_int / bin_int / dec_int}
+               / @constant{'true' / 'false'}
                / array
                / inline_table
 
 # --- Strings -----------------------------------------------------------
 # Multi-line forms come first because their opening/closing delimiters
 # are longer than the single-line forms.
-string_val    <- @string{string_body}
-string_body   <- basic_multiline / literal_multiline / basic_string / literal_string
 
-basic_string  <- '"' (basic_char / escape)* '"'
-basic_char    <- !["\\\n\r] .
-escape        <- '\\' (["\\bfnrt] / 'u' hex{4} / 'U' hex{8})
+basic_string  <- '"' ([^"\\\n\r] / escape)* '"'
+escape        <- '\\' (["\\bfnrt] / 'u' [\da-fA-F]{4} / 'U' [\da-fA-F]{8})
 
-basic_multiline <- '"""' multiline_basic_body '"""'
-multiline_basic_body <- .. '"""'
+basic_multiline <- '"""' ..= '"""'
 
-literal_string  <- "'" literal_char* "'"
-literal_char    <- !['\n\r] .
+literal_string  <- "'" [^'\n\r]* "'"
 
-literal_multiline <- "'''" multiline_literal_body "'''"
-multiline_literal_body <- .. "'''"
+literal_multiline <- "'''" ..= "'''"
 
 # --- Numbers -----------------------------------------------------------
-integer       <- @number{int_body}
-int_body      <- hex_int / oct_int / bin_int / dec_int
 dec_int       <- [+\-]? unsigned_dec
 unsigned_dec  <- '0' / [1-9] ('_'? \d)*
-hex_int       <- '0x' hex ('_'? hex)*
+hex_int       <- '0x' [\da-fA-F] ('_'? [\da-fA-F])*
 oct_int       <- '0o' [0-7] ('_'? [0-7])*
 bin_int       <- '0b' [01] ('_'? [01])*
 
-float         <- @number{float_body}
-float_body    <- [+\-]? unsigned_dec (frac exp? / exp)
 frac          <- '.' \d ('_'? \d)*
 exp           <- [eE] [+\-]? \d ('_'? \d)*
 
-inf_nan       <- [+\-]? ('inf' / 'nan')
-bool_lit      <- 'true' / 'false'
-
 # --- Datetime (RFC 3339 subset) ---------------------------------------
-datetime      <- @number{datetime_body}
-datetime_body <- full_datetime / local_datetime / local_date / local_time
 full_datetime <- date date_time_sep time time_offset
 local_datetime <- date date_time_sep time
 local_date    <- date
 local_time    <- time
 date_time_sep <- 'T' / 't' / ' '
 date          <- \d{4} '-' \d{2} '-' \d{2}
-time          <- \d{2} ':' \d{2} ':' \d{2} time_frac?
-time_frac     <- '.' \d+
+time          <- \d{2} ':' \d{2} ':' \d{2} ('.' \d+)?
 time_offset   <- 'Z' / 'z' / [+\-] \d{2} ':' \d{2}
 
 # --- Arrays (multiline, trailing comma, interior comments allowed) -----
-array         <- @punctuation{'['} array_ws array_body? array_ws @punctuation{']'}
-array_body    <- value (array_ws @punctuation{','} array_ws value)* (array_ws @punctuation{','})?
+array         <- @punctuation{'['} trivia array_body? trivia @punctuation{']'}
+array_body    <- value (trivia @punctuation{','} trivia value)* (trivia @punctuation{','})?
 
 # --- Inline tables (no newlines, no trailing comma per v1.0) ----------
 inline_table  <- @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
@@ -112,14 +96,8 @@ inline_pair   <- key inline_space @punctuation{'='} inline_space value
 
 # --- Whitespace & comments --------------------------------------------
 inline_space  <- \h*
-linebreak     <- \R
-comment       <- @comment{'#' .. linebreak}
+comment       <- @comment{'#' .. \R}
 
 # Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
-trivia        <- ws
-
-ws            <- (comment / \s)*
-array_ws      <- ws
-
-hex           <- [\da-fA-F]
+trivia        <- (comment / \s)*

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -510,11 +510,8 @@ The compiler treats one rule name specially:
   rules outside the `trivia` subgraph; only ignorable bytes go in.
 
   ```peg
-  trivia        <- ws
-  ws            <- (comment / [ \t\r\n])*
-  comment       <- @comment{line_comment / block_comment}
-  line_comment  <- '//' (!'\n' .)*
-  block_comment <- '/*' (!'*/' .)* '*/'
+  trivia        <- (comment / \s)*
+  comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
   ```
 
   Grammars without a `trivia` rule leave all trivia bits false;

--- a/tests/pegc_tests.rs
+++ b/tests/pegc_tests.rs
@@ -51,12 +51,12 @@ fn stats_json_grammar_emits_expected_record() {
     );
     assert_eq!(
         json_field_str(line, "instructions"),
-        Some("201"),
+        Some("205"),
         "JSON instruction count drifted"
     );
     assert_eq!(
         json_field_str(line, "rules"),
-        Some("17"),
+        Some("12"),
         "JSON rule count drifted"
     );
     let count: usize = json_field_str(line, "capture_kinds_count")


### PR DESCRIPTION
Post-#86 / #87 cleanup sweep across all eight shipped grammars: `trivia <- ws` / `ws <- (comment / \s)*` collapses to a single `trivia` rule, single-use thin aliases inline at their call sites, and the new `..= delim` form folds `'/*' (.. '*/') '*/'`-style block comments into `'/*' ..= '*/'`. Trailing `!.` becomes `\z` for consistency.

Bytecode shape (pre → post):

| grammar | instructions | rules |
|---|---|---|
| `c.peg` | 2626 → 2587 | 112 → 103 |
| `css.peg` | 713 → 632 | 56 → 36 |
| `go.peg` | 3386 → 3346 | 153 → 143 |
| `javascript.peg` | 3095 → 3060 | 149 → 140 |
| `json.peg` | 201 → 205 | 17 → 12 |
| `rust.peg` | 3599 → 3590 | 186 → 179 |
| `sqlite.peg` | 5777 → 5776 | 429 → 424 |
| `toml.peg` | 637 → 562 | 60 → 41 |

`json.peg` gains four instructions because `\s*` now expands at six call sites instead of going through a `spacing` rule; everywhere else the inlined alternates outweigh the saved call/return frames. The reserved-name `trivia` subgraph (see `src/pegc/analysis.rs::compute_trivia_rules`) is unchanged — the transitively reachable rule set is the same, the indirection through `ws` is just gone. The README example follows the new convention.
