### PR TITLE
tests: compile each grammar once per test process

### DIFF
--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
 
-fn compile_c() -> Program {
-    pegc::compile(C_GRAMMAR).expect("C grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static C_PROGRAM: OnceLock<Program> = OnceLock::new();
+static C_INIT: Mutex<()> = Mutex::new(());
+
+fn c_program() -> &'static Program {
+    if let Some(p) = C_PROGRAM.get() {
+        return p;
+    }
+    let _guard = C_INIT
+        .lock()
+        .expect("C grammar compile previously failed; see the first failure");
+    C_PROGRAM.get_or_init(|| pegc::compile(C_GRAMMAR).expect("C grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = c_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_c();
+    let prog = c_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -41,14 +60,14 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_c();
+    let prog = c_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
 
 #[test]
 fn capture_kinds_stay_in_theme_vocabulary() {
-    let prog = compile_c();
+    let prog = c_program();
     let allowed: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_css_tests.rs
+++ b/tests/grammar_css_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
 
-fn compile_css() -> Program {
-    pegc::compile(CSS_GRAMMAR).expect("CSS grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static CSS_PROGRAM: OnceLock<Program> = OnceLock::new();
+static CSS_INIT: Mutex<()> = Mutex::new(());
+
+fn css_program() -> &'static Program {
+    if let Some(p) = CSS_PROGRAM.get() {
+        return p;
+    }
+    let _guard = CSS_INIT
+        .lock()
+        .expect("CSS grammar compile previously failed; see the first failure");
+    CSS_PROGRAM.get_or_init(|| pegc::compile(CSS_GRAMMAR).expect("CSS grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = css_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_css();
+    let prog = css_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -41,14 +60,14 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_css();
+    let prog = css_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
 
 #[test]
 fn capture_kinds_stay_in_theme_vocabulary() {
-    let prog = compile_css();
+    let prog = css_program();
     let allowed: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 
-fn compile_go() -> Program {
-    pegc::compile(GO_GRAMMAR).expect("Go grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static GO_PROGRAM: OnceLock<Program> = OnceLock::new();
+static GO_INIT: Mutex<()> = Mutex::new(());
+
+fn go_program() -> &'static Program {
+    if let Some(p) = GO_PROGRAM.get() {
+        return p;
+    }
+    let _guard = GO_INIT
+        .lock()
+        .expect("Go grammar compile previously failed; see the first failure");
+    GO_PROGRAM.get_or_init(|| pegc::compile(GO_GRAMMAR).expect("Go grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = go_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_go();
+    let prog = go_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -57,14 +76,14 @@ fn non_ws_recovery_literals<'a>(
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_go();
+    let prog = go_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
 
 #[test]
 fn capture_kinds_stay_in_theme_vocabulary() {
-    let prog = compile_go();
+    let prog = go_program();
     let allowed: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 
-fn compile_js() -> Program {
-    pegc::compile(JS_GRAMMAR).expect("JavaScript grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static JS_PROGRAM: OnceLock<Program> = OnceLock::new();
+static JS_INIT: Mutex<()> = Mutex::new(());
+
+fn js_program() -> &'static Program {
+    if let Some(p) = JS_PROGRAM.get() {
+        return p;
+    }
+    let _guard = JS_INIT
+        .lock()
+        .expect("JavaScript grammar compile previously failed; see the first failure");
+    JS_PROGRAM.get_or_init(|| pegc::compile(JS_GRAMMAR).expect("JavaScript grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = js_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_js();
+    let prog = js_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -49,14 +68,14 @@ fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String>
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_js();
+    let prog = js_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
 
 #[test]
 fn capture_kinds_stay_in_theme_vocabulary() {
-    let prog = compile_js();
+    let prog = js_program();
     let allowed: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const RUST_GRAMMAR: &str = include_str!("../grammars/rust.peg");
 
-fn compile_rust() -> Program {
-    pegc::compile(RUST_GRAMMAR).expect("Rust grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static RUST_PROGRAM: OnceLock<Program> = OnceLock::new();
+static RUST_INIT: Mutex<()> = Mutex::new(());
+
+fn rust_program() -> &'static Program {
+    if let Some(p) = RUST_PROGRAM.get() {
+        return p;
+    }
+    let _guard = RUST_INIT
+        .lock()
+        .expect("Rust grammar compile previously failed; see the first failure");
+    RUST_PROGRAM.get_or_init(|| pegc::compile(RUST_GRAMMAR).expect("Rust grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = rust_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_rust();
+    let prog = rust_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -57,7 +76,7 @@ fn recovery_literals<'a>(captures: &[Capture], kinds: &[String], input: &'a str)
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_rust();
+    let prog = rust_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
@@ -66,7 +85,7 @@ fn grammar_parses_and_compiles() {
 fn capture_kinds_stay_in_theme_vocabulary() {
     // The grammar must not invent capture names outside the hardcoded
     // theme vocabulary in src/highlight/theme.rs.
-    let prog = compile_rust();
+    let prog = rust_program();
     let allowed: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -1,19 +1,36 @@
 use std::collections::HashSet;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const SQLITE_GRAMMAR: &str = include_str!("../grammars/sqlite.peg");
 
-fn compile_sql() -> &'static Program {
-    static SQLITE_PROGRAM: OnceLock<Program> = OnceLock::new();
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static SQLITE_PROGRAM: OnceLock<Program> = OnceLock::new();
+static SQLITE_INIT: Mutex<()> = Mutex::new(());
+
+fn sqlite_program() -> &'static Program {
+    if let Some(p) = SQLITE_PROGRAM.get() {
+        return p;
+    }
+    let _guard = SQLITE_INIT
+        .lock()
+        .expect("SQLite grammar compile previously failed; see the first failure");
     SQLITE_PROGRAM
         .get_or_init(|| pegc::compile(SQLITE_GRAMMAR).expect("SQLite grammar should compile"))
 }
 
+#[test]
+fn grammar_compiles() {
+    let _ = sqlite_program();
+}
+
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_sql();
+    let prog = sqlite_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -81,7 +98,7 @@ fn assert_not_clean_parse(input: &str) {
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_sql();
+    let prog = sqlite_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
     eprintln!(
@@ -99,7 +116,7 @@ fn bytecode_size_within_expected_range() {
     // something either shrank surprisingly (a regression) or grew
     // surprisingly (review warranted). Recompute if the change is
     // intentional.
-    let n_instr = compile_sql().code.len();
+    let n_instr = sqlite_program().code.len();
     assert!(
         (4500..=7500).contains(&n_instr),
         "bytecode size {n_instr} outside expected range [4500, 7500]; \
@@ -109,7 +126,7 @@ fn bytecode_size_within_expected_range() {
 
 #[test]
 fn capture_kinds_are_only_theme_kinds() {
-    let prog = compile_sql();
+    let prog = sqlite_program();
     let expected: HashSet<&str> = [
         "keyword",
         "string",

--- a/tests/grammar_toml_tests.rs
+++ b/tests/grammar_toml_tests.rs
@@ -1,16 +1,35 @@
 use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegvm::{Capture, Program, VM};
 
 const TOML_GRAMMAR: &str = include_str!("../grammars/toml.peg");
 
-fn compile_toml() -> Program {
-    pegc::compile(TOML_GRAMMAR).expect("TOML grammar should compile")
+// Compile the grammar exactly once per test process. The init lock's
+// poisoning is what concentrates a broken-grammar failure into one
+// informative panic plus N-1 trivial "previously failed" panics across
+// the rest of the file's tests.
+static TOML_PROGRAM: OnceLock<Program> = OnceLock::new();
+static TOML_INIT: Mutex<()> = Mutex::new(());
+
+fn toml_program() -> &'static Program {
+    if let Some(p) = TOML_PROGRAM.get() {
+        return p;
+    }
+    let _guard = TOML_INIT
+        .lock()
+        .expect("TOML grammar compile previously failed; see the first failure");
+    TOML_PROGRAM.get_or_init(|| pegc::compile(TOML_GRAMMAR).expect("TOML grammar should compile"))
+}
+
+#[test]
+fn grammar_compiles() {
+    let _ = toml_program();
 }
 
 fn run(input: &str) -> (usize, Vec<Capture>, Vec<String>, bool) {
-    let prog = compile_toml();
+    let prog = toml_program();
     let r = VM::new(&prog.code, input.as_bytes()).run();
     (
         r.matched,
@@ -48,14 +67,14 @@ fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
 
 #[test]
 fn grammar_parses_and_compiles() {
-    let prog = compile_toml();
+    let prog = toml_program();
     assert!(!prog.code.is_empty());
     assert!(!prog.capture_kinds.is_empty());
 }
 
 #[test]
 fn capture_kinds_are_only_theme_kinds() {
-    let prog = compile_toml();
+    let prog = toml_program();
     let expected: HashSet<&str> = [
         "comment",
         "property",


### PR DESCRIPTION
Each `tests/grammar_<lang>_tests.rs` used to re-compile its grammar at the start of every `#[test]`. A structural error in the grammar (an undefined rule, an unresolved boundary) then surfaced as N near-identical panics — PR #123 hit this with 32 simultaneous `undefined rule: bool_lit` failures in the Rust file.

Each per-grammar file now caches the compiled `Program` in a `OnceLock<Program>` whose initialiser is serialised behind a `Mutex<()>` used solely for poison semantics. The first thread to access the static panics with the real `CompileError`; the lock becomes poisoned; subsequent tests panic on `.lock()` with the one-line `previously failed; see the first failure` message. Cargo's output reports one informative red block plus N-1 trivial poison blocks.

A dedicated `grammar_compiles` test per file — alphabetically early — gives that real panic a stable, obviously-named slot in the test output, separating "grammar is broken" from "this specific assertion failed".

`grammar_sql_tests.rs` previously used `OnceLock` directly, which retries the initialiser on panic and so didn't mitigate the cascade. It's been migrated to the same `OnceLock` + `Mutex<()>` pattern.

Stays on the project's 1.78 MSRV — `LazyLock` would be cleaner but stabilised in 1.80, and clippy's `incompatible_msrv` rejects it under the `--all-targets` clippy CI gate.

Closes #127
