### PR TITLE
pegc: source spans on Pattern AST for diagnostic line:col

### DIFF
--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use super::compiler::CompileError;
 use super::parser::Grammar;
-use super::pattern::Pattern;
+use super::pattern::{Pattern, Span};
 use crate::pegvm::CharSet;
 
 /// Returns the set of rule names that are left-recursive — both direct
@@ -75,19 +75,19 @@ pub(crate) fn compute_nullable(rules: &HashMap<String, Pattern>) -> HashSet<Stri
 
 pub(crate) fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> bool {
     match pat {
-        Pattern::Literal(bytes) => bytes.is_empty(),
-        Pattern::CharClass(_) | Pattern::AnyChar => false,
-        Pattern::Sequence(items) => items.iter().all(|p| pattern_nullable(p, nullable)),
-        Pattern::OrderedChoice(items) => items.iter().any(|p| pattern_nullable(p, nullable)),
-        Pattern::Repeat(_) | Pattern::Optional(_) => true,
-        Pattern::RepeatOne(inner) => pattern_nullable(inner, nullable),
+        Pattern::Literal { bytes, .. } => bytes.is_empty(),
+        Pattern::CharClass { .. } | Pattern::AnyChar { .. } => false,
+        Pattern::Sequence { items, .. } => items.iter().all(|p| pattern_nullable(p, nullable)),
+        Pattern::OrderedChoice { alts, .. } => alts.iter().any(|p| pattern_nullable(p, nullable)),
+        Pattern::Repeat { .. } | Pattern::Optional { .. } => true,
+        Pattern::RepeatOne { inner, .. } => pattern_nullable(inner, nullable),
         // Predicates consume no input, so they always succeed-or-fail
         // without advancing — treated as nullable for sequence
         // propagation. They can still left-recurse: !A α matches only
         // if A would fail at sp, and A's evaluation can left-recurse
         // through itself just like a direct call.
-        Pattern::NotPredicate(_) | Pattern::AndPredicate(_) => true,
-        Pattern::Capture(_, inner) => pattern_nullable(inner, nullable),
+        Pattern::NotPredicate { .. } | Pattern::AndPredicate { .. } => true,
+        Pattern::Capture { inner, .. } => pattern_nullable(inner, nullable),
         // Catch succeeds-as-inner when inner succeeds, or
         // succeeds-as-recovery when inner fails. The recovery branch
         // only runs on inner's failure, so it never contributes a
@@ -95,13 +95,13 @@ pub(crate) fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> boo
         // inner.
         Pattern::Catch { inner, .. } => pattern_nullable(inner, nullable),
         // `~` is runtime-transparent.
-        Pattern::Lenient(inner) => pattern_nullable(inner, nullable),
+        Pattern::Lenient { inner, .. } => pattern_nullable(inner, nullable),
         // Pre-resolution placeholder for `^^lbl`. Nullability follows
         // inner just like `Catch` — the eventual recovery body
         // `(!B .)*` is always nullable but only contributes on
         // failure, same shape as `Catch`'s analysis.
         Pattern::InferBoundaryCatch { inner, .. } => pattern_nullable(inner, nullable),
-        Pattern::NonTerminal(name) => nullable.contains(name),
+        Pattern::NonTerminal { name, .. } => nullable.contains(name),
     }
 }
 
@@ -122,8 +122,8 @@ fn compute_first_calls(
 
 fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut HashSet<String>) {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
-        Pattern::Sequence(items) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Sequence { items, .. } => {
             for it in items {
                 collect_first_calls(it, nullable, out);
                 if !pattern_nullable(it, nullable) {
@@ -131,17 +131,17 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
                 }
             }
         }
-        Pattern::OrderedChoice(items) => {
-            for it in items {
+        Pattern::OrderedChoice { alts, .. } => {
+            for it in alts {
                 collect_first_calls(it, nullable, out);
             }
         }
-        Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner)
-        | Pattern::Optional(inner)
-        | Pattern::NotPredicate(inner)
-        | Pattern::AndPredicate(inner)
-        | Pattern::Capture(_, inner) => collect_first_calls(inner, nullable, out),
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. } => collect_first_calls(inner, nullable, out),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -154,13 +154,13 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
             collect_first_calls(inner, nullable, out);
             collect_first_calls(recovery, nullable, out);
         }
-        Pattern::Lenient(inner) => collect_first_calls(inner, nullable, out),
+        Pattern::Lenient { inner, .. } => collect_first_calls(inner, nullable, out),
         // Pre-resolution placeholder for `^^lbl`. Only the inner can
         // route a first-call edge — the synthesized recovery
         // `(!B .)*` has no non-terminals other than B, and the
         // resolver hasn't picked B yet.
         Pattern::InferBoundaryCatch { inner, .. } => collect_first_calls(inner, nullable, out),
-        Pattern::NonTerminal(name) => {
+        Pattern::NonTerminal { name, .. } => {
             out.insert(name.clone());
         }
     }
@@ -304,19 +304,19 @@ pub fn compute_first(grammar: &Grammar) -> HashMap<String, FollowSet> {
 fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
     let mut out = FollowSet::new();
     match pat {
-        Pattern::Literal(bytes) => {
+        Pattern::Literal { bytes, .. } => {
             out.insert(FollowElement::Literal(bytes.clone()));
         }
-        Pattern::CharClass(cs) => {
-            out.insert(FollowElement::CharClass(*cs));
+        Pattern::CharClass { set, .. } => {
+            out.insert(FollowElement::CharClass(*set));
         }
-        Pattern::AnyChar => {
+        Pattern::AnyChar { .. } => {
             out.insert(FollowElement::CharClass(CharSet::full()));
         }
-        Pattern::NonTerminal(name) => {
+        Pattern::NonTerminal { name, .. } => {
             out.insert(FollowElement::Rule(name.clone()));
         }
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             for it in items {
                 out.extend(pattern_first(it, nullable));
                 if !pattern_nullable(it, nullable) {
@@ -324,19 +324,21 @@ fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
                 }
             }
         }
-        Pattern::OrderedChoice(alts) => {
+        Pattern::OrderedChoice { alts, .. } => {
             for alt in alts {
                 out.extend(pattern_first(alt, nullable));
             }
         }
-        Pattern::Repeat(inner) | Pattern::RepeatOne(inner) | Pattern::Optional(inner) => {
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. } => {
             out.extend(pattern_first(inner, nullable));
         }
-        Pattern::NotPredicate(_) => {}
-        Pattern::AndPredicate(inner) => {
+        Pattern::NotPredicate { .. } => {}
+        Pattern::AndPredicate { inner, .. } => {
             out.extend(pattern_first(inner, nullable));
         }
-        Pattern::Capture(kind, inner) => {
+        Pattern::Capture { kind, inner, .. } => {
             for elem in pattern_first(inner, nullable) {
                 out.insert(FollowElement::Capture {
                     kind: kind.clone(),
@@ -349,7 +351,7 @@ fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
             // in FIRST.
             out.extend(pattern_first(inner, nullable));
         }
-        Pattern::Lenient(inner) => {
+        Pattern::Lenient { inner, .. } => {
             out.extend(pattern_first(inner, nullable));
         }
         // Pre-resolution placeholder for `^^lbl`. The eventual recovery
@@ -409,11 +411,11 @@ fn collect_follow(
     changed: &mut bool,
 ) {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
-        Pattern::NonTerminal(name) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::NonTerminal { name, .. } => {
             extend_follow(follow, name, trailing, changed);
         }
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             // For each item at index i, "trailing-for-item-i" is FIRST of
             // items[i+1..] (sequenced through nullable items) union the
             // outer trailing when all of items[i+1..] is nullable.
@@ -433,12 +435,12 @@ fn collect_follow(
                 collect_follow(&items[i], nullable, &sub_trailing, follow, changed);
             }
         }
-        Pattern::OrderedChoice(alts) => {
+        Pattern::OrderedChoice { alts, .. } => {
             for alt in alts {
                 collect_follow(alt, nullable, trailing, follow, changed);
             }
         }
-        Pattern::Repeat(inner) | Pattern::RepeatOne(inner) => {
+        Pattern::Repeat { inner, .. } | Pattern::RepeatOne { inner, .. } => {
             // The body can iterate, so its tail is followed by another
             // copy of FIRST(body). Plus whatever trails the repeat.
             let body_first = pattern_first(inner, nullable);
@@ -446,10 +448,10 @@ fn collect_follow(
             sub_trailing.extend(body_first);
             collect_follow(inner, nullable, &sub_trailing, follow, changed);
         }
-        Pattern::Optional(inner) => {
+        Pattern::Optional { inner, .. } => {
             collect_follow(inner, nullable, trailing, follow, changed);
         }
-        Pattern::NotPredicate(_) => {
+        Pattern::NotPredicate { .. } => {
             // Predicate consumes nothing; its body's FOLLOW relations
             // don't affect the outer sequence's flow. References inside
             // a `!p` predicate still need their FIRST recorded though,
@@ -457,7 +459,7 @@ fn collect_follow(
             // appear — but FOLLOW is "what's after when matched," and
             // a `!p` predicate doesn't match anything. Skip.
         }
-        Pattern::AndPredicate(inner) => {
+        Pattern::AndPredicate { inner, .. } => {
             // Similar zero-width logic. Inner FOLLOW relations are
             // structurally meaningful (a NonTerminal inside `&p` does
             // have its own callers expecting it to FIRST-match certain
@@ -465,7 +467,7 @@ fn collect_follow(
             // doesn't continue into a consumed tail.
             collect_follow(inner, nullable, &FollowSet::new(), follow, changed);
         }
-        Pattern::Capture(_, inner) => {
+        Pattern::Capture { inner, .. } => {
             collect_follow(inner, nullable, trailing, follow, changed);
         }
         Pattern::Catch {
@@ -483,7 +485,7 @@ fn collect_follow(
             collect_follow(inner, nullable, trailing, follow, changed);
             collect_follow(recovery, nullable, trailing, follow, changed);
         }
-        Pattern::Lenient(inner) => {
+        Pattern::Lenient { inner, .. } => {
             collect_follow(inner, nullable, trailing, follow, changed);
         }
         // Pre-resolution placeholder for `^^lbl`. Treat like `Catch`'s
@@ -536,6 +538,11 @@ pub struct LintFinding {
     pub rule: String,
     /// The rule whose body contains an unanchored call site to [`Self::rule`].
     pub caller: String,
+    /// Source position of the unanchored `NonTerminal` call within
+    /// `caller`'s body. Populated from [`Pattern::NonTerminal`]'s span;
+    /// rendered as `{line}:{col}:` in `CompileError::PartialMatchLeniency`'s
+    /// Display impl so each finding is directly navigable.
+    pub call_site: Span,
 }
 
 /// Static lint for the partial-match-leniency antipattern from PR #101.
@@ -609,10 +616,10 @@ struct LintCtx<'a> {
 fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
     let mut out = FollowSet::new();
     match pat {
-        Pattern::Optional(inner) => {
+        Pattern::Optional { inner, .. } => {
             out.extend(pattern_first(inner, nullable));
         }
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             for item in items.iter().rev() {
                 if pattern_nullable(item, nullable) {
                     if is_trailing_optional_like(item) {
@@ -623,7 +630,7 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
                 }
             }
         }
-        Pattern::Capture(_, inner) => {
+        Pattern::Capture { inner, .. } => {
             out.extend(trailing_first(inner, nullable));
         }
         Pattern::Catch { inner, .. } => {
@@ -631,7 +638,7 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         }
         // Definition-level `~name <-` opts the rule out of being a flag
         // target: its `trailing_first` is empty regardless of body shape.
-        Pattern::Lenient(_) => {}
+        Pattern::Lenient { .. } => {}
         _ => {}
     }
     out
@@ -643,8 +650,8 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
 /// chains.
 fn is_trailing_optional_like(pat: &Pattern) -> bool {
     match pat {
-        Pattern::Optional(_) => true,
-        Pattern::Capture(_, inner) => is_trailing_optional_like(inner),
+        Pattern::Optional { .. } => true,
+        Pattern::Capture { inner, .. } => is_trailing_optional_like(inner),
         Pattern::Catch { inner, .. } => is_trailing_optional_like(inner),
         _ => false,
     }
@@ -666,8 +673,8 @@ fn walk_for_call_sites<'a>(
     findings: &mut Vec<LintFinding>,
 ) {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
-        Pattern::NonTerminal(name) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::NonTerminal { name, span } => {
             let Some(t) = ctx.trailing.get(name) else {
                 return;
             };
@@ -688,9 +695,10 @@ fn walk_for_call_sites<'a>(
                 kind: LintKind::PartialMatchLeniency,
                 rule: name.clone(),
                 caller: caller.to_string(),
+                call_site: *span,
             });
         }
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             for i in 0..items.len() {
                 continuations.push(&items[i + 1..]);
                 walk_for_call_sites(
@@ -704,18 +712,18 @@ fn walk_for_call_sites<'a>(
                 continuations.pop();
             }
         }
-        Pattern::OrderedChoice(alts) => {
+        Pattern::OrderedChoice { alts, .. } => {
             for alt in alts {
                 walk_for_call_sites(alt, caller, continuations, inside_catch, ctx, findings);
             }
         }
-        Pattern::Optional(inner)
-        | Pattern::Capture(_, inner)
-        | Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner) => {
+        Pattern::Optional { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. } => {
             walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
         }
-        Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
+        Pattern::NotPredicate { inner, .. } | Pattern::AndPredicate { inner, .. } => {
             let mut isolated: Vec<&[Pattern]> = Vec::new();
             walk_for_call_sites(inner, caller, &mut isolated, inside_catch, ctx, findings);
         }
@@ -733,7 +741,7 @@ fn walk_for_call_sites<'a>(
         // empty — so the rule never appears as a flag target. The walker
         // still descends transparently to find unrelated unguarded calls
         // the lenient rule's body may itself contain.
-        Pattern::Lenient(inner) => {
+        Pattern::Lenient { inner, .. } => {
             walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
         }
         // The resolver runs before the lint, so the lint should
@@ -851,8 +859,8 @@ fn find_callsite_unguarded<'a>(
     found_callsite: &mut bool,
 ) -> bool {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => false,
-        Pattern::NonTerminal(name) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => false,
+        Pattern::NonTerminal { name, .. } => {
             if name != probe.target_caller {
                 return false;
             }
@@ -866,7 +874,7 @@ fn find_callsite_unguarded<'a>(
                 visited_callers,
             )
         }
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             for i in 0..items.len() {
                 continuations.push(&items[i + 1..]);
                 let leaked = find_callsite_unguarded(
@@ -885,7 +893,7 @@ fn find_callsite_unguarded<'a>(
             }
             false
         }
-        Pattern::OrderedChoice(alts) => {
+        Pattern::OrderedChoice { alts, .. } => {
             for alt in alts {
                 if find_callsite_unguarded(
                     alt,
@@ -901,10 +909,10 @@ fn find_callsite_unguarded<'a>(
             }
             false
         }
-        Pattern::Optional(inner)
-        | Pattern::Capture(_, inner)
-        | Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner) => find_callsite_unguarded(
+        Pattern::Optional { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. } => find_callsite_unguarded(
             inner,
             probe,
             continuations,
@@ -913,7 +921,7 @@ fn find_callsite_unguarded<'a>(
             visited_callers,
             found_callsite,
         ),
-        Pattern::NotPredicate(inner) | Pattern::AndPredicate(inner) => {
+        Pattern::NotPredicate { inner, .. } | Pattern::AndPredicate { inner, .. } => {
             let mut isolated: Vec<&[Pattern]> = Vec::new();
             find_callsite_unguarded(
                 inner,
@@ -954,7 +962,7 @@ fn find_callsite_unguarded<'a>(
         // the marker only suppresses the IMMEDIATE call's flag (handled
         // in `walk_for_call_sites`), not deeper detection or outward
         // propagation from nested rules' leniency.
-        Pattern::Lenient(inner) => find_callsite_unguarded(
+        Pattern::Lenient { inner, .. } => find_callsite_unguarded(
             inner,
             probe,
             continuations,
@@ -990,10 +998,10 @@ fn scan_frame_for_validator(
     nullable: &HashSet<String>,
 ) -> FrameOutcome {
     for item in frame {
-        if matches!(item, Pattern::AndPredicate(_)) {
+        if matches!(item, Pattern::AndPredicate { .. }) {
             return FrameOutcome::Anchored;
         }
-        if let Pattern::NotPredicate(inner) = item {
+        if let Pattern::NotPredicate { inner, .. } = item {
             // `!P` succeeds iff P fails. It rejects bytes that match P.
             // If FIRST(P) contains every element of target_trailing
             // (target's possible leftover all matches P), then `!P`
@@ -1070,44 +1078,47 @@ pub fn follow_set_to_boundary_pattern(fs: &FollowSet) -> Pattern {
                 has_char_class = true;
             }
             FollowElement::Literal(bytes) => {
-                alts.push(Pattern::Literal(bytes.clone()));
+                alts.push(Pattern::literal_bytes(bytes.clone()));
             }
             FollowElement::Rule(name) => {
-                alts.push(Pattern::NonTerminal(name.clone()));
+                alts.push(Pattern::nt(name.clone()));
             }
             FollowElement::Capture { kind, inner } => {
-                alts.push(Pattern::Capture(
+                alts.push(Pattern::capture(
                     kind.clone(),
-                    Box::new(follow_element_inner_to_pattern(inner)),
+                    follow_element_inner_to_pattern(inner),
                 ));
             }
             FollowElement::Eof => {
-                alts.push(Pattern::NotPredicate(Box::new(Pattern::AnyChar)));
+                alts.push(Pattern::not_predicate(Pattern::any_char()));
             }
         }
     }
     if has_char_class {
-        alts.insert(0, Pattern::CharClass(char_union));
+        alts.insert(0, Pattern::char_class(char_union));
     }
     if alts.len() == 1 {
         alts.into_iter().next().unwrap()
     } else {
-        Pattern::OrderedChoice(alts)
+        // Synthesized from FOLLOW set — no source position to inherit.
+        Pattern::OrderedChoice {
+            alts,
+            span: Span::SYNTHETIC,
+        }
     }
 }
 
 fn follow_element_inner_to_pattern(elem: &FollowElement) -> Pattern {
     match elem {
-        FollowElement::Literal(bytes) => Pattern::Literal(bytes.clone()),
-        FollowElement::CharClass(cs) => Pattern::CharClass(*cs),
-        FollowElement::Rule(name) => Pattern::NonTerminal(name.clone()),
-        FollowElement::Capture { kind, inner } => Pattern::Capture(
-            kind.clone(),
-            Box::new(follow_element_inner_to_pattern(inner)),
-        ),
+        FollowElement::Literal(bytes) => Pattern::literal_bytes(bytes.clone()),
+        FollowElement::CharClass(cs) => Pattern::char_class(*cs),
+        FollowElement::Rule(name) => Pattern::nt(name.clone()),
+        FollowElement::Capture { kind, inner } => {
+            Pattern::capture(kind.clone(), follow_element_inner_to_pattern(inner))
+        }
         // EOF nested inside a capture would be malformed in practice;
         // synthesize the same `!.` shape as the top-level case.
-        FollowElement::Eof => Pattern::NotPredicate(Box::new(Pattern::AnyChar)),
+        FollowElement::Eof => Pattern::not_predicate(Pattern::any_char()),
     }
 }
 
@@ -1138,11 +1149,11 @@ fn resolve_in_pattern(
     rule_name: &str,
 ) -> Result<Pattern, CompileError> {
     match pat {
-        Pattern::Literal(_)
-        | Pattern::CharClass(_)
-        | Pattern::AnyChar
-        | Pattern::NonTerminal(_) => Ok(pat.clone()),
-        Pattern::Sequence(items) => {
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::NonTerminal { .. } => Ok(pat.clone()),
+        Pattern::Sequence { items, span } => {
             let mut out = Vec::with_capacity(items.len());
             for i in 0..items.len() {
                 let sub_trailing = sequence_suffix_trailing(&items[i + 1..], trailing, nullable);
@@ -1153,62 +1164,85 @@ fn resolve_in_pattern(
                     rule_name,
                 )?);
             }
-            Ok(Pattern::Sequence(out))
+            Ok(Pattern::Sequence {
+                items: out,
+                span: *span,
+            })
         }
-        Pattern::OrderedChoice(alts) => {
+        Pattern::OrderedChoice { alts, span } => {
             let mut out = Vec::with_capacity(alts.len());
             for alt in alts {
                 out.push(resolve_in_pattern(alt, trailing, nullable, rule_name)?);
             }
-            Ok(Pattern::OrderedChoice(out))
+            Ok(Pattern::OrderedChoice {
+                alts: out,
+                span: *span,
+            })
         }
-        Pattern::Repeat(inner) | Pattern::RepeatOne(inner) => {
+        Pattern::Repeat { inner, span } => {
             // The inner can iterate; its successor includes FIRST(inner)
             // plus the outer trailing.
             let mut sub_trailing = trailing.clone();
             sub_trailing.extend(pattern_first(inner, nullable));
-            Ok(match pat {
-                Pattern::Repeat(_) => Pattern::Repeat(Box::new(resolve_in_pattern(
+            Ok(Pattern::Repeat {
+                inner: Box::new(resolve_in_pattern(
                     inner,
                     &sub_trailing,
                     nullable,
                     rule_name,
-                )?)),
-                Pattern::RepeatOne(_) => Pattern::RepeatOne(Box::new(resolve_in_pattern(
-                    inner,
-                    &sub_trailing,
-                    nullable,
-                    rule_name,
-                )?)),
-                _ => unreachable!(),
+                )?),
+                span: *span,
             })
         }
-        Pattern::Optional(inner) => Ok(Pattern::Optional(Box::new(resolve_in_pattern(
-            inner, trailing, nullable, rule_name,
-        )?))),
-        Pattern::NotPredicate(inner) => Ok(Pattern::NotPredicate(Box::new(resolve_in_pattern(
-            inner,
-            &FollowSet::new(),
-            nullable,
-            rule_name,
-        )?))),
-        Pattern::AndPredicate(inner) => Ok(Pattern::AndPredicate(Box::new(resolve_in_pattern(
-            inner,
-            &FollowSet::new(),
-            nullable,
-            rule_name,
-        )?))),
-        Pattern::Capture(kind, inner) => Ok(Pattern::Capture(
-            kind.clone(),
-            Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
-        )),
-        Pattern::Lenient(inner) => Ok(Pattern::Lenient(Box::new(resolve_in_pattern(
-            inner, trailing, nullable, rule_name,
-        )?))),
+        Pattern::RepeatOne { inner, span } => {
+            let mut sub_trailing = trailing.clone();
+            sub_trailing.extend(pattern_first(inner, nullable));
+            Ok(Pattern::RepeatOne {
+                inner: Box::new(resolve_in_pattern(
+                    inner,
+                    &sub_trailing,
+                    nullable,
+                    rule_name,
+                )?),
+                span: *span,
+            })
+        }
+        Pattern::Optional { inner, span } => Ok(Pattern::Optional {
+            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            span: *span,
+        }),
+        Pattern::NotPredicate { inner, span } => Ok(Pattern::NotPredicate {
+            inner: Box::new(resolve_in_pattern(
+                inner,
+                &FollowSet::new(),
+                nullable,
+                rule_name,
+            )?),
+            span: *span,
+        }),
+        Pattern::AndPredicate { inner, span } => Ok(Pattern::AndPredicate {
+            inner: Box::new(resolve_in_pattern(
+                inner,
+                &FollowSet::new(),
+                nullable,
+                rule_name,
+            )?),
+            span: *span,
+        }),
+        Pattern::Capture { kind, inner, span } => Ok(Pattern::Capture {
+            kind: kind.clone(),
+            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            span: *span,
+        }),
+        Pattern::Lenient { inner, span } => Ok(Pattern::Lenient {
+            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            span: *span,
+        }),
         Pattern::Catch {
             inner,
             label,
             recovery,
+            span,
         } => {
             // Success branch: inner inherits the catch's trailing.
             // Recovery branch: trailing is also the catch's trailing.
@@ -1216,13 +1250,15 @@ fn resolve_in_pattern(
                 inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
                 label: label.clone(),
                 recovery: Box::new(resolve_in_pattern(recovery, trailing, nullable, rule_name)?),
+                span: *span,
             })
         }
-        Pattern::InferBoundaryCatch { inner, label } => {
+        Pattern::InferBoundaryCatch { inner, label, span } => {
             if trailing.is_empty() {
                 return Err(CompileError::CannotInferBoundary {
                     rule: rule_name.into(),
                     label: label.clone(),
+                    span: *span,
                 });
             }
             let boundary = follow_set_to_boundary_pattern(trailing);
@@ -1232,6 +1268,7 @@ fn resolve_in_pattern(
                 resolved_inner,
                 label.clone(),
                 boundary,
+                *span,
             ))
         }
     }
@@ -1263,18 +1300,45 @@ fn sequence_suffix_trailing(
 
 /// Mirror of `parser::lower_boundary_catch` for the resolver path.
 /// Builds the same `Catch { Sequence([inner, &B]), label, @recovery{(!B .)*} }`
-/// shape from a synthesized boundary.
-fn lower_inferred_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
-    let lookahead = Pattern::AndPredicate(Box::new(boundary.clone()));
-    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(boundary)),
-        Pattern::AnyChar,
-    ])));
-    let recovery = Pattern::Capture("recovery".into(), Box::new(stop_loop));
+/// shape from a synthesized boundary. The produced tree inherits the
+/// original `^^lbl` placeholder's span; synthesized boundary subnodes
+/// already carry [`Span::SYNTHETIC`] from `follow_set_to_boundary_pattern`.
+fn lower_inferred_boundary_catch(
+    inner: Pattern,
+    label: String,
+    boundary: Pattern,
+    span: Span,
+) -> Pattern {
+    let lookahead = Pattern::AndPredicate {
+        inner: Box::new(boundary.clone()),
+        span,
+    };
+    let stop_loop = Pattern::Repeat {
+        inner: Box::new(Pattern::Sequence {
+            items: vec![
+                Pattern::NotPredicate {
+                    inner: Box::new(boundary),
+                    span,
+                },
+                Pattern::AnyChar { span },
+            ],
+            span,
+        }),
+        span,
+    };
+    let recovery = Pattern::Capture {
+        kind: "recovery".into(),
+        inner: Box::new(stop_loop),
+        span,
+    };
     Pattern::Catch {
-        inner: Box::new(Pattern::Sequence(vec![inner, lookahead])),
+        inner: Box::new(Pattern::Sequence {
+            items: vec![inner, lookahead],
+            span,
+        }),
         label,
         recovery: Box::new(recovery),
+        span,
     }
 }
 
@@ -1329,19 +1393,24 @@ pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<
 
 fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => {}
-        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Sequence { items, .. } => {
             for it in items {
                 collect_non_terminal_refs(it, out);
             }
         }
-        Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner)
-        | Pattern::Optional(inner)
-        | Pattern::NotPredicate(inner)
-        | Pattern::AndPredicate(inner)
-        | Pattern::Capture(_, inner)
-        | Pattern::Lenient(inner) => collect_non_terminal_refs(inner, out),
+        Pattern::OrderedChoice { alts, .. } => {
+            for it in alts {
+                collect_non_terminal_refs(it, out);
+            }
+        }
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. } => collect_non_terminal_refs(inner, out),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -1349,7 +1418,7 @@ fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
             collect_non_terminal_refs(recovery, out);
         }
         Pattern::InferBoundaryCatch { inner, .. } => collect_non_terminal_refs(inner, out),
-        Pattern::NonTerminal(name) => {
+        Pattern::NonTerminal { name, .. } => {
             out.insert(name.clone());
         }
     }
@@ -1358,19 +1427,18 @@ fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
 fn body_contains_catch(pat: &Pattern) -> bool {
     match pat {
         Pattern::Catch { .. } | Pattern::InferBoundaryCatch { .. } => true,
-        Pattern::Literal(_)
-        | Pattern::CharClass(_)
-        | Pattern::AnyChar
-        | Pattern::NonTerminal(_) => false,
-        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
-            items.iter().any(body_contains_catch)
-        }
-        Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner)
-        | Pattern::Optional(inner)
-        | Pattern::NotPredicate(inner)
-        | Pattern::AndPredicate(inner)
-        | Pattern::Capture(_, inner)
-        | Pattern::Lenient(inner) => body_contains_catch(inner),
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::NonTerminal { .. } => false,
+        Pattern::Sequence { items, .. } => items.iter().any(body_contains_catch),
+        Pattern::OrderedChoice { alts, .. } => alts.iter().any(body_contains_catch),
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. } => body_contains_catch(inner),
     }
 }

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::analysis::{analyze_left_recursion, LintFinding};
-use super::pattern::Pattern;
+use super::pattern::{Pattern, Span};
 use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, RuleKind};
 
 #[derive(Debug)]
@@ -10,15 +10,20 @@ pub enum CompileError {
     UnknownStartRule(String),
     /// One or more `^^lbl` catches have no following context to infer
     /// their boundary from. Emitted by `resolve_inferred_boundaries`.
+    /// `span` is the source position of the `^^lbl` placeholder in the
+    /// grammar; rendered as `{line}:{col}:` in [`Display`].
     CannotInferBoundary {
         rule: String,
         label: String,
+        span: Span,
     },
     /// `lint_partial_match` returned a non-empty result. Each finding
     /// names a `(rule, caller)` pair where a trailing-nullable rule's
     /// partial-match leniency reaches an unguarded scope. Anchor with
     /// `^^lbl B` (or `^^lbl`) when the leniency is a bug, or wrap the
-    /// call site with `~p` when the leniency is intentional.
+    /// call site with `~p` when the leniency is intentional. Each
+    /// [`LintFinding`] carries the call-site's span so the rendered
+    /// message points directly at the unanchored call.
     PartialMatchLeniency(Vec<LintFinding>),
 }
 
@@ -27,9 +32,9 @@ impl std::fmt::Display for CompileError {
         match self {
             CompileError::UndefinedRule(name) => write!(f, "undefined rule: {}", name),
             CompileError::UnknownStartRule(name) => write!(f, "unknown start rule: {}", name),
-            CompileError::CannotInferBoundary { rule, label } => write!(
+            CompileError::CannotInferBoundary { rule, label, span } => write!(
                 f,
-                "cannot infer boundary for `^^{label}` in rule `{rule}`: no following context. \
+                "{span}: cannot infer boundary for `^^{label}` in rule `{rule}`: no following context. \
                  Either delete the unreachable catch or specify an explicit boundary `^^{label} B`."
             ),
             CompileError::PartialMatchLeniency(findings) => {
@@ -37,9 +42,9 @@ impl std::fmt::Display for CompileError {
                 for finding in findings {
                     writeln!(
                         f,
-                        "  - rule `{}` is called unanchored by `{}`; its trailing optional \
+                        "  - {}: rule `{}` is called unanchored by `{}`; its trailing optional \
                          can succeed on a prefix, leaving bytes the caller does not validate",
-                        finding.rule, finding.caller
+                        finding.call_site, finding.rule, finding.caller
                     )?;
                 }
                 Ok(())
@@ -141,29 +146,29 @@ impl Compiler {
 
     fn compile_pat(&mut self, p: &Pattern) {
         match p {
-            Pattern::Literal(bytes) => {
+            Pattern::Literal { bytes, .. } => {
                 for &b in bytes {
                     self.emit(Instruction::Char(b));
                 }
             }
-            Pattern::CharClass(set) => {
+            Pattern::CharClass { set, .. } => {
                 self.emit(Instruction::Set(*set));
             }
-            Pattern::AnyChar => {
+            Pattern::AnyChar { .. } => {
                 self.emit(Instruction::Any(1));
             }
-            Pattern::Sequence(items) => {
+            Pattern::Sequence { items, .. } => {
                 for it in items {
                     self.compile_pat(it);
                 }
             }
-            Pattern::OrderedChoice(items) => {
-                if items.is_empty() {
+            Pattern::OrderedChoice { alts, .. } => {
+                if alts.is_empty() {
                     return;
                 }
                 let mut commit_indices = Vec::new();
-                let last_idx = items.len() - 1;
-                for (i, item) in items.iter().enumerate() {
+                let last_idx = alts.len() - 1;
+                for (i, item) in alts.iter().enumerate() {
                     if i < last_idx {
                         let choice = self.emit(Instruction::Choice(Label(0)));
                         self.compile_pat(item);
@@ -180,7 +185,7 @@ impl Compiler {
                     self.patch_jump(idx, end);
                 }
             }
-            Pattern::Repeat(inner) => {
+            Pattern::Repeat { inner, .. } => {
                 // Choice L2 ; L_body: <p> ; PartialCommit L_body ; L2:
                 // PartialCommit re-uses the existing Backtrack — we must NOT re-execute Choice.
                 let choice = self.emit(Instruction::Choice(Label(0)));
@@ -190,12 +195,15 @@ impl Compiler {
                 let l2 = self.pos();
                 self.patch_jump(choice, l2);
             }
-            Pattern::RepeatOne(inner) => {
+            Pattern::RepeatOne { inner, span } => {
                 // <p> ; (Repeat p)
                 self.compile_pat(inner);
-                self.compile_pat(&Pattern::Repeat(inner.clone()));
+                self.compile_pat(&Pattern::Repeat {
+                    inner: inner.clone(),
+                    span: *span,
+                });
             }
-            Pattern::Optional(inner) => {
+            Pattern::Optional { inner, .. } => {
                 // Choice L1 ; <p> ; Commit L1 ; L1:
                 let choice = self.emit(Instruction::Choice(Label(0)));
                 self.compile_pat(inner);
@@ -204,7 +212,7 @@ impl Compiler {
                 self.patch_jump(choice, l1);
                 self.patch_jump(commit, l1);
             }
-            Pattern::NotPredicate(inner) => {
+            Pattern::NotPredicate { inner, .. } => {
                 // Choice L1 ; <p> ; FailTwice ; L1:
                 let choice = self.emit(Instruction::Choice(Label(0)));
                 self.compile_pat(inner);
@@ -212,7 +220,7 @@ impl Compiler {
                 let l1 = self.pos();
                 self.patch_jump(choice, l1);
             }
-            Pattern::AndPredicate(inner) => {
+            Pattern::AndPredicate { inner, .. } => {
                 // Choice L1 ; <p> ; BackCommit L2 ; L1: Fail ; L2:
                 let choice = self.emit(Instruction::Choice(Label(0)));
                 self.compile_pat(inner);
@@ -223,13 +231,13 @@ impl Compiler {
                 self.patch_jump(choice, l1);
                 self.patch_jump(back, l2);
             }
-            Pattern::NonTerminal(name) => {
+            Pattern::NonTerminal { name, .. } => {
                 let idx = self.emit(Instruction::Call(Label(0)));
                 self.pending_calls.push((idx, name.clone()));
             }
-            Pattern::Capture(name, inner) => {
-                let kind = self.intern_capture(name);
-                self.emit(Instruction::CaptureBegin(kind));
+            Pattern::Capture { kind, inner, .. } => {
+                let kind_id = self.intern_capture(kind);
+                self.emit(Instruction::CaptureBegin(kind_id));
                 self.compile_pat(inner);
                 self.emit(Instruction::CaptureEnd);
             }
@@ -237,6 +245,7 @@ impl Compiler {
                 inner,
                 label,
                 recovery,
+                ..
             } => {
                 //              RecoverScopeBegin(label)
                 //              Choice rec
@@ -280,7 +289,7 @@ impl Compiler {
             }
             // Transparent at runtime — the `~` marker affects only
             // the lint walker. See `Pattern::Lenient` documentation.
-            Pattern::Lenient(inner) => self.compile_pat(inner),
+            Pattern::Lenient { inner, .. } => self.compile_pat(inner),
             // The FOLLOW-inferred resolver must run before bytecode
             // emission; reaching this arm is a bug.
             Pattern::InferBoundaryCatch { .. } => {
@@ -426,20 +435,26 @@ fn check_refs(
     rules: &HashMap<String, Pattern>,
 ) -> Result<(), CompileError> {
     match pat {
-        Pattern::Literal(_) | Pattern::CharClass(_) | Pattern::AnyChar => Ok(()),
-        Pattern::Sequence(items) | Pattern::OrderedChoice(items) => {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => Ok(()),
+        Pattern::Sequence { items, .. } => {
             for it in items {
                 check_refs(_rule, it, rules)?;
             }
             Ok(())
         }
-        Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner)
-        | Pattern::Optional(inner)
-        | Pattern::NotPredicate(inner)
-        | Pattern::AndPredicate(inner)
-        | Pattern::Capture(_, inner)
-        | Pattern::Lenient(inner) => check_refs(_rule, inner, rules),
+        Pattern::OrderedChoice { alts, .. } => {
+            for it in alts {
+                check_refs(_rule, it, rules)?;
+            }
+            Ok(())
+        }
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. } => check_refs(_rule, inner, rules),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -447,7 +462,7 @@ fn check_refs(
             check_refs(_rule, recovery, rules)
         }
         Pattern::InferBoundaryCatch { inner, .. } => check_refs(_rule, inner, rules),
-        Pattern::NonTerminal(name) => {
+        Pattern::NonTerminal { name, .. } => {
             if rules.contains_key(name) {
                 Ok(())
             } else {

--- a/src/pegc/mod.rs
+++ b/src/pegc/mod.rs
@@ -34,7 +34,7 @@ pub mod pattern;
 pub use analysis::{LintFinding, LintKind};
 pub use compiler::{compile_pattern, CompileError};
 pub use parser::{parse, Grammar, ParseError};
-pub use pattern::Pattern;
+pub use pattern::{Pattern, Span};
 
 use crate::pegvm::Program;
 

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::analysis::{lint_partial_match, resolve_inferred_boundaries};
 use super::compiler::{compile_rules, CompileError};
-use super::pattern::Pattern;
+use super::pattern::{Pattern, Span};
 use crate::pegvm::{CharSet, Program};
 
 /// Cap for the `p{n}` exact-count quantifier. Conservative typo guard:
@@ -83,14 +83,50 @@ pub fn parse(input: &str) -> Result<Grammar, ParseError> {
 struct Parser<'a> {
     src: &'a [u8],
     pos: usize,
+    /// Byte offset of the first byte of each line (1-indexed lines, so
+    /// `line_starts[0]` is the start of line 1 = 0). Precomputed once
+    /// in `Parser::new` so that `span_at(offset)` is O(log lines)
+    /// rather than O(offset). Every Pattern node carries a [`Span`];
+    /// the per-node lookup dominates parser cost without this.
+    line_starts: Vec<usize>,
 }
 
 impl<'a> Parser<'a> {
     fn new(input: &'a str) -> Self {
-        Parser {
-            src: input.as_bytes(),
-            pos: 0,
+        let src = input.as_bytes();
+        let mut line_starts = Vec::with_capacity(src.len() / 32 + 1);
+        line_starts.push(0);
+        for (i, &b) in src.iter().enumerate() {
+            if b == b'\n' {
+                line_starts.push(i + 1);
+            }
         }
+        Parser {
+            src,
+            pos: 0,
+            line_starts,
+        }
+    }
+
+    /// Convert a byte offset into a 1-based (line, col). O(log lines)
+    /// via binary search over `line_starts`.
+    fn span_at(&self, offset: usize) -> Span {
+        let offset = offset.min(self.src.len());
+        let line_idx = self
+            .line_starts
+            .partition_point(|&s| s <= offset)
+            .saturating_sub(1);
+        let line_start = self.line_starts[line_idx];
+        Span {
+            line: line_idx + 1,
+            col: offset - line_start + 1,
+        }
+    }
+
+    /// Span at the current parse position. Snapshot before consuming
+    /// the bytes that start the construct being built.
+    fn span(&self) -> Span {
+        self.span_at(self.pos)
     }
 
     fn parse_grammar(&mut self) -> Result<Grammar, ParseError> {
@@ -104,18 +140,21 @@ impl<'a> Parser<'a> {
             // of `name`. The marker touches the name (no whitespace);
             // the rule's body is wrapped with `Pattern::Lenient` so the
             // lint walker sees the same shape as a per-call-site `~p`.
-            let mut definition_lenient = false;
+            let mut lenient_span: Option<Span> = None;
             if self.peek() == Some(b'~') {
+                lenient_span = Some(self.span());
                 self.pos += 1;
-                definition_lenient = true;
             }
             let name = self.parse_ident()?;
             self.skip_ws();
             self.expect_str("<-")?;
             self.skip_ws();
             let mut pat = self.parse_choice()?;
-            if definition_lenient {
-                pat = Pattern::Lenient(Box::new(pat));
+            if let Some(span) = lenient_span {
+                pat = Pattern::Lenient {
+                    inner: Box::new(pat),
+                    span,
+                };
             }
             if rules.insert(name.clone(), pat).is_some() {
                 return Err(self.err(format!("rule '{}' defined twice", name)));
@@ -176,6 +215,10 @@ impl<'a> Parser<'a> {
             if self.peek() != Some(b'^') {
                 break;
             }
+            // Span of the catch / boundary-catch construct is the
+            // position of the leading `^` (or `^^`). Snapshot before
+            // consuming the operator bytes.
+            let catch_span = self.span();
             self.pos += 1;
             // Doubled-caret discriminator: a second `^` immediately
             // after the first marks the boundary-anchored family.
@@ -188,7 +231,7 @@ impl<'a> Parser<'a> {
                     self.pos += 3;
                     self.skip_ws();
                     let boundary = self.parse_prefix()?;
-                    lower_bracketed_close_catch(lhs, label, boundary)
+                    lower_bracketed_close_catch(lhs, label, boundary, catch_span)
                 } else if self.peek() == Some(b'.') && self.peek_at(1) == Some(b'.') {
                     // `INNER ^^lbl .. B` — rejected. The catch necessarily
                     // consumes B; the non-consuming form has no use here.
@@ -199,11 +242,12 @@ impl<'a> Parser<'a> {
                     ));
                 } else if self.at_prefix_start() {
                     let boundary = self.parse_prefix()?;
-                    lower_boundary_catch(lhs, label, boundary)
+                    lower_boundary_catch(lhs, label, boundary, catch_span)
                 } else {
                     Pattern::InferBoundaryCatch {
                         inner: Box::new(lhs),
                         label,
+                        span: catch_span,
                     }
                 };
                 // Trailing sequence atoms after `^^lbl B` (or
@@ -228,6 +272,7 @@ impl<'a> Parser<'a> {
                     inner: Box::new(lhs),
                     label,
                     recovery: Box::new(rhs),
+                    span: catch_span,
                 };
             }
         }
@@ -321,16 +366,24 @@ impl<'a> Parser<'a> {
     fn parse_prefix(&mut self) -> Result<Pattern, ParseError> {
         match self.peek() {
             Some(b'!') => {
+                let span = self.span();
                 self.pos += 1;
                 self.skip_ws();
                 let inner = self.parse_postfix()?;
-                Ok(Pattern::NotPredicate(Box::new(inner)))
+                Ok(Pattern::NotPredicate {
+                    inner: Box::new(inner),
+                    span,
+                })
             }
             Some(b'&') => {
+                let span = self.span();
                 self.pos += 1;
                 self.skip_ws();
                 let inner = self.parse_postfix()?;
-                Ok(Pattern::AndPredicate(Box::new(inner)))
+                Ok(Pattern::AndPredicate {
+                    inner: Box::new(inner),
+                    span,
+                })
             }
             _ => self.parse_postfix(),
         }
@@ -348,7 +401,8 @@ impl<'a> Parser<'a> {
                         let label = self.parse_optional_recovery_label()?;
                         atom = build_recover_repeat(atom, charset, label);
                     } else {
-                        atom = Pattern::Repeat(Box::new(atom));
+                        // Span of `Repeat` inherits its operand's span.
+                        atom = Pattern::repeat(atom);
                     }
                 }
                 Some(b'+') => {
@@ -361,12 +415,12 @@ impl<'a> Parser<'a> {
                         let head = atom.clone();
                         atom = Pattern::seq(vec![head, build_recover_repeat(atom, charset, label)]);
                     } else {
-                        atom = Pattern::RepeatOne(Box::new(atom));
+                        atom = Pattern::repeat_one(atom);
                     }
                 }
                 Some(b'?') => {
                     self.pos += 1;
-                    atom = Pattern::Optional(Box::new(atom));
+                    atom = Pattern::optional(atom);
                 }
                 Some(b'{') => {
                     self.pos += 1;
@@ -429,7 +483,7 @@ impl<'a> Parser<'a> {
             return Ok(None);
         }
         match self.parse_charclass()? {
-            Pattern::CharClass(set) => Ok(Some(set)),
+            Pattern::CharClass { set, .. } => Ok(Some(set)),
             _ => unreachable!("parse_charclass always returns Pattern::CharClass"),
         }
     }
@@ -459,6 +513,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_atom(&mut self) -> Result<Pattern, ParseError> {
+        let span = self.span();
         match self.peek() {
             Some(b'(') => {
                 self.pos += 1;
@@ -484,20 +539,20 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
                     let stop = self.parse_prefix()?;
                     return Ok(if inclusive {
-                        lower_until_inclusive(stop)
+                        lower_until_inclusive(stop, span)
                     } else {
-                        lower_until_exclusive(stop)
+                        lower_until_exclusive(stop, span)
                     });
                 }
                 self.pos += 1;
-                Ok(Pattern::AnyChar)
+                Ok(Pattern::AnyChar { span })
             }
             Some(b'@') => self.parse_capture(),
             Some(b'\\') => self.parse_backslash_atom(),
             Some(c) if is_ident_start(c) => {
                 // Disambiguation against `name <- ...` is handled by at_prefix_start.
                 let name = self.parse_ident()?;
-                Ok(Pattern::NonTerminal(name))
+                Ok(Pattern::NonTerminal { name, span })
             }
             Some(c) => Err(self.err(format!("unexpected '{}'", c as char))),
             None => Err(self.err("unexpected end of input".into())),
@@ -521,23 +576,47 @@ impl<'a> Parser<'a> {
     /// pointer back to this form.
     fn parse_backslash_atom(&mut self) -> Result<Pattern, ParseError> {
         debug_assert_eq!(self.peek(), Some(b'\\'));
+        // Span of the synthesized atom is the position of the leading
+        // `\`. The synthesized inner patterns (literals, AnyChar) are
+        // not directly authored — they all share the backslash atom's
+        // span so a diagnostic firing inside the desugar still points
+        // at the author's `\R` / `\z` site.
+        let span = self.span();
         self.pos += 1;
         match self.peek() {
             Some(c) if class_for_shortcut(c).is_some() => {
                 self.pos += 1;
-                Ok(Pattern::CharClass(class_for_shortcut(c).unwrap()))
+                Ok(Pattern::CharClass {
+                    set: class_for_shortcut(c).unwrap(),
+                    span,
+                })
             }
             Some(b'R') => {
                 self.pos += 1;
-                Ok(Pattern::OrderedChoice(vec![
-                    Pattern::literal("\r\n"),
-                    Pattern::literal("\n"),
-                    Pattern::literal("\r"),
-                ]))
+                Ok(Pattern::OrderedChoice {
+                    alts: vec![
+                        Pattern::Literal {
+                            bytes: b"\r\n".to_vec(),
+                            span,
+                        },
+                        Pattern::Literal {
+                            bytes: b"\n".to_vec(),
+                            span,
+                        },
+                        Pattern::Literal {
+                            bytes: b"\r".to_vec(),
+                            span,
+                        },
+                    ],
+                    span,
+                })
             }
             Some(b'z') => {
                 self.pos += 1;
-                Ok(Pattern::NotPredicate(Box::new(Pattern::AnyChar)))
+                Ok(Pattern::NotPredicate {
+                    inner: Box::new(Pattern::AnyChar { span }),
+                    span,
+                })
             }
             Some(c) => Err(self.err(format!(
                 "unknown atom '\\{}' (valid: \\d \\D \\s \\S \\h \\H \\R \\z)",
@@ -548,6 +627,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_capture(&mut self) -> Result<Pattern, ParseError> {
+        // Span of `Capture` is the position of the `@` sigil.
+        let span = self.span();
         self.expect(b'@')?;
         let name = self.parse_ident()?;
         self.expect(b'{')?;
@@ -555,10 +636,16 @@ impl<'a> Parser<'a> {
         let inner = self.parse_choice()?;
         self.skip_ws();
         self.expect(b'}')?;
-        Ok(Pattern::Capture(name, Box::new(inner)))
+        Ok(Pattern::Capture {
+            kind: name,
+            inner: Box::new(inner),
+            span,
+        })
     }
 
     fn parse_string(&mut self) -> Result<Pattern, ParseError> {
+        // Span of the literal is the position of the opening quote.
+        let span = self.span();
         let quote = self.peek().unwrap();
         self.pos += 1;
         let mut bytes = Vec::new();
@@ -571,7 +658,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(c) if c == quote => {
                     self.pos += 1;
-                    return Ok(Pattern::Literal(bytes));
+                    return Ok(Pattern::Literal { bytes, span });
                 }
                 Some(c) => {
                     bytes.push(c);
@@ -582,6 +669,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_charclass(&mut self) -> Result<Pattern, ParseError> {
+        // Span of the char class is the position of the opening `[`.
+        let span = self.span();
         self.expect(b'[')?;
         let negate = if self.peek() == Some(b'^') {
             self.pos += 1;
@@ -645,7 +734,10 @@ impl<'a> Parser<'a> {
         }
         self.expect(b']')?;
         let final_set = if negate { set.negate() } else { set };
-        Ok(Pattern::CharClass(final_set))
+        Ok(Pattern::CharClass {
+            set: final_set,
+            span,
+        })
     }
 
     fn parse_class_char(&mut self) -> Result<u8, ParseError> {
@@ -786,22 +878,8 @@ impl<'a> Parser<'a> {
     }
 
     fn err(&self, message: String) -> ParseError {
-        let (line, col) = self.line_col();
+        let Span { line, col } = self.span();
         ParseError { message, line, col }
-    }
-
-    fn line_col(&self) -> (usize, usize) {
-        let mut line = 1;
-        let mut col = 1;
-        for &b in &self.src[..self.pos.min(self.src.len())] {
-            if b == b'\n' {
-                line += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-        (line, col)
     }
 }
 
@@ -837,37 +915,72 @@ fn class_for_shortcut(c: u8) -> Option<CharSet> {
 }
 
 /// Lower `.. S` (skip-until exclusive) to `(!S .)*`. The stop pattern
-/// is a negative lookahead; `S` is not consumed.
-fn lower_until_exclusive(stop: Pattern) -> Pattern {
-    Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(stop)),
-        Pattern::AnyChar,
-    ])))
+/// is a negative lookahead; `S` is not consumed. All synthesized nodes
+/// inherit the leading `..`'s span so a diagnostic firing inside the
+/// desugar still points at the author's site.
+fn lower_until_exclusive(stop: Pattern, span: Span) -> Pattern {
+    Pattern::Repeat {
+        inner: Box::new(Pattern::Sequence {
+            items: vec![
+                Pattern::NotPredicate {
+                    inner: Box::new(stop),
+                    span,
+                },
+                Pattern::AnyChar { span },
+            ],
+            span,
+        }),
+        span,
+    }
 }
 
 /// Lower `..= S` (skip-until inclusive) to `(!S .)* S`. The stop is
 /// matched and consumed after the skip; its capture kind (if any) is
 /// preserved on the trailing consume.
-fn lower_until_inclusive(stop: Pattern) -> Pattern {
-    Pattern::Sequence(vec![lower_until_exclusive(stop.clone()), stop])
+fn lower_until_inclusive(stop: Pattern, span: Span) -> Pattern {
+    Pattern::Sequence {
+        items: vec![lower_until_exclusive(stop.clone(), span), stop],
+        span,
+    }
 }
 
 /// Lower `INNER ^^lbl B` to the explicit boundary-anchored catch
 /// shape: `Catch { Sequence([INNER, &B]), lbl, @recovery{(!B .)*} }`.
 /// Parse-time lowering — the compiler sees this as a regular `Catch`
 /// with an `AndPredicate` sibling, so the existing lint walker
-/// recognizes it as anchored without a new arm.
-fn lower_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
-    let lookahead = Pattern::AndPredicate(Box::new(boundary.clone()));
-    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(boundary)),
-        Pattern::AnyChar,
-    ])));
-    let recovery = Pattern::Capture("recovery".into(), Box::new(stop_loop));
+/// recognizes it as anchored without a new arm. All synthesized nodes
+/// inherit the catch operator's span.
+fn lower_boundary_catch(inner: Pattern, label: String, boundary: Pattern, span: Span) -> Pattern {
+    let lookahead = Pattern::AndPredicate {
+        inner: Box::new(boundary.clone()),
+        span,
+    };
+    let stop_loop = Pattern::Repeat {
+        inner: Box::new(Pattern::Sequence {
+            items: vec![
+                Pattern::NotPredicate {
+                    inner: Box::new(boundary),
+                    span,
+                },
+                Pattern::AnyChar { span },
+            ],
+            span,
+        }),
+        span,
+    };
+    let recovery = Pattern::Capture {
+        kind: "recovery".into(),
+        inner: Box::new(stop_loop),
+        span,
+    };
     Pattern::Catch {
-        inner: Box::new(Pattern::Sequence(vec![inner, lookahead])),
+        inner: Box::new(Pattern::Sequence {
+            items: vec![inner, lookahead],
+            span,
+        }),
         label,
         recovery: Box::new(recovery),
+        span,
     }
 }
 
@@ -882,19 +995,41 @@ fn lower_boundary_catch(inner: Pattern, label: String, boundary: Pattern) -> Pat
 /// the shape the `^block_close` sites across the shipped grammars
 /// need: the closing `}` keeps its `@punctuation` kind in both happy
 /// and recovery paths.
-fn lower_bracketed_close_catch(inner: Pattern, label: String, boundary: Pattern) -> Pattern {
-    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(boundary.clone())),
-        Pattern::AnyChar,
-    ])));
-    let recovery = Pattern::Sequence(vec![
-        Pattern::Capture("recovery".into(), Box::new(stop_loop)),
-        boundary,
-    ]);
+fn lower_bracketed_close_catch(
+    inner: Pattern,
+    label: String,
+    boundary: Pattern,
+    span: Span,
+) -> Pattern {
+    let stop_loop = Pattern::Repeat {
+        inner: Box::new(Pattern::Sequence {
+            items: vec![
+                Pattern::NotPredicate {
+                    inner: Box::new(boundary.clone()),
+                    span,
+                },
+                Pattern::AnyChar { span },
+            ],
+            span,
+        }),
+        span,
+    };
+    let recovery = Pattern::Sequence {
+        items: vec![
+            Pattern::Capture {
+                kind: "recovery".into(),
+                inner: Box::new(stop_loop),
+                span,
+            },
+            boundary,
+        ],
+        span,
+    };
     Pattern::Catch {
         inner: Box::new(inner),
         label,
         recovery: Box::new(recovery),
+        span,
     }
 }
 
@@ -911,25 +1046,50 @@ fn lower_bracketed_close_catch(inner: Pattern, label: String, boundary: Pattern)
 /// EOF, or `cs` missing before EOF), the failure propagates to the
 /// enclosing `*`'s Backtrack frame and the loop terminates without
 /// consuming further input.
+///
+/// The synthesized recover-repeat tree inherits its operand's span,
+/// matching the per-variant convention for `Repeat` ("start of
+/// operand").
 fn build_recover_repeat(
     inner: Pattern,
     charset: Option<CharSet>,
     label: Option<String>,
 ) -> Pattern {
+    let span = inner.span();
     let body = match charset {
-        None => Pattern::AnyChar,
-        Some(cs) => Pattern::Sequence(vec![
-            Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-                Pattern::NotPredicate(Box::new(Pattern::CharClass(cs))),
-                Pattern::AnyChar,
-            ]))),
-            Pattern::CharClass(cs),
-        ]),
+        None => Pattern::AnyChar { span },
+        Some(cs) => Pattern::Sequence {
+            items: vec![
+                Pattern::Repeat {
+                    inner: Box::new(Pattern::Sequence {
+                        items: vec![
+                            Pattern::NotPredicate {
+                                inner: Box::new(Pattern::CharClass { set: cs, span }),
+                                span,
+                            },
+                            Pattern::AnyChar { span },
+                        ],
+                        span,
+                    }),
+                    span,
+                },
+                Pattern::CharClass { set: cs, span },
+            ],
+            span,
+        },
     };
-    let recovery = Pattern::Capture("recovery".into(), Box::new(body));
-    Pattern::Repeat(Box::new(Pattern::Catch {
-        inner: Box::new(inner),
-        label: label.unwrap_or_else(|| "recovery".into()),
-        recovery: Box::new(recovery),
-    }))
+    let recovery = Pattern::Capture {
+        kind: "recovery".into(),
+        inner: Box::new(body),
+        span,
+    };
+    Pattern::Repeat {
+        inner: Box::new(Pattern::Catch {
+            inner: Box::new(inner),
+            label: label.unwrap_or_else(|| "recovery".into()),
+            recovery: Box::new(recovery),
+            span,
+        }),
+        span,
+    }
 }

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -1,19 +1,89 @@
 use crate::pegvm::CharSet;
 
+/// Source position of a [`Pattern`] node, captured by the parser when
+/// it enters the construct's parse function. One-based line and column,
+/// matching [`crate::pegc::parser::ParseError`].
+///
+/// Used by [`crate::pegc::analysis::LintFinding`] (call-site span) and
+/// [`crate::pegc::compiler::CompileError::CannotInferBoundary`] to give
+/// fatal grammar diagnostics a navigable position. Editor tooling (#39)
+/// can pick this up for hover / jump-to-definition without further AST
+/// surgery.
+///
+/// Synthesized nodes — those produced by the resolver / lowering passes
+/// from a FOLLOW set rather than directly from source — carry
+/// [`Span::SYNTHETIC`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Ord, PartialOrd)]
+pub struct Span {
+    pub line: usize,
+    pub col: usize,
+}
+
+impl Span {
+    /// Marker for nodes with no source position: the FOLLOW-set
+    /// boundary materialization, the `@recovery{(!B .)*}` body
+    /// synthesized in `lower_inferred_boundary_catch`, the
+    /// left-recursion alternative materialization, and Pattern trees
+    /// hand-built by tests.
+    pub const SYNTHETIC: Span = Span { line: 0, col: 0 };
+}
+
+impl std::fmt::Display for Span {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.line, self.col)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
-    Literal(Vec<u8>),
-    CharClass(CharSet),
-    AnyChar,
-    Sequence(Vec<Pattern>),
-    OrderedChoice(Vec<Pattern>),
-    Repeat(Box<Pattern>),
-    RepeatOne(Box<Pattern>),
-    Optional(Box<Pattern>),
-    NotPredicate(Box<Pattern>),
-    AndPredicate(Box<Pattern>),
-    NonTerminal(String),
-    Capture(String, Box<Pattern>),
+    Literal {
+        bytes: Vec<u8>,
+        span: Span,
+    },
+    CharClass {
+        set: CharSet,
+        span: Span,
+    },
+    AnyChar {
+        span: Span,
+    },
+    Sequence {
+        items: Vec<Pattern>,
+        span: Span,
+    },
+    OrderedChoice {
+        alts: Vec<Pattern>,
+        span: Span,
+    },
+    Repeat {
+        inner: Box<Pattern>,
+        span: Span,
+    },
+    RepeatOne {
+        inner: Box<Pattern>,
+        span: Span,
+    },
+    Optional {
+        inner: Box<Pattern>,
+        span: Span,
+    },
+    NotPredicate {
+        inner: Box<Pattern>,
+        span: Span,
+    },
+    AndPredicate {
+        inner: Box<Pattern>,
+        span: Span,
+    },
+    NonTerminal {
+        name: String,
+        span: Span,
+    },
+    Capture {
+        kind: String,
+        inner: Box<Pattern>,
+        span: Span,
+    },
     /// Try `inner`; on failure, materialize the failed attempt's
     /// deepest-reach captures (via `RecoverToScopedMax`) and run
     /// `recovery` from that resync point. If `recovery` also fails,
@@ -36,13 +106,17 @@ pub enum Pattern {
         inner: Box<Pattern>,
         label: String,
         recovery: Box<Pattern>,
+        span: Span,
     },
     /// Author-local marker that a pattern is intentionally lenient — the
     /// `lint_partial_match` walker treats this as an opaque barrier and
     /// does not descend into it for call-site detection. At runtime the
     /// wrapper is transparent: the compiler emits exactly the inner
     /// pattern's bytecode. Surface syntax: postfix `~p`.
-    Lenient(Box<Pattern>),
+    Lenient {
+        inner: Box<Pattern>,
+        span: Span,
+    },
     /// Boundary-anchored catch with the boundary inferred from the
     /// call site's FOLLOW set. Placeholder produced at parse time by
     /// the `^^lbl` surface form; resolved before bytecode emission by
@@ -56,27 +130,143 @@ pub enum Pattern {
     InferBoundaryCatch {
         inner: Box<Pattern>,
         label: String,
+        span: Span,
     },
 }
 
 impl Pattern {
-    pub fn literal(s: &str) -> Pattern {
-        Pattern::Literal(s.as_bytes().to_vec())
+    /// Span of this pattern: where the parser entered the construct.
+    /// See the per-variant convention documented on [`Span`].
+    pub fn span(&self) -> Span {
+        match self {
+            Pattern::Literal { span, .. }
+            | Pattern::CharClass { span, .. }
+            | Pattern::AnyChar { span }
+            | Pattern::Sequence { span, .. }
+            | Pattern::OrderedChoice { span, .. }
+            | Pattern::Repeat { span, .. }
+            | Pattern::RepeatOne { span, .. }
+            | Pattern::Optional { span, .. }
+            | Pattern::NotPredicate { span, .. }
+            | Pattern::AndPredicate { span, .. }
+            | Pattern::NonTerminal { span, .. }
+            | Pattern::Capture { span, .. }
+            | Pattern::Catch { span, .. }
+            | Pattern::Lenient { span, .. }
+            | Pattern::InferBoundaryCatch { span, .. } => *span,
+        }
     }
 
+    pub fn literal(s: &str) -> Pattern {
+        Pattern::Literal {
+            bytes: s.as_bytes().to_vec(),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn literal_bytes(bytes: Vec<u8>) -> Pattern {
+        Pattern::Literal {
+            bytes,
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn char_class(set: CharSet) -> Pattern {
+        Pattern::CharClass {
+            set,
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn any_char() -> Pattern {
+        Pattern::AnyChar {
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    /// Span of `Sequence` is the start of its first child — see the
+    /// per-variant convention on [`Span`]. Synthetic if `items` is
+    /// empty (only happens in tests; the parser rejects empty
+    /// sequences).
     pub fn seq(items: Vec<Pattern>) -> Pattern {
         if items.len() == 1 {
             items.into_iter().next().unwrap()
         } else {
-            Pattern::Sequence(items)
+            let span = items.first().map(Pattern::span).unwrap_or(Span::SYNTHETIC);
+            Pattern::Sequence { items, span }
         }
     }
 
+    /// Span of `OrderedChoice` is the start of its first alternative.
     pub fn choice(items: Vec<Pattern>) -> Pattern {
         if items.len() == 1 {
             items.into_iter().next().unwrap()
         } else {
-            Pattern::OrderedChoice(items)
+            let span = items.first().map(Pattern::span).unwrap_or(Span::SYNTHETIC);
+            Pattern::OrderedChoice { alts: items, span }
+        }
+    }
+
+    /// Span of `Repeat` is the start of its operand.
+    pub fn repeat(inner: Pattern) -> Pattern {
+        let span = inner.span();
+        Pattern::Repeat {
+            inner: Box::new(inner),
+            span,
+        }
+    }
+
+    /// Span of `RepeatOne` is the start of its operand.
+    pub fn repeat_one(inner: Pattern) -> Pattern {
+        let span = inner.span();
+        Pattern::RepeatOne {
+            inner: Box::new(inner),
+            span,
+        }
+    }
+
+    /// Span of `Optional` is the start of its operand.
+    pub fn optional(inner: Pattern) -> Pattern {
+        let span = inner.span();
+        Pattern::Optional {
+            inner: Box::new(inner),
+            span,
+        }
+    }
+
+    pub fn not_predicate(inner: Pattern) -> Pattern {
+        Pattern::NotPredicate {
+            inner: Box::new(inner),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn and_predicate(inner: Pattern) -> Pattern {
+        Pattern::AndPredicate {
+            inner: Box::new(inner),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn nt(name: impl Into<String>) -> Pattern {
+        Pattern::NonTerminal {
+            name: name.into(),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn capture(kind: impl Into<String>, inner: Pattern) -> Pattern {
+        Pattern::Capture {
+            kind: kind.into(),
+            inner: Box::new(inner),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    pub fn lenient(inner: Pattern) -> Pattern {
+        Pattern::Lenient {
+            inner: Box::new(inner),
+            span: Span::SYNTHETIC,
         }
     }
 
@@ -88,6 +278,85 @@ impl Pattern {
             inner: Box::new(inner),
             label: label.into(),
             recovery: Box::new(recovery),
+            span: Span::SYNTHETIC,
+        }
+    }
+
+    /// Return a clone with every node's span replaced by [`Span::SYNTHETIC`].
+    /// Test ergonomics: parsed grammars carry real positions, hand-built
+    /// fixtures use synthetic spans, and `assert_eq!` would diverge on
+    /// the span field even when the structural shape matches. Compare
+    /// the stripped form to assert "same shape, ignore positions".
+    pub fn strip_spans(&self) -> Pattern {
+        match self {
+            Pattern::Literal { bytes, .. } => Pattern::Literal {
+                bytes: bytes.clone(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::CharClass { set, .. } => Pattern::CharClass {
+                set: *set,
+                span: Span::SYNTHETIC,
+            },
+            Pattern::AnyChar { .. } => Pattern::AnyChar {
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Sequence { items, .. } => Pattern::Sequence {
+                items: items.iter().map(Pattern::strip_spans).collect(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::OrderedChoice { alts, .. } => Pattern::OrderedChoice {
+                alts: alts.iter().map(Pattern::strip_spans).collect(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Repeat { inner, .. } => Pattern::Repeat {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::RepeatOne { inner, .. } => Pattern::RepeatOne {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Optional { inner, .. } => Pattern::Optional {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::NotPredicate { inner, .. } => Pattern::NotPredicate {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::AndPredicate { inner, .. } => Pattern::AndPredicate {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::NonTerminal { name, .. } => Pattern::NonTerminal {
+                name: name.clone(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Capture { kind, inner, .. } => Pattern::Capture {
+                kind: kind.clone(),
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Catch {
+                inner,
+                label,
+                recovery,
+                ..
+            } => Pattern::Catch {
+                inner: Box::new(inner.strip_spans()),
+                label: label.clone(),
+                recovery: Box::new(recovery.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::Lenient { inner, .. } => Pattern::Lenient {
+                inner: Box::new(inner.strip_spans()),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::InferBoundaryCatch { inner, label, .. } => Pattern::InferBoundaryCatch {
+                inner: Box::new(inner.strip_spans()),
+                label: label.clone(),
+                span: Span::SYNTHETIC,
+            },
         }
     }
 }

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1596,7 +1596,7 @@ mod examined_max_tests {
     //! memo map — post-run the public `run_with_memo_stats` has already
     //! discarded it.
     use super::*;
-    use crate::pegc::{Grammar, Pattern};
+    use crate::pegc::{Grammar, Pattern, Span};
     use std::collections::HashMap;
 
     fn rule(rules: &mut HashMap<String, Pattern>, name: &str, pat: Pattern) {
@@ -1614,7 +1614,7 @@ mod examined_max_tests {
             "start",
             Pattern::seq(vec![
                 Pattern::literal("x"),
-                Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+                Pattern::and_predicate(Pattern::literal("y")),
             ]),
         );
         let prog = Grammar::new(rules, "start").compile().unwrap();
@@ -1643,7 +1643,7 @@ mod examined_max_tests {
             "start",
             Pattern::seq(vec![
                 Pattern::literal("x"),
-                Pattern::AndPredicate(Box::new(Pattern::literal("z"))),
+                Pattern::and_predicate(Pattern::literal("z")),
             ]),
         );
         let prog = Grammar::new(rules, "start").compile().unwrap();
@@ -1671,10 +1671,7 @@ mod examined_max_tests {
         rule(
             &mut rules,
             "outer",
-            Pattern::seq(vec![
-                Pattern::NonTerminal("inner".into()),
-                Pattern::literal("y"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("inner"), Pattern::literal("y")]),
         );
         rule(&mut rules, "inner", Pattern::literal("x"));
         let prog = Grammar::new(rules, "outer").compile().unwrap();
@@ -1709,14 +1706,8 @@ mod examined_max_tests {
             &mut rules,
             "start",
             Pattern::choice(vec![
-                Pattern::seq(vec![
-                    Pattern::NonTerminal("X".into()),
-                    Pattern::literal("aa"),
-                ]),
-                Pattern::seq(vec![
-                    Pattern::NonTerminal("X".into()),
-                    Pattern::literal("bb"),
-                ]),
+                Pattern::seq(vec![Pattern::nt("X"), Pattern::literal("aa")]),
+                Pattern::seq(vec![Pattern::nt("X"), Pattern::literal("bb")]),
             ]),
         );
         rule(&mut rules, "X", Pattern::literal("a"));
@@ -1756,14 +1747,12 @@ mod examined_max_tests {
         rule(
             &mut rules,
             "start",
-            Pattern::Repeat(Box::new(Pattern::Catch {
+            Pattern::repeat(Pattern::Catch {
                 inner: Box::new(Pattern::literal("ab")),
                 label: "recovery".into(),
-                recovery: Box::new(Pattern::Capture(
-                    "recovery".into(),
-                    Box::new(Pattern::AnyChar),
-                )),
-            })),
+                recovery: Box::new(Pattern::capture("recovery", Pattern::any_char())),
+                span: Span::SYNTHETIC,
+            }),
         );
         let prog = Grammar::new(rules, "start").compile().unwrap();
         let (result, _stats, memo) = VM::new(&prog.code, b"abxab")

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use syntax_highlighter::pegc::analysis::{
     compute_follow, lint_partial_match, FollowElement, LintFinding, LintKind,
 };
-use syntax_highlighter::pegc::{compile_pattern, parse, Grammar, Pattern};
+use syntax_highlighter::pegc::{compile_pattern, parse, Grammar, Pattern, Span};
 use syntax_highlighter::pegvm::{
     Capture, CaptureKind, CharSet, Instruction, Label, LabelId, MatchResult, MemoId, RuleKind, VM,
 };
@@ -39,7 +39,7 @@ fn literal_pattern() {
 
 #[test]
 fn char_class_pattern() {
-    let p = Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]));
+    let p = Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]));
     assert_eq!(
         run_pattern(&p, b"5"),
         MatchResult {
@@ -54,7 +54,7 @@ fn char_class_pattern() {
 
 #[test]
 fn any_char_pattern() {
-    let p = Pattern::AnyChar;
+    let p = Pattern::any_char();
     assert_eq!(
         run_pattern(&p, b"q"),
         MatchResult {
@@ -145,7 +145,7 @@ fn ordered_choice_three() {
 
 #[test]
 fn repeat_zero_or_more() {
-    let p = Pattern::Repeat(Box::new(Pattern::literal("a")));
+    let p = Pattern::repeat(Pattern::literal("a"));
     assert_eq!(
         run_pattern(&p, b""),
         MatchResult {
@@ -177,7 +177,7 @@ fn repeat_zero_or_more() {
 
 #[test]
 fn repeat_one_or_more() {
-    let p = Pattern::RepeatOne(Box::new(Pattern::literal("a")));
+    let p = Pattern::repeat_one(Pattern::literal("a"));
     assert!(!run_pattern(&p, b"").complete);
     assert_eq!(
         run_pattern(&p, b"a"),
@@ -206,11 +206,12 @@ fn repeat_one_or_more() {
 /// always picked `"recovery"`, and tests parameterize to exercise the
 /// label/capture-interning pipeline.
 fn recover(inner: Pattern, kind: &str) -> Pattern {
-    Pattern::Repeat(Box::new(Pattern::Catch {
+    Pattern::repeat(Pattern::Catch {
         inner: Box::new(inner),
         label: kind.into(),
-        recovery: Box::new(Pattern::Capture(kind.into(), Box::new(Pattern::AnyChar))),
-    }))
+        recovery: Box::new(Pattern::capture(kind, Pattern::any_char())),
+        span: Span::SYNTHETIC,
+    })
 }
 
 #[test]
@@ -281,7 +282,7 @@ fn recover_repeat_preserves_failed_inner_attempt_deepest_captures() {
     // before the recovery body, so @open interns first (id 0) and
     // @recovery second (id 1).
     let inner = Pattern::seq(vec![
-        Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+        Pattern::capture("open", Pattern::literal("a")),
         Pattern::literal("b"),
     ]);
     let p = recover(inner, "recovery");
@@ -313,7 +314,7 @@ fn recover_repeat_failed_attempt_reaching_eof_does_not_leak_clean_match() {
     // assert_not_clean_parse cases (e.g. "SELECT SELECT") for the
     // grammar-level analogue.
     let inner = Pattern::seq(vec![
-        Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+        Pattern::capture("open", Pattern::literal("a")),
         Pattern::literal("b"),
     ]);
     let p = recover(inner, "recovery");
@@ -347,7 +348,7 @@ fn recover_repeat_nested_loops_do_not_panic() {
     // parse runs to completion.
     let inner = recover(
         Pattern::seq(vec![
-            Pattern::Capture("a".into(), Box::new(Pattern::literal("a"))),
+            Pattern::capture("a", Pattern::literal("a")),
             Pattern::literal("X"),
         ]),
         "inner_rec",
@@ -388,10 +389,7 @@ fn recover_repeat_empty_capture_in_failed_inner_attempt_is_dropped() {
     // that tries to "improve" the empty-capture case is forced to
     // re-baseline this test deliberately.
     let inner = Pattern::seq(vec![
-        Pattern::Capture(
-            "x".into(),
-            Box::new(Pattern::NotPredicate(Box::new(Pattern::literal("x")))),
-        ),
+        Pattern::capture("x", Pattern::not_predicate(Pattern::literal("x"))),
         Pattern::literal("z"),
     ]);
     let p = recover(inner, "recovery");
@@ -426,12 +424,9 @@ fn recover_repeat_drops_unclosed_capture_from_failed_inner_attempt() {
     // every entry whose `end.is_none()` during the splice: a still-
     // open capture at the watermark belongs to a production that
     // didn't complete and must not become a token.
-    let inner = Pattern::Capture(
-        "kw".into(),
-        Box::new(Pattern::choice(vec![
-            Pattern::literal("abc"),
-            Pattern::literal("abd"),
-        ])),
+    let inner = Pattern::capture(
+        "kw",
+        Pattern::choice(vec![Pattern::literal("abc"), Pattern::literal("abd")]),
     );
     let p = recover(inner, "recovery");
     let r = run_pattern(&p, b"abx");
@@ -461,10 +456,7 @@ fn recover_repeat_inside_called_rule_returns_cleanly() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::seq(vec![
-            Pattern::literal("PRE"),
-            Pattern::NonTerminal("loop".into()),
-        ]),
+        Pattern::seq(vec![Pattern::literal("PRE"), Pattern::nt("loop")]),
     );
     rules.insert("loop".into(), recover(Pattern::literal("a"), "recovery"));
     let prog = Grammar::new(rules, "start").compile().unwrap();
@@ -487,14 +479,14 @@ fn catch_inner_success_does_not_run_recovery() {
     // inner = @open{"ab"}, recovery = @err{(!';' .)*}
     // Input matches inner cleanly; recovery branch must not fire.
     let p = catch(
-        Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        Pattern::capture("open", Pattern::literal("ab")),
         "lbl",
-        Pattern::Capture(
-            "err".into(),
-            Box::new(Pattern::Repeat(Box::new(Pattern::seq(vec![
-                Pattern::NotPredicate(Box::new(Pattern::literal(";"))),
-                Pattern::AnyChar,
-            ])))),
+        Pattern::capture(
+            "err",
+            Pattern::repeat(Pattern::seq(vec![
+                Pattern::not_predicate(Pattern::literal(";")),
+                Pattern::any_char(),
+            ])),
         ),
     );
     let r = run_pattern(&p, b"ab");
@@ -512,9 +504,9 @@ fn catch_inner_success_does_not_run_recovery() {
 fn catch_inner_failure_runs_recovery() {
     // inner = @open{"ab"} fails at sp=0; recovery = @err{.} consumes one byte.
     let p = catch(
-        Pattern::Capture("open".into(), Box::new(Pattern::literal("ab"))),
+        Pattern::capture("open", Pattern::literal("ab")),
         "lbl",
-        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+        Pattern::capture("err", Pattern::any_char()),
     );
     let r = run_pattern(&p, b"xy");
     assert!(r.complete);
@@ -539,11 +531,11 @@ fn catch_preserves_failed_inner_attempt_deepest_captures() {
     // (sp=1, after the 'a'), not at baseline (sp=0).
     let p = catch(
         Pattern::seq(vec![
-            Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+            Pattern::capture("open", Pattern::literal("a")),
             Pattern::literal("b"),
         ]),
         "lbl",
-        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+        Pattern::capture("err", Pattern::any_char()),
     );
     let r = run_pattern(&p, b"ax");
     assert!(r.complete);
@@ -622,11 +614,11 @@ fn catch_nested_inside_recover_repeat() {
     // rather than exact capture spans.
     let inner_catch = catch(
         Pattern::seq(vec![
-            Pattern::Capture("open".into(), Box::new(Pattern::literal("a"))),
+            Pattern::capture("open", Pattern::literal("a")),
             Pattern::literal("b"),
         ]),
         "lbl",
-        Pattern::Capture("err".into(), Box::new(Pattern::AnyChar)),
+        Pattern::capture("err", Pattern::any_char()),
     );
     let p = recover(inner_catch, "recovery");
     let r = run_pattern(&p, b"abaxabZ");
@@ -681,7 +673,7 @@ fn label_intern_shared_with_recover_repeat_recovery_kind() {
 #[test]
 fn optional_pattern() {
     let p = Pattern::seq(vec![
-        Pattern::Optional(Box::new(Pattern::literal("-"))),
+        Pattern::optional(Pattern::literal("-")),
         Pattern::literal("x"),
     ]);
     assert_eq!(
@@ -708,8 +700,8 @@ fn optional_pattern() {
 #[test]
 fn not_predicate_pattern() {
     let p = Pattern::seq(vec![
-        Pattern::NotPredicate(Box::new(Pattern::literal("a"))),
-        Pattern::AnyChar,
+        Pattern::not_predicate(Pattern::literal("a")),
+        Pattern::any_char(),
     ]);
     assert_eq!(
         run_pattern(&p, b"b"),
@@ -728,7 +720,7 @@ fn and_predicate_pattern() {
     // &"a" "ab"  -> matches "ab" only when first char is 'a' (always true here, but the
     // &-predicate consumes nothing)
     let p = Pattern::seq(vec![
-        Pattern::AndPredicate(Box::new(Pattern::literal("a"))),
+        Pattern::and_predicate(Pattern::literal("a")),
         Pattern::literal("ab"),
     ]);
     assert_eq!(
@@ -745,7 +737,7 @@ fn and_predicate_pattern() {
 
 #[test]
 fn capture_records_kind_and_span() {
-    let p = Pattern::Capture("number".into(), Box::new(Pattern::literal("42")));
+    let p = Pattern::capture("number", Pattern::literal("42"));
     let prog = compile_pattern(&p);
     assert_eq!(prog.capture_kinds, vec!["number".to_string()]);
     assert_eq!(
@@ -762,12 +754,12 @@ fn capture_records_kind_and_span() {
 #[test]
 fn nested_captures_flow_through_compile() {
     // @outer{ @inner{"a"} @inner{"b"} }
-    let p = Pattern::Capture(
-        "outer".into(),
-        Box::new(Pattern::seq(vec![
-            Pattern::Capture("inner".into(), Box::new(Pattern::literal("a"))),
-            Pattern::Capture("inner".into(), Box::new(Pattern::literal("b"))),
-        ])),
+    let p = Pattern::capture(
+        "outer",
+        Pattern::seq(vec![
+            Pattern::capture("inner", Pattern::literal("a")),
+            Pattern::capture("inner", Pattern::literal("b")),
+        ]),
     );
     let prog = compile_pattern(&p);
     // Kinds interned in the order they're first encountered during compile.
@@ -795,13 +787,10 @@ fn grammar_with_nonterminals() {
     // start <- digit+
     // digit <- [0-9]
     let mut rules = HashMap::new();
-    rules.insert(
-        "start".into(),
-        Pattern::RepeatOne(Box::new(Pattern::NonTerminal("digit".into()))),
-    );
+    rules.insert("start".into(), Pattern::repeat_one(Pattern::nt("digit")));
     rules.insert(
         "digit".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     assert_eq!(
@@ -819,7 +808,7 @@ fn grammar_with_nonterminals() {
 #[test]
 fn grammar_undefined_rule_errors() {
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("missing".into()));
+    rules.insert("start".into(), Pattern::nt("missing"));
     let err = Grammar::new(rules, "start").compile().unwrap_err();
     let msg = format!("{}", err);
     assert!(msg.contains("missing"), "got: {}", msg);
@@ -849,7 +838,7 @@ fn ordered_choice_emits_expected_skeleton() {
 
 #[test]
 fn repeat_emits_partial_commit() {
-    let p = Pattern::Repeat(Box::new(Pattern::literal("a")));
+    let p = Pattern::repeat(Pattern::literal("a"));
     let prog = compile_pattern(&p);
     // Choice jumps over the loop on first failure; PartialCommit jumps to the
     // body (index 1), NOT back to Choice — the existing backtrack entry is reused.
@@ -927,16 +916,17 @@ fn recover_repeat_labeled_interns_author_label() {
 /// `Catch(inner, "recovery", @recovery{(!cs .)* cs})`. Mirrors
 /// `build_recover_repeat` in `src/pegc/parser.rs`.
 fn sync_set_recover(inner: Pattern, charset: CharSet) -> Pattern {
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(charset))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(charset)]);
-    Pattern::Repeat(Box::new(Pattern::Catch {
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(charset)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(charset)]);
+    Pattern::repeat(Pattern::Catch {
         inner: Box::new(inner),
         label: "recovery".into(),
-        recovery: Box::new(Pattern::Capture("recovery".into(), Box::new(recovery_body))),
-    }))
+        recovery: Box::new(Pattern::capture("recovery", recovery_body)),
+        span: Span::SYNTHETIC,
+    })
 }
 
 #[test]
@@ -1058,7 +1048,7 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
         "start".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
-                Pattern::NonTerminal("start".into()),
+                Pattern::nt("start"),
                 Pattern::literal("+"),
                 Pattern::literal("n"),
             ]),
@@ -1116,7 +1106,7 @@ fn right_recursive_rule_is_not_marked_lr() {
             Pattern::seq(vec![
                 Pattern::literal("n"),
                 Pattern::literal("+"),
-                Pattern::NonTerminal("start".into()),
+                Pattern::nt("start"),
             ]),
             Pattern::literal("n"),
         ]),
@@ -1148,20 +1138,14 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
     rules.insert(
         "a".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("b".into()),
-                Pattern::literal("x"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("b"), Pattern::literal("x")]),
             Pattern::literal("y"),
         ]),
     );
     rules.insert(
         "b".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("a".into()),
-                Pattern::literal("z"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("a"), Pattern::literal("z")]),
             Pattern::literal("w"),
         ]),
     );
@@ -1200,30 +1184,21 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
     rules.insert(
         "a".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("b".into()),
-                Pattern::literal("x"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("b"), Pattern::literal("x")]),
             Pattern::literal("p"),
         ]),
     );
     rules.insert(
         "b".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("c".into()),
-                Pattern::literal("y"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("c"), Pattern::literal("y")]),
             Pattern::literal("q"),
         ]),
     );
     rules.insert(
         "c".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("a".into()),
-                Pattern::literal("z"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("a"), Pattern::literal("z")]),
             Pattern::literal("r"),
         ]),
     );
@@ -1266,20 +1241,14 @@ fn right_recursive_two_rule_grammar_is_not_marked_lr() {
     rules.insert(
         "a".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::literal("x"),
-                Pattern::NonTerminal("b".into()),
-            ]),
+            Pattern::seq(vec![Pattern::literal("x"), Pattern::nt("b")]),
             Pattern::literal("y"),
         ]),
     );
     rules.insert(
         "b".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::literal("z"),
-                Pattern::NonTerminal("a".into()),
-            ]),
+            Pattern::seq(vec![Pattern::literal("z"), Pattern::nt("a")]),
             Pattern::literal("w"),
         ]),
     );
@@ -1309,18 +1278,15 @@ fn lr_through_nullable_prefix_is_detected() {
         "start".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
-                Pattern::NonTerminal("opt".into()),
-                Pattern::NonTerminal("start".into()),
+                Pattern::nt("opt"),
+                Pattern::nt("start"),
                 Pattern::literal("+"),
                 Pattern::literal("n"),
             ]),
             Pattern::literal("n"),
         ]),
     );
-    rules.insert(
-        "opt".into(),
-        Pattern::Optional(Box::new(Pattern::literal("x"))),
-    );
+    rules.insert("opt".into(), Pattern::optional(Pattern::literal("x")));
     let prog = Grammar::new(rules, "start").compile().unwrap();
     assert!(prog
         .code
@@ -1349,7 +1315,7 @@ fn cap_lit(kind: &str, s: &str) -> FollowElement {
 fn follow_set_single_rule_tail() {
     // start <- a; a <- 'x'
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("start".into(), Pattern::nt("a"));
     rules.insert("a".into(), Pattern::literal("x"));
     let g = Grammar::new(rules, "start");
     let follow = compute_follow(&g);
@@ -1363,10 +1329,7 @@ fn follow_set_sequence_after() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::literal("y"),
-        ]),
+        Pattern::seq(vec![Pattern::nt("a"), Pattern::literal("y")]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
     let g = Grammar::new(rules, "start");
@@ -1380,10 +1343,7 @@ fn follow_set_choice_tail() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::choice(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::NonTerminal("b".into()),
-        ]),
+        Pattern::choice(vec![Pattern::nt("a"), Pattern::nt("b")]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
     rules.insert("b".into(), Pattern::literal("y"));
@@ -1398,10 +1358,7 @@ fn follow_set_choice_tail() {
 fn follow_set_repeat_self() {
     // start <- a*; a <- 'x'
     let mut rules = HashMap::new();
-    rules.insert(
-        "start".into(),
-        Pattern::Repeat(Box::new(Pattern::NonTerminal("a".into()))),
-    );
+    rules.insert("start".into(), Pattern::repeat(Pattern::nt("a")));
     rules.insert("a".into(), Pattern::literal("x"));
     let g = Grammar::new(rules, "start");
     let follow = compute_follow(&g);
@@ -1425,16 +1382,13 @@ fn follow_set_nullable_skip() {
     rules.insert(
         "start".into(),
         Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::NonTerminal("b".into()),
+            Pattern::nt("a"),
+            Pattern::nt("b"),
             Pattern::literal("z"),
         ]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
-    rules.insert(
-        "b".into(),
-        Pattern::Optional(Box::new(Pattern::literal("y"))),
-    );
+    rules.insert("b".into(), Pattern::optional(Pattern::literal("y")));
     let g = Grammar::new(rules, "start");
     let follow = compute_follow(&g);
     let f_a = &follow["a"];
@@ -1458,10 +1412,10 @@ fn follow_set_recursive() {
         "list".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
-            Pattern::Optional(Box::new(Pattern::seq(vec![
+            Pattern::optional(Pattern::seq(vec![
                 Pattern::literal(","),
-                Pattern::NonTerminal("list".into()),
-            ]))),
+                Pattern::nt("list"),
+            ])),
         ]),
     );
     let g = Grammar::new(rules, "list");
@@ -1479,8 +1433,8 @@ fn follow_set_capture_preserved() {
     rules.insert(
         "start".into(),
         Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::Capture("punctuation".into(), Box::new(Pattern::literal(","))),
+            Pattern::nt("a"),
+            Pattern::capture("punctuation", Pattern::literal(",")),
         ]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
@@ -1500,8 +1454,8 @@ fn follow_set_predicate_lookahead() {
     rules.insert(
         "start".into(),
         Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+            Pattern::nt("a"),
+            Pattern::and_predicate(Pattern::literal("y")),
             Pattern::literal("z"),
         ]),
     );
@@ -1560,11 +1514,16 @@ type BTreeSetOf<T> = std::collections::BTreeSet<T>;
 
 // -- partial-match leniency lint ----------------------------------------
 
+/// Helper for ergonomic `LintFinding` construction in tests that don't
+/// pin a specific call-site position. Existing tests just want to
+/// assert on `(rule, caller)` pairs; spans are tested separately by
+/// the per-position assertions added for #114.
 fn finding(rule: &str, caller: &str) -> LintFinding {
     LintFinding {
         kind: LintKind::PartialMatchLeniency,
         rule: rule.into(),
         caller: caller.into(),
+        call_site: Span::SYNTHETIC,
     }
 }
 
@@ -1574,12 +1533,12 @@ fn lint_partial_match_trailing_optional_with_eof_validator() {
     // a is called from the start rule, whose only continuation is Eof.
     // Eof rejects any non-empty leftover bytes — a validator. No flag.
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("start".into(), Pattern::nt("a"));
     rules.insert(
         "a".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
-            Pattern::Optional(Box::new(Pattern::literal("y"))),
+            Pattern::optional(Pattern::literal("y")),
         ]),
     );
     let g = Grammar::new(rules, "start");
@@ -1590,7 +1549,7 @@ fn lint_partial_match_trailing_optional_with_eof_validator() {
 fn lint_partial_match_no_trailing_nullable_skipped() {
     // start <- a; a <- 'x' 'y' — no trailing optional/nullable.
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("start".into(), Pattern::nt("a"));
     rules.insert(
         "a".into(),
         Pattern::seq(vec![Pattern::literal("x"), Pattern::literal("y")]),
@@ -1608,8 +1567,8 @@ fn lint_partial_match_anchored_via_andpredicate() {
     rules.insert(
         "start".into(),
         Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+            Pattern::nt("a"),
+            Pattern::and_predicate(Pattern::literal("y")),
             Pattern::literal("y"),
         ]),
     );
@@ -1617,7 +1576,7 @@ fn lint_partial_match_anchored_via_andpredicate() {
         "a".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
-            Pattern::Optional(Box::new(Pattern::literal("y"))),
+            Pattern::optional(Pattern::literal("y")),
         ]),
     );
     let g = Grammar::new(rules, "start");
@@ -1635,16 +1594,13 @@ fn lint_partial_match_validated_by_disjoint_consumer() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::seq(vec![
-            Pattern::NonTerminal("a".into()),
-            Pattern::literal("z"),
-        ]),
+        Pattern::seq(vec![Pattern::nt("a"), Pattern::literal("z")]),
     );
     rules.insert(
         "a".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
-            Pattern::Optional(Box::new(Pattern::literal("y"))),
+            Pattern::optional(Pattern::literal("y")),
         ]),
     );
     let g = Grammar::new(rules, "start");
@@ -1658,21 +1614,22 @@ fn lint_partial_match_absorbed_by_outer_catch_flagged() {
     // a's leniency at the call site is absorbed by the *^ recovery
     // wrapper — exactly the PR #101 shape.
     let mut rules = HashMap::new();
-    let recovery_body = Pattern::Repeat(Box::new(Pattern::seq(vec![
-        Pattern::NotPredicate(Box::new(Pattern::literal(";"))),
-        Pattern::AnyChar,
-    ])));
-    let call_inside_catch = Pattern::Repeat(Box::new(Pattern::Catch {
-        inner: Box::new(Pattern::NonTerminal("a".into())),
+    let recovery_body = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::literal(";")),
+        Pattern::any_char(),
+    ]));
+    let call_inside_catch = Pattern::repeat(Pattern::Catch {
+        inner: Box::new(Pattern::nt("a")),
         label: "recovery".into(),
         recovery: Box::new(recovery_body),
-    }));
+        span: Span::SYNTHETIC,
+    });
     rules.insert("start".into(), call_inside_catch);
     rules.insert(
         "a".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
-            Pattern::Optional(Box::new(Pattern::literal("y"))),
+            Pattern::optional(Pattern::literal("y")),
         ]),
     );
     let g = Grammar::new(rules, "start");
@@ -1709,10 +1666,10 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
     // Replace result_column's body with an unanchored version.
     g.rules.insert(
         "result_column".into(),
-        Pattern::OrderedChoice(vec![
-            Pattern::NonTerminal("table_star".into()),
-            Pattern::Capture("operator".into(), Box::new(Pattern::literal("*"))),
-            Pattern::NonTerminal("aliased_expr".into()),
+        Pattern::choice(vec![
+            Pattern::nt("table_star"),
+            Pattern::capture("operator", Pattern::literal("*")),
+            Pattern::nt("aliased_expr"),
         ]),
     );
     let findings = lint_partial_match(&g);
@@ -1734,8 +1691,8 @@ fn definition_lenient_marker_wraps_rule_body() {
     // call-site `~p` form produces.
     let g = parse("~r <- 'a'?").expect("parse");
     assert_eq!(
-        g.rules["r"],
-        Pattern::Lenient(Box::new(Pattern::Optional(Box::new(Pattern::literal("a"))))),
+        g.rules["r"].strip_spans(),
+        Pattern::lenient(Pattern::optional(Pattern::literal("a"))),
     );
 }
 
@@ -2036,4 +1993,125 @@ fn all_shipped_grammars_compile_clean() {
         g.compile()
             .unwrap_or_else(|e| panic!("compile {path:?}: {e}"));
     }
+}
+
+// ---- #114: Pattern AST spans surfaced through diagnostics ------------
+//
+// These tests pin the positional contract added by issue #114: every
+// `Pattern` node carries a source `Span`; the two fatal `CompileError`
+// variants that authors hit during grammar work — `PartialMatchLeniency`
+// and `CannotInferBoundary` — render `{line}:{col}:` so call sites are
+// directly navigable instead of requiring `grep -n` from the rule name.
+
+#[test]
+fn partial_match_leniency_carries_call_site_span_in_display() {
+    // `(r)*^[;]` is the catch-absorbed shape that reliably flags — the
+    // `r` reference at line 1, col 11 is the call site the lint
+    // surfaces. The rendered Display must include `{line}:{col}` so
+    // grammar authors can jump to the unanchored call directly.
+    let src = "start <- (r)*^[;]\nr <- 'x' 'y'?";
+    let g = parse(src).expect("parses");
+    let err = g.compile().expect_err("partial-match leniency expected");
+    let rendered = format!("{err}");
+    assert!(
+        rendered.contains("1:11:"),
+        "expected call-site `1:11:` (the `r` reference on line 1, col 11), got:\n{rendered}",
+    );
+}
+
+#[test]
+fn partial_match_leniency_finding_carries_call_site_span() {
+    // The structured `LintFinding.call_site` is the navigable position;
+    // the Display impl is a thin formatting layer over it. Pin the
+    // structured field directly so callers (e.g. editor diagnostics)
+    // get the same position the rendered text reports.
+    let src = "start <- (r)*^[;]\nr <- 'x' 'y'?";
+    let g = parse(src).expect("parses");
+    let findings = lint_partial_match(&g);
+    let f = findings
+        .iter()
+        .find(|f| f.rule == "r" && f.caller == "start")
+        .expect("r/start finding present");
+    assert_eq!(f.call_site, Span { line: 1, col: 11 });
+}
+
+#[test]
+fn cannot_infer_boundary_carries_placeholder_span_in_display() {
+    // The start rule's FOLLOW seeds with EOF, so a top-level `^^lbl`
+    // there resolves successfully. An unreachable rule has empty FOLLOW
+    // and triggers `CannotInferBoundary` — the placeholder's span at
+    // line 2, col 15 (start of `^^bad`) surfaces through both the
+    // structured error and its Display rendering.
+    let src = "start <- 'x'\norphan <- 'a' ^^bad";
+    let g = parse(src).expect("parses");
+    let err = g.compile().expect_err("CannotInferBoundary expected");
+    match &err {
+        syntax_highlighter::pegc::CompileError::CannotInferBoundary { span, .. } => {
+            assert_eq!(*span, Span { line: 2, col: 15 });
+        }
+        other => panic!("expected CannotInferBoundary, got: {other:?}"),
+    }
+    let rendered = format!("{err}");
+    assert!(
+        rendered.starts_with("2:15:"),
+        "expected `2:15:` prefix, got: {rendered}",
+    );
+}
+
+#[test]
+fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
+    // One assertion per per-variant convention (atom, sequence-child,
+    // operator-position) — locks in `Span` production for parsing.
+    // Atom: `NonTerminal` span = first byte of the identifier.
+    // Operator: `Optional` span inherits its operand's span.
+    // Operator: `Capture` span = position of the `@`.
+    // Operator: `Catch` span = position of the leading `^`.
+    let src = "r <- @kind{'a'?} ^lbl 'b'";
+    let g = parse(src).expect("parses");
+    let body = &g.rules["r"];
+
+    // Top-level is a `Catch`: span at the `^` (column 18 — `^lbl` follows
+    // `@kind{'a'?} `).
+    let Pattern::Catch { inner, span, .. } = body else {
+        panic!("expected Catch at root, got: {body:?}");
+    };
+    assert_eq!(
+        *span,
+        Span { line: 1, col: 18 },
+        "Catch span should anchor at `^`"
+    );
+
+    // Inner is a `Capture`: span at the `@` (column 6).
+    let Pattern::Capture {
+        inner: cap_inner,
+        span: cap_span,
+        ..
+    } = inner.as_ref()
+    else {
+        panic!("expected Capture, got: {inner:?}");
+    };
+    assert_eq!(
+        *cap_span,
+        Span { line: 1, col: 6 },
+        "Capture span should anchor at `@`"
+    );
+
+    // Inside the capture: `Optional` whose span inherits the operand's
+    // start position — the operand is `'a'` literal at column 12.
+    let Pattern::Optional {
+        inner: opt_inner,
+        span: opt_span,
+    } = cap_inner.as_ref()
+    else {
+        panic!("expected Optional inside Capture, got: {cap_inner:?}");
+    };
+    assert_eq!(
+        *opt_span,
+        Span { line: 1, col: 12 },
+        "Optional span should inherit operand's start (the `'`)"
+    );
+    let Pattern::Literal { span: lit_span, .. } = opt_inner.as_ref() else {
+        panic!("expected Literal inside Optional, got: {opt_inner:?}");
+    };
+    assert_eq!(*lit_span, Span { line: 1, col: 12 });
 }

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1,8 +1,20 @@
-use syntax_highlighter::pegc::{parse as parse_src, Pattern};
+use syntax_highlighter::pegc::{parse as parse_src, Pattern, Span};
 use syntax_highlighter::pegvm::CharSet;
 
+/// Parse, then strip spans from every rule body. Tests in this file
+/// assert structural shape via `assert_eq!` against hand-built
+/// fixtures that carry [`Span::SYNTHETIC`]; the parsed pattern's real
+/// positions would otherwise make the equality check diverge on the
+/// span field. The dedicated positional-assertion tests for #114 use
+/// `parse_src` directly to inspect real spans.
 fn parse(src: &str) -> syntax_highlighter::pegc::Grammar {
-    parse_src(src).expect("parse failed")
+    let mut g = parse_src(src).expect("parse failed");
+    g.rules = g
+        .rules
+        .into_iter()
+        .map(|(k, v)| (k, v.strip_spans()))
+        .collect();
+    g
 }
 
 #[test]
@@ -24,7 +36,7 @@ fn ordered_choice_in_grammar() {
     let g = parse("r <- 'a' / 'b' / 'c'");
     assert_eq!(
         g.rules["r"],
-        Pattern::OrderedChoice(vec![
+        Pattern::choice(vec![
             Pattern::literal("a"),
             Pattern::literal("b"),
             Pattern::literal("c"),
@@ -37,7 +49,7 @@ fn sequence_in_grammar() {
     let g = parse("r <- 'a' 'b' 'c'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("a"),
             Pattern::literal("b"),
             Pattern::literal("c"),
@@ -48,18 +60,9 @@ fn sequence_in_grammar() {
 #[test]
 fn postfix_operators() {
     let g = parse("a <- 'x'*\nb <- 'x'+\nc <- 'x'?");
-    assert_eq!(
-        g.rules["a"],
-        Pattern::Repeat(Box::new(Pattern::literal("x")))
-    );
-    assert_eq!(
-        g.rules["b"],
-        Pattern::RepeatOne(Box::new(Pattern::literal("x")))
-    );
-    assert_eq!(
-        g.rules["c"],
-        Pattern::Optional(Box::new(Pattern::literal("x")))
-    );
+    assert_eq!(g.rules["a"], Pattern::repeat(Pattern::literal("x")));
+    assert_eq!(g.rules["b"], Pattern::repeat_one(Pattern::literal("x")));
+    assert_eq!(g.rules["c"], Pattern::optional(Pattern::literal("x")));
 }
 
 #[test]
@@ -74,7 +77,7 @@ fn postfix_repeat_count_multiple() {
     let g = parse("r <- 'x'{4}");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
             Pattern::literal("x"),
             Pattern::literal("x"),
@@ -86,20 +89,20 @@ fn postfix_repeat_count_multiple() {
 #[test]
 fn postfix_repeat_count_on_backslash_atom() {
     let g = parse("r <- \\d{4}");
-    let digit = Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]));
+    let digit = Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]));
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![digit.clone(), digit.clone(), digit.clone(), digit])
+        Pattern::seq(vec![digit.clone(), digit.clone(), digit.clone(), digit])
     );
 }
 
 #[test]
 fn postfix_repeat_count_on_group() {
     let g = parse("r <- ('a' / 'b'){3}");
-    let choice = Pattern::OrderedChoice(vec![Pattern::literal("a"), Pattern::literal("b")]);
+    let choice = Pattern::choice(vec![Pattern::literal("a"), Pattern::literal("b")]);
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![choice.clone(), choice.clone(), choice])
+        Pattern::seq(vec![choice.clone(), choice.clone(), choice])
     );
 }
 
@@ -110,10 +113,10 @@ fn postfix_repeat_count_chains_with_star() {
     let g = parse("r <- 'x'{2}*");
     assert_eq!(
         g.rules["r"],
-        Pattern::Repeat(Box::new(Pattern::Sequence(vec![
+        Pattern::repeat(Pattern::seq(vec![
             Pattern::literal("x"),
             Pattern::literal("x"),
-        ])))
+        ]))
     );
 }
 
@@ -122,7 +125,7 @@ fn postfix_repeat_count_at_maximum_accepted() {
     // Boundary case: 1024 is the cap, must be accepted.
     let g = parse("r <- 'x'{1024}");
     match &g.rules["r"] {
-        Pattern::Sequence(items) => assert_eq!(items.len(), 1024),
+        Pattern::Sequence { items, .. } => assert_eq!(items.len(), 1024),
         other => panic!("expected Sequence of 1024 items, got: {other:?}"),
     }
 }
@@ -214,11 +217,12 @@ fn desugared_recover_repeat_with_label(
     recovery_body: Pattern,
     label: &str,
 ) -> Pattern {
-    Pattern::Repeat(Box::new(Pattern::Catch {
+    Pattern::repeat(Pattern::Catch {
         inner: Box::new(inner),
         label: label.into(),
-        recovery: Box::new(Pattern::Capture("recovery".into(), Box::new(recovery_body))),
-    }))
+        recovery: Box::new(Pattern::capture("recovery", recovery_body)),
+        span: Span::SYNTHETIC,
+    })
 }
 
 #[test]
@@ -227,7 +231,7 @@ fn recover_repeat_postfix_star_caret() {
     let g = parse("r <- 'x'*^");
     assert_eq!(
         g.rules["r"],
-        desugared_recover_repeat(Pattern::literal("x"), Pattern::AnyChar)
+        desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char())
     );
 }
 
@@ -237,9 +241,9 @@ fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
     let g = parse("r <- 'x'+^");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
-            desugared_recover_repeat(Pattern::literal("x"), Pattern::AnyChar),
+            desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char()),
         ])
     );
 }
@@ -249,11 +253,11 @@ fn sync_set_postfix_star_caret_charset() {
     // `p*^[;]` desugars to `(p ^recovery @recovery{(![;] .)* [;]})*`.
     let semi = CharSet::from_bytes(b";");
     let g = parse("r <- 'x'*^[;]");
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(semi)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(semi)]);
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat(Pattern::literal("x"), recovery_body)
@@ -265,14 +269,14 @@ fn sync_set_postfix_plus_caret_charset() {
     // `p+^[;]` lowers to `p (p*^[;])`.
     let semi = CharSet::from_bytes(b";");
     let g = parse("r <- 'x'+^[;]");
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(semi)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(semi)]);
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
             desugared_recover_repeat(Pattern::literal("x"), recovery_body),
         ])
@@ -288,9 +292,9 @@ fn sync_set_requires_no_whitespace_before_bracket() {
     let semi = CharSet::from_bytes(b";");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
-            desugared_recover_repeat(Pattern::literal("x"), Pattern::AnyChar),
-            Pattern::CharClass(semi),
+        Pattern::seq(vec![
+            desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char()),
+            Pattern::char_class(semi),
         ])
     );
 }
@@ -304,11 +308,11 @@ fn sync_set_accepts_negated_and_ranges() {
     let mut alpha = CharSet::empty();
     alpha.add_range(b'a', b'z');
     let neg_alpha = alpha.negate();
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(neg_alpha))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(neg_alpha)]);
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(neg_alpha)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(neg_alpha)]);
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat(Pattern::literal("x"), recovery_body)
@@ -322,7 +326,7 @@ fn recover_repeat_postfix_star_caret_with_label() {
     let g = parse("r <- 'x'*^:bad");
     assert_eq!(
         g.rules["r"],
-        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "bad")
+        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::any_char(), "bad")
     );
 }
 
@@ -333,9 +337,9 @@ fn recover_repeat_postfix_plus_caret_with_label() {
     let g = parse("r <- 'x'+^:bad");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
-            desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "bad"),
+            desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::any_char(), "bad"),
         ])
     );
 }
@@ -346,11 +350,11 @@ fn sync_set_postfix_star_caret_charset_with_label() {
     // (sync-set skip) is unchanged.
     let semi = CharSet::from_bytes(b";");
     let g = parse("r <- 'x'*^[;]:bad_stmt");
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(semi)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(semi)]);
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat_with_label(Pattern::literal("x"), recovery_body, "bad_stmt")
@@ -362,14 +366,14 @@ fn sync_set_postfix_plus_caret_charset_with_label() {
     // `p+^[;]:bad_stmt` lowers to `p (p*^[;]:bad_stmt)`.
     let semi = CharSet::from_bytes(b";");
     let g = parse("r <- 'x'+^[;]:bad_stmt");
-    let skip_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(Pattern::CharClass(semi))),
-        Pattern::AnyChar,
-    ])));
-    let recovery_body = Pattern::Sequence(vec![skip_loop, Pattern::CharClass(semi)]);
+    let skip_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(Pattern::char_class(semi)),
+        Pattern::any_char(),
+    ]));
+    let recovery_body = Pattern::seq(vec![skip_loop, Pattern::char_class(semi)]);
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
             desugared_recover_repeat_with_label(Pattern::literal("x"), recovery_body, "bad_stmt"),
         ])
@@ -383,7 +387,7 @@ fn recovery_label_default_is_recovery() {
     // so the existing tests cover it; this is a self-documenting
     // sentinel that the default has not drifted.
     let g = parse("r <- 'x'*^");
-    let Pattern::Repeat(inner) = &g.rules["r"] else {
+    let Pattern::Repeat { inner, .. } = &g.rules["r"] else {
         panic!("expected Repeat, got {:?}", g.rules["r"]);
     };
     let Pattern::Catch { label, .. } = inner.as_ref() else {
@@ -452,7 +456,7 @@ fn recovery_label_accepts_underscore_prefixed_identifier() {
     let g = parse("r <- 'x'*^:_foo");
     assert_eq!(
         g.rules["r"],
-        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::AnyChar, "_foo")
+        desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::any_char(), "_foo")
     );
 }
 
@@ -465,6 +469,7 @@ fn catch_basic_parses_to_pattern_catch() {
             inner: Box::new(Pattern::literal("a")),
             label: "lbl".into(),
             recovery: Box::new(Pattern::literal("b")),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -475,11 +480,12 @@ fn catch_binds_tighter_than_choice() {
     let g = parse("r <- 'a' ^lbl 'b' / 'c'");
     assert_eq!(
         g.rules["r"],
-        Pattern::OrderedChoice(vec![
+        Pattern::choice(vec![
             Pattern::Catch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
                 recovery: Box::new(Pattern::literal("b")),
+                span: Span::SYNTHETIC,
             },
             Pattern::literal("c"),
         ])
@@ -493,15 +499,16 @@ fn catch_binds_looser_than_sequence() {
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
-            inner: Box::new(Pattern::Sequence(vec![
+            inner: Box::new(Pattern::seq(vec![
                 Pattern::literal("a"),
                 Pattern::literal("b"),
             ])),
             label: "lbl".into(),
-            recovery: Box::new(Pattern::Sequence(vec![
+            recovery: Box::new(Pattern::seq(vec![
                 Pattern::literal("c"),
                 Pattern::literal("d"),
             ])),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -517,9 +524,11 @@ fn catch_is_left_associative() {
                 inner: Box::new(Pattern::literal("a")),
                 label: "l1".into(),
                 recovery: Box::new(Pattern::literal("b")),
+                span: Span::SYNTHETIC,
             }),
             label: "l2".into(),
             recovery: Box::new(Pattern::literal("c")),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -533,14 +542,15 @@ fn catch_does_not_collide_with_star_caret() {
     let g = parse("a <- 'x'*^\nb <- 'x'* ^lbl 'y'");
     assert_eq!(
         g.rules["a"],
-        desugared_recover_repeat(Pattern::literal("x"), Pattern::AnyChar)
+        desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char())
     );
     assert_eq!(
         g.rules["b"],
         Pattern::Catch {
-            inner: Box::new(Pattern::Repeat(Box::new(Pattern::literal("x")))),
+            inner: Box::new(Pattern::repeat(Pattern::literal("x"))),
             label: "lbl".into(),
             recovery: Box::new(Pattern::literal("y")),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -556,10 +566,11 @@ fn catch_parens_force_grouping_on_recovery() {
         Pattern::Catch {
             inner: Box::new(Pattern::literal("a")),
             label: "lbl".into(),
-            recovery: Box::new(Pattern::OrderedChoice(vec![
+            recovery: Box::new(Pattern::choice(vec![
                 Pattern::literal("b"),
                 Pattern::literal("c"),
             ])),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -575,6 +586,7 @@ fn catch_label_touches_caret_whitespace_insensitive_on_left() {
         inner: Box::new(Pattern::literal("a")),
         label: "lbl".into(),
         recovery: Box::new(Pattern::literal("b")),
+        span: Span::SYNTHETIC,
     };
     assert_eq!(with_space.rules["r"], expected);
     assert_eq!(glued.rules["r"], expected);
@@ -612,17 +624,15 @@ fn catch_rejects_reserved_underscore_label() {
 /// is `@recovery{(!B .)*}`. Mirrors `lower_boundary_catch` in the
 /// parser.
 fn lowered_boundary_catch(inner: Pattern, label: &str, boundary: Pattern) -> Pattern {
-    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(boundary.clone())),
-        Pattern::AnyChar,
-    ])));
+    let stop_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(boundary.clone()),
+        Pattern::any_char(),
+    ]));
     Pattern::Catch {
-        inner: Box::new(Pattern::Sequence(vec![
-            inner,
-            Pattern::AndPredicate(Box::new(boundary)),
-        ])),
+        inner: Box::new(Pattern::seq(vec![inner, Pattern::and_predicate(boundary)])),
         label: label.into(),
-        recovery: Box::new(Pattern::Capture("recovery".into(), Box::new(stop_loop))),
+        recovery: Box::new(Pattern::capture("recovery", stop_loop)),
+        span: Span::SYNTHETIC,
     }
 }
 
@@ -640,11 +650,7 @@ fn boundary_catch_with_rule_boundary() {
     let g = parse("r <- 'a' ^^lbl b\nb <- 'x'");
     assert_eq!(
         g.rules["r"],
-        lowered_boundary_catch(
-            Pattern::literal("a"),
-            "lbl",
-            Pattern::NonTerminal("b".into())
-        ),
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::nt("b")),
     );
 }
 
@@ -657,17 +663,14 @@ fn boundary_catch_with_charset_boundary() {
     delim.add(b')');
     assert_eq!(
         g.rules["r"],
-        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::CharClass(delim)),
+        lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::char_class(delim)),
     );
 }
 
 #[test]
 fn boundary_catch_with_grouped_boundary() {
     let g = parse("r <- 'a' ^^lbl (b c)\nb <- 'x'\nc <- 'y'");
-    let boundary = Pattern::Sequence(vec![
-        Pattern::NonTerminal("b".into()),
-        Pattern::NonTerminal("c".into()),
-    ]);
+    let boundary = Pattern::seq(vec![Pattern::nt("b"), Pattern::nt("c")]);
     assert_eq!(
         g.rules["r"],
         lowered_boundary_catch(Pattern::literal("a"), "lbl", boundary),
@@ -699,7 +702,7 @@ fn boundary_catch_does_not_swallow_trailing_atoms() {
     let g = parse("r <- 'a' ^^lbl 'b' 'c'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
             Pattern::literal("c"),
         ]),
@@ -716,10 +719,8 @@ fn bare_catch_with_capture_rhs_still_parses() {
         Pattern::Catch {
             inner: Box::new(Pattern::literal("a")),
             label: "lbl".into(),
-            recovery: Box::new(Pattern::Capture(
-                "rec".into(),
-                Box::new(Pattern::literal("b"))
-            )),
+            recovery: Box::new(Pattern::capture("rec", Pattern::literal("b"))),
+            span: Span::SYNTHETIC,
         },
     );
 }
@@ -752,6 +753,7 @@ fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
         Pattern::InferBoundaryCatch {
             inner: Box::new(Pattern::literal("a")),
             label: "lbl".into(),
+            span: Span::SYNTHETIC,
         },
     );
 }
@@ -761,10 +763,11 @@ fn inferred_catch_before_choice_separator() {
     let g = parse("r <- 'a' ^^lbl / 'b'");
     assert_eq!(
         g.rules["r"],
-        Pattern::OrderedChoice(vec![
+        Pattern::choice(vec![
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                span: Span::SYNTHETIC,
             },
             Pattern::literal("b"),
         ]),
@@ -776,10 +779,11 @@ fn inferred_catch_before_paren_close() {
     let g = parse("r <- ('a' ^^lbl) 'c'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                span: Span::SYNTHETIC,
             },
             Pattern::literal("c"),
         ]),
@@ -794,7 +798,7 @@ fn inferred_vs_explicit_no_ambiguity() {
     let explicit = parse("r <- 'a' ^^lbl 'b' 'c'");
     assert_eq!(
         explicit.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
             Pattern::literal("c"),
         ]),
@@ -802,10 +806,11 @@ fn inferred_vs_explicit_no_ambiguity() {
     let inferred = parse("r <- 'a' ^^lbl / 'b'");
     assert_eq!(
         inferred.rules["r"],
-        Pattern::OrderedChoice(vec![
+        Pattern::choice(vec![
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                span: Span::SYNTHETIC,
             },
             Pattern::literal("b"),
         ]),
@@ -830,6 +835,7 @@ fn catch_accepts_underscore_prefixed_labels() {
             inner: Box::new(Pattern::literal("a")),
             label: "_foo".into(),
             recovery: Box::new(Pattern::literal("b")),
+            span: Span::SYNTHETIC,
         }
     );
 }
@@ -839,15 +845,15 @@ fn predicate_operators() {
     let g = parse("a <- !'x' .\nb <- &'y' 'y'");
     assert_eq!(
         g.rules["a"],
-        Pattern::Sequence(vec![
-            Pattern::NotPredicate(Box::new(Pattern::literal("x"))),
-            Pattern::AnyChar,
+        Pattern::seq(vec![
+            Pattern::not_predicate(Pattern::literal("x")),
+            Pattern::any_char(),
         ])
     );
     assert_eq!(
         g.rules["b"],
-        Pattern::Sequence(vec![
-            Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
+        Pattern::seq(vec![
+            Pattern::and_predicate(Pattern::literal("y")),
             Pattern::literal("y"),
         ])
     );
@@ -858,7 +864,7 @@ fn char_class_with_range() {
     let g = parse("d <- [0-9]");
     assert_eq!(
         g.rules["d"],
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]))
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]))
     );
 }
 
@@ -868,7 +874,7 @@ fn char_class_negated() {
     let mut excluded = CharSet::empty();
     excluded.add(b'"');
     excluded.add(b'\\');
-    assert_eq!(g.rules["nq"], Pattern::CharClass(excluded.negate()));
+    assert_eq!(g.rules["nq"], Pattern::char_class(excluded.negate()));
 }
 
 #[test]
@@ -882,7 +888,7 @@ fn char_class_mixed_chars_and_ranges() {
         s.add(b'_');
         s
     };
-    assert_eq!(g.rules["alnum"], Pattern::CharClass(expected));
+    assert_eq!(g.rules["alnum"], Pattern::char_class(expected));
 }
 
 #[test]
@@ -890,7 +896,7 @@ fn capture_annotation() {
     let g = parse("r <- @keyword{'while'}");
     assert_eq!(
         g.rules["r"],
-        Pattern::Capture("keyword".into(), Box::new(Pattern::literal("while")))
+        Pattern::capture("keyword", Pattern::literal("while"))
     );
 }
 
@@ -914,9 +920,9 @@ fn parens_and_precedence() {
     let g = parse("r <- 'a' ('b' / 'c') 'd'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("a"),
-            Pattern::OrderedChoice(vec![Pattern::literal("b"), Pattern::literal("c")]),
+            Pattern::choice(vec![Pattern::literal("b"), Pattern::literal("c")]),
             Pattern::literal("d"),
         ])
     );
@@ -925,13 +931,16 @@ fn parens_and_precedence() {
 #[test]
 fn nonterminal_reference() {
     let g = parse("a <- b\nb <- 'x'");
-    assert_eq!(g.rules["a"], Pattern::NonTerminal("b".into()));
+    assert_eq!(g.rules["a"], Pattern::nt("b"));
 }
 
 #[test]
 fn escape_sequences_in_string() {
     let g = parse("r <- '\\n\\t\\\\'");
-    assert_eq!(g.rules["r"], Pattern::Literal(vec![b'\n', b'\t', b'\\']));
+    assert_eq!(
+        g.rules["r"],
+        Pattern::literal_bytes(vec![b'\n', b'\t', b'\\'])
+    );
 }
 
 #[test]
@@ -940,7 +949,7 @@ fn dash_in_class_at_end_is_literal() {
     let mut s = CharSet::empty();
     s.add(b'+');
     s.add(b'-');
-    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+    assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
@@ -948,7 +957,7 @@ fn backslash_d_atom() {
     let g = parse("r <- \\d");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]))
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]))
     );
 }
 
@@ -957,7 +966,7 @@ fn backslash_d_negated_atom() {
     let g = parse("r <- \\D");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]).negate())
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]).negate())
     );
 }
 
@@ -966,7 +975,7 @@ fn backslash_s_atom() {
     let g = parse("r <- \\s");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_bytes(b" \t\n\r"))
+        Pattern::char_class(CharSet::from_bytes(b" \t\n\r"))
     );
 }
 
@@ -975,7 +984,7 @@ fn backslash_s_negated_atom() {
     let g = parse("r <- \\S");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_bytes(b" \t\n\r").negate())
+        Pattern::char_class(CharSet::from_bytes(b" \t\n\r").negate())
     );
 }
 
@@ -984,7 +993,7 @@ fn backslash_h_atom() {
     let g = parse("r <- \\h");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_bytes(b" \t"))
+        Pattern::char_class(CharSet::from_bytes(b" \t"))
     );
 }
 
@@ -993,7 +1002,7 @@ fn backslash_h_negated_atom() {
     let g = parse("r <- \\H");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_bytes(b" \t").negate())
+        Pattern::char_class(CharSet::from_bytes(b" \t").negate())
     );
 }
 
@@ -1002,7 +1011,7 @@ fn backslash_cap_r_linebreak_atom() {
     let g = parse("r <- \\R");
     assert_eq!(
         g.rules["r"],
-        Pattern::OrderedChoice(vec![
+        Pattern::choice(vec![
             Pattern::literal("\r\n"),
             Pattern::literal("\n"),
             Pattern::literal("\r"),
@@ -1013,10 +1022,7 @@ fn backslash_cap_r_linebreak_atom() {
 #[test]
 fn backslash_z_atom() {
     let g = parse("r <- \\z");
-    assert_eq!(
-        g.rules["r"],
-        Pattern::NotPredicate(Box::new(Pattern::AnyChar))
-    );
+    assert_eq!(g.rules["r"], Pattern::not_predicate(Pattern::any_char()));
 }
 
 #[test]
@@ -1024,7 +1030,7 @@ fn backslash_d_in_class_unions_digits() {
     let g = parse("r <- [\\d_]");
     let mut s = CharSet::from_ranges(&[(b'0', b'9')]);
     s.add(b'_');
-    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+    assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
@@ -1034,7 +1040,7 @@ fn backslash_d_in_class_with_range_neighbor() {
     let mut s = CharSet::from_ranges(&[(b'0', b'9')]);
     s.add_range(b'a', b'f');
     s.add_range(b'A', b'F');
-    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+    assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
@@ -1042,7 +1048,7 @@ fn backslash_s_in_class_unions_whitespace() {
     let g = parse("r <- [\\sX]");
     let mut s = CharSet::from_bytes(b" \t\n\r");
     s.add(b'X');
-    assert_eq!(g.rules["r"], Pattern::CharClass(s));
+    assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
@@ -1051,7 +1057,7 @@ fn backslash_d_in_negated_class() {
     let g = parse("r <- [^\\d]");
     assert_eq!(
         g.rules["r"],
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')]).negate())
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')]).negate())
     );
 }
 
@@ -1265,17 +1271,17 @@ fn duplicate_rule_errors() {
 /// `Repeat(Seq(NotPredicate(S), AnyChar))`. Mirrors
 /// `lower_until_exclusive` in `src/pegc/parser.rs`.
 fn desugared_until_exclusive(stop: Pattern) -> Pattern {
-    Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(stop)),
-        Pattern::AnyChar,
-    ])))
+    Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(stop),
+        Pattern::any_char(),
+    ]))
 }
 
 /// Builds the desugared AST that `..= S` lowers to:
 /// `Seq(.. S, S)`. Mirrors `lower_until_inclusive` in
 /// `src/pegc/parser.rs`.
 fn desugared_until_inclusive(stop: Pattern) -> Pattern {
-    Pattern::Sequence(vec![desugared_until_exclusive(stop.clone()), stop])
+    Pattern::seq(vec![desugared_until_exclusive(stop.clone()), stop])
 }
 
 #[test]
@@ -1301,7 +1307,7 @@ fn skip_until_inclusive_vs_exclusive_distinction() {
     // Same stop pattern; ASTs differ exactly in the trailing consume.
     let excl = parse("r <- .. 'b'").rules["r"].clone();
     let incl = parse("r <- ..= 'b'").rules["r"].clone();
-    assert_eq!(incl, Pattern::Sequence(vec![excl, Pattern::literal("b")]));
+    assert_eq!(incl, Pattern::seq(vec![excl, Pattern::literal("b")]));
 }
 
 #[test]
@@ -1309,7 +1315,7 @@ fn skip_until_inside_sequence() {
     let g = parse("r <- 'x' .. 'b' 'y'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
+        Pattern::seq(vec![
             Pattern::literal("x"),
             desugared_until_exclusive(Pattern::literal("b")),
             Pattern::literal("y"),
@@ -1323,9 +1329,9 @@ fn skip_until_requires_adjacent_dots() {
     let g = parse("r <- . . 'b'");
     assert_eq!(
         g.rules["r"],
-        Pattern::Sequence(vec![
-            Pattern::AnyChar,
-            Pattern::AnyChar,
+        Pattern::seq(vec![
+            Pattern::any_char(),
+            Pattern::any_char(),
             Pattern::literal("b"),
         ])
     );
@@ -1357,7 +1363,7 @@ fn skip_until_whitespace_after_operator_ok() {
 #[test]
 fn skip_until_with_charclass_stop() {
     let g = parse("r <- .. [;]");
-    let stop = Pattern::CharClass({
+    let stop = Pattern::char_class({
         let mut s = CharSet::empty();
         s.add(b';');
         s
@@ -1369,7 +1375,7 @@ fn skip_until_with_charclass_stop() {
 fn skip_until_inclusive_with_grouped_stop() {
     // Mirrors the sqlite `bracket_id` shape: stop is an OrderedChoice.
     let g = parse("r <- ..= (']' / 'x')");
-    let stop = Pattern::OrderedChoice(vec![Pattern::literal("]"), Pattern::literal("x")]);
+    let stop = Pattern::choice(vec![Pattern::literal("]"), Pattern::literal("x")]);
     assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
 }
 
@@ -1389,14 +1395,14 @@ fn skip_until_inclusive_with_capture_stop() {
     // consume in `..= S` retains the same capture kind so themes
     // render the consumed delimiter consistently.
     let g = parse("r <- ..= @punctuation{'}'}");
-    let stop = Pattern::Capture("punctuation".into(), Box::new(Pattern::literal("}")));
+    let stop = Pattern::capture("punctuation", Pattern::literal("}"));
     assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
 }
 
 #[test]
 fn skip_until_with_capture_stop_exclusive() {
     let g = parse("r <- .. @comment{'#'}");
-    let stop = Pattern::Capture("comment".into(), Box::new(Pattern::literal("#")));
+    let stop = Pattern::capture("comment", Pattern::literal("#"));
     assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
 }
 
@@ -1405,18 +1411,16 @@ fn skip_until_with_capture_stop_exclusive() {
 /// anchor on the inner. Mirrors `lower_bracketed_close_catch` in
 /// `src/pegc/parser.rs`.
 fn desugared_bracketed_close_catch(inner: Pattern, label: &str, boundary: Pattern) -> Pattern {
-    let stop_loop = Pattern::Repeat(Box::new(Pattern::Sequence(vec![
-        Pattern::NotPredicate(Box::new(boundary.clone())),
-        Pattern::AnyChar,
-    ])));
-    let recovery = Pattern::Sequence(vec![
-        Pattern::Capture("recovery".into(), Box::new(stop_loop)),
-        boundary,
-    ]);
+    let stop_loop = Pattern::repeat(Pattern::seq(vec![
+        Pattern::not_predicate(boundary.clone()),
+        Pattern::any_char(),
+    ]));
+    let recovery = Pattern::seq(vec![Pattern::capture("recovery", stop_loop), boundary]);
     Pattern::Catch {
         inner: Box::new(inner),
         label: label.into(),
         recovery: Box::new(recovery),
+        span: Span::SYNTHETIC,
     }
 }
 
@@ -1435,7 +1439,7 @@ fn bracketed_close_catch_with_capture_boundary() {
     // consume — `}` is captured as `@punctuation` in both happy and
     // recovery paths.
     let g = parse("r <- 'a' ^^lbl ..= @punctuation{'}'}");
-    let boundary = Pattern::Capture("punctuation".into(), Box::new(Pattern::literal("}")));
+    let boundary = Pattern::capture("punctuation", Pattern::literal("}"));
     assert_eq!(
         g.rules["r"],
         desugared_bracketed_close_catch(Pattern::literal("a"), "lbl", boundary)
@@ -1463,7 +1467,7 @@ fn bracketed_close_catch_vs_boundary_catch_distinction() {
         ) => {
             // Anchored inner is a Sequence ending in AndPredicate; bracketed inner is the bare INNER.
             assert!(
-                matches!(i_anch.as_ref(), Pattern::Sequence(items) if matches!(items.last(), Some(Pattern::AndPredicate(_)))),
+                matches!(i_anch.as_ref(), Pattern::Sequence { items, .. } if matches!(items.last(), Some(Pattern::AndPredicate { .. }))),
                 "anchored form should have &B on inner: {i_anch:?}"
             );
             assert_eq!(
@@ -1473,11 +1477,11 @@ fn bracketed_close_catch_vs_boundary_catch_distinction() {
             );
             // Anchored recovery is just the capture; bracketed recovery is Seq(capture, B).
             assert!(
-                matches!(r_anch.as_ref(), Pattern::Capture(_, _)),
+                matches!(r_anch.as_ref(), Pattern::Capture { .. }),
                 "anchored recovery should be a capture, got: {r_anch:?}"
             );
             assert!(
-                matches!(r_brkt.as_ref(), Pattern::Sequence(_)),
+                matches!(r_brkt.as_ref(), Pattern::Sequence { .. }),
                 "bracketed recovery should be a Sequence, got: {r_brkt:?}"
             );
         }
@@ -1503,7 +1507,7 @@ fn bracketed_close_catch_does_not_swallow_trailing_atoms() {
     // after the boundary belong to the enclosing sequence.
     let g = parse("r <- 'a' ^^lbl ..= '}' 'c'");
     match &g.rules["r"] {
-        Pattern::Sequence(items) => {
+        Pattern::Sequence { items, .. } => {
             assert_eq!(items.len(), 2, "expected Seq(catch, 'c'), got: {items:?}");
             assert!(matches!(&items[0], Pattern::Catch { .. }));
             assert_eq!(items[1], Pattern::literal("c"));

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -34,16 +34,14 @@ fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
     rules.insert(
         "start".into(),
         Pattern::seq(vec![
-            Pattern::NonTerminal("word".into()),
+            Pattern::nt("word"),
             Pattern::literal(" "),
-            Pattern::NonTerminal("word".into()),
+            Pattern::nt("word"),
         ]),
     );
     rules.insert(
         "word".into(),
-        Pattern::RepeatOne(Box::new(Pattern::CharClass(CharSet::from_ranges(&[(
-            b'a', b'z',
-        )])))),
+        Pattern::repeat_one(Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')]))),
     );
     Grammar::new(rules, "start").compile().unwrap()
 }

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -32,19 +32,13 @@ fn second_alternative_reuses_memoized_x() {
     rules.insert(
         "start".into(),
         Pattern::choice(vec![
-            Pattern::seq(vec![
-                Pattern::NonTerminal("X".into()),
-                Pattern::literal("aa"),
-            ]),
-            Pattern::seq(vec![
-                Pattern::NonTerminal("X".into()),
-                Pattern::literal("bb"),
-            ]),
+            Pattern::seq(vec![Pattern::nt("X"), Pattern::literal("aa")]),
+            Pattern::seq(vec![Pattern::nt("X"), Pattern::literal("bb")]),
         ]),
     );
     rules.insert(
         "X".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"abb")
@@ -69,14 +63,11 @@ fn memo_table_populates_on_success() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::seq(vec![
-            Pattern::NonTerminal("X".into()),
-            Pattern::NonTerminal("X".into()),
-        ]),
+        Pattern::seq(vec![Pattern::nt("X"), Pattern::nt("X")]),
     );
     rules.insert(
         "X".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     let (_, stats) = VM::new(&prog.code, b"ab")
@@ -118,25 +109,19 @@ fn memo_hit_inside_outer_capture_preserves_nesting() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::Capture(
-            "outer".into(),
-            Box::new(Pattern::choice(vec![
-                Pattern::seq(vec![
-                    Pattern::NonTerminal("Inner".into()),
-                    Pattern::literal("x"),
-                ]),
-                Pattern::seq(vec![
-                    Pattern::NonTerminal("Inner".into()),
-                    Pattern::literal("y"),
-                ]),
-            ])),
+        Pattern::capture(
+            "outer",
+            Pattern::choice(vec![
+                Pattern::seq(vec![Pattern::nt("Inner"), Pattern::literal("x")]),
+                Pattern::seq(vec![Pattern::nt("Inner"), Pattern::literal("y")]),
+            ]),
         ),
     );
     rules.insert(
         "Inner".into(),
-        Pattern::Capture(
-            "inner".into(),
-            Box::new(Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')]))),
+        Pattern::capture(
+            "inner",
+            Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')])),
         ),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
@@ -188,11 +173,11 @@ fn cached_failure_short_circuits_not_predicate() {
         "start".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
-                Pattern::NotPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::not_predicate(Pattern::nt("A")),
                 Pattern::literal("b"),
             ]),
             Pattern::seq(vec![
-                Pattern::NotPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::not_predicate(Pattern::nt("A")),
                 Pattern::literal("c"),
             ]),
         ]),
@@ -220,22 +205,16 @@ fn nested_memoized_rule_failures_both_cached() {
     let mut rules = HashMap::new();
     rules.insert(
         "start".into(),
-        Pattern::choice(vec![
-            Pattern::NonTerminal("outer".into()),
-            Pattern::NonTerminal("fallback".into()),
-        ]),
+        Pattern::choice(vec![Pattern::nt("outer"), Pattern::nt("fallback")]),
     );
     rules.insert(
         "outer".into(),
-        Pattern::seq(vec![
-            Pattern::NonTerminal("inner".into()),
-            Pattern::literal("b"),
-        ]),
+        Pattern::seq(vec![Pattern::nt("inner"), Pattern::literal("b")]),
     );
     rules.insert("inner".into(), Pattern::literal("a"));
     rules.insert(
         "fallback".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"x")
@@ -263,18 +242,18 @@ fn and_predicate_with_memoized_rule() {
         "start".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
-                Pattern::AndPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::and_predicate(Pattern::nt("A")),
                 Pattern::literal("z"),
             ]),
             Pattern::seq(vec![
-                Pattern::AndPredicate(Box::new(Pattern::NonTerminal("A".into()))),
+                Pattern::and_predicate(Pattern::nt("A")),
                 Pattern::literal("y"),
             ]),
         ]),
     );
     rules.insert(
         "A".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'a', b'z')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"y")
@@ -336,13 +315,10 @@ fn lr_converged_seed_persists_across_parses() {
 #[test]
 fn memoization_does_not_change_results_on_linear_parse() {
     let mut rules = HashMap::new();
-    rules.insert(
-        "start".into(),
-        Pattern::RepeatOne(Box::new(Pattern::NonTerminal("digit".into()))),
-    );
+    rules.insert("start".into(), Pattern::repeat_one(Pattern::nt("digit")));
     rules.insert(
         "digit".into(),
-        Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')])),
+        Pattern::char_class(CharSet::from_ranges(&[(b'0', b'9')])),
     );
     let prog = Grammar::new(rules, "start").compile().unwrap();
     let result = VM::new(&prog.code, b"12345").run();


### PR DESCRIPTION
Closes #114.

Fatal grammar diagnostics now print `{line}:{col}:` so every finding is directly navigable from the terminal. Before:

```
partial-match leniency detected:
  - rule `r` is called unanchored by `start`; …
```

After:

```
partial-match leniency detected:
  - 1:11: rule `r` is called unanchored by `start`; …
```

Same treatment for `CompileError::CannotInferBoundary` and any future diagnostic: every `Pattern` variant now carries a `Span`, accessible via `Pattern::span()`. `LintFinding` gains a `call_site` field; `CompileError::CannotInferBoundary` gains a `span` field. Per-variant span convention is documented on `Span` in `src/pegc/pattern.rs`.

<details>
<summary>Design notes</summary>

Spans on every variant (vs. only diagnostic-consumers, vs. side-table) — picked the uniform-AST option to keep `pat.span()` constant-time and so future diagnostics and editor tooling (#39 jump-to-def / hover) don't pay a second round of AST surgery. The resolver/lowering passes preserve span through every rebuild; nodes synthesized from FOLLOW sets carry `Span::SYNTHETIC`.

Production cost: the parser precomputes `line_starts` once in `Parser::new` so each per-node `span_at(offset)` is O(log lines). `cargo run --bin pegc -- stats grammars/sqlite.peg` (424 rules, 5776 instructions) compiles within noise.

Test ergonomics: `Pattern` exposes per-variant synthetic-span constructors (`nt`, `repeat`, `optional`, …) and a `strip_spans()` helper used by `tests/grammar_tests.rs::parse()` so existing structural assertions keep working unchanged against parsed grammars.
</details>
