### PR TITLE
pegc: reserved root/trivia rules with implicit EOF + auto-trivia

### DIFF
--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -1,5 +1,4 @@
 # C (pragmatic subset) grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: highlighting, not compilation. The classic C grammar
 # ambiguity between `typedef-name IDENT` and `IDENT * IDENT` (is `a *
@@ -30,32 +29,32 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-*trivia       <- (comment / \s)*
+trivia        <- (comment / \s)*
 
-root          <- trivia (external_decl)*^ trivia
+root          <- (external_decl)*^
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
 pp_line       <- @keyword{pp_body}
-pp_body       <- '#' (pp_cont / [^\n])*
-pp_cont       <- '\\' '\n'
+*pp_body      <- '#' (pp_cont / [^\n])*
+*pp_cont      <- '\\' '\n'
                 / '\\' '\r' '\n'
 
 # --- External declarations -------------------------------------------
 
-external_decl <- pp_line trivia
+external_decl <- pp_line
                / fn_def
                / decl
 
 # Type-specifier + declarator + block.
-fn_def        <- decl_spec_list trivia declarator trivia (decl trivia)* compound_stmt trivia
+fn_def        <- decl_spec_list declarator decl* compound_stmt
 
 # Declarations end in `;`. Must start with at least one specifier
 # (storage/qualifier/type keyword, `typedef`, `struct`, `union`,
 # `enum`) so we don't accidentally parse `a * b;` as a declaration.
-decl          <- decl_spec_list trivia init_declarator_list? trivia @punctuation{';'} trivia
+decl          <- decl_spec_list init_declarator_list? @punctuation{';'}
 
-decl_spec_list <- decl_spec (trivia decl_spec)*
+decl_spec_list <- decl_spec+
 decl_spec     <- storage_spec
                / type_qualifier
                / type_spec
@@ -80,7 +79,7 @@ type_spec     <- struct_or_union_spec
                / @type{typedef_name}
 
 predef_type   <- @type{predef_type_name}
-predef_type_name <- ('void' / 'char' / 'short' / 'long long' / 'long'
+*predef_type_name <- ('void' / 'char' / 'short' / 'long long' / 'long'
                    / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
                    / '_Bool' / '_Complex' / '_Imaginary') !ident_body
 
@@ -89,63 +88,63 @@ predef_type_name <- ('void' / 'char' / 'short' / 'long long' / 'long'
 # expression statement. The `_t` arm uses the standard PEG non-greedy
 # idiom `(!end_t ident_body)*` because PEG `*` is possessive — a
 # greedy `ident_body*` would swallow the trailing `_t`.
-typedef_name  <- [A-Z] ident_body*
+*typedef_name <- [A-Z] ident_body*
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-typedef_t_end <- '_t' !ident_body
+*typedef_t_end <- '_t' !ident_body
 
-struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'}) trivia
-                       (@type{ident})? (trivia @punctuation{'{'} trivia struct_decl* trivia @punctuation{'}'})?
-struct_decl   <- decl_spec_list trivia struct_declarator_list? trivia @punctuation{';'} trivia
-               / pp_line trivia
-struct_declarator_list <- struct_declarator (trivia @punctuation{','} trivia struct_declarator)*
-struct_declarator <- struct_field_declarator (trivia @punctuation{':'} trivia expr_cond)?
-                   / @punctuation{':'} trivia expr_cond
-struct_field_declarator <- pointer? trivia struct_field_direct
+struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'})
+                       (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
+struct_decl   <- decl_spec_list struct_declarator_list? @punctuation{';'}
+               / pp_line
+struct_declarator_list <- struct_declarator (@punctuation{','} struct_declarator)*
+struct_declarator <- struct_field_declarator (@punctuation{':'} expr_cond)?
+                   / @punctuation{':'} expr_cond
+struct_field_declarator <- pointer? struct_field_direct
 struct_field_direct <- @property{ident} struct_field_tail*
-                     / @punctuation{'('} trivia struct_field_declarator trivia @punctuation{')'} struct_field_tail*
-struct_field_tail <- trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'}
-                   / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'}
+                     / @punctuation{'('} struct_field_declarator @punctuation{')'} struct_field_tail*
+struct_field_tail <- @punctuation{'['} (expr / '')? @punctuation{']'}
+                   / @punctuation{'('} param_list? @punctuation{')'}
 
-enum_spec     <- @keyword{'enum'} trivia (@type{ident})?
-                 (trivia @punctuation{'{'} trivia enum_list? trivia @punctuation{'}'})?
-enum_list     <- enum_item (trivia @punctuation{','} trivia enum_item)* (trivia @punctuation{','})?
-enum_item     <- @constant{ident} (trivia @operator{'='} trivia expr_cond)?
+enum_spec     <- @keyword{'enum'} (@type{ident})?
+                 (@punctuation{'{'} enum_list? @punctuation{'}'})?
+enum_list     <- enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
+enum_item     <- @constant{ident} (@operator{'='} expr_cond)?
 
 # --- Declarators -----------------------------------------------------
 
-init_declarator_list <- init_declarator (trivia @punctuation{','} trivia init_declarator)*
-init_declarator <- declarator (trivia @operator{'='} trivia initializer)?
+init_declarator_list <- init_declarator (@punctuation{','} init_declarator)*
+init_declarator <- declarator (@operator{'='} initializer)?
 
-declarator    <- pointer? trivia direct_declarator
-pointer       <- (@operator{'*'} (trivia type_qualifier)*)+
+declarator    <- pointer? direct_declarator
+pointer       <- (@operator{'*'} type_qualifier*)+
 direct_declarator <- simple_declarator direct_declarator_tail*
-simple_declarator <- @function{ident} &(trivia @punctuation{'('})
+simple_declarator <- @function{ident} &(@punctuation{'('})
                    / @variable{ident}
-                   / @punctuation{'('} trivia declarator trivia @punctuation{')'}
-direct_declarator_tail <- trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'}
-                        / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'}
-                        / trivia @punctuation{'('} trivia ident_list? trivia @punctuation{')'}
+                   / @punctuation{'('} declarator @punctuation{')'}
+direct_declarator_tail <- @punctuation{'['} (expr / '')? @punctuation{']'}
+                        / @punctuation{'('} param_list? @punctuation{')'}
+                        / @punctuation{'('} ident_list? @punctuation{')'}
 
-param_list    <- param (trivia @punctuation{','} trivia param)* (trivia @punctuation{','} trivia @operator{'...'})?
+param_list    <- param (@punctuation{','} param)* (@punctuation{','} @operator{'...'})?
                / @operator{'...'}
-param         <- decl_spec_list (trivia (declarator / abstract_declarator))?
-abstract_declarator <- pointer (trivia direct_abstract_declarator)?
+param         <- decl_spec_list (declarator / abstract_declarator)?
+abstract_declarator <- pointer direct_abstract_declarator?
                      / direct_abstract_declarator
-direct_abstract_declarator <- (@punctuation{'('} trivia abstract_declarator trivia @punctuation{')'} / @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'})
-                              (trivia @punctuation{'['} trivia (expr / '')? trivia @punctuation{']'} / trivia @punctuation{'('} trivia param_list? trivia @punctuation{')'})*
+direct_abstract_declarator <- (@punctuation{'('} abstract_declarator @punctuation{')'} / @punctuation{'['} (expr / '')? @punctuation{']'})
+                              (@punctuation{'['} (expr / '')? @punctuation{']'} / @punctuation{'('} param_list? @punctuation{')'})*
 
-ident_list    <- @variable{ident} (trivia @punctuation{','} trivia @variable{ident})*
+ident_list    <- @variable{ident} (@punctuation{','} @variable{ident})*
 
-initializer   <- @punctuation{'{'} trivia initializer_list? trivia @punctuation{','}? trivia @punctuation{'}'}
+initializer   <- @punctuation{'{'} initializer_list? @punctuation{','}? @punctuation{'}'}
                / expr_assign
-initializer_list <- designation? initializer (trivia @punctuation{','} trivia designation? initializer)*
-designation   <- designator+ trivia @operator{'='}
-designator    <- trivia @punctuation{'['} trivia expr_cond trivia @punctuation{']'}
-               / trivia @punctuation{'.'} @property{ident}
+initializer_list <- designation? initializer (@punctuation{','} designation? initializer)*
+designation   <- designator+ @operator{'='}
+designator    <- @punctuation{'['} expr_cond @punctuation{']'}
+               / @punctuation{'.'} @property{ident}
 
 # --- Statements ------------------------------------------------------
 
-compound_stmt <- @punctuation{'{'} trivia ((block_item trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+compound_stmt <- @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_item    <- pp_line
                / decl
                / stmt
@@ -164,24 +163,24 @@ stmt          <- labeled_stmt
                / empty_stmt
                / expr_stmt
 
-labeled_stmt  <- @variable{ident} trivia @punctuation{':'} trivia stmt
-               / @keyword{'case'} trivia expr_cond trivia @punctuation{':'} trivia stmt
-               / @keyword{'default'} trivia @punctuation{':'} trivia stmt
+labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
+               / @keyword{'case'} expr_cond @punctuation{':'} stmt
+               / @keyword{'default'} @punctuation{':'} stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt      <- @keyword{'if'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
-                 (trivia @keyword{'else'} trivia stmt)?
-for_stmt      <- @keyword{'for'} trivia @punctuation{'('} trivia for_init trivia expr? trivia @punctuation{';'} trivia expr? trivia @punctuation{')'} trivia stmt
+~if_stmt      <- @keyword{'if'} @punctuation{'('} expr @punctuation{')'} stmt
+                 (@keyword{'else'} stmt)?
+for_stmt      <- @keyword{'for'} @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
 for_init      <- decl
-               / expr? trivia @punctuation{';'}
-while_stmt    <- @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
-do_while_stmt <- @keyword{'do'} trivia stmt trivia @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia @punctuation{';'}
-switch_stmt   <- @keyword{'switch'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
-return_stmt   <- @keyword{'return'} (trivia expr)? trivia @punctuation{';'}
-break_stmt    <- @keyword{'break'} trivia @punctuation{';'}
-continue_stmt <- @keyword{'continue'} trivia @punctuation{';'}
-goto_stmt     <- @keyword{'goto'} trivia @variable{ident} trivia @punctuation{';'}
+               / expr? @punctuation{';'}
+while_stmt    <- @keyword{'while'} @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt <- @keyword{'do'} stmt @keyword{'while'} @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
+switch_stmt   <- @keyword{'switch'} @punctuation{'('} expr @punctuation{')'} stmt
+return_stmt   <- @keyword{'return'} expr? @punctuation{';'}
+break_stmt    <- @keyword{'break'} @punctuation{';'}
+continue_stmt <- @keyword{'continue'} @punctuation{';'}
+goto_stmt     <- @keyword{'goto'} @variable{ident} @punctuation{';'}
 empty_stmt    <- @punctuation{';'}
-expr_stmt     <- expr trivia @punctuation{';'}
+expr_stmt     <- expr @punctuation{';'}
 
 # --- Expressions ----------------------------------------------------
 #
@@ -193,8 +192,8 @@ expr_stmt     <- expr trivia @punctuation{';'}
 # doesn't eat a fragment of a longer operator that belongs higher up.
 # Assignment (right-associative) and ternary stay outside the LR ladder.
 
-expr          <- expr_assign (trivia @punctuation{','} trivia expr_assign)*
-expr_assign   <- expr_unary trivia assign_op trivia expr_assign
+expr          <- expr_assign (@punctuation{','} expr_assign)*
+expr_assign   <- expr_unary assign_op expr_assign
                / expr_cond
 
 
@@ -204,18 +203,18 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'='} !'='
 
 # Trailing ternary `?` leniency absorbed by top-level `*^`.
-~expr_cond    <- expr_lor (trivia @operator{'?'} trivia expr trivia @punctuation{':'} trivia expr_assign)?
+~expr_cond    <- expr_lor (@operator{'?'} expr @punctuation{':'} expr_assign)?
 
-expr_lor      <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
-expr_land     <- expr_land trivia @operator{'&&'} trivia expr_bor / expr_bor
-expr_bor      <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
-expr_band     <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_eq / expr_eq
-expr_eq       <- expr_eq trivia (@operator{'=='} / @operator{'!='}) trivia expr_rel / expr_rel
-expr_rel      <- expr_rel trivia (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_shift / expr_shift
-expr_shift    <- expr_shift trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
-expr_add      <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
-expr_mul      <- expr_mul trivia (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_unary / expr_unary
+expr_lor      <- expr_lor @operator{'||'} expr_land / expr_land
+expr_land     <- expr_land @operator{'&&'} expr_bor / expr_bor
+expr_bor      <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor     <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band     <- expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq       <- expr_eq (@operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel      <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_shift / expr_shift
+expr_shift    <- expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add      <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_unary / expr_unary
 
 # `sizeof_type` is tried before the generic prefix loop so that
 # `sizeof(struct X)` / `sizeof(union X)` / `sizeof(counter_size_t)`
@@ -225,23 +224,23 @@ expr_mul      <- expr_mul trivia (@operator{'*'} !'=' / @operator{'/'} !'=' / @o
 # fall back to the prefix path so `sizeof expr` and `sizeof(expr)`
 # still parse.
 expr_unary    <- sizeof_type
-               / (unary_prefix trivia)* expr_postfix
+               / unary_prefix* expr_postfix
 unary_prefix  <- @operator{'++'} / @operator{'--'}
                / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
                / @operator{'*'} / @operator{'&'}
-               / @keyword{'sizeof'} &(trivia (@punctuation{'('} / [A-Za-z_]))
+               / @keyword{'sizeof'} &(@punctuation{'('} / [A-Za-z_])
                / @keyword{'_Alignof'}
 
-expr_postfix  <- expr_primary (trivia postfix_op)*
+expr_postfix  <- expr_primary postfix_op*
 postfix_op    <- @operator{'++'} / @operator{'--'}
-               / @punctuation{'('} trivia arg_list? trivia @punctuation{')'}
-               / @punctuation{'['} trivia expr trivia @punctuation{']'}
+               / @punctuation{'('} arg_list? @punctuation{')'}
+               / @punctuation{'['} expr @punctuation{']'}
                / @operator{'->'} postfix_member
                / @punctuation{'.'} postfix_member
-postfix_member <- @function{ident} &(trivia @punctuation{'('})
+postfix_member <- @function{ident} &(@punctuation{'('})
                 / @property{ident}
 
-arg_list      <- expr_assign (trivia @punctuation{','} trivia expr_assign)*
+arg_list      <- expr_assign (@punctuation{','} expr_assign)*
 
 expr_primary  <- string_lit
                / char_lit
@@ -255,28 +254,28 @@ expr_primary  <- string_lit
                / @variable{ident}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
-sizeof_type   <- @keyword{'sizeof'} trivia @punctuation{'('} trivia type_name trivia @punctuation{')'}
-type_name     <- decl_spec_list (trivia abstract_declarator)?
+sizeof_type   <- @keyword{'sizeof'} @punctuation{'('} type_name @punctuation{')'}
+type_name     <- decl_spec_list abstract_declarator?
 
 # `(T)expr` vs `(expr)` — try cast first (uses decl_spec which
 # requires a type keyword/qualifier, making the distinction
 # unambiguous for real-world C).
-cast_or_paren <- @punctuation{'('} trivia type_name trivia @punctuation{')'} trivia expr_unary
-               / @punctuation{'('} trivia expr trivia @punctuation{')'}
+cast_or_paren <- @punctuation{'('} type_name @punctuation{')'} expr_unary
+               / @punctuation{'('} expr @punctuation{')'}
 
-call_ident    <- @function{ident} &(trivia @punctuation{'('})
+call_ident    <- @function{ident} &(@punctuation{'('})
 
 # --- Literals --------------------------------------------------------
 
 string_lit    <- @string{string_pieces}
-string_pieces <- string_piece (trivia string_piece)*
-string_piece  <- ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
+string_pieces <- string_piece+
+*string_piece <- ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
 char_lit      <- @string{char_body}
-char_body     <- ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
+*char_body    <- ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
 
 number_lit    <- @number{num_body}
-num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+*num_body     <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
                / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
                / '0b' bin_digits int_suffix?
                / '0' [0-7]* int_suffix?
@@ -284,20 +283,20 @@ num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffi
                / '.' digit_seq exp_part? float_suffix?
                / digit_seq exp_part float_suffix?
                / digit_seq int_suffix?
-digit_seq     <- \d [\d']*
-hex_digits    <- [\da-fA-F] [\da-fA-F']*
-bin_digits    <- [01] [01']*
-exp_part      <- [eE] [+\-]? \d+
+*digit_seq    <- \d [\d']*
+*hex_digits   <- [\da-fA-F] [\da-fA-F']*
+*bin_digits   <- [01] [01']*
+*exp_part     <- [eE] [+\-]? \d+
 int_suffix    <- ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
 float_suffix  <- [fFlL]
 
 # --- Identifiers ----------------------------------------------------
 
-ident         <- !reserved [A-Za-z_] ident_body*
+*ident        <- !reserved [A-Za-z_] ident_body*
 ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords that must not be matched as identifiers.
-reserved      <- reserved_word !ident_body
+*reserved     <- reserved_word !ident_body
 reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
                / 'default' / 'do' / 'double' / 'else' / 'enum' / 'extern'
                / 'float' / 'for' / 'goto' / 'if' / 'inline' / 'int'
@@ -309,4 +308,4 @@ reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
 
 # --- Whitespace / comments ------------------------------------------
 
-comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -29,9 +29,9 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-trivia        <- (comment / \s)*
-
 root          <- (external_decl)*^
+
+trivia        <- (comment / \s)*
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -30,7 +30,9 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-c_file        <- trivia (external_decl)*^ trivia \z
+*trivia       <- (comment / \s)*
+
+root          <- trivia (external_decl)*^ trivia
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
@@ -308,5 +310,3 @@ reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
 # --- Whitespace / comments ------------------------------------------
 
 comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
-
-trivia        <- (comment / \s)*

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -23,9 +23,9 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-trivia        <- (comment / \s)*
-
 root          <- (statement)*^
+
+trivia        <- (comment / \s)*
 
 statement     <- at_rule
                 / rule

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -1,5 +1,4 @@
 # CSS grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: highlighting, not conformance validation. Covers standard
 # rules, at-rules (`@media`, `@keyframes`, `@import`, ...), nested
@@ -24,27 +23,27 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-*trivia       <- (comment / \s)*
+trivia        <- (comment / \s)*
 
-root          <- trivia (statement)*^ trivia
+root          <- (statement)*^
 
 statement     <- at_rule
                 / rule
 
 # --- At-rules --------------------------------------------------------
 
-at_rule       <- at_name trivia prelude trivia (block / @punctuation{';'}) trivia
-at_name       <- @keyword{'@' ident_body+}
+at_rule       <- at_name prelude (block / @punctuation{';'})
+*at_name      <- @keyword{'@' ident_body+}
 
 # Prelude: tokens up to `{` or `;` — sequences of value-like tokens.
-prelude       <- (prelude_token trivia)*
+prelude       <- prelude_token*
 prelude_token <- string_lit
                 / fn_call
                 / hex_color
                 / number_with_unit
                 / @keyword{'!important'}
                 / @type{ident}
-                / @punctuation{'('} trivia prelude trivia @punctuation{')'}
+                / @punctuation{'('} prelude @punctuation{')'}
                 / @punctuation{','}
                 / @punctuation{':'}
                 / @operator{'='}
@@ -56,45 +55,45 @@ prelude_token <- string_lit
 
 # --- Rules -----------------------------------------------------------
 
-rule          <- selector_list trivia block trivia
-selector_list <- selector (trivia @punctuation{','} trivia selector)*
-selector      <- compound_selector (trivia combinator_and_next)*
-combinator_and_next <- @operator{'>'} trivia compound_selector
-                     / @operator{'+'} trivia compound_selector
-                     / @operator{'~'} trivia compound_selector
+rule          <- selector_list block
+selector_list <- selector (@punctuation{','} selector)*
+selector      <- compound_selector combinator_and_next*
+combinator_and_next <- @operator{'>'} compound_selector
+                     / @operator{'+'} compound_selector
+                     / @operator{'~'} compound_selector
                      / compound_selector
 
 compound_selector <- selector_atom+
-selector_atom <- @property{'.' ident}
-               / @constant{'#' ident}
-               / @function{'::' ident pseudo_args?}
-               / @function{':' ident pseudo_args?}
-               / @punctuation{'['} trivia (.. ']') trivia @punctuation{']'}
-               / @punctuation{'&'}
-               / @punctuation{'*'}
-               / @type{ident}
+*selector_atom <- @property{'.' ident}
+                / @constant{'#' ident}
+                / @function{'::' ident pseudo_args?}
+                / @function{':' ident pseudo_args?}
+                / @punctuation{'['} (.. ']') @punctuation{']'}
+                / @punctuation{'&'}
+                / @punctuation{'*'}
+                / @type{ident}
 
-pseudo_args    <- '(' ..= ')'
+*pseudo_args  <- '(' ..= ')'
 
 # --- Blocks & declarations ------------------------------------------
 
-block         <- @punctuation{'{'} trivia ((block_item trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         <- @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 block_item    <- at_rule
                 / declaration
                 / rule
                 / @punctuation{';'}
 
-# Trailing `important? trivia (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
-~declaration  <- @property{prop_ident} trivia @punctuation{':'} trivia value_list trivia
-                 @keyword{'!important'}? trivia (@punctuation{';'} / &'}')
+# Trailing `important? (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
+~declaration  <- @property{prop_ident} @punctuation{':'} value_list
+                 @keyword{'!important'}? (@punctuation{';'} / &'}')
 
-prop_ident    <- '--' ident_body+
+*prop_ident   <- '--' ident_body+
                 / '-'? ident
 
 # --- Values ---------------------------------------------------------
 
-value_list    <- value_term (trivia @punctuation{','} trivia value_term)*
-value_term    <- value_factor (trivia value_factor)*
+value_list    <- value_term (@punctuation{','} value_term)*
+value_term    <- value_factor+
 value_factor  <- string_lit
                 / fn_call
                 / hex_color
@@ -106,37 +105,37 @@ value_factor  <- string_lit
                 / @operator{'-'}
                 / @operator{'*'}
 
-fn_call       <- @function{ident} @punctuation{'('} trivia fn_args? trivia @punctuation{')'}
-fn_args       <- value_term (trivia @punctuation{','} trivia value_term)*
+fn_call       <- @function{ident} @punctuation{'('} fn_args? @punctuation{')'}
+fn_args       <- value_term (@punctuation{','} value_term)*
 
 # Unquoted `url(...)` arg — bare text till the closing paren.
-url_unquoted  <- @function{'url'} @punctuation{'('} trivia @string{.. ')'} trivia @punctuation{')'}
+url_unquoted  <- @function{'url'} @punctuation{'('} @string{.. ')'} @punctuation{')'}
 
 # --- Literals -------------------------------------------------------
 
-hex_color     <- @constant{'#' [\da-fA-F]+}
+*hex_color    <- @constant{'#' [\da-fA-F]+}
 
 number_with_unit <- @number{num_body}
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
-~num_body     <- [+\-]? (num_float / \d+) num_unit?
-num_float     <- \d* '.' \d+
+*~num_body    <- [+\-]? (num_float / \d+) num_unit?
+*num_float    <- \d* '.' \d+
                 / \d+ '.' \d*
 num_unit      <- '%'
                 / ident
 
 string_lit    <- @string{dq_string / sq_string}
-dq_string     <- '"' (str_escape / !'"' !'\n' .)* '"'
-sq_string     <- "'" (str_escape / !"'" !'\n' .)* "'"
-str_escape    <- '\\' .
+*dq_string    <- '"' (str_escape / !'"' !'\n' .)* '"'
+*sq_string    <- "'" (str_escape / !"'" !'\n' .)* "'"
+*str_escape   <- '\\' .
 
 # --- Identifiers ----------------------------------------------------
 
-ident         <- [A-Za-z_\-] ident_body*
+*ident        <- [A-Za-z_\-] ident_body*
 ident_body    <- [A-Za-z\d_\-]
 
 # --- Whitespace / comments -----------------------------------------
 #
 # CSS has only block comments.
 
-comment       <- @comment{'/*' ..= '*/'}
+*comment      <- @comment{'/*' ..= '*/'}

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -24,7 +24,9 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-css_file      <- trivia (statement)*^ trivia \z
+*trivia       <- (comment / \s)*
+
+root          <- trivia (statement)*^ trivia
 
 statement     <- at_rule
                 / rule
@@ -138,5 +140,3 @@ ident_body    <- [A-Za-z\d_\-]
 # CSS has only block comments.
 
 comment       <- @comment{'/*' ..= '*/'}
-
-trivia        <- (comment / \s)*

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -1,5 +1,4 @@
 # Go (pragmatic subset) grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: highlighting, not compilation. Parses real-world Go at the
 # token/declaration level. Precedence is flattened and semantic
@@ -25,20 +24,20 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-*trivia       <- (comment / \s)*
+trivia        <- (comment / \s)*
 
-root          <- trivia package_clause trivia (import_decl trivia)* (top_decl trivia)*^
+root          <- package_clause import_decl* (top_decl)*^
 
 # --- Package / imports ----------------------------------------------
 
-package_clause <- @keyword{'package'} trivia @variable{ident} trivia opt_semi
+package_clause <- @keyword{'package'} @variable{ident} opt_semi
 
-import_decl   <- @keyword{'import'} trivia import_spec_group trivia opt_semi
-               / @keyword{'import'} trivia import_spec trivia opt_semi
-import_spec_group <- @punctuation{'('} trivia (import_spec trivia opt_semi)* trivia @punctuation{')'}
+import_decl   <- @keyword{'import'} import_spec_group opt_semi
+               / @keyword{'import'} import_spec opt_semi
+import_spec_group <- @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
 import_spec   <- import_alias? string_lit
-import_alias  <- @punctuation{'.'} trivia
-               / @variable{ident} trivia
+import_alias  <- @punctuation{'.'}
+               / @variable{ident}
 
 # --- Top-level declarations -----------------------------------------
 
@@ -48,45 +47,45 @@ top_decl      <- decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl         <- @keyword{'var'} trivia var_spec_group
-               / @keyword{'var'} trivia var_spec trivia opt_semi
-               / @keyword{'const'} trivia const_spec_group
-               / @keyword{'const'} trivia const_spec trivia opt_semi
-               / @keyword{'type'} trivia type_spec_group
-               / @keyword{'type'} trivia type_spec trivia opt_semi
+~decl         <- @keyword{'var'} var_spec_group
+               / @keyword{'var'} var_spec opt_semi
+               / @keyword{'const'} const_spec_group
+               / @keyword{'const'} const_spec opt_semi
+               / @keyword{'type'} type_spec_group
+               / @keyword{'type'} type_spec opt_semi
 
-var_spec_group <- @punctuation{'('} trivia (var_spec trivia opt_semi)* trivia @punctuation{')'}
-var_spec      <- ident_list trivia type_expr trivia @operator{'='} trivia expr_list
-               / ident_list trivia type_expr
-               / ident_list trivia @operator{'='} trivia expr_list
+var_spec_group <- @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
+var_spec      <- ident_list type_expr @operator{'='} expr_list
+               / ident_list type_expr
+               / ident_list @operator{'='} expr_list
 
-const_spec_group <- @punctuation{'('} trivia (const_spec trivia opt_semi)* trivia @punctuation{')'}
+const_spec_group <- @punctuation{'('} (const_spec opt_semi)* @punctuation{')'}
 # Trailing `(= expr)?` absorbed by outer recovery.
-~const_spec   <- const_ident_list (trivia type_expr)? (trivia @operator{'='} trivia expr_list)?
+~const_spec   <- const_ident_list type_expr? (@operator{'='} expr_list)?
 
-type_spec_group <- @punctuation{'('} trivia (type_spec trivia opt_semi)* trivia @punctuation{')'}
-type_spec     <- @type{ident} trivia type_params? trivia (@operator{'='})? trivia type_expr
+type_spec_group <- @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
+type_spec     <- @type{ident} type_params? @operator{'='}? type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl    <- @keyword{'func'} trivia @function{ident} type_params? trivia fn_signature trivia block?
-~method_decl  <- @keyword{'func'} trivia method_receiver trivia @function{ident} trivia fn_signature trivia block?
-method_receiver <- @punctuation{'('} trivia (@variable{ident} trivia)? type_expr trivia @punctuation{')'}
+~func_decl    <- @keyword{'func'} @function{ident} type_params? fn_signature block?
+~method_decl  <- @keyword{'func'} method_receiver @function{ident} fn_signature block?
+method_receiver <- @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
-type_params   <- @punctuation{'['} trivia type_param_list trivia @punctuation{']'}
-type_param_list <- type_param (trivia @punctuation{','} trivia type_param)* (trivia @punctuation{','})?
-type_param    <- ident_list trivia type_constraint
+type_params   <- @punctuation{'['} type_param_list @punctuation{']'}
+type_param_list <- type_param (@punctuation{','} type_param)* (@punctuation{','})?
+type_param    <- ident_list type_constraint
 type_constraint <- type_union
-type_union    <- type_term (trivia @operator{'|'} trivia type_term)*
-type_term     <- @operator{'~'} trivia type_expr
+type_union    <- type_term (@operator{'|'} type_term)*
+type_term     <- @operator{'~'} type_expr
                / type_expr
 
-# Trailing `(trivia fn_result)?` absorbed by outer recovery.
-~fn_signature <- fn_params (trivia fn_result)?
-fn_params     <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
-fn_param_list <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
-fn_param      <- ident_list trivia (@operator{'...'} trivia)? type_expr
-               / (@operator{'...'} trivia)? type_expr
+# Trailing `fn_result?` absorbed by outer recovery.
+~fn_signature <- fn_params fn_result?
+fn_params     <- @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param      <- ident_list @operator{'...'}? type_expr
+               / @operator{'...'}? type_expr
 fn_result     <- fn_params
                / type_expr
 
@@ -102,26 +101,26 @@ type_expr     <- type_ptr
                / type_paren
                / type_name
 
-type_ptr      <- @operator{'*'} trivia type_expr
-type_slice_or_array <- @punctuation{'['} trivia (@operator{'...'} / expr)? trivia @punctuation{']'} trivia type_expr
-type_map      <- @keyword{'map'} trivia @punctuation{'['} trivia type_expr trivia @punctuation{']'} trivia type_expr
-type_chan     <- @operator{'<-'} trivia @keyword{'chan'} trivia type_expr
-               / @keyword{'chan'} trivia @operator{'<-'} trivia type_expr
-               / @keyword{'chan'} trivia type_expr
-type_func     <- @keyword{'func'} trivia fn_signature
-type_struct   <- @keyword{'struct'} trivia @punctuation{'{'} trivia struct_field_list? trivia @punctuation{'}'}
-struct_field_list <- struct_field (trivia opt_semi trivia struct_field)* (trivia opt_semi)?
-struct_field  <- @property{ident} (trivia @punctuation{','} trivia @property{ident})* trivia type_expr (trivia string_lit)?
-               / (@operator{'*'} trivia)? type_name (trivia string_lit)?       # embedded field
-type_interface <- @keyword{'interface'} trivia @punctuation{'{'} trivia interface_members? trivia @punctuation{'}'}
-interface_members <- interface_member (trivia opt_semi trivia interface_member)* (trivia opt_semi)?
-interface_member <- @function{ident} trivia fn_signature
+type_ptr      <- @operator{'*'} type_expr
+type_slice_or_array <- @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
+type_map      <- @keyword{'map'} @punctuation{'['} type_expr @punctuation{']'} type_expr
+type_chan     <- @operator{'<-'} @keyword{'chan'} type_expr
+               / @keyword{'chan'} @operator{'<-'} type_expr
+               / @keyword{'chan'} type_expr
+type_func     <- @keyword{'func'} fn_signature
+type_struct   <- @keyword{'struct'} @punctuation{'{'} struct_field_list? @punctuation{'}'}
+struct_field_list <- struct_field (opt_semi struct_field)* opt_semi?
+struct_field  <- @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
+               / @operator{'*'}? type_name string_lit?       # embedded field
+type_interface <- @keyword{'interface'} @punctuation{'{'} interface_members? @punctuation{'}'}
+interface_members <- interface_member (opt_semi interface_member)* opt_semi?
+interface_member <- @function{ident} fn_signature
                   / type_term
-type_paren    <- @punctuation{'('} trivia type_expr trivia @punctuation{')'}
+type_paren    <- @punctuation{'('} type_expr @punctuation{')'}
 # Trailing `type_args?` leniency absorbed by outer recovery.
 ~type_name    <- @type{qualified_ident} type_args?
-type_args     <- @punctuation{'['} trivia type_arg_list trivia @punctuation{']'}
-type_arg_list <- type_expr (trivia @punctuation{','} trivia type_expr)* (trivia @punctuation{','})?
+type_args     <- @punctuation{'['} type_arg_list @punctuation{']'}
+type_arg_list <- type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
 # `pkg.Name` or `Name`.
 # Trailing `(.ident)?` leniency absorbed by outer recovery.
@@ -129,9 +128,9 @@ type_arg_list <- type_expr (trivia @punctuation{','} trivia type_expr)* (trivia 
 
 # --- Statements ------------------------------------------------------
 
-block         <- @punctuation{'{'} trivia ((stmt trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          <- decl trivia opt_semi
+stmt          <- decl opt_semi
                / block
                / labeled_stmt
                / if_stmt
@@ -145,10 +144,10 @@ stmt          <- decl trivia opt_semi
                / continue_stmt
                / goto_stmt
                / fallthrough_stmt
-               / simple_stmt trivia opt_semi
+               / simple_stmt opt_semi
                / empty_stmt
 
-empty_stmt    <- @punctuation{';'} trivia
+empty_stmt    <- @punctuation{';'}
 
 simple_stmt   <- send_stmt
                / inc_dec_stmt
@@ -156,10 +155,10 @@ simple_stmt   <- send_stmt
                / short_var_decl
                / expr_stmt
 
-send_stmt     <- expr_no_compound trivia @operator{'<-'} trivia expr_no_compound
-inc_dec_stmt  <- expr_no_compound trivia (@operator{'++'} / @operator{'--'})
-short_var_decl <- ident_list trivia @operator{':='} trivia expr_list
-assignment    <- expr_no_compound_list trivia assign_op trivia expr_list
+send_stmt     <- expr_no_compound @operator{'<-'} expr_no_compound
+inc_dec_stmt  <- expr_no_compound (@operator{'++'} / @operator{'--'})
+short_var_decl <- ident_list @operator{':='} expr_list
+assignment    <- expr_no_compound_list assign_op expr_list
 expr_stmt     <- expr_no_compound
 
 assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
@@ -167,44 +166,44 @@ assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator
                / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
                / @operator{'='} !'='
 
-labeled_stmt  <- @variable{ident} trivia @punctuation{':'} trivia stmt
+labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt      <- @keyword{'if'} trivia (simple_stmt trivia @punctuation{';'} trivia)? expr_no_compound trivia block
-                 (trivia @keyword{'else'} trivia (if_stmt / block))?
-for_stmt      <- @keyword{'for'} trivia for_header? trivia block
+~if_stmt      <- @keyword{'if'} (simple_stmt @punctuation{';'})? expr_no_compound block
+                 (@keyword{'else'} (if_stmt / block))?
+for_stmt      <- @keyword{'for'} for_header? block
 for_header    <- for_range
                / for_c_style
                / expr_no_compound
-for_range     <- (ident_list trivia (@operator{'='} / @operator{':='}) trivia)? @keyword{'range'} trivia expr_no_compound
-for_c_style   <- simple_stmt? trivia @punctuation{';'} trivia expr_no_compound? trivia @punctuation{';'} trivia simple_stmt?
+for_range     <- (ident_list (@operator{'='} / @operator{':='}))? @keyword{'range'} expr_no_compound
+for_c_style   <- simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
 
-switch_stmt   <- @keyword{'switch'} trivia type_switch_header trivia @punctuation{'{'} trivia type_case* trivia @punctuation{'}'}
-               / @keyword{'switch'} trivia expr_switch_header trivia @punctuation{'{'} trivia expr_case* trivia @punctuation{'}'}
-expr_switch_header <- (simple_stmt trivia @punctuation{';'} trivia)? expr_no_compound?
+switch_stmt   <- @keyword{'switch'} type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
+               / @keyword{'switch'} expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
+expr_switch_header <- (simple_stmt @punctuation{';'})? expr_no_compound?
                / ''
-type_switch_header <- (simple_stmt trivia @punctuation{';'} trivia)? type_switch_guard
-type_switch_guard  <- (@variable{ident} trivia @operator{':='} trivia)? expr_no_compound @punctuation{'.'} @punctuation{'('} trivia @keyword{'type'} trivia @punctuation{')'}
-expr_case     <- @keyword{'case'} trivia expr_list trivia @punctuation{':'} trivia (stmt trivia)*
-               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
-type_case     <- @keyword{'case'} trivia type_list trivia @punctuation{':'} trivia (stmt trivia)*
-               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
-type_list     <- type_expr (trivia @punctuation{','} trivia type_expr)*
+type_switch_header <- (simple_stmt @punctuation{';'})? type_switch_guard
+type_switch_guard  <- (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} @keyword{'type'} @punctuation{')'}
+expr_case     <- @keyword{'case'} expr_list @punctuation{':'} stmt*
+               / @keyword{'default'} @punctuation{':'} stmt*
+type_case     <- @keyword{'case'} type_list @punctuation{':'} stmt*
+               / @keyword{'default'} @punctuation{':'} stmt*
+type_list     <- type_expr (@punctuation{','} type_expr)*
 
-select_stmt   <- @keyword{'select'} trivia @punctuation{'{'} trivia comm_case* trivia @punctuation{'}'}
-comm_case     <- @keyword{'case'} trivia comm_clause trivia @punctuation{':'} trivia (stmt trivia)*
-               / @keyword{'default'} trivia @punctuation{':'} trivia (stmt trivia)*
+select_stmt   <- @keyword{'select'} @punctuation{'{'} comm_case* @punctuation{'}'}
+comm_case     <- @keyword{'case'} comm_clause @punctuation{':'} stmt*
+               / @keyword{'default'} @punctuation{':'} stmt*
 comm_clause   <- send_stmt
                / recv_stmt
-recv_stmt     <- (ident_list trivia (@operator{'='} / @operator{':='}) trivia)? expr_no_compound
+recv_stmt     <- (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
 
-go_stmt       <- @keyword{'go'} trivia expr
-defer_stmt    <- @keyword{'defer'} trivia expr
+go_stmt       <- @keyword{'go'} expr
+defer_stmt    <- @keyword{'defer'} expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt  <- @keyword{'return'} (trivia expr_list)?
-~break_stmt   <- @keyword{'break'} (trivia @variable{ident})?
-~continue_stmt <- @keyword{'continue'} (trivia @variable{ident})?
-goto_stmt     <- @keyword{'goto'} trivia @variable{ident}
+~return_stmt  <- @keyword{'return'} expr_list?
+~break_stmt   <- @keyword{'break'} (@variable{ident})?
+~continue_stmt <- @keyword{'continue'} (@variable{ident})?
+goto_stmt     <- @keyword{'goto'} @variable{ident}
 fallthrough_stmt <- @keyword{'fallthrough'}
 
 # --- Expressions -----------------------------------------------------
@@ -225,56 +224,56 @@ fallthrough_stmt <- @keyword{'fallthrough'}
 expr             <- expr_lor
 expr_no_compound <- expr_lor_nc
 
-expr_lor         <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
-expr_land        <- expr_land trivia @operator{'&&'} trivia expr_rel / expr_rel
-expr_rel         <- expr_rel trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_add / expr_add
-expr_add         <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') trivia expr_mul / expr_mul
-expr_mul         <- expr_mul trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') trivia expr_unary / expr_unary
+expr_lor         <- expr_lor @operator{'||'} expr_land / expr_land
+expr_land        <- expr_land @operator{'&&'} expr_rel / expr_rel
+expr_rel         <- expr_rel (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add / expr_add
+expr_add         <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul / expr_mul
+expr_mul         <- expr_mul (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary / expr_unary
 
-expr_lor_nc      <- expr_lor_nc trivia @operator{'||'} trivia expr_land_nc / expr_land_nc
-expr_land_nc     <- expr_land_nc trivia @operator{'&&'} trivia expr_rel_nc / expr_rel_nc
-expr_rel_nc      <- expr_rel_nc trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_add_nc / expr_add_nc
-expr_add_nc      <- expr_add_nc trivia (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') trivia expr_mul_nc / expr_mul_nc
-expr_mul_nc      <- expr_mul_nc trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') trivia expr_unary_nc / expr_unary_nc
+expr_lor_nc      <- expr_lor_nc @operator{'||'} expr_land_nc / expr_land_nc
+expr_land_nc     <- expr_land_nc @operator{'&&'} expr_rel_nc / expr_rel_nc
+expr_rel_nc      <- expr_rel_nc (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add_nc / expr_add_nc
+expr_add_nc      <- expr_add_nc (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul_nc / expr_mul_nc
+expr_mul_nc      <- expr_mul_nc (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary_nc / expr_unary_nc
 
-expr_unary    <- (unary_op trivia)* expr_postfix
-expr_unary_nc <- (unary_op trivia)* expr_postfix_nc
+expr_unary    <- unary_op* expr_postfix
+expr_unary_nc <- unary_op* expr_postfix_nc
 unary_op      <- @operator{'!'} / @operator{'+'} / @operator{'-'}
                / @operator{'^'} / @operator{'*'} / @operator{'&'}
                / @operator{'<-'}
 
-expr_postfix  <- expr_primary (trivia postfix_op)*
-expr_postfix_nc <- expr_primary_nc (trivia postfix_op_nc)*
+expr_postfix  <- expr_primary postfix_op*
+expr_postfix_nc <- expr_primary_nc postfix_op_nc*
 
 postfix_op    <- @punctuation{'.'} postfix_selector
-               / @punctuation{'['} trivia slice_or_index trivia @punctuation{']'}
-               / @punctuation{'('} trivia call_args? trivia @punctuation{')'}
+               / @punctuation{'['} slice_or_index @punctuation{']'}
+               / @punctuation{'('} call_args? @punctuation{')'}
                / composite_body
 postfix_op_nc <- @punctuation{'.'} postfix_selector
-               / @punctuation{'['} trivia slice_or_index trivia @punctuation{']'}
-               / @punctuation{'('} trivia call_args? trivia @punctuation{')'}
-postfix_selector <- @punctuation{'('} trivia type_expr trivia @punctuation{')'}                   # x.(T) type assertion
-                  / @function{ident} &(trivia @punctuation{'('})
+               / @punctuation{'['} slice_or_index @punctuation{']'}
+               / @punctuation{'('} call_args? @punctuation{')'}
+postfix_selector <- @punctuation{'('} type_expr @punctuation{')'}                   # x.(T) type assertion
+                  / @function{ident} &(@punctuation{'('})
                   / @property{ident}
 # `x.(type)` is intentionally not a postfix here: it is only valid inside
 # a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
 # Letting `postfix_selector` swallow it would leave nothing for the guard
 # to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
-slice_or_index <- expr? trivia @punctuation{':'} trivia expr? (trivia @punctuation{':'} trivia expr)?
+slice_or_index <- expr? @punctuation{':'} expr? (@punctuation{':'} expr)?
                / expr
 
-call_args     <- arg (trivia @punctuation{','} trivia arg)* (trivia @punctuation{','})?
-arg           <- expr trivia @operator{'...'}
+call_args     <- arg (@punctuation{','} arg)* (@punctuation{','})?
+arg           <- expr @operator{'...'}
                / expr
                / type_expr
 
 # Composite literal body: `{ ... }` after a type expression.
-composite_body <- @punctuation{'{'} trivia composite_elems? trivia @punctuation{'}'}
-composite_elems <- composite_elem (trivia @punctuation{','} trivia composite_elem)* (trivia @punctuation{','})?
-composite_elem <- composite_key trivia @punctuation{':'} trivia composite_value
+composite_body <- @punctuation{'{'} composite_elems? @punctuation{'}'}
+composite_elems <- composite_elem (@punctuation{','} composite_elem)* (@punctuation{','})?
+composite_elem <- composite_key @punctuation{':'} composite_value
                / composite_value
 composite_key  <- @property{ident}
-                / @punctuation{'['} trivia expr trivia @punctuation{']'}
+                / @punctuation{'['} expr @punctuation{']'}
                 / string_lit
                 / number_lit
 composite_value <- composite_body
@@ -288,7 +287,7 @@ expr_primary  <- literal
                / @type{upper_ident}
                / @constant{predeclared_const}
                / @type{predeclared_type}
-               / @function{predeclared_fn} &(trivia @punctuation{'('})
+               / @function{predeclared_fn} &(@punctuation{'('})
                / @variable{lower_ident}
                / paren_expr
 expr_primary_nc <- literal
@@ -298,32 +297,32 @@ expr_primary_nc <- literal
                  / @type{upper_ident}
                  / @constant{predeclared_const}
                  / @type{predeclared_type}
-                 / @function{predeclared_fn} &(trivia @punctuation{'('})
+                 / @function{predeclared_fn} &(@punctuation{'('})
                  / @variable{lower_ident}
                  / paren_expr
 
-paren_expr    <- @punctuation{'('} trivia expr trivia @punctuation{')'}
+paren_expr    <- @punctuation{'('} expr @punctuation{')'}
 
 # Composite literal: `T{...}` where T is a named/qualified type.
 composite_lit <- @type{qualified_ident} composite_body
-               / @keyword{'map'} trivia @punctuation{'['} trivia type_expr trivia @punctuation{']'} trivia type_expr trivia composite_body
-               / @punctuation{'['} trivia (@operator{'...'} / expr)? trivia @punctuation{']'} trivia type_expr trivia composite_body
-               / @keyword{'struct'} trivia type_struct_body trivia composite_body
-type_struct_body <- @punctuation{'{'} trivia struct_field_list? trivia @punctuation{'}'}
+               / @keyword{'map'} @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
+               / @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr composite_body
+               / @keyword{'struct'} type_struct_body composite_body
+type_struct_body <- @punctuation{'{'} struct_field_list? @punctuation{'}'}
 
 # Type conversion: `T(x)` where T is a named type — only triggers if
 # immediately followed by `(`.
-type_conv     <- @type{predeclared_type} @punctuation{'('} trivia expr trivia @punctuation{')'}
+type_conv     <- @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
 
 # Function literal.
-fn_lit        <- @keyword{'func'} trivia fn_signature trivia block
+fn_lit        <- @keyword{'func'} fn_signature block
 
-call_ident    <- @function{ident} &(trivia @punctuation{'('})
+call_ident    <- @function{ident} &(@punctuation{'('})
 
-ident_list    <- @variable{ident} (trivia @punctuation{','} trivia @variable{ident})*
-const_ident_list <- @constant{ident} (trivia @punctuation{','} trivia @constant{ident})*
-expr_list     <- expr (trivia @punctuation{','} trivia expr)*
-expr_no_compound_list <- expr_no_compound (trivia @punctuation{','} trivia expr_no_compound)*
+ident_list    <- @variable{ident} (@punctuation{','} @variable{ident})*
+const_ident_list <- @constant{ident} (@punctuation{','} @constant{ident})*
+expr_list     <- expr (@punctuation{','} expr)*
+expr_no_compound_list <- expr_no_compound (@punctuation{','} expr_no_compound)*
 
 # --- Literals -------------------------------------------------------
 
@@ -333,34 +332,34 @@ literal       <- string_lit / number_lit / rune_lit
                / @constant{'iota' !ident_body}
 
 string_lit    <- @string{raw_string / interp_string}
-raw_string    <- '`' ..= '`'
-interp_string <- '"' ('\\' . / !'"' !'\n' .)* '"'
+*raw_string   <- '`' ..= '`'
+*interp_string <- '"' ('\\' . / !'"' !'\n' .)* '"'
 
-rune_lit      <- @string{"'" ('\\' . / !"'" .)* "'"}
+*rune_lit     <- @string{"'" ('\\' . / !"'" .)* "'"}
 
 number_lit    <- @number{num_body}
-num_body      <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+*num_body     <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
                / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
                / '0o' oct_digits 'i'?
                / '0b' bin_digits 'i'?
                / digit_seq '.' digit_seq? exp_part? 'i'?
                / '.' digit_seq exp_part? 'i'?
                / digit_seq exp_part? 'i'?
-digit_seq     <- \d ([\d_])*
-hex_digits    <- [\da-fA-F] [\da-fA-F_]*
-oct_digits    <- [0-7] [0-7_]*
-bin_digits    <- [01] [01_]*
-exp_part      <- [eE] [+\-]? \d+
+*digit_seq    <- \d ([\d_])*
+*hex_digits   <- [\da-fA-F] [\da-fA-F_]*
+*oct_digits   <- [0-7] [0-7_]*
+*bin_digits   <- [01] [01_]*
+*exp_part     <- [eE] [+\-]? \d+
 
 # --- Identifiers / predeclared names ---------------------------------
 
-ident         <- !reserved [A-Za-z_] ident_body*
-upper_ident   <- !reserved [A-Z] ident_body*
-lower_ident   <- !reserved [a-z_] ident_body*
+*ident        <- !reserved [A-Za-z_] ident_body*
+*upper_ident  <- !reserved [A-Z] ident_body*
+*lower_ident  <- !reserved [a-z_] ident_body*
 ident_body    <- [A-Za-z\d_]
 
 # Reserved keywords blocking identifier capture.
-reserved      <- reserved_word !ident_body
+*reserved     <- reserved_word !ident_body
 reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
                / 'defer' / 'default' / 'else' / 'fallthrough' / 'for'
                / 'func' / 'go' / 'goto' / 'if' / 'import' / 'interface'
@@ -370,13 +369,13 @@ reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-predeclared_const <- ('true' / 'false' / 'nil' / 'iota') !ident_body
-predeclared_type <- ('uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+*predeclared_const <- ('true' / 'false' / 'nil' / 'iota') !ident_body
+*predeclared_type <- ('uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
                    / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
                    / 'float32' / 'float64' / 'complex64' / 'complex128'
                    / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
                    / 'error' / 'any' / 'comparable') !ident_body
-predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
+*predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
                  / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
                  / 'print' / 'println' / 'real' / 'recover') !ident_body
 
@@ -385,6 +384,6 @@ predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
 # we accept optional explicit `;` and let `trivia` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
-~opt_semi     <- (@punctuation{';'} trivia)?
+~opt_semi     <- @punctuation{';'}?
 
-comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -25,7 +25,9 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-go_file       <- trivia package_clause trivia (import_decl trivia)* (top_decl trivia)*^ \z
+*trivia       <- (comment / \s)*
+
+root          <- trivia package_clause trivia (import_decl trivia)* (top_decl trivia)*^
 
 # --- Package / imports ----------------------------------------------
 
@@ -386,5 +388,3 @@ predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
 ~opt_semi     <- (@punctuation{';'} trivia)?
 
 comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
-
-trivia        <- (comment / \s)*

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -24,9 +24,9 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-trivia        <- (comment / \s)*
-
 root          <- package_clause import_decl* (top_decl)*^
+
+trivia        <- (comment / \s)*
 
 # --- Package / imports ----------------------------------------------
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -30,7 +30,9 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-js_file        <- trivia (stmt trivia)*^ \z
+*trivia        <- (comment / \s)*
+
+root           <- trivia (stmt trivia)*^
 
 # --- Statements -------------------------------------------------------
 #
@@ -370,5 +372,3 @@ reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
 # --- Whitespace / comments --------------------------------------------
 
 comment        <- @comment{'//' .. '\n' / '/*' ..= '*/'}
-
-trivia         <- (comment / \s)*

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -29,9 +29,9 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-trivia         <- (comment / \s)*
-
 root           <- (stmt)*^
+
+trivia         <- (comment / \s)*
 
 # --- Statements -------------------------------------------------------
 #

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -1,5 +1,4 @@
 # JavaScript (pragmatic subset) grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: highlighting, not execution. Parses ES2020-ish JavaScript at
 # the token level. Precedence is not enforced and semantic constraints
@@ -30,9 +29,9 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-*trivia        <- (comment / \s)*
+trivia         <- (comment / \s)*
 
-root           <- trivia (stmt trivia)*^
+root           <- (stmt)*^
 
 # --- Statements -------------------------------------------------------
 #
@@ -44,7 +43,7 @@ stmt           <- import_decl
                 / export_decl
                 / fn_decl
                 / class_decl
-                / var_decl trivia opt_semi
+                / var_decl opt_semi
                 / if_stmt
                 / for_stmt
                 / while_stmt
@@ -59,139 +58,139 @@ stmt           <- import_decl
                 / labeled_stmt
                 / block_stmt
                 / empty_stmt
-                / expr trivia opt_semi
+                / expr opt_semi
 
 # Definition-level `~` on `~opt_semi` covers every ASI call site; the
 # missing-else / missing-catch / missing-finally leniency on the other
 # `~`-marked stmts below is absorbed by stmt-level `*^` and
 # `block`'s `^block_close` recovery.
-~opt_semi      <- (@punctuation{';'} trivia)?
-empty_stmt     <- @punctuation{';'} trivia
+~opt_semi      <- @punctuation{';'}?
+empty_stmt     <- @punctuation{';'}
 
 # --- Imports / exports ------------------------------------------------
 
-import_decl    <- @keyword{'import'} trivia import_body trivia opt_semi
-import_body    <- import_clause trivia @keyword{'from'} trivia string_lit
+import_decl    <- @keyword{'import'} import_body opt_semi
+import_body    <- import_clause @keyword{'from'} string_lit
                 / string_lit
-import_clause  <- import_default trivia @punctuation{','} trivia import_ns_or_named
+import_clause  <- import_default @punctuation{','} import_ns_or_named
                 / import_default
                 / import_ns_or_named
 import_default <- @variable{ident}
 import_ns_or_named <- import_namespace / import_named
-import_namespace <- @operator{'*'} trivia @keyword{'as'} trivia @variable{ident}
-import_named   <- @punctuation{'{'} trivia import_specifier_list? trivia @punctuation{'}'}
-import_specifier_list <- import_specifier (trivia @punctuation{','} trivia import_specifier)* (trivia @punctuation{','})?
-import_specifier <- @variable{ident_name} trivia @keyword{'as'} trivia @variable{ident}
+import_namespace <- @operator{'*'} @keyword{'as'} @variable{ident}
+import_named   <- @punctuation{'{'} import_specifier_list? @punctuation{'}'}
+import_specifier_list <- import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
+import_specifier <- @variable{ident_name} @keyword{'as'} @variable{ident}
                   / @variable{ident}
 
-export_decl    <- @keyword{'export'} trivia @keyword{'default'} trivia export_default_body
-                / @keyword{'export'} trivia @operator{'*'} trivia (@keyword{'as'} trivia @variable{ident_name} trivia)? @keyword{'from'} trivia string_lit trivia opt_semi
-                / @keyword{'export'} trivia export_named
-                / @keyword{'export'} trivia fn_decl
-                / @keyword{'export'} trivia class_decl
-                / @keyword{'export'} trivia var_decl trivia opt_semi
+export_decl    <- @keyword{'export'} @keyword{'default'} export_default_body
+                / @keyword{'export'} @operator{'*'} (@keyword{'as'} @variable{ident_name})? @keyword{'from'} string_lit opt_semi
+                / @keyword{'export'} export_named
+                / @keyword{'export'} fn_decl
+                / @keyword{'export'} class_decl
+                / @keyword{'export'} var_decl opt_semi
 export_default_body <- fn_decl
                      / class_decl
-                     / expr trivia opt_semi
+                     / expr opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named  <- @punctuation{'{'} trivia export_specifier_list? trivia @punctuation{'}'} (trivia @keyword{'from'} trivia string_lit)? trivia opt_semi
-export_specifier_list <- export_specifier (trivia @punctuation{','} trivia export_specifier)* (trivia @punctuation{','})?
-export_specifier <- @variable{ident_name} trivia @keyword{'as'} trivia @variable{ident_name}
+~export_named  <- @punctuation{'{'} export_specifier_list? @punctuation{'}'} (@keyword{'from'} string_lit)? opt_semi
+export_specifier_list <- export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
+export_specifier <- @variable{ident_name} @keyword{'as'} @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
 
-fn_decl        <- @keyword{'async'} trivia fn_decl_core
+fn_decl        <- @keyword{'async'} fn_decl_core
                 / fn_decl_core
-fn_decl_core   <- @keyword{'function'} (trivia @operator{'*'})? trivia @function{ident} trivia fn_params trivia block
+fn_decl_core   <- @keyword{'function'} @operator{'*'}? @function{ident} fn_params block
 
-class_decl     <- @keyword{'class'} trivia @type{ident} trivia class_heritage? trivia class_body
-class_heritage <- @keyword{'extends'} trivia expr_lhs
-class_body     <- @punctuation{'{'} trivia class_member* trivia @punctuation{'}'}
-class_member   <- @punctuation{';'} trivia
+class_decl     <- @keyword{'class'} @type{ident} class_heritage? class_body
+class_heritage <- @keyword{'extends'} expr_lhs
+class_body     <- @punctuation{'{'} class_member* @punctuation{'}'}
+class_member   <- @punctuation{';'}
                 / class_method_or_field
-class_method_or_field <- (@keyword{'static'} trivia)? (class_method / class_field)
-class_method   <- (@keyword{'async'} trivia)? (@operator{'*'} trivia)? method_head trivia fn_params trivia block trivia
-                / (@keyword{'get'} / @keyword{'set'}) trivia method_head trivia fn_params trivia block trivia
+class_method_or_field <- @keyword{'static'}? (class_method / class_field)
+class_method   <- @keyword{'async'}? @operator{'*'}? method_head fn_params block
+                / (@keyword{'get'} / @keyword{'set'}) method_head fn_params block
 method_head    <- computed_prop
                 / @function{ident_name}
                 / string_lit
                 / number_lit
-class_field    <- (computed_prop / @property{ident_name}) trivia (@operator{'='} trivia expr_no_comma)? trivia opt_semi
+class_field    <- (computed_prop / @property{ident_name}) (@operator{'='} expr_no_comma)? opt_semi
 
 # --- Variable declarations -------------------------------------------
 
-var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) trivia var_declarator_list
-var_declarator_list <- var_declarator (trivia @punctuation{','} trivia var_declarator)*
+var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) var_declarator_list
+var_declarator_list <- var_declarator (@punctuation{','} var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
-~var_declarator <- pattern (trivia @operator{'='} trivia expr_no_comma)?
+~var_declarator <- pattern (@operator{'='} expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt       <- @keyword{'if'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
-                  (trivia @keyword{'else'} trivia stmt)?
-for_stmt       <- @keyword{'for'} (trivia @keyword{'await'})? trivia @punctuation{'('} trivia for_head trivia @punctuation{')'} trivia stmt
+~if_stmt       <- @keyword{'if'} @punctuation{'('} expr @punctuation{')'} stmt
+                  (@keyword{'else'} stmt)?
+for_stmt       <- @keyword{'for'} @keyword{'await'}? @punctuation{'('} for_head @punctuation{')'} stmt
 for_head       <- for_c_style
                 / for_in_of
-for_c_style    <- for_init? trivia @punctuation{';'} trivia expr? trivia @punctuation{';'} trivia expr?
-for_in_of      <- for_binding trivia (@keyword{'in'} / @keyword{'of'}) trivia expr
+for_c_style    <- for_init? @punctuation{';'} expr? @punctuation{';'} expr?
+for_in_of      <- for_binding (@keyword{'in'} / @keyword{'of'}) expr
 for_init       <- var_decl
                 / expr
-for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) trivia pattern
+for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) pattern
                 / pattern
 
-while_stmt     <- @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia stmt
-do_while_stmt  <- @keyword{'do'} trivia stmt trivia @keyword{'while'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia opt_semi
-switch_stmt    <- @keyword{'switch'} trivia @punctuation{'('} trivia expr trivia @punctuation{')'} trivia
-                  @punctuation{'{'} trivia switch_case* trivia @punctuation{'}'}
-switch_case    <- @keyword{'case'} trivia expr trivia @punctuation{':'} trivia (!switch_case_term stmt trivia)*
-                / @keyword{'default'} trivia @punctuation{':'} trivia (!switch_case_term stmt trivia)*
+while_stmt     <- @keyword{'while'} @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt  <- @keyword{'do'} stmt @keyword{'while'} @punctuation{'('} expr @punctuation{')'} opt_semi
+switch_stmt    <- @keyword{'switch'} @punctuation{'('} expr @punctuation{')'}
+                  @punctuation{'{'} switch_case* @punctuation{'}'}
+switch_case    <- @keyword{'case'} expr @punctuation{':'} (!switch_case_term stmt)*
+                / @keyword{'default'} @punctuation{':'} (!switch_case_term stmt)*
 switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt      <- @keyword{'try'} trivia block (trivia catch_clause)? (trivia finally_clause)?
-catch_clause   <- @keyword{'catch'} (trivia @punctuation{'('} trivia pattern trivia @punctuation{')'})? trivia block
-finally_clause <- @keyword{'finally'} trivia block
-throw_stmt     <- @keyword{'throw'} trivia expr trivia opt_semi
-# Trailing `(trivia expr)?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt   <- @keyword{'return'} (trivia expr)? trivia opt_semi
-~break_stmt    <- @keyword{'break'} (trivia @variable{ident})? trivia opt_semi
-~continue_stmt <- @keyword{'continue'} (trivia @variable{ident})? trivia opt_semi
-debugger_stmt  <- @keyword{'debugger'} trivia opt_semi
-labeled_stmt   <- @variable{ident} trivia @punctuation{':'} trivia stmt
+~try_stmt      <- @keyword{'try'} block catch_clause? finally_clause?
+catch_clause   <- @keyword{'catch'} (@punctuation{'('} pattern @punctuation{')'})? block
+finally_clause <- @keyword{'finally'} block
+throw_stmt     <- @keyword{'throw'} expr opt_semi
+# Trailing `expr?` leniency on `~return_stmt` absorbed by stmt recovery.
+~return_stmt   <- @keyword{'return'} expr? opt_semi
+~break_stmt    <- @keyword{'break'} (@variable{ident})? opt_semi
+~continue_stmt <- @keyword{'continue'} (@variable{ident})? opt_semi
+debugger_stmt  <- @keyword{'debugger'} opt_semi
+labeled_stmt   <- @variable{ident} @punctuation{':'} stmt
 block_stmt     <- block
-block          <- @punctuation{'{'} trivia ((stmt trivia)* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block          <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------
 
-fn_params      <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
-fn_param_list  <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
+fn_params      <- @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list  <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
 fn_param       <- @operator{'...'} pattern
-                / pattern (trivia @operator{'='} trivia expr_no_comma)?
+                / pattern (@operator{'='} expr_no_comma)?
 
 # --- Destructuring patterns ------------------------------------------
 
 pattern        <- array_pattern / object_pattern / @variable{ident}
-array_pattern  <- @punctuation{'['} trivia array_pattern_list? trivia @punctuation{']'}
-array_pattern_list <- array_pattern_el (trivia @punctuation{','} trivia array_pattern_el)* (trivia @punctuation{','})?
+array_pattern  <- @punctuation{'['} array_pattern_list? @punctuation{']'}
+array_pattern_list <- array_pattern_el (@punctuation{','} array_pattern_el)* (@punctuation{','})?
 array_pattern_el <- @operator{'...'} pattern
-                  / pattern (trivia @operator{'='} trivia expr_no_comma)?
+                  / pattern (@operator{'='} expr_no_comma)?
                   / ''
-object_pattern <- @punctuation{'{'} trivia object_pattern_list? trivia @punctuation{'}'}
-object_pattern_list <- object_pattern_prop (trivia @punctuation{','} trivia object_pattern_prop)* (trivia @punctuation{','})?
+object_pattern <- @punctuation{'{'} object_pattern_list? @punctuation{'}'}
+object_pattern_list <- object_pattern_prop (@punctuation{','} object_pattern_prop)* (@punctuation{','})?
 object_pattern_prop <- @operator{'...'} pattern
-                     / (computed_prop / @property{ident_name}) trivia @punctuation{':'} trivia pattern (trivia @operator{'='} trivia expr_no_comma)?
-                     / @property{ident} (trivia @operator{'='} trivia expr_no_comma)?
+                     / (computed_prop / @property{ident_name}) @punctuation{':'} pattern (@operator{'='} expr_no_comma)?
+                     / @property{ident} (@operator{'='} expr_no_comma)?
 
-computed_prop  <- @punctuation{'['} trivia expr trivia @punctuation{']'}
+computed_prop  <- @punctuation{'['} expr @punctuation{']'}
 
 # --- Expressions ------------------------------------------------------
 
-expr           <- expr_no_comma (trivia @punctuation{','} trivia expr_no_comma)*
+expr           <- expr_no_comma (@punctuation{','} expr_no_comma)*
 expr_no_comma  <- expr_assign
 expr_assign    <- expr_arrow
                 / expr_yield
-                / expr_conditional (trivia assign_op trivia expr_assign)?
+                / expr_conditional (assign_op expr_assign)?
 
 assign_op      <- @operator{'**='}
                 / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
@@ -202,17 +201,17 @@ assign_op      <- @operator{'**='}
 
 # Arrow functions tried first. `async x => ...`, `x => ...`,
 # `(a, b) => ...`, `() => ...`.
-expr_arrow     <- arrow_head trivia @operator{'=>'} trivia arrow_body
-arrow_head     <- @keyword{'async'} trivia arrow_params
+expr_arrow     <- arrow_head @operator{'=>'} arrow_body
+arrow_head     <- @keyword{'async'} arrow_params
                 / arrow_params
 arrow_params   <- @variable{ident}
                 / arrow_paren_params
-arrow_paren_params <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
+arrow_paren_params <- @punctuation{'('} fn_param_list? @punctuation{')'}
 arrow_body     <- block
                 / expr_no_comma
 
-# Trailing `(trivia *)? (trivia expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield    <- @keyword{'yield'} (trivia @operator{'*'})? (trivia expr_assign)?
+# Trailing `(*)? (expr_assign)?` absorbed by stmt-level recovery.
+~expr_yield    <- @keyword{'yield'} @operator{'*'}? expr_assign?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
@@ -221,24 +220,24 @@ arrow_body     <- block
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
 # Trailing ternary leniency absorbed by stmt-level recovery.
-~expr_conditional <- expr_nullish (trivia @operator{'?'} trivia expr_no_comma trivia @punctuation{':'} trivia expr_no_comma)?
+~expr_conditional <- expr_nullish (@operator{'?'} expr_no_comma @punctuation{':'} expr_no_comma)?
 
-expr_nullish   <- expr_nullish trivia @operator{'??'} !'=' trivia expr_lor / expr_lor
-expr_lor       <- expr_lor trivia @operator{'||'} !'=' trivia expr_land / expr_land
-expr_land      <- expr_land trivia @operator{'&&'} !'=' trivia expr_bor / expr_bor
-expr_bor       <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
-expr_bxor      <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
-expr_band      <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_eq / expr_eq
-expr_eq        <- expr_eq trivia (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) trivia expr_rel / expr_rel
-expr_rel       <- expr_rel trivia (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) trivia expr_shift / expr_shift
-expr_shift     <- expr_shift trivia (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
-expr_add       <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
-expr_mul       <- expr_mul trivia (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_pow / expr_pow
+expr_nullish   <- expr_nullish @operator{'??'} !'=' expr_lor / expr_lor
+expr_lor       <- expr_lor @operator{'||'} !'=' expr_land / expr_land
+expr_land      <- expr_land @operator{'&&'} !'=' expr_bor / expr_bor
+expr_bor       <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor      <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band      <- expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq        <- expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel       <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) expr_shift / expr_shift
+expr_shift     <- expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add       <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul       <- expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
 
 # Right-associative: stays right-recursive, not LR.
-expr_pow       <- expr_unary trivia @operator{'**'} !'=' trivia expr_pow / expr_unary
+expr_pow       <- expr_unary @operator{'**'} !'=' expr_pow / expr_unary
 
-expr_unary     <- (unary_op trivia)* expr_postfix
+expr_unary     <- unary_op* expr_postfix
 unary_op       <- @keyword{'typeof'}
                 / @keyword{'void'}
                 / @keyword{'delete'}
@@ -248,30 +247,30 @@ unary_op       <- @keyword{'typeof'}
                 / @operator{'!'} / @operator{'~'}
 
 # Postfix: calls, member, optional chain, index, `++`/`--`.
-expr_postfix   <- expr_lhs (trivia postfix_op)*
+expr_postfix   <- expr_lhs postfix_op*
 postfix_op     <- @operator{'++'}
                 / @operator{'--'}
-                / @operator{'?.'} trivia postfix_after_optional
+                / @operator{'?.'} postfix_after_optional
                 / @punctuation{'.'} member_target
-                / @punctuation{'['} trivia expr trivia @punctuation{']'}
+                / @punctuation{'['} expr @punctuation{']'}
                 / call_args
                 / template_lit
 postfix_after_optional <- call_args
-                        / @punctuation{'['} trivia expr trivia @punctuation{']'}
+                        / @punctuation{'['} expr @punctuation{']'}
                         / member_target
-member_target  <- @function{ident_name} &(trivia @punctuation{'('})
+member_target  <- @function{ident_name} &(@punctuation{'('})
                 / @property{ident_name}
-call_args      <- @punctuation{'('} trivia arg_list? trivia @punctuation{')'}
-arg_list       <- arg (trivia @punctuation{','} trivia arg)* (trivia @punctuation{','})?
+call_args      <- @punctuation{'('} arg_list? @punctuation{')'}
+arg_list       <- arg (@punctuation{','} arg)* (@punctuation{','})?
 arg            <- @operator{'...'} expr_no_comma
                 / expr_no_comma
 
 expr_lhs       <- expr_new / expr_primary
-expr_new       <- @keyword{'new'} trivia expr_new_target
+expr_new       <- @keyword{'new'} expr_new_target
 expr_new_target <- @type{upper_ident} new_tail?
                  / @variable{lower_ident} new_tail?
                  / expr_primary new_tail?
-new_tail       <- (trivia postfix_op)+
+new_tail       <- postfix_op+
 
 expr_primary   <- literal
                 / expr_this
@@ -285,26 +284,26 @@ expr_primary   <- literal
                 / @type{upper_ident}
                 / @variable{lower_ident}
 
-call_ident     <- @function{ident} &(trivia @punctuation{'('})
+call_ident     <- @function{ident} &(@punctuation{'('})
 
 expr_this      <- @keyword{'this'}
 expr_super     <- @keyword{'super'}
-expr_fn        <- (@keyword{'async'} trivia)? @keyword{'function'} (trivia @operator{'*'})? trivia (@function{ident} trivia)? fn_params trivia block
-expr_class     <- @keyword{'class'} (trivia @type{ident})? trivia class_heritage? trivia class_body
-expr_array     <- @punctuation{'['} trivia array_elem_list? trivia @punctuation{']'}
-array_elem_list <- array_elem (trivia @punctuation{','} trivia array_elem)* (trivia @punctuation{','})?
+expr_fn        <- @keyword{'async'}? @keyword{'function'} @operator{'*'}? @function{ident}? fn_params block
+expr_class     <- @keyword{'class'} @type{ident}? class_heritage? class_body
+expr_array     <- @punctuation{'['} array_elem_list? @punctuation{']'}
+array_elem_list <- array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
 array_elem     <- @operator{'...'} expr_no_comma
                 / expr_no_comma
                 / ''
-expr_object    <- @punctuation{'{'} trivia object_props? trivia @punctuation{'}'}
-object_props   <- object_prop (trivia @punctuation{','} trivia object_prop)* (trivia @punctuation{','})?
+expr_object    <- @punctuation{'{'} object_props? @punctuation{'}'}
+object_props   <- object_prop (@punctuation{','} object_prop)* (@punctuation{','})?
 object_prop    <- @operator{'...'} expr_no_comma
                 / object_method
-                / (computed_prop / string_lit / number_lit / @property{ident_name}) trivia @punctuation{':'} trivia expr_no_comma
+                / (computed_prop / string_lit / number_lit / @property{ident_name}) @punctuation{':'} expr_no_comma
                 / @property{ident}
-object_method  <- (@keyword{'async'} trivia)? (@operator{'*'} trivia)? method_head trivia fn_params trivia block
-                / (@keyword{'get'} / @keyword{'set'}) trivia method_head trivia fn_params trivia block
-expr_paren     <- @punctuation{'('} trivia expr trivia @punctuation{')'}
+object_method  <- @keyword{'async'}? @operator{'*'}? method_head fn_params block
+                / (@keyword{'get'} / @keyword{'set'}) method_head fn_params block
+expr_paren     <- @punctuation{'('} expr @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 
@@ -316,42 +315,42 @@ literal        <- template_lit
                 / @constant{'undefined' !ident_body}
 
 string_lit     <- @string{sq_string / dq_string}
-sq_string      <- "'" ('\\' . / !"'" !'\n' .)* "'"
-dq_string      <- '"' ('\\' . / !'"' !'\n' .)* '"'
+*sq_string     <- "'" ('\\' . / !"'" !'\n' .)* "'"
+*dq_string     <- '"' ('\\' . / !'"' !'\n' .)* '"'
 
 # Template literals with ${...} interpolation. Chunks outside the
 # interpolations get @string; the interpolation braces stay
 # @punctuation and the inner expression is parsed as normal.
-template_lit   <- @string{'`'} template_body @string{'`'}
-template_body  <- (template_chunk / template_interp)*
-template_chunk <- @string{('\\' . / !'`' !'${' .)+}
-template_interp <- @punctuation{'${'} trivia expr trivia @punctuation{'}'}
+*template_lit  <- @string{'`'} template_body @string{'`'}
+*template_body <- (template_chunk / template_interp)*
+*template_chunk <- @string{('\\' . / !'`' !'${' .)+}
+template_interp <- @punctuation{'${'} expr @punctuation{'}'}
 
 number_lit     <- @number{num_body}
-num_body       <- '0x' hex_digits 'n'?
+*num_body      <- '0x' hex_digits 'n'?
                 / '0o' oct_digits 'n'?
                 / '0b' bin_digits 'n'?
                 / decimal_num 'n'?
-decimal_num    <- digit_seq '.' digit_seq? exp_part?
+*decimal_num   <- digit_seq '.' digit_seq? exp_part?
                 / '.' digit_seq exp_part?
                 / digit_seq exp_part?
-digit_seq      <- \d ([\d_])*
-hex_digits     <- [\da-fA-F] [\da-fA-F_]*
-oct_digits     <- [0-7] [0-7_]*
-bin_digits     <- [01] [01_]*
-exp_part       <- [eE] [+\-]? \d+
+*digit_seq     <- \d ([\d_])*
+*hex_digits    <- [\da-fA-F] [\da-fA-F_]*
+*oct_digits    <- [0-7] [0-7_]*
+*bin_digits    <- [01] [01_]*
+*exp_part      <- [eE] [+\-]? \d+
 
 # --- Identifiers / reserved words ------------------------------------
 
-ident          <- !reserved [A-Za-z_$] ident_body*
+*ident         <- !reserved [A-Za-z_$] ident_body*
 # `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
 # `!reserved` guard is dropped so reserved words are accepted. Use at
 # positions where ES allows IdentifierName but not BindingIdentifier
 # (member access after `.` / `?.`, property keys, imported/exported
 # names that aren't local bindings).
-ident_name     <- [A-Za-z_$] ident_body*
-upper_ident    <- !reserved [A-Z] ident_body*
-lower_ident    <- !reserved [a-z_$] ident_body*
+*ident_name    <- [A-Za-z_$] ident_body*
+*upper_ident   <- !reserved [A-Z] ident_body*
+*lower_ident   <- !reserved [a-z_$] ident_body*
 ident_body     <- [A-Za-z\d_$]
 
 # Reserved words that must not appear as identifiers. The grammar uses
@@ -360,7 +359,7 @@ ident_body     <- [A-Za-z\d_$]
 # `of`, `from`, `as`, `get`, `set`, `static`, `yield` outside
 # generators) are intentionally omitted so they can still be used as
 # identifiers where the language allows.
-reserved       <- reserved_word !ident_body
+*reserved      <- reserved_word !ident_body
 reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
                 / 'debugger' / 'default' / 'delete' / 'do' / 'else'
                 / 'export' / 'extends' / 'false' / 'finally' / 'for'
@@ -371,4 +370,4 @@ reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
 
 # --- Whitespace / comments --------------------------------------------
 
-comment        <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,8 +1,8 @@
 # JSON grammar with highlight annotations.
 
-trivia      <- \s*
-
 root        <- value
+
+trivia      <- \s*
 
 value       <- @string{string}
              / @number{number}

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,8 +1,8 @@
 # JSON grammar with highlight annotations.
 
-*trivia     <- \s*
+trivia      <- \s*
 
-root        <- \s* value \s*
+root        <- value
 
 value       <- @string{string}
              / @number{number}
@@ -12,22 +12,22 @@ value       <- @string{string}
              / @constant{'false'}
              / @constant{'null'}
 
-object      <- @punctuation{'{'} \s*
-               (pair (\s* @punctuation{','} \s* pair)*)?
-               \s* @punctuation{'}'}
+object      <- @punctuation{'{'}
+               (pair (@punctuation{','} pair)*)?
+               @punctuation{'}'}
 
-pair        <- @property{string} \s* @punctuation{':'} \s* value
+pair        <- @property{string} @punctuation{':'} value
 
-array       <- @punctuation{'['} \s*
-               (value (\s* @punctuation{','} \s* value)*)?
-               \s* @punctuation{']'}
+array       <- @punctuation{'['}
+               (value (@punctuation{','} value)*)?
+               @punctuation{']'}
 
-string      <- '"' string_char* '"'
-string_char <- '\\' ["\\/bfnrt]
-             / '\\' 'u' [\da-fA-F]{4}
-             / [^"\\]
+*string      <- '"' string_char* '"'
+*string_char <- '\\' ["\\/bfnrt]
+              / '\\' 'u' [\da-fA-F]{4}
+              / [^"\\]
 
-number      <- '-'? int frac? exp?
-int         <- '0' / [1-9] \d*
-frac        <- '.' \d+
-exp         <- [eE] [+\-]? \d+
+*number      <- '-'? int frac? exp?
+*int         <- '0' / [1-9] \d*
+*frac        <- '.' \d+
+*exp         <- [eE] [+\-]? \d+

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,7 +1,8 @@
 # JSON grammar with highlight annotations.
-# The first rule is the start rule.
 
-json        <- \s* value \s* \z
+*trivia     <- \s*
+
+root        <- \s* value \s*
 
 value       <- @string{string}
              / @number{number}
@@ -30,5 +31,3 @@ number      <- '-'? int frac? exp?
 int         <- '0' / [1-9] \d*
 frac        <- '.' \d+
 exp         <- [eE] [+\-]? \d+
-
-trivia      <- \s*

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -24,9 +24,9 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-trivia        <- (comment / \s)*
-
 root          <- (item)*^
+
+trivia        <- (comment / \s)*
 
 # --- Items -------------------------------------------------------------
 #

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -25,7 +25,9 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-rust_file     <- trivia (item)*^ trivia \z
+*trivia       <- (comment / \s)*
+
+root          <- trivia (item)*^ trivia
 
 # --- Items -------------------------------------------------------------
 #
@@ -471,5 +473,3 @@ ident_body    <- [A-Za-z\d_]
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
 comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
-
-trivia        <- (comment / \s)*

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -1,5 +1,4 @@
 # Rust (pragmatic subset) grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: highlighting, not compilation. The grammar parses most real-
 # world Rust code to completion at the item/expression/type level.
@@ -25,9 +24,9 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-*trivia       <- (comment / \s)*
+trivia        <- (comment / \s)*
 
-root          <- trivia (item)*^ trivia
+root          <- (item)*^
 
 # --- Items -------------------------------------------------------------
 #
@@ -52,17 +51,17 @@ item          <- attr_outer
                / stmt
 
 # Attributes and doc-comments at item position.
-attr_outer    <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'} trivia
-attr_inner    <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'} trivia
-attr_body     <- .. ']'
+*attr_outer   <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_inner   <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_body    <- .. ']'
 
 # `use foo::bar::{baz, qux as q};`
-use_item      <- @keyword{'use'} trivia use_tree trivia @punctuation{';'} trivia
+use_item      <- @keyword{'use'} use_tree @punctuation{';'}
 use_tree      <- use_path use_tail?
-use_tail      <- trivia @keyword{'as'} trivia ident_any
+use_tail      <- @keyword{'as'} ident_any
                / @punctuation{'::'} @punctuation{'*'}
-               / @punctuation{'::'} @punctuation{'{'} trivia use_tree_list? trivia @punctuation{'}'}
-use_tree_list <- use_tree (trivia @punctuation{','} trivia use_tree)* (trivia @punctuation{','})?
+               / @punctuation{'::'} @punctuation{'{'} use_tree_list? @punctuation{'}'}
+use_tree_list <- use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
 use_path      <- use_seg (@punctuation{'::'} use_seg)*
 use_seg       <- @keyword{'self'}
                / @keyword{'super'}
@@ -71,102 +70,102 @@ use_seg       <- @keyword{'self'}
                / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       <- vis? trivia fn_qualifiers @keyword{'fn'} trivia @function{ident} generic_params? trivia
-                 fn_params trivia fn_return? trivia where_clause? trivia (block / @punctuation{';'}) trivia
-fn_qualifiers <- (fn_qualifier trivia)*
+fn_item       <- vis? fn_qualifiers @keyword{'fn'} @function{ident} generic_params?
+                 fn_params fn_return? where_clause? (block / @punctuation{';'})
+fn_qualifiers <- fn_qualifier*
 fn_qualifier  <- @keyword{'const'}
                / @keyword{'async'}
                / @keyword{'unsafe'}
-               / @keyword{'extern'} (trivia string_lit)?
-fn_params     <- @punctuation{'('} trivia fn_param_list? trivia @punctuation{')'}
-fn_param_list <- fn_param (trivia @punctuation{','} trivia fn_param)* (trivia @punctuation{','})?
+               / @keyword{'extern'} string_lit?
+fn_params     <- @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
 fn_param      <- attr_outer? self_param
                / attr_outer? fn_param_named
-fn_param_named <- pattern_no_or trivia @punctuation{':'} trivia type_expr
-self_param    <- ref_marker? trivia (@keyword{'mut'} trivia)? @keyword{'self'}
-               / @keyword{'mut'} trivia @keyword{'self'}
-               / @keyword{'self'} trivia @punctuation{':'} trivia type_expr
+fn_param_named <- pattern_no_or @punctuation{':'} type_expr
+self_param    <- ref_marker? @keyword{'mut'}? @keyword{'self'}
+               / @keyword{'mut'} @keyword{'self'}
+               / @keyword{'self'} @punctuation{':'} type_expr
 ref_marker    <- @punctuation{'&'} lifetime?
-fn_return     <- @punctuation{'->'} trivia type_expr
+fn_return     <- @punctuation{'->'} type_expr
 
 # `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
-struct_item   <- vis? trivia @keyword{'struct'} trivia @type{ident} generic_params? trivia
-                 (struct_body_named / struct_body_tuple / @punctuation{';'}) trivia
-struct_body_named <- where_clause? trivia @punctuation{'{'} trivia struct_fields? trivia @punctuation{'}'}
-struct_body_tuple <- @punctuation{'('} trivia tuple_fields? trivia @punctuation{')'} trivia where_clause? trivia @punctuation{';'}
-struct_fields <- struct_field (trivia @punctuation{','} trivia struct_field)* (trivia @punctuation{','})?
-struct_field  <- (attr_outer trivia)* vis? trivia @property{ident} trivia @punctuation{':'} trivia type_expr
-tuple_fields  <- tuple_field (trivia @punctuation{','} trivia tuple_field)* (trivia @punctuation{','})?
-tuple_field   <- (attr_outer trivia)* vis? trivia type_expr
+struct_item   <- vis? @keyword{'struct'} @type{ident} generic_params?
+                 (struct_body_named / struct_body_tuple / @punctuation{';'})
+struct_body_named <- where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
+struct_body_tuple <- @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
+struct_fields <- struct_field (@punctuation{','} struct_field)* (@punctuation{','})?
+struct_field  <- attr_outer* vis? @property{ident} @punctuation{':'} type_expr
+tuple_fields  <- tuple_field (@punctuation{','} tuple_field)* (@punctuation{','})?
+tuple_field   <- attr_outer* vis? type_expr
 
 # `enum E { A, B(T), C { x: T } }`
-enum_item     <- vis? trivia @keyword{'enum'} trivia @type{ident} generic_params? trivia where_clause? trivia
-                 @punctuation{'{'} trivia enum_variants? trivia @punctuation{'}'} trivia
-enum_variants <- enum_variant (trivia @punctuation{','} trivia enum_variant)* (trivia @punctuation{','})?
-enum_variant  <- (attr_outer trivia)* @type{ident} enum_variant_body?
-enum_variant_body <- trivia @punctuation{'('} trivia tuple_fields? trivia @punctuation{')'}
-                   / trivia @punctuation{'{'} trivia struct_fields? trivia @punctuation{'}'}
-                   / trivia @punctuation{'='} trivia expr
+enum_item     <- vis? @keyword{'enum'} @type{ident} generic_params? where_clause?
+                 @punctuation{'{'} enum_variants? @punctuation{'}'}
+enum_variants <- enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
+enum_variant  <- attr_outer* @type{ident} enum_variant_body?
+enum_variant_body <- @punctuation{'('} tuple_fields? @punctuation{')'}
+                   / @punctuation{'{'} struct_fields? @punctuation{'}'}
+                   / @punctuation{'='} expr
 
 # `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
-impl_item     <- @keyword{'impl'} generic_params? trivia impl_head trivia where_clause? trivia
-                 @punctuation{'{'} trivia impl_body trivia @punctuation{'}'} trivia
-impl_head     <- type_expr (trivia @keyword{'for'} trivia type_expr)?
-impl_body     <- (item)*
+impl_item     <- @keyword{'impl'} generic_params? impl_head where_clause?
+                 @punctuation{'{'} impl_body @punctuation{'}'}
+impl_head     <- type_expr (@keyword{'for'} type_expr)?
+impl_body     <- item*
 
 # `trait T<U>: Bound { ... }`
-trait_item    <- vis? trivia (@keyword{'unsafe'} trivia)? @keyword{'trait'} trivia @type{ident}
-                 generic_params? trait_bounds? trivia where_clause? trivia
-                 @punctuation{'{'} trivia impl_body trivia @punctuation{'}'} trivia
-trait_bounds  <- trivia @punctuation{':'} trivia bound_list
+trait_item    <- vis? @keyword{'unsafe'}? @keyword{'trait'} @type{ident}
+                 generic_params? trait_bounds? where_clause?
+                 @punctuation{'{'} impl_body @punctuation{'}'}
+trait_bounds  <- @punctuation{':'} bound_list
 
 # `mod name;` / `mod name { ... }`
-mod_item      <- vis? trivia @keyword{'mod'} trivia @variable{ident} trivia
-                 (@punctuation{';'} / @punctuation{'{'} trivia (item)* trivia @punctuation{'}'}) trivia
+mod_item      <- vis? @keyword{'mod'} @variable{ident}
+                 (@punctuation{';'} / @punctuation{'{'} item* @punctuation{'}'})
 
 # `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
-extern_item   <- @keyword{'extern'} (trivia string_lit)? trivia @punctuation{'{'} trivia (item)* trivia @punctuation{'}'} trivia
+extern_item   <- @keyword{'extern'} string_lit? @punctuation{'{'} item* @punctuation{'}'}
 
-const_item    <- vis? trivia @keyword{'const'} trivia @constant{ident} trivia @punctuation{':'} trivia type_expr trivia
-                 @punctuation{'='} trivia expr trivia @punctuation{';'} trivia
-static_item   <- vis? trivia @keyword{'static'} (trivia @keyword{'mut'})? trivia @constant{ident} trivia @punctuation{':'} trivia type_expr trivia
-                 @punctuation{'='} trivia expr trivia @punctuation{';'} trivia
-type_alias_item <- vis? trivia @keyword{'type'} trivia @type{ident} generic_params? trivia where_clause? trivia
-                   @punctuation{'='} trivia type_expr trivia @punctuation{';'} trivia
+const_item    <- vis? @keyword{'const'} @constant{ident} @punctuation{':'} type_expr
+                 @punctuation{'='} expr @punctuation{';'}
+static_item   <- vis? @keyword{'static'} @keyword{'mut'}? @constant{ident} @punctuation{':'} type_expr
+                 @punctuation{'='} expr @punctuation{';'}
+type_alias_item <- vis? @keyword{'type'} @type{ident} generic_params? where_clause?
+                   @punctuation{'='} type_expr @punctuation{';'}
 
 # `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
 # soup; balance braces.
-macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} trivia @function{ident} trivia brace_block trivia
+macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} @function{ident} brace_block
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
-# Trailing `;?` absorbed by `rust_file`'s `*^`.
-~macro_invocation_stmt <- @function{ident} @punctuation{'!'} trivia macro_args trivia (@punctuation{';'})? trivia
+# Trailing `;?` absorbed by `root`'s `*^`.
+~macro_invocation_stmt <- @function{ident} @punctuation{'!'} macro_args (@punctuation{';'})?
 macro_args    <- paren_group
                / brace_block
                / bracket_group
 
 # Visibility modifier.
-vis           <- @keyword{'pub'} (trivia @punctuation{'('} trivia vis_scope trivia @punctuation{')'})?
+vis           <- @keyword{'pub'} (@punctuation{'('} vis_scope @punctuation{')'})?
 vis_scope     <- @keyword{'crate'} / @keyword{'self'} / @keyword{'super'}
-               / @keyword{'in'} trivia use_path
+               / @keyword{'in'} use_path
 
 # --- Generic parameters and where-clauses ----------------------------
 
-generic_params <- @punctuation{'<'} trivia generic_param_list? trivia @punctuation{'>'}
-generic_param_list <- generic_param (trivia @punctuation{','} trivia generic_param)* (trivia @punctuation{','})?
+generic_params <- @punctuation{'<'} generic_param_list? @punctuation{'>'}
+generic_param_list <- generic_param (@punctuation{','} generic_param)* (@punctuation{','})?
 generic_param <- lifetime_param
                / type_param
                / const_param
-lifetime_param <- lifetime (trivia @punctuation{':'} trivia lifetime_bounds)?
-lifetime_bounds <- lifetime (trivia @punctuation{'+'} trivia lifetime)*
-type_param    <- @type{ident} (trivia @punctuation{':'} trivia bound_list)? (trivia @punctuation{'='} trivia type_expr)?
-const_param   <- @keyword{'const'} trivia @constant{ident} trivia @punctuation{':'} trivia type_expr
+lifetime_param <- lifetime (@punctuation{':'} lifetime_bounds)?
+lifetime_bounds <- lifetime (@punctuation{'+'} lifetime)*
+type_param    <- @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
+const_param   <- @keyword{'const'} @constant{ident} @punctuation{':'} type_expr
 
-where_clause  <- @keyword{'where'} trivia where_pred (trivia @punctuation{','} trivia where_pred)* (trivia @punctuation{','})?
-where_pred    <- lifetime trivia @punctuation{':'} trivia lifetime_bounds
-               / type_expr trivia @punctuation{':'} trivia bound_list
+where_clause  <- @keyword{'where'} where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
+where_pred    <- lifetime @punctuation{':'} lifetime_bounds
+               / type_expr @punctuation{':'} bound_list
 
-bound_list    <- bound (trivia @punctuation{'+'} trivia bound)*
+bound_list    <- bound (@punctuation{'+'} bound)*
 bound         <- lifetime
                / (@punctuation{'?'})? type_path
 
@@ -186,20 +185,20 @@ type_expr     <- type_fn
                / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn      <- (type_fn_qualifier trivia)* @keyword{'fn'} trivia @punctuation{'('} trivia type_list? trivia @punctuation{')'}
-                 (trivia @punctuation{'->'} trivia type_expr)?
+~type_fn      <- type_fn_qualifier* @keyword{'fn'} @punctuation{'('} type_list? @punctuation{')'}
+                 (@punctuation{'->'} type_expr)?
 type_fn_qualifier <- @keyword{'unsafe'}
-                   / @keyword{'extern'} (trivia string_lit)?
-type_list     <- type_expr (trivia @punctuation{','} trivia type_expr)* (trivia @punctuation{','})?
+                   / @keyword{'extern'} string_lit?
+type_list     <- type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
-type_impl     <- @keyword{'impl'} trivia bound_list
-type_dyn      <- @keyword{'dyn'} trivia bound_list
+type_impl     <- @keyword{'impl'} bound_list
+type_dyn      <- @keyword{'dyn'} bound_list
 
-type_ref      <- @punctuation{'&'} lifetime? trivia (@keyword{'mut'} trivia)? type_expr
-type_ptr      <- @punctuation{'*'} trivia (@keyword{'mut'} / @keyword{'const'}) trivia type_expr
+type_ref      <- @punctuation{'&'} lifetime? @keyword{'mut'}? type_expr
+type_ptr      <- @punctuation{'*'} (@keyword{'mut'} / @keyword{'const'}) type_expr
 
-type_array_or_slice <- @punctuation{'['} trivia type_expr (trivia @punctuation{';'} trivia expr)? trivia @punctuation{']'}
-type_tuple_or_group <- @punctuation{'('} trivia type_list? trivia @punctuation{')'}
+type_array_or_slice <- @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
+type_tuple_or_group <- @punctuation{'('} type_list? @punctuation{')'}
 
 type_never    <- @punctuation{'!'}
 
@@ -217,14 +216,14 @@ type_path_seg <- @type{upper_ident} path_tail?
 path_tail     <- generic_args
                / paren_generic_args
 
-generic_args  <- @punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'}
-               / @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'}
+generic_args  <- @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'}
+               / @punctuation{'<'} generic_arg_list? @punctuation{'>'}
 # Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
-~paren_generic_args <- @punctuation{'('} trivia type_list? trivia @punctuation{')'} (trivia @punctuation{'->'} trivia type_expr)?
-generic_arg_list <- generic_arg (trivia @punctuation{','} trivia generic_arg)* (trivia @punctuation{','})?
+~paren_generic_args <- @punctuation{'('} type_list? @punctuation{')'} (@punctuation{'->'} type_expr)?
+generic_arg_list <- generic_arg (@punctuation{','} generic_arg)* (@punctuation{','})?
 generic_arg   <- lifetime
                / type_expr
-               / @constant{ident} trivia @punctuation{'='} trivia type_expr
+               / @constant{ident} @punctuation{'='} type_expr
                / expr_block
                / literal
 
@@ -237,7 +236,7 @@ generic_arg   <- lifetime
 
 pattern       <- pattern_or
 pattern_no_or <- pattern_atom
-pattern_or    <- pattern_atom (trivia @punctuation{'|'} trivia pattern_atom)*
+pattern_or    <- pattern_atom (@punctuation{'|'} pattern_atom)*
 pattern_atom  <- pattern_ref
                / pattern_box
                / pattern_tuple
@@ -248,26 +247,26 @@ pattern_atom  <- pattern_ref
                / pattern_wild
                / pattern_rest
                / pattern_binding
-pattern_ref   <- @punctuation{'&'} (trivia @keyword{'mut'})? trivia pattern_atom
-pattern_box   <- @keyword{'box'} trivia pattern_atom
-pattern_tuple <- @punctuation{'('} trivia pattern_list? trivia @punctuation{')'}
-pattern_list  <- pattern (trivia @punctuation{','} trivia pattern)* (trivia @punctuation{','})?
+pattern_ref   <- @punctuation{'&'} @keyword{'mut'}? pattern_atom
+pattern_box   <- @keyword{'box'} pattern_atom
+pattern_tuple <- @punctuation{'('} pattern_list? @punctuation{')'}
+pattern_list  <- pattern (@punctuation{','} pattern)* (@punctuation{','})?
 # Trailing `::` chain leniency absorbed by outer recovery.
 ~pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
-                          (trivia pattern_struct_body / trivia pattern_tuple)?
-pattern_struct_body <- @punctuation{'{'} trivia pattern_struct_fields? trivia @punctuation{'}'}
-pattern_struct_fields <- pattern_struct_field (trivia @punctuation{','} trivia pattern_struct_field)* (trivia @punctuation{','})?
-pattern_struct_field  <- @property{ident} trivia @punctuation{':'} trivia pattern
+                          (pattern_struct_body / pattern_tuple)?
+pattern_struct_body <- @punctuation{'{'} pattern_struct_fields? @punctuation{'}'}
+pattern_struct_fields <- pattern_struct_field (@punctuation{','} pattern_struct_field)* (@punctuation{','})?
+pattern_struct_field  <- @property{ident} @punctuation{':'} pattern
                        / @property{ident}
                        / @punctuation{'..'}
-pattern_slice <- @punctuation{'['} trivia pattern_list? trivia @punctuation{']'}
-pattern_range <- pattern_literal trivia (@punctuation{'..='} / @punctuation{'..'}) trivia pattern_literal
+pattern_slice <- @punctuation{'['} pattern_list? @punctuation{']'}
+pattern_range <- pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
 pattern_literal <- string_lit / char_lit / number_lit / @constant{'true' / 'false'}
 pattern_wild  <- @punctuation{'_'}
 pattern_rest  <- @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding <- (@keyword{'ref'} trivia)? (@keyword{'mut'} trivia)? @variable{ident}
-                   (trivia @punctuation{'@'} trivia pattern_atom)?
+~pattern_binding <- @keyword{'ref'}? @keyword{'mut'}? @variable{ident}
+                   (@punctuation{'@'} pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
 #
@@ -283,7 +282,7 @@ pattern_rest  <- @punctuation{'..'}
 expr          <- expr_assign
 
 # Right-associative: `a = b = c` parses as `a = (b = c)`.
-expr_assign   <- expr_range trivia assign_op trivia expr_assign / expr_range
+expr_assign   <- expr_range assign_op expr_assign / expr_range
 
 assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'+='}  / @operator{'-='}
@@ -293,42 +292,42 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'='} !'='
 
 # Range: `a..b`, `a..=b`, `..b`, `a..`, `..`. Non-associative.
-expr_range    <- expr_lor (trivia (@punctuation{'..='} / @punctuation{'..'}) trivia expr_lor?)?
-               / (@punctuation{'..='} / @punctuation{'..'}) trivia expr_lor?
+expr_range    <- expr_lor ((@punctuation{'..='} / @punctuation{'..'}) expr_lor?)?
+               / (@punctuation{'..='} / @punctuation{'..'}) expr_lor?
 
-expr_lor      <- expr_lor trivia @operator{'||'} trivia expr_land / expr_land
-expr_land     <- expr_land trivia @operator{'&&'} trivia expr_cmp / expr_cmp
-expr_cmp      <- expr_cmp trivia (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') trivia expr_bor / expr_bor
-expr_bor      <- expr_bor trivia @operator{'|'} !'|' !'=' trivia expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor trivia @operator{'^'} !'=' trivia expr_band / expr_band
-expr_band     <- expr_band trivia @operator{'&'} !'&' !'=' trivia expr_shift / expr_shift
-expr_shift    <- expr_shift trivia (@operator{'<<'} !'=' / @operator{'>>'} !'=') trivia expr_add / expr_add
-expr_add      <- expr_add trivia (@operator{'+'} !'=' / @operator{'-'} !'=') trivia expr_mul / expr_mul
-expr_mul      <- expr_mul trivia (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') trivia expr_as / expr_as
-expr_as       <- expr_as trivia @keyword{'as'} trivia type_expr_suffix_marker / expr_unary
+expr_lor      <- expr_lor @operator{'||'} expr_land / expr_land
+expr_land     <- expr_land @operator{'&&'} expr_cmp / expr_cmp
+expr_cmp      <- expr_cmp (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_bor / expr_bor
+expr_bor      <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor     <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band     <- expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
+expr_shift    <- expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add      <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
+expr_as       <- expr_as @keyword{'as'} type_expr_suffix_marker / expr_unary
 
 # A marker rule: when `as` matches, consume the following type. Split
 # from the cascade so the type_expr stays attached.
 type_expr_suffix_marker <- type_expr
 
-expr_unary    <- (unary_op trivia)* expr_postfix
-unary_op      <- @operator{'&'} lifetime? (trivia @keyword{'mut'})?
+expr_unary    <- unary_op* expr_postfix
+unary_op      <- @operator{'&'} lifetime? @keyword{'mut'}?
                / @operator{'*'}
                / @operator{'-'}
                / @operator{'!'}
 
 # Postfix chain: calls, indexing, field access, try `?`.
-expr_postfix  <- expr_primary (trivia postfix_op)*
+expr_postfix  <- expr_primary postfix_op*
 postfix_op    <- @punctuation{'?'}
                / @punctuation{'.'} @keyword{'await'}
                / @punctuation{'.'} postfix_member
-               / @punctuation{'('} trivia expr_list? trivia @punctuation{')'}
-               / @punctuation{'['} trivia expr trivia @punctuation{']'}
+               / @punctuation{'('} expr_list? @punctuation{')'}
+               / @punctuation{'['} expr @punctuation{']'}
 postfix_member <- turbofish_method
-                / @function{ident} (trivia @punctuation{'('} trivia expr_list? trivia @punctuation{')'})?
+                / @function{ident} (@punctuation{'('} expr_list? @punctuation{')'})?
                 / @number{digit_seq}
 # Trailing `(args)?` absorbed by outer recovery.
-~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'} (trivia @punctuation{'('} trivia expr_list? trivia @punctuation{')'})?
+~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'} (@punctuation{'('} expr_list? @punctuation{')'})?
 
 expr_primary  <- literal
                / expr_if
@@ -348,73 +347,76 @@ expr_primary  <- literal
                / expr_macro_or_path
                / expr_keyword
 
-# Trailing `(else (if | block))?` leniency absorbed by `rust_file`'s `*^` and `block`'s `^block_close`.
-~expr_if      <- @keyword{'if'} trivia (@keyword{'let'} trivia pattern trivia @operator{'='} trivia)? expr trivia block
-                 (trivia @keyword{'else'} trivia (expr_if / block))?
-expr_match    <- @keyword{'match'} trivia expr trivia @punctuation{'{'} trivia match_arms? trivia @punctuation{'}'}
-match_arms    <- match_arm (trivia @punctuation{','} trivia match_arm)* (trivia @punctuation{','})?
-match_arm     <- (attr_outer trivia)* pattern (trivia @keyword{'if'} trivia expr)? trivia @punctuation{'=>'} trivia expr
-expr_while    <- @keyword{'while'} trivia (@keyword{'let'} trivia pattern trivia @operator{'='} trivia)? expr trivia block
-expr_loop     <- (loop_label trivia)? @keyword{'loop'} trivia block
-expr_for      <- @keyword{'for'} trivia pattern trivia @keyword{'in'} trivia expr trivia block
+# Trailing `(else (if | block))?` leniency absorbed by `root`'s `*^` and `block`'s `^block_close`.
+~expr_if      <- @keyword{'if'} (@keyword{'let'} pattern @operator{'='})? expr block
+                 (@keyword{'else'} (expr_if / block))?
+expr_match    <- @keyword{'match'} expr @punctuation{'{'} match_arms? @punctuation{'}'}
+match_arms    <- match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
+match_arm     <- attr_outer* pattern (@keyword{'if'} expr)? @punctuation{'=>'} expr
+expr_while    <- @keyword{'while'} (@keyword{'let'} pattern @operator{'='})? expr block
+expr_loop     <- loop_label? @keyword{'loop'} block
+expr_for      <- @keyword{'for'} pattern @keyword{'in'} expr block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return  <- @keyword{'return'} (trivia expr)?
-~expr_break   <- @keyword{'break'} (trivia loop_label)? (trivia expr)?
-~expr_continue <- @keyword{'continue'} (trivia loop_label)?
-expr_unsafe   <- @keyword{'unsafe'} trivia block
-expr_closure  <- (@keyword{'move'} trivia)? @punctuation{'|'} trivia closure_params? trivia @punctuation{'|'}
-                 (trivia @punctuation{'->'} trivia type_expr)? trivia expr
-closure_params <- closure_param (trivia @punctuation{','} trivia closure_param)* (trivia @punctuation{','})?
-closure_param <- pattern_no_or (trivia @punctuation{':'} trivia type_expr)?
+~expr_return  <- @keyword{'return'} expr?
+~expr_break   <- @keyword{'break'} loop_label? expr?
+~expr_continue <- @keyword{'continue'} loop_label?
+expr_unsafe   <- @keyword{'unsafe'} block
+expr_closure  <- @keyword{'move'}? @punctuation{'|'} closure_params? @punctuation{'|'}
+                 (@punctuation{'->'} type_expr)? expr
+closure_params <- closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
+closure_param <- pattern_no_or (@punctuation{':'} type_expr)?
 expr_block    <- block
-expr_async_block <- @keyword{'async'} (trivia @keyword{'move'})? trivia block
-expr_tuple_or_paren <- @punctuation{'('} trivia expr_list? trivia @punctuation{')'}
-expr_array    <- @punctuation{'['} trivia expr_array_body? trivia @punctuation{']'}
-expr_array_body <- expr trivia @punctuation{';'} trivia expr
-                 / expr (trivia @punctuation{','} trivia expr)* (trivia @punctuation{','})?
-expr_list     <- expr (trivia @punctuation{','} trivia expr)* (trivia @punctuation{','})?
+expr_async_block <- @keyword{'async'} @keyword{'move'}? block
+expr_tuple_or_paren <- @punctuation{'('} expr_list? @punctuation{')'}
+expr_array    <- @punctuation{'['} expr_array_body? @punctuation{']'}
+expr_array_body <- expr @punctuation{';'} expr
+                 / expr (@punctuation{','} expr)* (@punctuation{','})?
+expr_list     <- expr (@punctuation{','} expr)* (@punctuation{','})?
 expr_keyword  <- @keyword{'self'} / @keyword{'Self'} / @keyword{'super'} / @keyword{'crate'}
 
-loop_label    <- @punctuation{'\''} @variable{ident} @punctuation{':'}
+*loop_label   <- @punctuation{'\''} @variable{ident} @punctuation{':'}
 
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
 # Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
-~expr_macro_or_path <- path_expr (trivia struct_init / @punctuation{'!'} trivia macro_args)?
+~expr_macro_or_path <- path_expr (struct_init / @punctuation{'!'} macro_args)?
 path_expr     <- path_seg (@punctuation{'::'} path_seg)*
-path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'})?
-               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} trivia generic_arg_list? trivia @punctuation{'>'})?
+path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
+               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
 
-struct_init   <- @punctuation{'{'} trivia struct_init_fields? trivia @punctuation{'}'}
-struct_init_fields <- struct_init_field (trivia @punctuation{','} trivia struct_init_field)* (trivia @punctuation{','} trivia struct_init_base?)?
+struct_init   <- @punctuation{'{'} struct_init_fields? @punctuation{'}'}
+struct_init_fields <- struct_init_field (@punctuation{','} struct_init_field)* (@punctuation{','} struct_init_base?)?
 struct_init_field  <- @punctuation{'..'} expr
-                    / @property{ident} trivia @punctuation{':'} trivia expr
+                    / @property{ident} @punctuation{':'} expr
                     / @property{ident}
 struct_init_base   <- @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         <- @punctuation{'{'} trivia (block_body trivia @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_body    <- (stmt)*
+block         <- @punctuation{'{'} (block_body @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block_body    <- stmt*
 
 stmt          <- let_stmt
-               / expr trivia @punctuation{';'} trivia
-               / expr trivia                                    # trailing expression (block-valued)
+               / expr @punctuation{';'}
+               / expr                                    # trailing expression (block-valued)
 
-let_stmt      <- @keyword{'let'} trivia pattern (trivia @punctuation{':'} trivia type_expr)?
-                 (trivia @punctuation{'='} trivia expr)? (trivia @keyword{'else'} trivia block)? trivia @punctuation{';'} trivia
+let_stmt      <- @keyword{'let'} pattern (@punctuation{':'} type_expr)?
+                 (@punctuation{'='} expr)? (@keyword{'else'} block)? @punctuation{';'}
 
 # --- Balanced-bracket helpers (used for macro bodies) -----------------
 #
 # Skip over arbitrary Rust token soup, respecting () [] {} nesting
 # and Rust string / char / comment literals so we don't mis-balance
 # a `}` inside a string. This is the pragmatic alternative to a real
-# token-tree grammar.
+# token-tree grammar. These rules stay non-atomic so the call-site
+# `trivia` auto-insertion still consumes leading whitespace inside
+# the brackets — necessary for multi-line macro argument lists like
+# `vec![\n  1,\n]`.
 
 brace_block   <- @punctuation{'{'} balanced_body @punctuation{'}'}
 paren_group   <- @punctuation{'('} balanced_body @punctuation{')'}
 bracket_group <- @punctuation{'['} balanced_body @punctuation{']'}
-balanced_body <- (balanced_atom)*
+balanced_body <- balanced_atom*
 balanced_atom <- brace_block
                / paren_group
                / bracket_group
@@ -429,47 +431,47 @@ literal       <- string_lit / char_lit / number_lit / @constant{'true' / 'false'
 
 # Raw strings first (longer prefix), then regular.
 string_lit    <- @string{raw_string / byte_string / regular_string}
-regular_string <- '"' ('\\' (!'\n' .) / !'"' .)* '"'
-byte_string   <- 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
-raw_string    <- 'r' raw_hashes '"' (.. '"') '"' raw_hashes
+*regular_string <- '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*byte_string  <- 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*raw_string   <- 'r' raw_hashes '"' (.. '"') '"' raw_hashes
                / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
 # Consume matching hash fences; the body is "up to the closing delim".
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
-raw_hashes    <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
+*raw_hashes   <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
 
-char_lit      <- @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
+*char_lit     <- @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
 
 number_lit    <- @number{num_body}
-num_body      <- float_num / int_num
-float_num     <- digit_seq '.' digit_seq (exp_part)? num_suffix?
+*num_body     <- float_num / int_num
+*float_num    <- digit_seq '.' digit_seq (exp_part)? num_suffix?
                / digit_seq exp_part num_suffix?
-int_num       <- '0x' hex_digits num_suffix?
+*int_num      <- '0x' hex_digits num_suffix?
                / '0o' oct_digits num_suffix?
                / '0b' bin_digits num_suffix?
                / digit_seq num_suffix?
-digit_seq     <- \d ([\d_])*
-hex_digits    <- [\da-fA-F] [\da-fA-F_]*
-oct_digits    <- [0-7] [0-7_]*
-bin_digits    <- [01] [01_]*
-exp_part      <- [eE] [+\-]? digit_seq
-num_suffix    <- [a-zA-Z_] [a-zA-Z\d_]*
+*digit_seq    <- \d ([\d_])*
+*hex_digits   <- [\da-fA-F] [\da-fA-F_]*
+*oct_digits   <- [0-7] [0-7_]*
+*bin_digits   <- [01] [01_]*
+*exp_part     <- [eE] [+\-]? digit_seq
+*num_suffix   <- [a-zA-Z_] [a-zA-Z\d_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
-lifetime      <- @type{"'" ident_body+}
+*lifetime     <- @type{"'" ident_body+}
 
 # `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
 # of special meaning for highlighting.
 ident_any     <- @type{upper_ident}
                / @variable{lower_ident}
-upper_ident   <- 'r#'? [A-Z] ident_body*
-lower_ident   <- 'r#'? [a-z_] ident_body*
-ident         <- 'r#'? [A-Za-z_] ident_body*
+*upper_ident  <- 'r#'? [A-Z] ident_body*
+*lower_ident  <- 'r#'? [a-z_] ident_body*
+*ident        <- 'r#'? [A-Za-z_] ident_body*
 ident_body    <- [A-Za-z\d_]
 
 # --- Whitespace and comments ------------------------------------------
 
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -1,5 +1,4 @@
 # Full SQLite grammar with highlight annotations.
-# The first rule is the start rule.
 #
 # Scope: the SQLite dialect. SELECT (with WITH RECURSIVE, compound
 # SELECT, CTEs, window functions), DML (INSERT with UPSERT and

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -54,7 +54,9 @@
 
 # --- Top level --------------------------------------------------------
 
-sql_file   <- (trivia statement stmt_sep?)*^[;] trivia \z
+*trivia    <- (comment / \s)*
+
+root       <- (trivia statement stmt_sep?)*^[;] trivia
 stmt_sep   <- trivia @punctuation{';'} trivia
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt
@@ -111,7 +113,7 @@ result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{'
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
                         / kw_union / kw_intersect / kw_except
-                        / \z
+                        / !.
 table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
 aliased_expr   <- expr (trivia kw_as trivia @variable{bare_ident_nonkw}
                       / trivia @variable{bare_ident_nonkw})?
@@ -152,7 +154,7 @@ where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
                        / kw_union / kw_intersect / kw_except
-                       / \z
+                       / !.
 group_clause   <- kw_group trivia kw_by trivia expr (trivia @punctuation{','} trivia expr)*
 having_clause  <- kw_having trivia expr
 
@@ -996,5 +998,3 @@ keyword_word <-
 # --- Whitespace & comments -------------------------------------------
 
 comment       <- @comment{'--' .. \R / '/*' ..= '*/'}
-
-trivia        <- (comment / \s)*

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -54,10 +54,10 @@
 
 # --- Top level --------------------------------------------------------
 
-*trivia    <- (comment / \s)*
+trivia    <- (comment / \s)*
 
-root       <- (trivia statement stmt_sep?)*^[;] trivia
-stmt_sep   <- trivia @punctuation{';'} trivia
+root       <- (statement stmt_sep?)*^[;]
+stmt_sep   <- @punctuation{';'}
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt
                  / insert_stmt
@@ -90,58 +90,58 @@ statement_body  <- select_stmt
 # Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
 ~select_stmt   <- with_clause? select_core compound_tail* order_clause? limit_clause?
 
-with_clause    <- kw_with (trivia kw_recursive)? trivia cte_defn (trivia @punctuation{','} trivia cte_defn)* trivia
+with_clause    <- kw_with (kw_recursive)? cte_defn (@punctuation{','} cte_defn)*
 cte_defn       <- @type{bare_ident}
-                  (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
-                  trivia kw_as trivia @punctuation{'('} trivia select_stmt trivia @punctuation{')'}
+                  (@punctuation{'('} ident_list @punctuation{')'})?
+                  kw_as @punctuation{'('} select_stmt @punctuation{')'}
 
 # Trailing `(window_clause)?` absorbed by `*^[;]`.
-~select_core   <- kw_select (trivia (kw_distinct / kw_all))? trivia result_list
-                  (trivia from_clause)? (trivia where_clause)? (trivia group_clause)? (trivia having_clause)?
-                  (trivia window_clause)?
+~select_core   <- kw_select ((kw_distinct / kw_all))? result_list
+                  (from_clause)? (where_clause)? (group_clause)? (having_clause)?
+                  (window_clause)?
 
-result_list    <- result_column (trivia @punctuation{','} trivia result_column)*
+result_list    <- result_column (@punctuation{','} result_column)*
 # A column expression that didn't reach a known boundary is treated
-# as malformed. The `^^bad_column (trivia result_column_boundary)`
+# as malformed. The `^^bad_column (result_column_boundary)`
 # operator anchors the inner branch on the boundary (so e.g.
 # `blob.rid IN leaf` fails because `IN` isn't in the boundary set)
-# and synthesizes the recovery body `(!(trivia result_column_boundary) .)*`
+# and synthesizes the recovery body `(!(result_column_boundary) .)*`
 # from the same argument.
 result_column  <- (table_star / @operator{'*'} / aliased_expr)
-                  ^^bad_column (trivia result_column_boundary)
+                  ^^bad_column (result_column_boundary)
 result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{';'}
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
                         / kw_union / kw_intersect / kw_except
                         / !.
 table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
-aliased_expr   <- expr (trivia kw_as trivia @variable{bare_ident_nonkw}
-                      / trivia @variable{bare_ident_nonkw})?
+aliased_expr   <- expr (kw_as @variable{bare_ident_nonkw}
+                      / @variable{bare_ident_nonkw})?
 
-compound_tail  <- trivia (kw_union (trivia kw_all)? / kw_intersect / kw_except) trivia select_core
+compound_tail  <- (kw_union (kw_all)? / kw_intersect / kw_except) select_core
 
-from_clause    <- kw_from trivia table_or_subquery (trivia join_clause)*
-table_or_subquery <- @punctuation{'('} trivia select_stmt trivia @punctuation{')'} (trivia table_alias)?
-                   / qualified_table_name (trivia table_alias)?
+from_clause    <- kw_from table_or_subquery (join_clause)*
+table_or_subquery <- @punctuation{'('} select_stmt @punctuation{')'} (table_alias)?
+                   / qualified_table_name (table_alias)?
 # Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
 ~qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
-table_alias    <- kw_as trivia @variable{bare_ident_nonkw}
+table_alias    <- kw_as @variable{bare_ident_nonkw}
                 / @variable{bare_ident_nonkw}
 
 # Trailing `(join_constraint)?` absorbed by `*^[;]`.
-~join_clause   <- join_op trivia table_or_subquery (trivia join_constraint)?
+~join_clause   <- join_op table_or_subquery (join_constraint)?
 join_op        <- @punctuation{','}
-                / kw_natural (trivia join_type)? trivia kw_join
-                / join_type trivia kw_join
+                / kw_natural (join_type)? kw_join
+                / join_type kw_join
                 / kw_join
-join_type      <- kw_left (trivia kw_outer)?
-                / kw_right (trivia kw_outer)?
-                / kw_full (trivia kw_outer)?
+join_type      <- kw_left (kw_outer)?
+                / kw_right (kw_outer)?
+                / kw_full (kw_outer)?
                 / kw_inner
                 / kw_cross
-join_constraint<- kw_on trivia expr
-                / kw_using trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'}
-ident_list     <- @variable{bare_ident_nonkw} (trivia @punctuation{','} trivia @variable{bare_ident_nonkw})*
+join_constraint<- kw_on expr
+                / kw_using @punctuation{'('} ident_list @punctuation{')'}
+ident_list     <- @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_ident_nonkw})*
 
 # Like `result_column`, `where_clause` uses `^^bad_where` to turn
 # partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY …`
@@ -149,22 +149,22 @@ ident_list     <- @variable{bare_ident_nonkw} (trivia @punctuation{','} trivia @
 # The operator sits *inside* the `kw_where` match so a missing WHERE
 # keyword still fails the rule cleanly (no spurious empty recovery
 # captures on clean SELECTs).
-where_clause   <- kw_where trivia (expr ^^bad_where (trivia where_clause_boundary))
+where_clause   <- kw_where (expr ^^bad_where (where_clause_boundary))
 where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
                        / kw_union / kw_intersect / kw_except
                        / !.
-group_clause   <- kw_group trivia kw_by trivia expr (trivia @punctuation{','} trivia expr)*
-having_clause  <- kw_having trivia expr
+group_clause   <- kw_group kw_by expr (@punctuation{','} expr)*
+having_clause  <- kw_having expr
 
-order_clause   <- trivia kw_order trivia kw_by trivia order_item (trivia @punctuation{','} trivia order_item)*
+order_clause   <- kw_order kw_by order_item (@punctuation{','} order_item)*
 # Trailing `(asc/desc)?` absorbed by `*^[;]`.
-~order_item    <- expr (trivia (kw_asc / kw_desc))?
+~order_item    <- expr ((kw_asc / kw_desc))?
 
 # Trailing `(offset)?` absorbed by `*^[;]`.
-~limit_clause  <- trivia kw_limit trivia expr (trivia kw_offset trivia expr
-                                      / trivia @punctuation{','} trivia expr)?
+~limit_clause  <- kw_limit expr (kw_offset expr
+                                      / @punctuation{','} expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
 # Not counted as reserved keywords in SQLite aside from WINDOW and
@@ -173,33 +173,33 @@ order_clause   <- trivia kw_order trivia kw_by trivia order_item (trivia @punctu
 # are matched positionally here, so existing SELECTs that use any of
 # those as identifiers keep working.
 
-window_clause  <- kw_window trivia named_window (trivia @punctuation{','} trivia named_window)*
-named_window   <- @variable{bare_ident_nonkw} trivia kw_as trivia window_defn
+window_clause  <- kw_window named_window (@punctuation{','} named_window)*
+named_window   <- @variable{bare_ident_nonkw} kw_as window_defn
 
-filter_clause  <- kw_filter trivia @punctuation{'('} trivia kw_where trivia expr trivia @punctuation{')'}
+filter_clause  <- kw_filter @punctuation{'('} kw_where expr @punctuation{')'}
 
-window_defn    <- @punctuation{'('} trivia
-                      (!window_section_keyword @variable{bare_ident_nonkw} trivia)?
-                      (kw_partition trivia kw_by trivia expr (trivia @punctuation{','} trivia expr)* trivia)?
-                      (window_order_body trivia)?
-                      (frame_spec trivia)? @punctuation{')'}
+window_defn    <- @punctuation{'('}
+                      (!window_section_keyword @variable{bare_ident_nonkw})?
+                      (kw_partition kw_by expr (@punctuation{','} expr)*)?
+                      (window_order_body)?
+                      (frame_spec)? @punctuation{')'}
 # Guard the optional base-window-name slot against consuming a keyword
 # that actually starts the next positional section (PARTITION / ORDER /
 # RANGE / ROWS / GROUPS). Without the lookahead, PEG would eat
 # `PARTITION` as a bare identifier and then fail on the partition clause.
 window_section_keyword <- kw_partition / kw_order / kw_range / kw_rows / kw_groups
-window_order_body <- kw_order trivia kw_by trivia order_item (trivia @punctuation{','} trivia order_item)*
+window_order_body <- kw_order kw_by order_item (@punctuation{','} order_item)*
 window_ref     <- window_defn / @variable{bare_ident_nonkw}
 
-frame_spec     <- (kw_range / kw_rows / kw_groups) trivia
-                  (kw_between trivia frame_bound trivia kw_and trivia frame_bound
+frame_spec     <- (kw_range / kw_rows / kw_groups)
+                  (kw_between frame_bound kw_and frame_bound
                    / frame_bound)
-                  (trivia kw_exclude trivia frame_exclude)?
-frame_bound    <- kw_unbounded trivia (kw_preceding / kw_following)
-                / kw_current trivia kw_row
-                / expr trivia (kw_preceding / kw_following)
-frame_exclude  <- kw_no trivia kw_others
-                / kw_current trivia kw_row
+                  (kw_exclude frame_exclude)?
+frame_bound    <- kw_unbounded (kw_preceding / kw_following)
+                / kw_current kw_row
+                / expr (kw_preceding / kw_following)
+frame_exclude  <- kw_no kw_others
+                / kw_current kw_row
                 / kw_group
                 / kw_ties
 
@@ -208,42 +208,42 @@ frame_exclude  <- kw_no trivia kw_others
 # `update_set_list`, which is defined here.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~insert_stmt   <- with_clause? insert_prefix trivia kw_into trivia qualified_table_name
-                  (trivia kw_as trivia @variable{bare_ident_nonkw})?
-                  (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
-                  trivia insert_source
-                  (trivia upsert_clause)*
-                  (trivia returning_clause)?
+~insert_stmt   <- with_clause? insert_prefix kw_into qualified_table_name
+                  (kw_as @variable{bare_ident_nonkw})?
+                  (@punctuation{'('} ident_list @punctuation{')'})?
+                  insert_source
+                  (upsert_clause)*
+                  (returning_clause)?
 
-insert_prefix  <- kw_insert (trivia kw_or trivia conflict_action)?
+insert_prefix  <- kw_insert (kw_or conflict_action)?
                 / kw_replace
 
-insert_source  <- kw_default trivia kw_values
-                / kw_values trivia values_row (trivia @punctuation{','} trivia values_row)*
+insert_source  <- kw_default kw_values
+                / kw_values values_row (@punctuation{','} values_row)*
                 / select_stmt
-values_row     <- @punctuation{'('} trivia expr (trivia @punctuation{','} trivia expr)* trivia @punctuation{')'}
+values_row     <- @punctuation{'('} expr (@punctuation{','} expr)* @punctuation{')'}
 
 conflict_action <- kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
 
-upsert_clause  <- kw_on trivia kw_conflict
-                  (trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'} (trivia where_clause)?)?
-                  trivia kw_do trivia (kw_nothing
-                             / kw_update trivia kw_set trivia update_set_list (trivia where_clause)?)
+upsert_clause  <- kw_on kw_conflict
+                  (@punctuation{'('} indexed_col_list @punctuation{')'} (where_clause)?)?
+                  kw_do (kw_nothing
+                             / kw_update kw_set update_set_list (where_clause)?)
 
-indexed_col_list <- indexed_col (trivia @punctuation{','} trivia indexed_col)*
-indexed_col      <- expr (trivia kw_collate trivia @type{bare_ident})? (trivia (kw_asc / kw_desc))?
+indexed_col_list <- indexed_col (@punctuation{','} indexed_col)*
+indexed_col      <- expr (kw_collate @type{bare_ident})? ((kw_asc / kw_desc))?
 
-update_set_list <- update_set_item (trivia @punctuation{','} trivia update_set_item)*
-update_set_item <- @variable{bare_ident_nonkw} trivia @operator{'='} trivia expr
-                 / @punctuation{'('} trivia ident_list trivia @punctuation{')'} trivia @operator{'='} trivia row_value
+update_set_list <- update_set_item (@punctuation{','} update_set_item)*
+update_set_item <- @variable{bare_ident_nonkw} @operator{'='} expr
+                 / @punctuation{'('} ident_list @punctuation{')'} @operator{'='} row_value
 # RHS of a column-tuple assignment: parens-wrapped row-value (literal
 # list or sub-select) or a single expression that yields a row.
-row_value        <- @punctuation{'('} trivia
-                    (select_stmt / expr (trivia @punctuation{','} trivia expr)*)
-                    trivia @punctuation{')'}
+row_value        <- @punctuation{'('}
+                    (select_stmt / expr (@punctuation{','} expr)*)
+                    @punctuation{')'}
                   / expr
 
-returning_clause <- kw_returning trivia result_list
+returning_clause <- kw_returning result_list
 
 # --- DML: UPDATE, DELETE ---------------------------------------------
 # UPDATE FROM and DELETE reuse `from_clause` and `where_clause` from
@@ -252,20 +252,20 @@ returning_clause <- kw_returning trivia result_list
 # should not pretend the syntax doesn't exist.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~update_stmt <- with_clause? kw_update (trivia kw_or trivia conflict_action)? trivia
-               qualified_table_name (trivia table_alias)?
-               trivia kw_set trivia update_set_list
-               (trivia from_clause)?
-               (trivia where_clause)?
+~update_stmt <- with_clause? kw_update (kw_or conflict_action)?
+               qualified_table_name (table_alias)?
+               kw_set update_set_list
+               (from_clause)?
+               (where_clause)?
                order_clause?
                limit_clause?
-               (trivia returning_clause)?
+               (returning_clause)?
 
-~delete_stmt <- with_clause? kw_delete trivia kw_from trivia qualified_table_name (trivia table_alias)?
-               (trivia where_clause)?
+~delete_stmt <- with_clause? kw_delete kw_from qualified_table_name (table_alias)?
+               (where_clause)?
                order_clause?
                limit_clause?
-               (trivia returning_clause)?
+               (returning_clause)?
 
 # --- DDL: CREATE / DROP / ALTER TABLE --------------------------------
 # Interleaves column_def with table_constraint because SQLite does
@@ -274,133 +274,133 @@ returning_clause <- kw_returning trivia result_list
 # requires a non-keyword leading identifier, while table_constraint
 # starts with CONSTRAINT, PRIMARY, UNIQUE, CHECK, or FOREIGN.
 
-create_table_stmt <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_table
-                     (trivia kw_if trivia kw_not trivia kw_exists)?
-                     trivia qualified_table_name
-                     trivia (@punctuation{'('} trivia
+create_table_stmt <- kw_create ((kw_temporary / kw_temp))? kw_table
+                     (kw_if kw_not kw_exists)?
+                     qualified_table_name
+                     (@punctuation{'('}
                              (column_def / table_constraint)
-                             (trivia @punctuation{','} trivia (column_def / table_constraint))*
-                         trivia @punctuation{')'}
-                         (trivia table_option (trivia @punctuation{','} trivia table_option)*)?
-                       / kw_as trivia select_stmt)
+                             (@punctuation{','} (column_def / table_constraint))*
+                         @punctuation{')'}
+                         (table_option (@punctuation{','} table_option)*)?
+                       / kw_as select_stmt)
 
 # Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
 ~column_def    <- @variable{bare_ident_nonkw}
-                  (trivia type_name)?
-                  (trivia column_constraint)*
+                  (type_name)?
+                  (column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
 # Trailing `(...)?` leniency absorbed by `*^[;]`.
-~type_name     <- @type{bare_ident_nonkw} (trivia @type{bare_ident_nonkw})*
-                  (trivia @punctuation{'('} trivia signed_number
-                       (trivia @punctuation{','} trivia signed_number)? trivia @punctuation{')'})?
+~type_name     <- @type{bare_ident_nonkw} (@type{bare_ident_nonkw})*
+                  (@punctuation{'('} signed_number
+                       (@punctuation{','} signed_number)? @punctuation{')'})?
 
-signed_number  <- (@operator{'-'} / @operator{'+'})? trivia @number{number_body}
+signed_number  <- (@operator{'-'} / @operator{'+'})? @number{number_body}
 
-column_constraint      <- (kw_constraint trivia @variable{bare_ident_nonkw} trivia)? column_constraint_body
+column_constraint      <- (kw_constraint @variable{bare_ident_nonkw})? column_constraint_body
 column_constraint_body <-
-      kw_primary trivia kw_key (trivia (kw_asc / kw_desc))? (trivia conflict_clause)? (trivia kw_autoincrement)?
-    / (kw_not trivia)? kw_null (trivia conflict_clause)?
-    / kw_unique (trivia conflict_clause)?
-    / kw_check trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
-    / kw_default trivia (signed_number / literal / @punctuation{'('} trivia expr trivia @punctuation{')'})
-    / kw_collate trivia @type{bare_ident}
+      kw_primary kw_key ((kw_asc / kw_desc))? (conflict_clause)? (kw_autoincrement)?
+    / (kw_not)? kw_null (conflict_clause)?
+    / kw_unique (conflict_clause)?
+    / kw_check @punctuation{'('} expr @punctuation{')'}
+    / kw_default (signed_number / literal / @punctuation{'('} expr @punctuation{')'})
+    / kw_collate @type{bare_ident}
     / foreign_key_clause
-    / (kw_generated trivia kw_always trivia)? kw_as trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
-      (trivia (kw_stored / kw_virtual))?
+    / (kw_generated kw_always)? kw_as @punctuation{'('} expr @punctuation{')'}
+      ((kw_stored / kw_virtual))?
 
-table_constraint      <- (kw_constraint trivia @variable{bare_ident_nonkw} trivia)? table_constraint_body
+table_constraint      <- (kw_constraint @variable{bare_ident_nonkw})? table_constraint_body
 table_constraint_body <-
-      (kw_primary trivia kw_key / kw_unique)
-          trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'}
-          (trivia conflict_clause)?
-    / kw_check trivia @punctuation{'('} trivia expr trivia @punctuation{')'}
-    / kw_foreign trivia kw_key trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'}
-          trivia foreign_key_clause
+      (kw_primary kw_key / kw_unique)
+          @punctuation{'('} indexed_col_list @punctuation{')'}
+          (conflict_clause)?
+    / kw_check @punctuation{'('} expr @punctuation{')'}
+    / kw_foreign kw_key @punctuation{'('} ident_list @punctuation{')'}
+          foreign_key_clause
 
 # Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
-~foreign_key_clause <- kw_references trivia @type{bare_ident_nonkw}
-                      (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
-                      (trivia fk_action)*
-                      (trivia fk_deferrable)?
-fk_action      <- kw_on trivia (kw_delete / kw_update) trivia fk_action_body
-                / kw_match trivia @variable{bare_ident_nonkw}
-fk_action_body <- kw_set trivia (kw_null / kw_default)
+~foreign_key_clause <- kw_references @type{bare_ident_nonkw}
+                      (@punctuation{'('} ident_list @punctuation{')'})?
+                      (fk_action)*
+                      (fk_deferrable)?
+fk_action      <- kw_on (kw_delete / kw_update) fk_action_body
+                / kw_match @variable{bare_ident_nonkw}
+fk_action_body <- kw_set (kw_null / kw_default)
                 / kw_cascade
                 / kw_restrict
-                / kw_no trivia kw_action
+                / kw_no kw_action
 # Trailing `(initially)?` absorbed by `*^[;]`.
-~fk_deferrable <- (kw_not trivia)? kw_deferrable (trivia kw_initially trivia (kw_immediate / kw_deferred))?
+~fk_deferrable <- (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
 
-conflict_clause <- kw_on trivia kw_conflict trivia conflict_action
+conflict_clause <- kw_on kw_conflict conflict_action
 
-table_option   <- kw_without trivia kw_rowid / kw_strict
+table_option   <- kw_without kw_rowid / kw_strict
 
-drop_table_stmt <- kw_drop trivia kw_table (trivia kw_if trivia kw_exists)? trivia qualified_table_name
+drop_table_stmt <- kw_drop kw_table (kw_if kw_exists)? qualified_table_name
 
-alter_table_stmt <- kw_alter trivia kw_table trivia qualified_table_name trivia (
-      kw_rename trivia kw_to trivia @type{bare_ident_nonkw}
-    / kw_rename (trivia kw_column)? trivia @variable{bare_ident_nonkw}
-        trivia kw_to trivia @variable{bare_ident_nonkw}
-    / kw_add (trivia kw_column)? trivia column_def
-    / kw_drop (trivia kw_column)? trivia @variable{bare_ident_nonkw}
+alter_table_stmt <- kw_alter kw_table qualified_table_name (
+      kw_rename kw_to @type{bare_ident_nonkw}
+    / kw_rename (kw_column)? @variable{bare_ident_nonkw}
+        kw_to @variable{bare_ident_nonkw}
+    / kw_add (kw_column)? column_def
+    / kw_drop (kw_column)? @variable{bare_ident_nonkw}
   )
 
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
 # Trailing `(where_clause)?` absorbed by `*^[;]`.
-~create_index_stmt <- kw_create (trivia kw_unique)? trivia kw_index
-                     (trivia kw_if trivia kw_not trivia kw_exists)?
-                     trivia qualified_table_name
-                     trivia kw_on trivia @type{bare_ident_nonkw}
-                     trivia @punctuation{'('} trivia indexed_col_list trivia @punctuation{')'}
-                     (trivia where_clause)?
+~create_index_stmt <- kw_create (kw_unique)? kw_index
+                     (kw_if kw_not kw_exists)?
+                     qualified_table_name
+                     kw_on @type{bare_ident_nonkw}
+                     @punctuation{'('} indexed_col_list @punctuation{')'}
+                     (where_clause)?
 
-drop_index_stmt   <- kw_drop trivia kw_index (trivia kw_if trivia kw_exists)? trivia qualified_table_name
+drop_index_stmt   <- kw_drop kw_index (kw_if kw_exists)? qualified_table_name
 
-create_view_stmt  <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_view
-                     (trivia kw_if trivia kw_not trivia kw_exists)?
-                     trivia qualified_table_name
-                     (trivia @punctuation{'('} trivia ident_list trivia @punctuation{')'})?
-                     trivia kw_as trivia select_stmt
+create_view_stmt  <- kw_create ((kw_temporary / kw_temp))? kw_view
+                     (kw_if kw_not kw_exists)?
+                     qualified_table_name
+                     (@punctuation{'('} ident_list @punctuation{')'})?
+                     kw_as select_stmt
 
-drop_view_stmt    <- kw_drop trivia kw_view (trivia kw_if trivia kw_exists)? trivia qualified_table_name
+drop_view_stmt    <- kw_drop kw_view (kw_if kw_exists)? qualified_table_name
 
 # --- DDL: CREATE / DROP TRIGGER --------------------------------------
 # Trigger bodies are `;`-separated sequences of DML/SELECT wrapped in
 # BEGIN...END. The inner `;` is mandatory after each body statement,
 # which keeps the nesting disjoint from sql_file's top-level stmt_sep.
 
-create_trigger_stmt <- kw_create (trivia (kw_temporary / kw_temp))? trivia kw_trigger
-                       (trivia kw_if trivia kw_not trivia kw_exists)?
-                       trivia qualified_table_name
-                       (trivia (kw_before / kw_after / kw_instead trivia kw_of))?
-                       trivia trigger_event
-                       trivia kw_on trivia @type{bare_ident_nonkw}
-                       (trivia kw_for trivia kw_each trivia kw_row)?
-                       (trivia kw_when trivia expr)?
-                       trivia kw_begin
-                       trivia (trigger_body_stmt trivia @punctuation{';'} trivia)+
+create_trigger_stmt <- kw_create ((kw_temporary / kw_temp))? kw_trigger
+                       (kw_if kw_not kw_exists)?
+                       qualified_table_name
+                       ((kw_before / kw_after / kw_instead kw_of))?
+                       trigger_event
+                       kw_on @type{bare_ident_nonkw}
+                       (kw_for kw_each kw_row)?
+                       (kw_when expr)?
+                       kw_begin
+                       (trigger_body_stmt @punctuation{';'})+
                        kw_end
 trigger_event     <- kw_delete
                    / kw_insert
-                   / kw_update (trivia kw_of trivia ident_list)?
+                   / kw_update (kw_of ident_list)?
 trigger_body_stmt <- insert_stmt / update_stmt / delete_stmt / select_stmt
 
-drop_trigger_stmt <- kw_drop trivia kw_trigger (trivia kw_if trivia kw_exists)? trivia qualified_table_name
+drop_trigger_stmt <- kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
 
 # --- Transactions & savepoints ---------------------------------------
 
 # Trailing `(transaction-mode)?` absorbed by `*^[;]`.
-~begin_stmt    <- kw_begin (trivia (kw_deferred / kw_immediate / kw_exclusive))?
-                  (trivia kw_transaction)?
+~begin_stmt    <- kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
+                  (kw_transaction)?
 # Trailing `(transaction)?` absorbed by `*^[;]`.
-~commit_stmt   <- (kw_commit / kw_end) (trivia kw_transaction)?
-~rollback_stmt <- kw_rollback (trivia kw_transaction)?
-                  (trivia kw_to (trivia kw_savepoint)? trivia @variable{bare_ident_nonkw})?
-savepoint_stmt <- kw_savepoint trivia @variable{bare_ident_nonkw}
-release_stmt   <- kw_release (trivia kw_savepoint)? trivia @variable{bare_ident_nonkw}
+~commit_stmt   <- (kw_commit / kw_end) (kw_transaction)?
+~rollback_stmt <- kw_rollback (kw_transaction)?
+                  (kw_to (kw_savepoint)? @variable{bare_ident_nonkw})?
+savepoint_stmt <- kw_savepoint @variable{bare_ident_nonkw}
+release_stmt   <- kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
 
 # --- PRAGMA, admin statements, EXPLAIN, CREATE VIRTUAL TABLE ---------
 # EXPLAIN wraps statement_body rather than statement, so
@@ -410,32 +410,32 @@ release_stmt   <- kw_release (trivia kw_savepoint)? trivia @variable{bare_ident_
 # the module is invoked, not merely referenced.
 
 # Trailing `(value)?` absorbed by `*^[;]`.
-~pragma_stmt    <- kw_pragma trivia qualified_table_name
-                   (trivia @operator{'='} trivia pragma_value
-                    / trivia @punctuation{'('} trivia pragma_value trivia @punctuation{')'})?
+~pragma_stmt    <- kw_pragma qualified_table_name
+                   (@operator{'='} pragma_value
+                    / @punctuation{'('} pragma_value @punctuation{')'})?
 pragma_value    <- signed_number / string_lit / @variable{bare_ident}
 
 # Trailing `(into)?` absorbed by `*^[;]`.
-~vacuum_stmt    <- kw_vacuum (trivia @type{bare_ident_nonkw})? (trivia kw_into trivia string_lit)?
+~vacuum_stmt    <- kw_vacuum (@type{bare_ident_nonkw})? (kw_into string_lit)?
 
-attach_stmt     <- kw_attach (trivia kw_database)? trivia expr trivia kw_as
-                   trivia @type{bare_ident_nonkw}
-detach_stmt     <- kw_detach (trivia kw_database)? trivia @type{bare_ident_nonkw}
+attach_stmt     <- kw_attach (kw_database)? expr kw_as
+                   @type{bare_ident_nonkw}
+detach_stmt     <- kw_detach (kw_database)? @type{bare_ident_nonkw}
 
 # Trailing `(target)?` absorbed by `*^[;]`.
-~reindex_stmt   <- kw_reindex (trivia qualified_table_name)?
-~analyze_stmt   <- kw_analyze (trivia qualified_table_name)?
+~reindex_stmt   <- kw_reindex (qualified_table_name)?
+~analyze_stmt   <- kw_analyze (qualified_table_name)?
 
-explain_stmt    <- kw_explain (trivia kw_query trivia kw_plan)? trivia statement_body
+explain_stmt    <- kw_explain (kw_query kw_plan)? statement_body
 
 # Trailing `(args)?` absorbed by `*^[;]`.
 ~create_virtual_table_stmt <-
-    kw_create trivia kw_virtual trivia kw_table
-    (trivia kw_if trivia kw_not trivia kw_exists)?
-    trivia qualified_table_name
-    trivia kw_using trivia @function{bare_ident_nonkw}
-    (trivia @punctuation{'('} trivia vtab_args? trivia @punctuation{')'})?
-vtab_args       <- vtab_arg (trivia @punctuation{','} trivia vtab_arg)*
+    kw_create kw_virtual kw_table
+    (kw_if kw_not kw_exists)?
+    qualified_table_name
+    kw_using @function{bare_ident_nonkw}
+    (@punctuation{'('} vtab_args? @punctuation{')'})?
+vtab_args       <- vtab_arg (@punctuation{','} vtab_arg)*
 # Module args are deliberately permissive — fts5/rtree/etc have
 # module-specific mini-grammars that are not worth modelling.
 vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
@@ -446,30 +446,30 @@ vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
 # operator. No shared-prefix issues between levels.
 
 expr        <- or_expr
-or_expr     <- and_expr (trivia kw_or trivia and_expr)*
-and_expr    <- not_expr (trivia kw_and trivia not_expr)*
-not_expr    <- kw_not trivia not_expr / cmp_expr
+or_expr     <- and_expr (kw_or and_expr)*
+and_expr    <- not_expr (kw_and not_expr)*
+not_expr    <- kw_not not_expr / cmp_expr
 cmp_expr    <- bit_expr cmp_tail*
-cmp_tail    <- trivia kw_is trivia (kw_not trivia)? bit_expr
-             / trivia (kw_not trivia)? kw_between trivia bit_expr trivia kw_and trivia bit_expr
-             / trivia (kw_not trivia)? kw_in trivia @punctuation{'('} trivia in_args? trivia @punctuation{')'}
-             / trivia (kw_not trivia)? kw_like trivia bit_expr (trivia kw_escape trivia bit_expr)?
-             / trivia (kw_not trivia)? kw_glob trivia bit_expr
-             / trivia (kw_not trivia)? kw_match trivia bit_expr
-             / trivia (kw_not trivia)? kw_regexp trivia bit_expr
-             / trivia cmp_op trivia bit_expr
-in_args     <- select_stmt / expr (trivia @punctuation{','} trivia expr)*
+cmp_tail    <- kw_is (kw_not)? bit_expr
+             / (kw_not)? kw_between bit_expr kw_and bit_expr
+             / (kw_not)? kw_in @punctuation{'('} in_args? @punctuation{')'}
+             / (kw_not)? kw_like bit_expr (kw_escape bit_expr)?
+             / (kw_not)? kw_glob bit_expr
+             / (kw_not)? kw_match bit_expr
+             / (kw_not)? kw_regexp bit_expr
+             / cmp_op bit_expr
+in_args     <- select_stmt / expr (@punctuation{','} expr)*
 cmp_op      <- @operator{'=='} / @operator{'<='} / @operator{'>='}
              / @operator{'!='} / @operator{'<>'} / @operator{'='}
              / @operator{'<'} / @operator{'>'}
-bit_expr    <- add_expr (trivia bit_op trivia add_expr)*
+bit_expr    <- add_expr (bit_op add_expr)*
 bit_op      <- @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
-add_expr    <- mul_expr (trivia add_op trivia mul_expr)*
+add_expr    <- mul_expr (add_op mul_expr)*
 add_op      <- @operator{'+'} / @operator{'-'}
-mul_expr    <- concat_expr (trivia mul_op trivia concat_expr)*
+mul_expr    <- concat_expr (mul_op concat_expr)*
 mul_op      <- @operator{'*'} / @operator{'/'} / @operator{'%'}
-concat_expr <- unary_expr (trivia @operator{'||'} trivia unary_expr)*
-unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) trivia unary_expr
+concat_expr <- unary_expr (@operator{'||'} unary_expr)*
+unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) unary_expr
              / primary
 
 # Shared-prefix hotspots: function_call / qualified_column_ref /
@@ -485,24 +485,24 @@ primary     <- literal
              / column_ref_bare
              / bind_param
 
-paren_primary <- @punctuation{'('} trivia (select_stmt / expr) trivia @punctuation{')'}
+paren_primary <- @punctuation{'('} (select_stmt / expr) @punctuation{')'}
 
 # Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
-~function_call <- @function{bare_ident_nonkw} trivia @punctuation{'('} trivia func_args? trivia @punctuation{')'}
-                 (trivia filter_clause)?
-                 (trivia kw_over trivia window_ref)?
+~function_call <- @function{bare_ident_nonkw} @punctuation{'('} func_args? @punctuation{')'}
+                 (filter_clause)?
+                 (kw_over window_ref)?
 func_args   <- @operator{'*'}
-             / (kw_distinct trivia)? expr (trivia @punctuation{','} trivia expr)*
+             / (kw_distinct)? expr (@punctuation{','} expr)*
 
 qualified_column_ref <- @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
 column_ref_bare      <- @variable{bare_ident_nonkw}
 
-case_expr   <- kw_case (trivia expr)? (trivia when_clause)+ (trivia kw_else trivia expr)? trivia kw_end
-when_clause <- kw_when trivia expr trivia kw_then trivia expr
+case_expr   <- kw_case (expr)? (when_clause)+ (kw_else expr)? kw_end
+when_clause <- kw_when expr kw_then expr
 
-cast_expr   <- kw_cast trivia @punctuation{'('} trivia expr trivia kw_as trivia @type{bare_ident} trivia @punctuation{')'}
+cast_expr   <- kw_cast @punctuation{'('} expr kw_as @type{bare_ident} @punctuation{')'}
 
-exists_expr <- kw_exists trivia @punctuation{'('} trivia select_stmt trivia @punctuation{')'}
+exists_expr <- kw_exists @punctuation{'('} select_stmt @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 # Order matters: blob before string (X' prefix consumed first); number
@@ -510,27 +510,27 @@ exists_expr <- kw_exists trivia @punctuation{'('} trivia select_stmt trivia @pun
 
 literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
 
-null_lit    <- @constant{null_body !ident_char}
-bool_lit    <- @constant{bool_body !ident_char}
-null_body   <- [nN][uU][lL][lL]
-bool_body   <- [tT][rR][uU][eE] / [fF][aA][lL][sS][eE]
+*null_lit    <- @constant{null_body !ident_char}
+*bool_lit    <- @constant{bool_body !ident_char}
+*null_body   <- [nN][uU][lL][lL]
+*bool_body   <- [tT][rR][uU][eE] / [fF][aA][lL][sS][eE]
 
-blob_lit    <- @string{blob_body}
-blob_body   <- [xX] "'" [\da-fA-F]* "'"
-string_lit  <- @string{string_body}
-string_body <- "'" ("''" / !"'" .)* "'"
+*blob_lit    <- @string{blob_body}
+*blob_body   <- [xX] "'" [\da-fA-F]* "'"
+*string_lit  <- @string{string_body}
+*string_body <- "'" ("''" / !"'" .)* "'"
 
-number_body <- '0x' [\da-fA-F]+ !ident_char
+*number_body <- '0x' [\da-fA-F]+ !ident_char
              / float_body
              / int_body
-float_body  <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
+*float_body  <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
              / \d+ [eE] [+\-]? \d+
-int_body    <- \d+
+*int_body    <- \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.
-bind_param  <- @variable{bind_body}
-bind_body   <- '?' \d*
+*bind_param  <- @variable{bind_body}
+*bind_body   <- '?' \d*
              / [:@$] ident_start ident_cont*
 
 # --- Identifiers ------------------------------------------------------
@@ -541,18 +541,18 @@ bind_body   <- '?' \d*
 # names and CTE heads where a keyword like INTEGER is actually the
 # content we want to capture as @type).
 
-bare_ident_nonkw  <- quoted_ident / !keyword_word bare_raw
-bare_ident        <- quoted_ident / bare_raw
-quoted_ident      <- double_quoted_id / backtick_id / bracket_id
+*bare_ident_nonkw  <- quoted_ident / !keyword_word bare_raw
+*bare_ident        <- quoted_ident / bare_raw
+*quoted_ident      <- double_quoted_id / backtick_id / bracket_id
 
-bare_raw          <- ident_start ident_cont*
-ident_start       <- [a-zA-Z_]
-ident_cont        <- [a-zA-Z\d_]
-ident_char        <- [a-zA-Z\d_]
+*bare_raw          <- ident_start ident_cont*
+*ident_start       <- [a-zA-Z_]
+*ident_cont        <- [a-zA-Z\d_]
+*ident_char        <- [a-zA-Z\d_]
 
-double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
-backtick_id       <- '`' ('``' / !'`' !\R .)* '`'
-bracket_id        <- '[' .. (']' / \R) ']'
+*double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
+*backtick_id       <- '`' ('``' / !'`' !\R .)* '`'
+*bracket_id        <- '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Per-letter character classes give case-insensitive matching without
@@ -561,295 +561,295 @@ bracket_id        <- '[' .. (']' / \R) ']'
 # `SELECTED`. `keyword_word` reuses the same boundary for the
 # identifier-exclusion negative lookahead.
 
-kw_select    <- @keyword{sel_body !ident_char}
-kw_from      <- @keyword{from_body !ident_char}
-kw_where     <- @keyword{where_body !ident_char}
-kw_group     <- @keyword{group_body !ident_char}
-kw_by        <- @keyword{by_body !ident_char}
-kw_having    <- @keyword{having_body !ident_char}
-kw_order     <- @keyword{order_body !ident_char}
-kw_asc       <- @keyword{asc_body !ident_char}
-kw_desc      <- @keyword{desc_body !ident_char}
-kw_limit     <- @keyword{limit_body !ident_char}
-kw_offset    <- @keyword{offset_body !ident_char}
-kw_join      <- @keyword{join_body !ident_char}
-kw_inner     <- @keyword{inner_body !ident_char}
-kw_left      <- @keyword{left_body !ident_char}
-kw_right     <- @keyword{right_body !ident_char}
-kw_full      <- @keyword{full_body !ident_char}
-kw_outer     <- @keyword{outer_body !ident_char}
-kw_cross     <- @keyword{cross_body !ident_char}
-kw_natural   <- @keyword{natural_body !ident_char}
-kw_on        <- @keyword{on_body !ident_char}
-kw_using     <- @keyword{using_body !ident_char}
-kw_as        <- @keyword{as_body !ident_char}
-kw_distinct  <- @keyword{distinct_body !ident_char}
-kw_all       <- @keyword{all_body !ident_char}
-kw_union     <- @keyword{union_body !ident_char}
-kw_intersect <- @keyword{intersect_body !ident_char}
-kw_except    <- @keyword{except_body !ident_char}
-kw_with      <- @keyword{with_body !ident_char}
-kw_and       <- @keyword{and_body !ident_char}
-kw_or        <- @keyword{or_body !ident_char}
-kw_not       <- @keyword{not_body !ident_char}
-kw_is        <- @keyword{is_body !ident_char}
-kw_in        <- @keyword{in_body !ident_char}
-kw_like      <- @keyword{like_body !ident_char}
-kw_glob      <- @keyword{glob_body !ident_char}
-kw_match     <- @keyword{match_body !ident_char}
-kw_regexp    <- @keyword{regexp_body !ident_char}
-kw_between   <- @keyword{between_body !ident_char}
-kw_escape    <- @keyword{escape_body !ident_char}
-kw_case      <- @keyword{case_body !ident_char}
-kw_when      <- @keyword{when_body !ident_char}
-kw_then      <- @keyword{then_body !ident_char}
-kw_else      <- @keyword{else_body !ident_char}
-kw_end       <- @keyword{end_body !ident_char}
-kw_cast      <- @keyword{cast_body !ident_char}
-kw_exists    <- @keyword{exists_body !ident_char}
-kw_collate   <- @keyword{collate_body !ident_char}
+*kw_select    <- @keyword{sel_body !ident_char}
+*kw_from      <- @keyword{from_body !ident_char}
+*kw_where     <- @keyword{where_body !ident_char}
+*kw_group     <- @keyword{group_body !ident_char}
+*kw_by        <- @keyword{by_body !ident_char}
+*kw_having    <- @keyword{having_body !ident_char}
+*kw_order     <- @keyword{order_body !ident_char}
+*kw_asc       <- @keyword{asc_body !ident_char}
+*kw_desc      <- @keyword{desc_body !ident_char}
+*kw_limit     <- @keyword{limit_body !ident_char}
+*kw_offset    <- @keyword{offset_body !ident_char}
+*kw_join      <- @keyword{join_body !ident_char}
+*kw_inner     <- @keyword{inner_body !ident_char}
+*kw_left      <- @keyword{left_body !ident_char}
+*kw_right     <- @keyword{right_body !ident_char}
+*kw_full      <- @keyword{full_body !ident_char}
+*kw_outer     <- @keyword{outer_body !ident_char}
+*kw_cross     <- @keyword{cross_body !ident_char}
+*kw_natural   <- @keyword{natural_body !ident_char}
+*kw_on        <- @keyword{on_body !ident_char}
+*kw_using     <- @keyword{using_body !ident_char}
+*kw_as        <- @keyword{as_body !ident_char}
+*kw_distinct  <- @keyword{distinct_body !ident_char}
+*kw_all       <- @keyword{all_body !ident_char}
+*kw_union     <- @keyword{union_body !ident_char}
+*kw_intersect <- @keyword{intersect_body !ident_char}
+*kw_except    <- @keyword{except_body !ident_char}
+*kw_with      <- @keyword{with_body !ident_char}
+*kw_and       <- @keyword{and_body !ident_char}
+*kw_or        <- @keyword{or_body !ident_char}
+*kw_not       <- @keyword{not_body !ident_char}
+*kw_is        <- @keyword{is_body !ident_char}
+*kw_in        <- @keyword{in_body !ident_char}
+*kw_like      <- @keyword{like_body !ident_char}
+*kw_glob      <- @keyword{glob_body !ident_char}
+*kw_match     <- @keyword{match_body !ident_char}
+*kw_regexp    <- @keyword{regexp_body !ident_char}
+*kw_between   <- @keyword{between_body !ident_char}
+*kw_escape    <- @keyword{escape_body !ident_char}
+*kw_case      <- @keyword{case_body !ident_char}
+*kw_when      <- @keyword{when_body !ident_char}
+*kw_then      <- @keyword{then_body !ident_char}
+*kw_else      <- @keyword{else_body !ident_char}
+*kw_end       <- @keyword{end_body !ident_char}
+*kw_cast      <- @keyword{cast_body !ident_char}
+*kw_exists    <- @keyword{exists_body !ident_char}
+*kw_collate   <- @keyword{collate_body !ident_char}
 
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-kw_recursive <- @keyword{recursive_body !ident_char}
-kw_window    <- @keyword{window_body !ident_char}
-kw_over      <- @keyword{over_body !ident_char}
-kw_filter    <- @keyword{filter_body !ident_char}
-kw_partition <- @keyword{partition_body !ident_char}
-kw_range     <- @keyword{range_body !ident_char}
-kw_rows      <- @keyword{rows_body !ident_char}
-kw_groups    <- @keyword{groups_body !ident_char}
-kw_unbounded <- @keyword{unbounded_body !ident_char}
-kw_preceding <- @keyword{preceding_body !ident_char}
-kw_following <- @keyword{following_body !ident_char}
-kw_current   <- @keyword{current_body !ident_char}
-kw_row       <- @keyword{row_body !ident_char}
-kw_exclude   <- @keyword{exclude_body !ident_char}
-kw_ties      <- @keyword{ties_body !ident_char}
-kw_others    <- @keyword{others_body !ident_char}
-kw_no        <- @keyword{no_body !ident_char}
+*kw_recursive <- @keyword{recursive_body !ident_char}
+*kw_window    <- @keyword{window_body !ident_char}
+*kw_over      <- @keyword{over_body !ident_char}
+*kw_filter    <- @keyword{filter_body !ident_char}
+*kw_partition <- @keyword{partition_body !ident_char}
+*kw_range     <- @keyword{range_body !ident_char}
+*kw_rows      <- @keyword{rows_body !ident_char}
+*kw_groups    <- @keyword{groups_body !ident_char}
+*kw_unbounded <- @keyword{unbounded_body !ident_char}
+*kw_preceding <- @keyword{preceding_body !ident_char}
+*kw_following <- @keyword{following_body !ident_char}
+*kw_current   <- @keyword{current_body !ident_char}
+*kw_row       <- @keyword{row_body !ident_char}
+*kw_exclude   <- @keyword{exclude_body !ident_char}
+*kw_ties      <- @keyword{ties_body !ident_char}
+*kw_others    <- @keyword{others_body !ident_char}
+*kw_no        <- @keyword{no_body !ident_char}
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
 # rule goes here so UPSERT's DO UPDATE path can use it now.
-kw_insert    <- @keyword{insert_body !ident_char}
-kw_replace   <- @keyword{replace_body !ident_char}
-kw_into      <- @keyword{into_body !ident_char}
-kw_values    <- @keyword{values_body !ident_char}
-kw_default   <- @keyword{default_body !ident_char}
-kw_conflict  <- @keyword{conflict_body !ident_char}
-kw_do        <- @keyword{do_body !ident_char}
-kw_nothing   <- @keyword{nothing_body !ident_char}
-kw_rollback  <- @keyword{rollback_body !ident_char}
-kw_abort     <- @keyword{abort_body !ident_char}
-kw_fail      <- @keyword{fail_body !ident_char}
-kw_ignore    <- @keyword{ignore_body !ident_char}
-kw_set       <- @keyword{set_body !ident_char}
-kw_returning <- @keyword{returning_body !ident_char}
-kw_update    <- @keyword{update_body !ident_char}
-kw_delete    <- @keyword{delete_body !ident_char}
+*kw_insert    <- @keyword{insert_body !ident_char}
+*kw_replace   <- @keyword{replace_body !ident_char}
+*kw_into      <- @keyword{into_body !ident_char}
+*kw_values    <- @keyword{values_body !ident_char}
+*kw_default   <- @keyword{default_body !ident_char}
+*kw_conflict  <- @keyword{conflict_body !ident_char}
+*kw_do        <- @keyword{do_body !ident_char}
+*kw_nothing   <- @keyword{nothing_body !ident_char}
+*kw_rollback  <- @keyword{rollback_body !ident_char}
+*kw_abort     <- @keyword{abort_body !ident_char}
+*kw_fail      <- @keyword{fail_body !ident_char}
+*kw_ignore    <- @keyword{ignore_body !ident_char}
+*kw_set       <- @keyword{set_body !ident_char}
+*kw_returning <- @keyword{returning_body !ident_char}
+*kw_update    <- @keyword{update_body !ident_char}
+*kw_delete    <- @keyword{delete_body !ident_char}
 
 # DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
-kw_create    <- @keyword{create_body !ident_char}
-kw_table     <- @keyword{table_body !ident_char}
-kw_alter     <- @keyword{alter_body !ident_char}
-kw_drop      <- @keyword{drop_body !ident_char}
-kw_rename    <- @keyword{rename_body !ident_char}
-kw_add       <- @keyword{add_body !ident_char}
-kw_column    <- @keyword{column_body !ident_char}
-kw_if        <- @keyword{if_body !ident_char}
-kw_temp      <- @keyword{temp_body !ident_char}
-kw_temporary <- @keyword{temporary_body !ident_char}
-kw_primary   <- @keyword{primary_body !ident_char}
-kw_key       <- @keyword{key_body !ident_char}
-kw_unique    <- @keyword{unique_body !ident_char}
-kw_check     <- @keyword{check_body !ident_char}
-kw_null      <- @keyword{null_body !ident_char}
-kw_references <- @keyword{references_body !ident_char}
-kw_generated <- @keyword{generated_body !ident_char}
-kw_always    <- @keyword{always_body !ident_char}
-kw_stored    <- @keyword{stored_body !ident_char}
-kw_virtual   <- @keyword{virtual_body !ident_char}
-kw_constraint<- @keyword{constraint_body !ident_char}
-kw_foreign   <- @keyword{foreign_body !ident_char}
-kw_action    <- @keyword{action_body !ident_char}
-kw_cascade   <- @keyword{cascade_body !ident_char}
-kw_restrict  <- @keyword{restrict_body !ident_char}
-kw_deferrable<- @keyword{deferrable_body !ident_char}
-kw_initially <- @keyword{initially_body !ident_char}
-kw_immediate <- @keyword{immediate_body !ident_char}
-kw_deferred  <- @keyword{deferred_body !ident_char}
-kw_autoincrement <- @keyword{autoincrement_body !ident_char}
-kw_rowid     <- @keyword{rowid_body !ident_char}
-kw_strict    <- @keyword{strict_body !ident_char}
-kw_without   <- @keyword{without_body !ident_char}
-kw_to        <- @keyword{to_body !ident_char}
-kw_index     <- @keyword{index_body !ident_char}
-kw_view      <- @keyword{view_body !ident_char}
-kw_trigger   <- @keyword{trigger_body !ident_char}
-kw_before    <- @keyword{before_body !ident_char}
-kw_after     <- @keyword{after_body !ident_char}
-kw_instead   <- @keyword{instead_body !ident_char}
-kw_of        <- @keyword{of_body !ident_char}
-kw_for       <- @keyword{for_body !ident_char}
-kw_each      <- @keyword{each_body !ident_char}
-kw_begin     <- @keyword{begin_body !ident_char}
-kw_commit    <- @keyword{commit_body !ident_char}
-kw_transaction <- @keyword{transaction_body !ident_char}
-kw_savepoint <- @keyword{savepoint_body !ident_char}
-kw_release   <- @keyword{release_body !ident_char}
-kw_exclusive <- @keyword{exclusive_body !ident_char}
-kw_pragma    <- @keyword{pragma_body !ident_char}
-kw_vacuum    <- @keyword{vacuum_body !ident_char}
-kw_attach    <- @keyword{attach_body !ident_char}
-kw_detach    <- @keyword{detach_body !ident_char}
-kw_database  <- @keyword{database_body !ident_char}
-kw_reindex   <- @keyword{reindex_body !ident_char}
-kw_analyze   <- @keyword{analyze_body !ident_char}
-kw_explain   <- @keyword{explain_body !ident_char}
-kw_query     <- @keyword{query_body !ident_char}
-kw_plan      <- @keyword{plan_body !ident_char}
+*kw_create    <- @keyword{create_body !ident_char}
+*kw_table     <- @keyword{table_body !ident_char}
+*kw_alter     <- @keyword{alter_body !ident_char}
+*kw_drop      <- @keyword{drop_body !ident_char}
+*kw_rename    <- @keyword{rename_body !ident_char}
+*kw_add       <- @keyword{add_body !ident_char}
+*kw_column    <- @keyword{column_body !ident_char}
+*kw_if        <- @keyword{if_body !ident_char}
+*kw_temp      <- @keyword{temp_body !ident_char}
+*kw_temporary <- @keyword{temporary_body !ident_char}
+*kw_primary   <- @keyword{primary_body !ident_char}
+*kw_key       <- @keyword{key_body !ident_char}
+*kw_unique    <- @keyword{unique_body !ident_char}
+*kw_check     <- @keyword{check_body !ident_char}
+*kw_null      <- @keyword{null_body !ident_char}
+*kw_references <- @keyword{references_body !ident_char}
+*kw_generated <- @keyword{generated_body !ident_char}
+*kw_always    <- @keyword{always_body !ident_char}
+*kw_stored    <- @keyword{stored_body !ident_char}
+*kw_virtual   <- @keyword{virtual_body !ident_char}
+*kw_constraint<- @keyword{constraint_body !ident_char}
+*kw_foreign   <- @keyword{foreign_body !ident_char}
+*kw_action    <- @keyword{action_body !ident_char}
+*kw_cascade   <- @keyword{cascade_body !ident_char}
+*kw_restrict  <- @keyword{restrict_body !ident_char}
+*kw_deferrable<- @keyword{deferrable_body !ident_char}
+*kw_initially <- @keyword{initially_body !ident_char}
+*kw_immediate <- @keyword{immediate_body !ident_char}
+*kw_deferred  <- @keyword{deferred_body !ident_char}
+*kw_autoincrement <- @keyword{autoincrement_body !ident_char}
+*kw_rowid     <- @keyword{rowid_body !ident_char}
+*kw_strict    <- @keyword{strict_body !ident_char}
+*kw_without   <- @keyword{without_body !ident_char}
+*kw_to        <- @keyword{to_body !ident_char}
+*kw_index     <- @keyword{index_body !ident_char}
+*kw_view      <- @keyword{view_body !ident_char}
+*kw_trigger   <- @keyword{trigger_body !ident_char}
+*kw_before    <- @keyword{before_body !ident_char}
+*kw_after     <- @keyword{after_body !ident_char}
+*kw_instead   <- @keyword{instead_body !ident_char}
+*kw_of        <- @keyword{of_body !ident_char}
+*kw_for       <- @keyword{for_body !ident_char}
+*kw_each      <- @keyword{each_body !ident_char}
+*kw_begin     <- @keyword{begin_body !ident_char}
+*kw_commit    <- @keyword{commit_body !ident_char}
+*kw_transaction <- @keyword{transaction_body !ident_char}
+*kw_savepoint <- @keyword{savepoint_body !ident_char}
+*kw_release   <- @keyword{release_body !ident_char}
+*kw_exclusive <- @keyword{exclusive_body !ident_char}
+*kw_pragma    <- @keyword{pragma_body !ident_char}
+*kw_vacuum    <- @keyword{vacuum_body !ident_char}
+*kw_attach    <- @keyword{attach_body !ident_char}
+*kw_detach    <- @keyword{detach_body !ident_char}
+*kw_database  <- @keyword{database_body !ident_char}
+*kw_reindex   <- @keyword{reindex_body !ident_char}
+*kw_analyze   <- @keyword{analyze_body !ident_char}
+*kw_explain   <- @keyword{explain_body !ident_char}
+*kw_query     <- @keyword{query_body !ident_char}
+*kw_plan      <- @keyword{plan_body !ident_char}
 
 # Keyword bodies — raw letter matchers, no boundary check.
 
-sel_body       <- [sS][eE][lL][eE][cC][tT]
-from_body      <- [fF][rR][oO][mM]
-where_body     <- [wW][hH][eE][rR][eE]
-group_body     <- [gG][rR][oO][uU][pP]
-by_body        <- [bB][yY]
-having_body    <- [hH][aA][vV][iI][nN][gG]
-order_body     <- [oO][rR][dD][eE][rR]
-asc_body       <- [aA][sS][cC]
-desc_body      <- [dD][eE][sS][cC]
-limit_body     <- [lL][iI][mM][iI][tT]
-offset_body    <- [oO][fF][fF][sS][eE][tT]
-join_body      <- [jJ][oO][iI][nN]
-inner_body     <- [iI][nN][nN][eE][rR]
-left_body      <- [lL][eE][fF][tT]
-right_body     <- [rR][iI][gG][hH][tT]
-full_body      <- [fF][uU][lL][lL]
-outer_body     <- [oO][uU][tT][eE][rR]
-cross_body     <- [cC][rR][oO][sS][sS]
-natural_body   <- [nN][aA][tT][uU][rR][aA][lL]
-on_body        <- [oO][nN]
-using_body     <- [uU][sS][iI][nN][gG]
-as_body        <- [aA][sS]
-distinct_body  <- [dD][iI][sS][tT][iI][nN][cC][tT]
-all_body       <- [aA][lL][lL]
-union_body     <- [uU][nN][iI][oO][nN]
-intersect_body <- [iI][nN][tT][eE][rR][sS][eE][cC][tT]
-except_body    <- [eE][xX][cC][eE][pP][tT]
-with_body      <- [wW][iI][tT][hH]
-and_body       <- [aA][nN][dD]
-or_body        <- [oO][rR]
-not_body       <- [nN][oO][tT]
-is_body        <- [iI][sS]
-in_body        <- [iI][nN]
-like_body      <- [lL][iI][kK][eE]
-glob_body      <- [gG][lL][oO][bB]
-match_body     <- [mM][aA][tT][cC][hH]
-regexp_body    <- [rR][eE][gG][eE][xX][pP]
-between_body   <- [bB][eE][tT][wW][eE][eE][nN]
-escape_body    <- [eE][sS][cC][aA][pP][eE]
-case_body      <- [cC][aA][sS][eE]
-when_body      <- [wW][hH][eE][nN]
-then_body      <- [tT][hH][eE][nN]
-else_body      <- [eE][lL][sS][eE]
-end_body       <- [eE][nN][dD]
-cast_body      <- [cC][aA][sS][tT]
-exists_body    <- [eE][xX][iI][sS][tT][sS]
-collate_body   <- [cC][oO][lL][lL][aA][tT][eE]
-recursive_body <- [rR][eE][cC][uU][rR][sS][iI][vV][eE]
-window_body    <- [wW][iI][nN][dD][oO][wW]
-over_body      <- [oO][vV][eE][rR]
-filter_body    <- [fF][iI][lL][tT][eE][rR]
-partition_body <- [pP][aA][rR][tT][iI][tT][iI][oO][nN]
-range_body     <- [rR][aA][nN][gG][eE]
-rows_body      <- [rR][oO][wW][sS]
-groups_body    <- [gG][rR][oO][uU][pP][sS]
-unbounded_body <- [uU][nN][bB][oO][uU][nN][dD][eE][dD]
-preceding_body <- [pP][rR][eE][cC][eE][dD][iI][nN][gG]
-following_body <- [fF][oO][lL][lL][oO][wW][iI][nN][gG]
-current_body   <- [cC][uU][rR][rR][eE][nN][tT]
-row_body       <- [rR][oO][wW]
-exclude_body   <- [eE][xX][cC][lL][uU][dD][eE]
-ties_body      <- [tT][iI][eE][sS]
-others_body    <- [oO][tT][hH][eE][rR][sS]
-no_body        <- [nN][oO]
-insert_body    <- [iI][nN][sS][eE][rR][tT]
-replace_body   <- [rR][eE][pP][lL][aA][cC][eE]
-into_body      <- [iI][nN][tT][oO]
-values_body    <- [vV][aA][lL][uU][eE][sS]
-default_body   <- [dD][eE][fF][aA][uU][lL][tT]
-conflict_body  <- [cC][oO][nN][fF][lL][iI][cC][tT]
-do_body        <- [dD][oO]
-nothing_body   <- [nN][oO][tT][hH][iI][nN][gG]
-rollback_body  <- [rR][oO][lL][lL][bB][aA][cC][kK]
-abort_body     <- [aA][bB][oO][rR][tT]
-fail_body      <- [fF][aA][iI][lL]
-ignore_body    <- [iI][gG][nN][oO][rR][eE]
-set_body       <- [sS][eE][tT]
-returning_body <- [rR][eE][tT][uU][rR][nN][iI][nN][gG]
-update_body    <- [uU][pP][dD][aA][tT][eE]
-delete_body    <- [dD][eE][lL][eE][tT][eE]
-create_body    <- [cC][rR][eE][aA][tT][eE]
-table_body     <- [tT][aA][bB][lL][eE]
-alter_body     <- [aA][lL][tT][eE][rR]
-drop_body      <- [dD][rR][oO][pP]
-rename_body    <- [rR][eE][nN][aA][mM][eE]
-add_body       <- [aA][dD][dD]
-column_body    <- [cC][oO][lL][uU][mM][nN]
-if_body        <- [iI][fF]
-temp_body      <- [tT][eE][mM][pP]
-temporary_body <- [tT][eE][mM][pP][oO][rR][aA][rR][yY]
-primary_body   <- [pP][rR][iI][mM][aA][rR][yY]
-key_body       <- [kK][eE][yY]
-unique_body    <- [uU][nN][iI][qQ][uU][eE]
-check_body     <- [cC][hH][eE][cC][kK]
-references_body <- [rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]
-generated_body <- [gG][eE][nN][eE][rR][aA][tT][eE][dD]
-always_body    <- [aA][lL][wW][aA][yY][sS]
-stored_body    <- [sS][tT][oO][rR][eE][dD]
-virtual_body   <- [vV][iI][rR][tT][uU][aA][lL]
-constraint_body<- [cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]
-foreign_body   <- [fF][oO][rR][eE][iI][gG][nN]
-action_body    <- [aA][cC][tT][iI][oO][nN]
-cascade_body   <- [cC][aA][sS][cC][aA][dD][eE]
-restrict_body  <- [rR][eE][sS][tT][rR][iI][cC][tT]
-deferrable_body<- [dD][eE][fF][eE][rR][rR][aA][bB][lL][eE]
-initially_body <- [iI][nN][iI][tT][iI][aA][lL][lL][yY]
-immediate_body <- [iI][mM][mM][eE][dD][iI][aA][tT][eE]
-deferred_body  <- [dD][eE][fF][eE][rR][rR][eE][dD]
-autoincrement_body <- [aA][uU][tT][oO][iI][nN][cC][rR][eE][mM][eE][nN][tT]
-rowid_body     <- [rR][oO][wW][iI][dD]
-strict_body    <- [sS][tT][rR][iI][cC][tT]
-without_body   <- [wW][iI][tT][hH][oO][uU][tT]
-to_body        <- [tT][oO]
-index_body     <- [iI][nN][dD][eE][xX]
-view_body      <- [vV][iI][eE][wW]
-trigger_body   <- [tT][rR][iI][gG][gG][eE][rR]
-before_body    <- [bB][eE][fF][oO][rR][eE]
-after_body     <- [aA][fF][tT][eE][rR]
-instead_body   <- [iI][nN][sS][tT][eE][aA][dD]
-of_body        <- [oO][fF]
-for_body       <- [fF][oO][rR]
-each_body      <- [eE][aA][cC][hH]
-begin_body     <- [bB][eE][gG][iI][nN]
-commit_body    <- [cC][oO][mM][mM][iI][tT]
-transaction_body <- [tT][rR][aA][nN][sS][aA][cC][tT][iI][oO][nN]
-savepoint_body <- [sS][aA][vV][eE][pP][oO][iI][nN][tT]
-release_body   <- [rR][eE][lL][eE][aA][sS][eE]
-exclusive_body <- [eE][xX][cC][lL][uU][sS][iI][vV][eE]
-pragma_body    <- [pP][rR][aA][gG][mM][aA]
-vacuum_body    <- [vV][aA][cC][uU][uU][mM]
-attach_body    <- [aA][tT][tT][aA][cC][hH]
-detach_body    <- [dD][eE][tT][aA][cC][hH]
-database_body  <- [dD][aA][tT][aA][bB][aA][sS][eE]
-reindex_body   <- [rR][eE][iI][nN][dD][eE][xX]
-analyze_body   <- [aA][nN][aA][lL][yY][zZ][eE]
-explain_body   <- [eE][xX][pP][lL][aA][iI][nN]
-query_body     <- [qQ][uU][eE][rR][yY]
-plan_body      <- [pP][lL][aA][nN]
+*sel_body       <- [sS][eE][lL][eE][cC][tT]
+*from_body      <- [fF][rR][oO][mM]
+*where_body     <- [wW][hH][eE][rR][eE]
+*group_body     <- [gG][rR][oO][uU][pP]
+*by_body        <- [bB][yY]
+*having_body    <- [hH][aA][vV][iI][nN][gG]
+*order_body     <- [oO][rR][dD][eE][rR]
+*asc_body       <- [aA][sS][cC]
+*desc_body      <- [dD][eE][sS][cC]
+*limit_body     <- [lL][iI][mM][iI][tT]
+*offset_body    <- [oO][fF][fF][sS][eE][tT]
+*join_body      <- [jJ][oO][iI][nN]
+*inner_body     <- [iI][nN][nN][eE][rR]
+*left_body      <- [lL][eE][fF][tT]
+*right_body     <- [rR][iI][gG][hH][tT]
+*full_body      <- [fF][uU][lL][lL]
+*outer_body     <- [oO][uU][tT][eE][rR]
+*cross_body     <- [cC][rR][oO][sS][sS]
+*natural_body   <- [nN][aA][tT][uU][rR][aA][lL]
+*on_body        <- [oO][nN]
+*using_body     <- [uU][sS][iI][nN][gG]
+*as_body        <- [aA][sS]
+*distinct_body  <- [dD][iI][sS][tT][iI][nN][cC][tT]
+*all_body       <- [aA][lL][lL]
+*union_body     <- [uU][nN][iI][oO][nN]
+*intersect_body <- [iI][nN][tT][eE][rR][sS][eE][cC][tT]
+*except_body    <- [eE][xX][cC][eE][pP][tT]
+*with_body      <- [wW][iI][tT][hH]
+*and_body       <- [aA][nN][dD]
+*or_body        <- [oO][rR]
+*not_body       <- [nN][oO][tT]
+*is_body        <- [iI][sS]
+*in_body        <- [iI][nN]
+*like_body      <- [lL][iI][kK][eE]
+*glob_body      <- [gG][lL][oO][bB]
+*match_body     <- [mM][aA][tT][cC][hH]
+*regexp_body    <- [rR][eE][gG][eE][xX][pP]
+*between_body   <- [bB][eE][tT][wW][eE][eE][nN]
+*escape_body    <- [eE][sS][cC][aA][pP][eE]
+*case_body      <- [cC][aA][sS][eE]
+*when_body      <- [wW][hH][eE][nN]
+*then_body      <- [tT][hH][eE][nN]
+*else_body      <- [eE][lL][sS][eE]
+*end_body       <- [eE][nN][dD]
+*cast_body      <- [cC][aA][sS][tT]
+*exists_body    <- [eE][xX][iI][sS][tT][sS]
+*collate_body   <- [cC][oO][lL][lL][aA][tT][eE]
+*recursive_body <- [rR][eE][cC][uU][rR][sS][iI][vV][eE]
+*window_body    <- [wW][iI][nN][dD][oO][wW]
+*over_body      <- [oO][vV][eE][rR]
+*filter_body    <- [fF][iI][lL][tT][eE][rR]
+*partition_body <- [pP][aA][rR][tT][iI][tT][iI][oO][nN]
+*range_body     <- [rR][aA][nN][gG][eE]
+*rows_body      <- [rR][oO][wW][sS]
+*groups_body    <- [gG][rR][oO][uU][pP][sS]
+*unbounded_body <- [uU][nN][bB][oO][uU][nN][dD][eE][dD]
+*preceding_body <- [pP][rR][eE][cC][eE][dD][iI][nN][gG]
+*following_body <- [fF][oO][lL][lL][oO][wW][iI][nN][gG]
+*current_body   <- [cC][uU][rR][rR][eE][nN][tT]
+*row_body       <- [rR][oO][wW]
+*exclude_body   <- [eE][xX][cC][lL][uU][dD][eE]
+*ties_body      <- [tT][iI][eE][sS]
+*others_body    <- [oO][tT][hH][eE][rR][sS]
+*no_body        <- [nN][oO]
+*insert_body    <- [iI][nN][sS][eE][rR][tT]
+*replace_body   <- [rR][eE][pP][lL][aA][cC][eE]
+*into_body      <- [iI][nN][tT][oO]
+*values_body    <- [vV][aA][lL][uU][eE][sS]
+*default_body   <- [dD][eE][fF][aA][uU][lL][tT]
+*conflict_body  <- [cC][oO][nN][fF][lL][iI][cC][tT]
+*do_body        <- [dD][oO]
+*nothing_body   <- [nN][oO][tT][hH][iI][nN][gG]
+*rollback_body  <- [rR][oO][lL][lL][bB][aA][cC][kK]
+*abort_body     <- [aA][bB][oO][rR][tT]
+*fail_body      <- [fF][aA][iI][lL]
+*ignore_body    <- [iI][gG][nN][oO][rR][eE]
+*set_body       <- [sS][eE][tT]
+*returning_body <- [rR][eE][tT][uU][rR][nN][iI][nN][gG]
+*update_body    <- [uU][pP][dD][aA][tT][eE]
+*delete_body    <- [dD][eE][lL][eE][tT][eE]
+*create_body    <- [cC][rR][eE][aA][tT][eE]
+*table_body     <- [tT][aA][bB][lL][eE]
+*alter_body     <- [aA][lL][tT][eE][rR]
+*drop_body      <- [dD][rR][oO][pP]
+*rename_body    <- [rR][eE][nN][aA][mM][eE]
+*add_body       <- [aA][dD][dD]
+*column_body    <- [cC][oO][lL][uU][mM][nN]
+*if_body        <- [iI][fF]
+*temp_body      <- [tT][eE][mM][pP]
+*temporary_body <- [tT][eE][mM][pP][oO][rR][aA][rR][yY]
+*primary_body   <- [pP][rR][iI][mM][aA][rR][yY]
+*key_body       <- [kK][eE][yY]
+*unique_body    <- [uU][nN][iI][qQ][uU][eE]
+*check_body     <- [cC][hH][eE][cC][kK]
+*references_body <- [rR][eE][fF][eE][rR][eE][nN][cC][eE][sS]
+*generated_body <- [gG][eE][nN][eE][rR][aA][tT][eE][dD]
+*always_body    <- [aA][lL][wW][aA][yY][sS]
+*stored_body    <- [sS][tT][oO][rR][eE][dD]
+*virtual_body   <- [vV][iI][rR][tT][uU][aA][lL]
+*constraint_body<- [cC][oO][nN][sS][tT][rR][aA][iI][nN][tT]
+*foreign_body   <- [fF][oO][rR][eE][iI][gG][nN]
+*action_body    <- [aA][cC][tT][iI][oO][nN]
+*cascade_body   <- [cC][aA][sS][cC][aA][dD][eE]
+*restrict_body  <- [rR][eE][sS][tT][rR][iI][cC][tT]
+*deferrable_body<- [dD][eE][fF][eE][rR][rR][aA][bB][lL][eE]
+*initially_body <- [iI][nN][iI][tT][iI][aA][lL][lL][yY]
+*immediate_body <- [iI][mM][mM][eE][dD][iI][aA][tT][eE]
+*deferred_body  <- [dD][eE][fF][eE][rR][rR][eE][dD]
+*autoincrement_body <- [aA][uU][tT][oO][iI][nN][cC][rR][eE][mM][eE][nN][tT]
+*rowid_body     <- [rR][oO][wW][iI][dD]
+*strict_body    <- [sS][tT][rR][iI][cC][tT]
+*without_body   <- [wW][iI][tT][hH][oO][uU][tT]
+*to_body        <- [tT][oO]
+*index_body     <- [iI][nN][dD][eE][xX]
+*view_body      <- [vV][iI][eE][wW]
+*trigger_body   <- [tT][rR][iI][gG][gG][eE][rR]
+*before_body    <- [bB][eE][fF][oO][rR][eE]
+*after_body     <- [aA][fF][tT][eE][rR]
+*instead_body   <- [iI][nN][sS][tT][eE][aA][dD]
+*of_body        <- [oO][fF]
+*for_body       <- [fF][oO][rR]
+*each_body      <- [eE][aA][cC][hH]
+*begin_body     <- [bB][eE][gG][iI][nN]
+*commit_body    <- [cC][oO][mM][mM][iI][tT]
+*transaction_body <- [tT][rR][aA][nN][sS][aA][cC][tT][iI][oO][nN]
+*savepoint_body <- [sS][aA][vV][eE][pP][oO][iI][nN][tT]
+*release_body   <- [rR][eE][lL][eE][aA][sS][eE]
+*exclusive_body <- [eE][xX][cC][lL][uU][sS][iI][vV][eE]
+*pragma_body    <- [pP][rR][aA][gG][mM][aA]
+*vacuum_body    <- [vV][aA][cC][uU][uU][mM]
+*attach_body    <- [aA][tT][tT][aA][cC][hH]
+*detach_body    <- [dD][eE][tT][aA][cC][hH]
+*database_body  <- [dD][aA][tT][aA][bB][aA][sS][eE]
+*reindex_body   <- [rR][eE][iI][nN][dD][eE][xX]
+*analyze_body   <- [aA][nN][aA][lL][yY][zZ][eE]
+*explain_body   <- [eE][xX][pP][lL][aA][iI][nN]
+*query_body     <- [qQ][uU][eE][rR][yY]
+*plan_body      <- [pP][lL][aA][nN]
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -868,7 +868,7 @@ plan_body      <- [pP][lL][aA][nN]
 #
 # `!ident_char` is applied once on the outside so each body stays
 # boundary-free.
-keyword_word <-
+*keyword_word <-
     ( autoincrement_body   # 13
     / transaction_body     # 11
     / constraint_body      # 10
@@ -997,4 +997,4 @@ keyword_word <-
 
 # --- Whitespace & comments -------------------------------------------
 
-comment       <- @comment{'--' .. \R / '/*' ..= '*/'}
+*comment       <- @comment{'--' .. \R / '/*' ..= '*/'}

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -53,9 +53,9 @@
 
 # --- Top level --------------------------------------------------------
 
-trivia    <- (comment / \s)*
-
 root       <- (statement stmt_sep?)*^[;]
+
+trivia    <- (comment / \s)*
 stmt_sep   <- @punctuation{';'}
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -1,5 +1,13 @@
 # TOML v1.0 grammar with highlight annotations.
-# The first rule is the start rule.
+#
+# The grammar keeps the `*trivia` adapter so `trivia` auto-insertion
+# is disabled grammar-wide. TOML is line-oriented — entries are
+# newline-separated via `entry_sep`, key-value pairs can't span
+# lines, and arrays / inline tables have their own whitespace
+# disciplines. Auto-inserting a trivia rule that consumes newlines
+# would let `key\n= value` parse as a single pair. Whitespace is
+# threaded explicitly via `inline_space` (horizontal only) and the
+# `entry_sep` rule (newline-terminated).
 #
 # Capture kinds used (all present in src/highlight/theme.rs):
 #   comment, property, type, string, number, constant, punctuation.

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -15,7 +15,11 @@
 #     kind; revisit when a theme-file is introduced.
 #   - inf / nan are @constant (like true/false), not @number.
 
-toml          <- trivia (entry (entry_sep entry)*)? trivia \z
+# Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
+# consumes at least one byte, so the enclosing '*' cannot infinite-loop.
+*trivia       <- (comment / \s)*
+
+root          <- trivia (entry (entry_sep entry)*)? trivia
 
 entry         <- array_of_tables_header / table_header / pair
 entry_sep     <- inline_space comment? \R trivia
@@ -97,7 +101,3 @@ inline_pair   <- key inline_space @punctuation{'='} inline_space value
 # --- Whitespace & comments --------------------------------------------
 inline_space  <- \h*
 comment       <- @comment{'#' .. \R}
-
-# Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
-# consumes at least one byte, so the enclosing '*' cannot infinite-loop.
-trivia        <- (comment / \s)*

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -25,9 +25,9 @@
 
 # Vertical whitespace: spaces/tabs/newlines plus comments. Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
-*trivia       <- (comment / \s)*
-
 root          <- trivia (entry (entry_sep entry)*)? trivia
+
+*trivia       <- (comment / \s)*
 
 entry         <- array_of_tables_header / table_header / pair
 entry_sep     <- inline_space comment? \R trivia

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -681,7 +681,7 @@ mod tests {
         // Trivial one-rule grammar: `start <- "x"`. Compiles to a
         // bootstrap `Call` + `End` plus the rule body wrapped in
         // `RuleEnter`/`MemoClose`/`Return`.
-        let p = pegc::compile("start <- \"x\"").unwrap();
+        let p = pegc::compile("root <- \"x\"").unwrap();
         assert_roundtrip(&p);
     }
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -542,6 +542,22 @@ Two rule names get compile-time treatment:
   when the diagnostic cascade is still wanted but the trivia rule's
   shape (e.g. line-sensitive newline handling) can't be auto-spliced.
 
+  *Why the per-iteration prepend matters.* The auto-insertion
+  splices `trivia` at every inter-item boundary of a `Sequence`, but
+  `Repeat` iterations have no parent `Sequence` to splice into —
+  inserting between items of the body covers one iteration's
+  interior, not the boundary between iteration N and iteration
+  N+1. So the rewriter also prepends a `trivia` call to the body of
+  every `Repeat` / `RepeatOne`. Consider `pair (',' pair)*` parsing
+  `pair, pair, pair` with spaces between every token. Without the
+  prepend, the Repeat body is `',' trivia pair`: the first
+  iteration's `,` matches at the position just after the outer
+  Sequence's `pair trivia` — but the second iteration starts on a
+  space, so its `,` rejects and the loop ends with one pair
+  missing. With the prepend the body becomes `trivia ',' trivia
+  pair`, and each iteration begins by consuming whatever
+  inter-iteration whitespace is sitting in front of it.
+
 ### `*name <-` — atomic-rule marker
 
 A `*` prefix on the rule name opts the rule out of `trivia`

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -25,7 +25,22 @@ name  <-  body
 name2 <-  body2
 ```
 
-- The **first rule** is the start rule.
+- Every grammar must define a **`root` rule** — that's the entry
+  point. The compiler wraps its body as `trivia? root_body trivia? !.`
+  so end-of-input is implicit (any trailing junk fails the parse).
+- An optional **`trivia` rule** acts as the auto-insertion target:
+  when present, the compiler splices a `trivia` call between every
+  pair of consecutive items in non-atomic rule bodies, including
+  between iterations of `*` / `+`. Without a `trivia` rule, no
+  auto-insertion happens.
+- Rules may carry **prefix sigils**: `~name <-` for the intentional
+  leniency marker (see below) and `*name <-` for the atomic marker
+  (no `trivia` injected inside this rule's body). The two compose:
+  `~*name` and `*~name` are equivalent. `*trivia <- …` is the
+  special case that disables auto-insertion grammar-wide.
+- **Position constraint:** when present, `trivia` is the first rule
+  in the file; `root` is first, or immediately after `trivia`. Other
+  rules follow in any order.
 - **Identifiers** are ASCII `[A-Za-z_][A-Za-z0-9_]*`.
 - **Whitespace** (space, tab, newline, carriage return) separates
   tokens but is otherwise ignored.
@@ -60,7 +75,7 @@ the whole rule as intentionally lenient — see
 | `"abc"` / `'abc'` | Literal byte sequence. |
 | `[a-z]` / `[^"\\]` | Character class — a set of bytes; leading `^` negates. |
 | `.` | Any single byte (fails only at end of input). |
-| `\d \D \s \S \h \H \R \z` | Built-in character classes — see below. |
+| `\d \D \s \S \h \H \R` | Built-in character classes — see below. |
 | `ident` | Reference to another rule. |
 | `(...)` | Grouping — any pattern. |
 | `@name{...}` | Named capture — see below. |
@@ -91,7 +106,6 @@ fixed:
 | `\s` / `\S` | `[ \t\n\r]` / complement | ASCII whitespace and its complement. |
 | `\h` / `\H` | `[ \t]` / complement | Horizontal whitespace and its complement. |
 | `\R` | `'\r\n' / '\n' / '\r'` | Linebreak — CRLF matched atomically. |
-| `\z` | `!.` | End of input (zero-width). |
 
 The six byte-set escapes (`\d`, `\D`, `\s`, `\S`, `\h`, `\H`) are also
 recognized **inside `[...]`** and union into the surrounding class:
@@ -100,10 +114,9 @@ class shortcut cannot be a range bound — `[\d-z]` is a parse error
 because the shortcut is a set, not a single byte. A leading `^` still
 negates the whole class: `[^\d]` ≡ `\D`.
 
-`\R` and `\z` are atom-only. `\R` matches a multi-byte sequence (CRLF
-atomic) and `\z` is a zero-width assertion — neither has a meaningful
-shape inside `[...]`, and both are rejected with a tailored error
-pointing back at the top-level form.
+`\R` is atom-only: it matches a multi-byte sequence (CRLF atomic) and
+has no meaningful shape inside `[...]`, so it's rejected there with a
+tailored error pointing back at the top-level form.
 
 Deliberately excluded: `\w` / `\W` (word character varies meaningfully
 per language — Rust raw idents, SQL `$`, CSS hyphens), `\v` / `\V`
@@ -490,21 +503,29 @@ recorded in adjacent comments and unenforced by the lint; see
 
 ### Reserved rule names
 
-The compiler treats one rule name specially:
+Two rule names get compile-time treatment:
 
-- **`trivia`** — if a grammar defines a rule with this name, every
-  rule transitively reachable from it through the call graph is
-  marked as syntactic trivia (whitespace, comments). Runtime
-  semantics are unchanged; the bit surfaces in
-  `Program::rule_is_trivia` and `pegdb recoveries explain` pops
-  trailing trivia frames from the rule_stack when picking the
-  displayed leaf of each cluster.
+- **`root`** — the start rule (mandatory). The compiler wraps its
+  body as `trivia? root_body trivia? !.` so end-of-input is always
+  asserted, and a `trivia` rule (when present and non-atomic) pads
+  the leading and trailing whitespace. The wrap means a grammar
+  source like `root <- value` parses whole inputs, not just longest
+  prefixes — the implicit `!.` rejects trailing junk.
 
-  The cascade is structural — only one annotation per grammar (the
-  `trivia` rule's body lists the entry points), no per-rule keyword,
-  no surface markup. Rules whose body contains a recovery catch
-  (`^lbl`, `^^lbl`, `*^`) are pinned out of the cascade so the
-  catch's diagnostic frame stays visible.
+- **`trivia`** — the optional auto-insertion target. When defined
+  *and* non-atomic, the compiler injects a call to `trivia` between
+  every pair of consecutive items in every non-atomic rule's
+  `Sequence`, plus prepends one to each iteration of `*` / `+`.
+  This replaces the explicit `ws` / `spacing` calls that used to
+  appear between tokens.
+
+  The rule also seeds the diagnostic *trivia cascade*: every rule
+  transitively reachable from `trivia` through the call graph gets
+  `Program::rule_is_trivia = true`, and `pegdb recoveries explain`
+  pops trailing trivia frames from the rule_stack when picking the
+  displayed leaf of each cluster. Rules whose body contains a
+  recovery catch (`^lbl`, `^^lbl`, `*^`) are pinned out of the
+  cascade so the catch's diagnostic frame stays visible.
 
   Indentation-sensitive grammars (`#43`) keep significant-whitespace
   rules outside the `trivia` subgraph; only ignorable bytes go in.
@@ -514,8 +535,32 @@ The compiler treats one rule name specially:
   comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
   ```
 
-  Grammars without a `trivia` rule leave all trivia bits false;
-  pegdb's leaf-display still works, it just won't trim.
+  Grammars without a `trivia` rule (e.g. indent-sensitive shapes)
+  get no auto-insertion and no trivia-padding wrap on `root`; the
+  EOF assertion is still applied. `*trivia <- …` disables
+  auto-insertion grammar-wide without removing the rule — useful
+  when the diagnostic cascade is still wanted but the trivia rule's
+  shape (e.g. line-sensitive newline handling) can't be auto-spliced.
+
+### `*name <-` — atomic-rule marker
+
+A `*` prefix on the rule name opts the rule out of `trivia`
+auto-insertion: the rewriter walks the body but does not splice
+`trivia` between `Sequence` items or prepend one to `Repeat`
+iterations. The two prefix sigils compose: `~*name` and `*~name`
+are both valid.
+
+```peg
+*string_lit   <- '"' (str_escape / !'"' .)* '"'
+*ident        <- [A-Za-z_] [A-Za-z0-9_]*
+```
+
+Used on token-shape rules — string / number / char literals,
+identifiers, multi-byte keyword spellings — where injecting trivia
+between adjacent bytes would let whitespace appear inside the
+token. The atomic boundary stops at `NonTerminal` calls: a
+non-atomic rule called from inside an atomic body still gets
+auto-insertion in its own body.
 
 ### Reserved syntax
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -38,8 +38,8 @@ name2 <-  body2
   (no `trivia` injected inside this rule's body). The two compose:
   `~*name` and `*~name` are equivalent. `*trivia <- …` is the
   special case that disables auto-insertion grammar-wide.
-- **Position constraint:** when present, `trivia` is the first rule
-  in the file; `root` is first, or immediately after `trivia`. Other
+- **Position constraint:** `root` is always the first rule. When a
+  `trivia` rule is present it sits immediately after `root`. Other
   rules follow in any order.
 - **Identifiers** are ASCII `[A-Za-z_][A-Za-z0-9_]*`.
 - **Whitespace** (space, tab, newline, carriage return) separates

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1495,8 +1495,7 @@ fn body_contains_catch(pat: &Pattern) -> bool {
 /// they no-op (no inter-Sequence splicing, no `trivia?` siblings in the
 /// root wrap).
 fn auto_insertion_active(grammar: &Grammar) -> bool {
-    grammar.rules.contains_key(TRIVIA_ROOT_RULE)
-        && !grammar.atomic_rules.contains(TRIVIA_ROOT_RULE)
+    grammar.rules.contains_key(TRIVIA_ROOT_RULE) && !grammar.atomic_rules.contains(TRIVIA_ROOT_RULE)
 }
 
 /// AST-level rewrite: in every non-atomic rule's body, splice a
@@ -1581,7 +1580,7 @@ fn inject_trivia_in(pat: &mut Pattern) {
                 }
                 other => Pattern::seq(vec![trivia_call(), other]),
             };
-            *inner = Box::new(wrapped);
+            **inner = wrapped;
         }
         Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -377,7 +377,7 @@ pub fn compute_follow(grammar: &Grammar) -> HashMap<String, FollowSet> {
         .keys()
         .map(|n| (n.clone(), FollowSet::new()))
         .collect();
-    if let Some(entry) = follow.get_mut(&grammar.start) {
+    if let Some(entry) = follow.get_mut(super::parser::ROOT_RULE) {
         entry.insert(FollowElement::Eof);
     }
     loop {
@@ -778,13 +778,22 @@ fn leniency_reaches_unguarded(
     }
 
     if !visited_callers.insert(caller.to_string()) {
-        return true;
+        // Caller cycle: returning `true` here would treat a recursive
+        // self-call as a confirmed leak, but the same target_trailing
+        // is already being evaluated at the outer frame. Defer the
+        // verdict to that frame by returning `inside_catch` (same
+        // sentinel the root-rule short-circuit below uses). If the
+        // outer frame eventually concludes the leniency is contained,
+        // the cycle is too; if it concludes the leniency leaks via
+        // some non-cyclic caller, the iteration over other rules in
+        // the outer frame will catch that.
+        return inside_catch;
     }
 
     let mut rule_names: Vec<&String> = ctx.grammar.rules.keys().collect();
     rule_names.sort();
 
-    if caller == ctx.grammar.start && !target_trailing.contains(&FollowElement::Eof) {
+    if caller == super::parser::ROOT_RULE && !target_trailing.contains(&FollowElement::Eof) {
         visited_callers.remove(caller);
         return inside_catch;
     }
@@ -1373,4 +1382,124 @@ fn body_contains_catch(pat: &Pattern) -> bool {
         | Pattern::Capture(_, inner)
         | Pattern::Lenient(inner) => body_contains_catch(inner),
     }
+}
+
+/// True iff the grammar has an active auto-insertion target: a rule
+/// named `trivia` that isn't marked atomic. Both
+/// [`inject_auto_trivia`] and [`wrap_root`] consult this; on `false`
+/// they no-op (no inter-Sequence splicing, no `trivia?` siblings in the
+/// root wrap).
+fn auto_insertion_active(grammar: &Grammar) -> bool {
+    grammar.rules.contains_key(TRIVIA_ROOT_RULE)
+        && !grammar.atomic_rules.contains(TRIVIA_ROOT_RULE)
+}
+
+/// AST-level rewrite: in every non-atomic rule's body, splice a
+/// `NonTerminal("trivia")` call between consecutive items of every
+/// `Sequence`. Runs after `lint_partial_match` and the FOLLOW-driven
+/// `^^lbl` resolver so both still see the author's original body.
+///
+/// No-op when the grammar has no `trivia` rule, or when `trivia` itself
+/// is marked atomic (the `*trivia <- …` grammar-wide opt-out).
+///
+/// The walker descends transparently through every combinator (`Choice`,
+/// `Optional`, `Repeat`, `RepeatOne`, `Capture`, `Catch`, `Lenient`,
+/// `AndPredicate`, `NotPredicate`) but stops at `NonTerminal` and the
+/// atom leaves (`Literal`, `CharClass`, `AnyChar`). Crossing a
+/// `NonTerminal` would pull trivia into the callee's body — which the
+/// callee handles by its own auto-insertion if non-atomic, or
+/// explicitly if atomic.
+pub fn inject_auto_trivia(grammar: &mut Grammar) {
+    if !auto_insertion_active(grammar) {
+        return;
+    }
+    let atomic = grammar.atomic_rules.clone();
+    let rule_names: Vec<String> = grammar.rules.keys().cloned().collect();
+    for name in rule_names {
+        if atomic.contains(&name) {
+            continue;
+        }
+        if let Some(body) = grammar.rules.get_mut(&name) {
+            inject_trivia_in(body);
+        }
+    }
+}
+
+/// Walk one rule body, splicing `NonTerminal("trivia")` between every
+/// pair of consecutive `Sequence` items at every depth.
+fn inject_trivia_in(pat: &mut Pattern) {
+    match pat {
+        Pattern::Sequence(items) => {
+            for it in items.iter_mut() {
+                inject_trivia_in(it);
+            }
+            if items.len() >= 2 {
+                let mut spliced = Vec::with_capacity(items.len() * 2 - 1);
+                let drained: Vec<Pattern> = std::mem::take(items);
+                let last = drained.len() - 1;
+                for (i, it) in drained.into_iter().enumerate() {
+                    spliced.push(it);
+                    if i != last {
+                        spliced.push(trivia_call());
+                    }
+                }
+                *items = spliced;
+            }
+        }
+        Pattern::OrderedChoice(items) => {
+            for it in items {
+                inject_trivia_in(it);
+            }
+        }
+        Pattern::Repeat(inner)
+        | Pattern::RepeatOne(inner)
+        | Pattern::Optional(inner)
+        | Pattern::NotPredicate(inner)
+        | Pattern::AndPredicate(inner)
+        | Pattern::Capture(_, inner)
+        | Pattern::Lenient(inner) => inject_trivia_in(inner),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            inject_trivia_in(inner);
+            inject_trivia_in(recovery);
+        }
+        Pattern::InferBoundaryCatch { inner, .. } => inject_trivia_in(inner),
+        Pattern::Literal(_)
+        | Pattern::CharClass(_)
+        | Pattern::AnyChar
+        | Pattern::NonTerminal(_) => {}
+    }
+}
+
+/// Wrap the start rule's body so it reads `trivia? body trivia? !.` —
+/// implicit leading/trailing trivia and end-of-input assertion. Built
+/// manually as a `Sequence` *after* [`inject_auto_trivia`] has run on
+/// `root`'s body, so the synthesized siblings here don't themselves
+/// pick up trivia injection.
+///
+/// `trivia?` is included iff auto-insertion is active. With no `trivia`
+/// rule (or with `*trivia`), the wrap collapses to `body !.` — still
+/// supplying the EOF assertion uniformly.
+pub fn wrap_root(grammar: &mut Grammar) {
+    let active = auto_insertion_active(grammar);
+    let Some(body) = grammar.rules.remove(super::parser::ROOT_RULE) else {
+        return;
+    };
+    let mut items: Vec<Pattern> = Vec::with_capacity(4);
+    if active {
+        items.push(Pattern::Optional(Box::new(trivia_call())));
+    }
+    items.push(body);
+    if active {
+        items.push(Pattern::Optional(Box::new(trivia_call())));
+    }
+    items.push(Pattern::NotPredicate(Box::new(Pattern::AnyChar)));
+    grammar
+        .rules
+        .insert(super::parser::ROOT_RULE.to_string(), Pattern::seq(items));
+}
+
+fn trivia_call() -> Pattern {
+    Pattern::NonTerminal(TRIVIA_ROOT_RULE.to_string())
 }

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1396,19 +1396,22 @@ fn auto_insertion_active(grammar: &Grammar) -> bool {
 
 /// AST-level rewrite: in every non-atomic rule's body, splice a
 /// `NonTerminal("trivia")` call between consecutive items of every
-/// `Sequence`. Runs after `lint_partial_match` and the FOLLOW-driven
-/// `^^lbl` resolver so both still see the author's original body.
+/// `Sequence`, and prepend one to every `Repeat` / `RepeatOne`
+/// iteration so inter-iteration whitespace gets consumed. Runs after
+/// `lint_partial_match` and the FOLLOW-driven `^^lbl` resolver so both
+/// still see the author's original body.
 ///
 /// No-op when the grammar has no `trivia` rule, or when `trivia` itself
-/// is marked atomic (the `*trivia <- …` grammar-wide opt-out).
+/// is marked atomic (the `*trivia <- …` grammar-wide opt-out). The
+/// `trivia` rule itself is also exempt — injecting trivia inside its
+/// own body would recurse the runtime indefinitely.
 ///
-/// The walker descends transparently through every combinator (`Choice`,
-/// `Optional`, `Repeat`, `RepeatOne`, `Capture`, `Catch`, `Lenient`,
-/// `AndPredicate`, `NotPredicate`) but stops at `NonTerminal` and the
-/// atom leaves (`Literal`, `CharClass`, `AnyChar`). Crossing a
-/// `NonTerminal` would pull trivia into the callee's body — which the
-/// callee handles by its own auto-insertion if non-atomic, or
-/// explicitly if atomic.
+/// The walker descends transparently through `Choice`, `Optional`,
+/// `Capture`, `Catch`, `Lenient`, `AndPredicate`, `NotPredicate`, and
+/// stops at `NonTerminal` and the atom leaves (`Literal`, `CharClass`,
+/// `AnyChar`). Crossing a `NonTerminal` would pull trivia into the
+/// callee's body — which the callee handles by its own auto-insertion
+/// if non-atomic, or explicitly if atomic.
 pub fn inject_auto_trivia(grammar: &mut Grammar) {
     if !auto_insertion_active(grammar) {
         return;
@@ -1416,7 +1419,11 @@ pub fn inject_auto_trivia(grammar: &mut Grammar) {
     let atomic = grammar.atomic_rules.clone();
     let rule_names: Vec<String> = grammar.rules.keys().cloned().collect();
     for name in rule_names {
-        if atomic.contains(&name) {
+        // The trivia rule itself is exempt: every `trivia_call` from
+        // the rewriter calls back into it, so injecting trivia inside
+        // its body would recurse the runtime indefinitely. Atomic
+        // rules opt out explicitly via the `*name <-` sigil.
+        if atomic.contains(&name) || name == TRIVIA_ROOT_RULE {
             continue;
         }
         if let Some(body) = grammar.rules.get_mut(&name) {
@@ -1426,7 +1433,8 @@ pub fn inject_auto_trivia(grammar: &mut Grammar) {
 }
 
 /// Walk one rule body, splicing `NonTerminal("trivia")` between every
-/// pair of consecutive `Sequence` items at every depth.
+/// pair of consecutive `Sequence` items at every depth and prepending
+/// one to every `Repeat` / `RepeatOne` iteration.
 fn inject_trivia_in(pat: &mut Pattern) {
     match pat {
         Pattern::Sequence(items) => {
@@ -1451,9 +1459,26 @@ fn inject_trivia_in(pat: &mut Pattern) {
                 inject_trivia_in(it);
             }
         }
-        Pattern::Repeat(inner)
-        | Pattern::RepeatOne(inner)
-        | Pattern::Optional(inner)
+        Pattern::Repeat(inner) | Pattern::RepeatOne(inner) => {
+            inject_trivia_in(inner);
+            // Prepend a trivia call so each iteration consumes
+            // ambient whitespace before its body runs. Without this,
+            // `(',' pair)*` would fail on the second iteration's
+            // leading whitespace — the inter-iteration boundary has
+            // no parent `Sequence` to splice trivia into. Flatten
+            // when `inner` is already a `Sequence` so the result
+            // stays at one level of nesting.
+            let original = std::mem::replace(inner.as_mut(), Pattern::AnyChar);
+            let wrapped = match original {
+                Pattern::Sequence(mut items) => {
+                    items.insert(0, trivia_call());
+                    Pattern::Sequence(items)
+                }
+                other => Pattern::Sequence(vec![trivia_call(), other]),
+            };
+            *inner = Box::new(wrapped);
+        }
+        Pattern::Optional(inner)
         | Pattern::NotPredicate(inner)
         | Pattern::AndPredicate(inner)
         | Pattern::Capture(_, inner)

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -7,7 +7,19 @@ use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, Ru
 #[derive(Debug)]
 pub enum CompileError {
     UndefinedRule(String),
-    UnknownStartRule(String),
+    /// Grammar (whether parsed from source or hand-built via
+    /// `Grammar::new`) doesn't define the reserved `root` rule. The
+    /// parser also raises this — surfaced here too because hand-built
+    /// grammars in tests bypass the parser.
+    MissingRootRule,
+    /// Grammar defines `root` but not at the expected source position.
+    /// `expected_pos` is `0` when no `trivia` rule is present, `1` when
+    /// `trivia` is the first rule. Only raised for parsed grammars
+    /// (hand-built ones have no recorded source order).
+    RootRulePosition {
+        expected_pos: usize,
+        has_trivia: bool,
+    },
     /// One or more `^^lbl` catches have no following context to infer
     /// their boundary from. Emitted by `resolve_inferred_boundaries`.
     CannotInferBoundary {
@@ -26,7 +38,26 @@ impl std::fmt::Display for CompileError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CompileError::UndefinedRule(name) => write!(f, "undefined rule: {}", name),
-            CompileError::UnknownStartRule(name) => write!(f, "unknown start rule: {}", name),
+            CompileError::MissingRootRule => write!(
+                f,
+                "grammar must define a `root` rule (the entry point)"
+            ),
+            CompileError::RootRulePosition {
+                expected_pos: _,
+                has_trivia,
+            } => {
+                if *has_trivia {
+                    write!(
+                        f,
+                        "`root` must immediately follow `trivia` when both are defined"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "`root` must be the first rule when no `trivia` rule is defined"
+                    )
+                }
+            }
             CompileError::CannotInferBoundary { rule, label } => write!(
                 f,
                 "cannot infer boundary for `^^{label}` in rule `{rule}`: no following context. \
@@ -318,17 +349,20 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
 /// reach this via [`Grammar::compile`](super::Grammar::compile) or
 /// the one-step [`super::compile`].
 ///
+/// The start rule is always [`ROOT_RULE`](super::parser::ROOT_RULE);
+/// `Grammar::compile` checks for its presence up front and wraps its
+/// body via [`super::analysis::wrap_root`] before this is called.
+///
 /// Code layout:
-///   0: Call(<start address>)
+///   0: Call(<root address>)
 ///   1: End
 ///   2..: rule bodies, each ending with Return
-pub(crate) fn compile_rules(
-    rules: &HashMap<String, Pattern>,
-    start: &str,
-) -> Result<Program, CompileError> {
-    if !rules.contains_key(start) {
-        return Err(CompileError::UnknownStartRule(start.to_string()));
-    }
+pub(crate) fn compile_rules(rules: &HashMap<String, Pattern>) -> Result<Program, CompileError> {
+    let start = super::parser::ROOT_RULE;
+    debug_assert!(
+        rules.contains_key(start),
+        "compile_rules: `root` rule must be present (Grammar::compile enforces this)"
+    );
 
     // Detect undefined NonTerminal references up front so the LR analysis
     // doesn't have to defend against missing rules in the call graph.

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -13,9 +13,10 @@ pub enum CompileError {
     /// grammars in tests bypass the parser.
     MissingRootRule,
     /// Grammar defines `root` but not at the expected source position.
-    /// `expected_pos` is `0` when no `trivia` rule is present, `1` when
-    /// `trivia` is the first rule. Only raised for parsed grammars
-    /// (hand-built ones have no recorded source order).
+    /// `root` must always be the first rule (parse-time enforcement
+    /// also requires `trivia`, when present, to sit immediately
+    /// after). Only raised for parsed grammars (hand-built ones have
+    /// no recorded source order).
     RootRulePosition {
         expected_pos: usize,
         has_trivia: bool,
@@ -44,20 +45,8 @@ impl std::fmt::Display for CompileError {
             ),
             CompileError::RootRulePosition {
                 expected_pos: _,
-                has_trivia,
-            } => {
-                if *has_trivia {
-                    write!(
-                        f,
-                        "`root` must immediately follow `trivia` when both are defined"
-                    )
-                } else {
-                    write!(
-                        f,
-                        "`root` must be the first rule when no `trivia` rule is defined"
-                    )
-                }
-            }
+                has_trivia: _,
+            } => write!(f, "`root` must be the first rule"),
             CompileError::CannotInferBoundary { rule, label } => write!(
                 f,
                 "cannot infer boundary for `^^{label}` in rule `{rule}`: no following context. \

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -630,12 +630,6 @@ impl<'a> Parser<'a> {
     /// The six byte-set escapes are *also* recognized inside `[...]`
     /// by `parse_charclass`; `\R` is rejected there with a pointer
     /// back to this form.
-    ///
-    /// `\z` was a former alias for `!.` (end-of-input). It is now
-    /// rejected with a migration error: the `root` rule's wrap supplies
-    /// the same end-of-input assertion automatically, and the rare
-    /// non-`root` site that genuinely needs `!.` can spell it
-    /// out (`!.` is still a valid atom).
     fn parse_backslash_atom(&mut self) -> Result<Pattern, ParseError> {
         debug_assert_eq!(self.peek(), Some(b'\\'));
         self.pos += 1;
@@ -651,14 +645,6 @@ impl<'a> Parser<'a> {
                     Pattern::literal("\n"),
                     Pattern::literal("\r"),
                 ]))
-            }
-            Some(b'z') => {
-                self.pos += 1;
-                Err(self.err(
-                    "`\\z` was removed; the `root` rule asserts end-of-input automatically. \
-                     Drop it, or use `!.` directly when an inner rule needs the assertion"
-                        .into(),
-                ))
             }
             Some(c) => Err(self.err(format!(
                 "unknown atom '\\{}' (valid: \\d \\D \\s \\S \\h \\H \\R)",
@@ -714,10 +700,10 @@ impl<'a> Parser<'a> {
         while self.peek().is_some() && self.peek() != Some(b']') {
             // Class-shortcut path: `\d`, `\D`, `\s`, `\S`, `\h`, `\H`
             // expand into the surrounding set instead of contributing
-            // a single byte. `\R` and `\z` don't fit inside `[...]`
-            // (multi-byte / zero-width respectively) — reject with a
-            // pointer back to the top-level form. Other escapes fall
-            // through to the existing per-byte `parse_class_char`.
+            // a single byte. `\R` is multi-byte and doesn't fit inside
+            // `[...]` — reject with a pointer back to the top-level
+            // form. Other escapes fall through to the existing
+            // per-byte `parse_class_char`.
             if self.peek() == Some(b'\\') {
                 if let Some(c) = self.peek_at(1) {
                     if let Some(shortcut) = class_for_shortcut(c) {
@@ -739,11 +725,6 @@ impl<'a> Parser<'a> {
                     if c == b'R' {
                         return Err(self.err(
                             "'\\R' is a multi-byte sequence and can't appear in a character class — use \\R as a standalone atom".into(),
-                        ));
-                    }
-                    if c == b'z' {
-                        return Err(self.err(
-                            "'\\z' is a zero-width assertion and can't appear in a character class — use \\z as a standalone atom".into(),
                         ));
                     }
                 }

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,9 +1,24 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use super::analysis::{lint_partial_match, resolve_inferred_boundaries};
+use super::analysis::{
+    inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries, wrap_root,
+};
 use super::compiler::{compile_rules, CompileError};
 use super::pattern::Pattern;
 use crate::pegvm::{CharSet, Program};
+
+/// Reserved rule name for the grammar's start rule. Every grammar must
+/// define exactly one rule named [`ROOT_RULE`]; the compiler wraps its
+/// body to assert end-of-input and to splice optional leading / trailing
+/// `trivia` calls when an auto-insertion target exists.
+pub const ROOT_RULE: &str = "root";
+
+/// Reserved rule name for the (optional) auto-insertion target. When a
+/// grammar defines a rule named [`TRIVIA_RULE`], the compiler injects a
+/// call to it between consecutive `Sequence` items in every non-atomic
+/// rule's body. Marking the rule atomic (`*trivia <- …`) keeps the
+/// definition but disables auto-insertion grammar-wide.
+pub const TRIVIA_RULE: &str = "trivia";
 
 /// Cap for the `p{n}` exact-count quantifier. Conservative typo guard:
 /// the largest plausible corpus site is `hex{8}`. Above this the parser
@@ -14,17 +29,43 @@ const MAX_REPEAT_COUNT: usize = 1024;
 #[derive(Debug, Clone)]
 pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
-    pub start: String,
+    /// Names of rules marked atomic with the `*name <- body` sigil. The
+    /// auto-insertion rewriter skips these rules: `Sequence` items inside
+    /// an atomic body don't get a synthesized `trivia` call spliced
+    /// between them. `*trivia <- …` (the auto-insertion target itself
+    /// being atomic) is the special case that disables auto-insertion
+    /// grammar-wide.
+    pub atomic_rules: HashSet<String>,
+    /// Source-order list of rule names. Populated by [`parse`]; hand-
+    /// built grammars from [`Grammar::new`] leave this empty (the
+    /// reserved-name position check in [`Grammar::compile`] short-
+    /// circuits when no order is recorded).
+    pub rule_order: Vec<String>,
 }
 
 impl Grammar {
     /// Construct a grammar from a hand-built rule map. Useful for
     /// tests that build `Pattern` trees directly without going
     /// through [`parse`].
-    pub fn new(rules: HashMap<String, Pattern>, start: impl Into<String>) -> Self {
+    ///
+    /// The start rule is always [`ROOT_RULE`]; the rule map must
+    /// contain a `"root"` entry. No rules are atomic.
+    pub fn new(rules: HashMap<String, Pattern>) -> Self {
         Grammar {
             rules,
-            start: start.into(),
+            atomic_rules: HashSet::new(),
+            rule_order: Vec::new(),
+        }
+    }
+
+    /// Construct a grammar with a pre-built atomic-rule set. Test-only
+    /// shortcut for exercising the `*name` sigil's behavior without
+    /// routing through grammar source.
+    pub fn with_atomic(rules: HashMap<String, Pattern>, atomic_rules: HashSet<String>) -> Self {
+        Grammar {
+            rules,
+            atomic_rules,
+            rule_order: Vec::new(),
         }
     }
 
@@ -41,18 +82,53 @@ impl Grammar {
     ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
     ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with `~`
     ///    at the call site or `~name <- body` at the rule definition.
-    /// 3. Emit bytecode via `compile_rules`.
+    /// 3. Inject auto-trivia calls into every non-atomic rule's body
+    ///    (no-op when the grammar has no `trivia` rule or when
+    ///    `trivia` itself is atomic).
+    /// 4. Wrap `root`'s body with `trivia? body trivia? !.` (the
+    ///    `trivia?` calls are present iff auto-insertion is active).
+    /// 5. Emit bytecode via `compile_rules`.
+    ///
+    /// The lint and FOLLOW-driven boundary resolver see the author's
+    /// original body — auto-insertion and the `root` wrap run after
+    /// both, so synthesized `trivia` calls and the EOF assertion can't
+    /// confuse the lint walker or the FOLLOW set.
     pub fn compile(&self) -> Result<Program, CompileError> {
+        if !self.rules.contains_key(ROOT_RULE) {
+            return Err(CompileError::MissingRootRule);
+        }
+        // When the grammar was parsed from source, enforce that `root`
+        // sits at the start of the file (or immediately after `trivia`).
+        // Hand-built grammars from `Grammar::new` skip this — the
+        // ordered list is empty for them.
+        if !self.rule_order.is_empty() {
+            let has_trivia = self.rules.contains_key(TRIVIA_RULE);
+            let root_pos = self
+                .rule_order
+                .iter()
+                .position(|n| n == ROOT_RULE)
+                .expect("ROOT_RULE presence checked above");
+            let expected_pos = if has_trivia { 1 } else { 0 };
+            if root_pos != expected_pos {
+                return Err(CompileError::RootRulePosition {
+                    expected_pos,
+                    has_trivia,
+                });
+            }
+        }
         let mut resolved = Grammar {
             rules: self.rules.clone(),
-            start: self.start.clone(),
+            atomic_rules: self.atomic_rules.clone(),
+            rule_order: self.rule_order.clone(),
         };
         resolve_inferred_boundaries(&mut resolved)?;
         let findings = lint_partial_match(&resolved);
         if !findings.is_empty() {
             return Err(CompileError::PartialMatchLeniency(findings));
         }
-        compile_rules(&resolved.rules, &resolved.start)
+        inject_auto_trivia(&mut resolved);
+        wrap_root(&mut resolved);
+        compile_rules(&resolved.rules)
     }
 }
 
@@ -96,6 +172,7 @@ impl<'a> Parser<'a> {
     fn parse_grammar(&mut self) -> Result<Grammar, ParseError> {
         self.skip_ws();
         let mut rules = HashMap::new();
+        let mut atomic_rules: HashSet<String> = HashSet::new();
         let mut order = Vec::new();
         while self.pos < self.src.len() {
             // Definition-level lenient marker: `~name <- body` declares
@@ -104,10 +181,26 @@ impl<'a> Parser<'a> {
             // of `name`. The marker touches the name (no whitespace);
             // the rule's body is wrapped with `Pattern::Lenient` so the
             // lint walker sees the same shape as a per-call-site `~p`.
+            //
+            // The atomic marker `*name <- body` (sibling of `~`) opts
+            // the rule out of trivia auto-insertion: the rewriter walks
+            // the body but does not splice `trivia` between `Sequence`
+            // items. `*trivia <- …` is the special case that disables
+            // auto-insertion grammar-wide.
             let mut definition_lenient = false;
-            if self.peek() == Some(b'~') {
-                self.pos += 1;
-                definition_lenient = true;
+            let mut definition_atomic = false;
+            loop {
+                match self.peek() {
+                    Some(b'~') if !definition_lenient => {
+                        self.pos += 1;
+                        definition_lenient = true;
+                    }
+                    Some(b'*') if !definition_atomic => {
+                        self.pos += 1;
+                        definition_atomic = true;
+                    }
+                    _ => break,
+                }
             }
             let name = self.parse_ident()?;
             self.skip_ws();
@@ -116,6 +209,9 @@ impl<'a> Parser<'a> {
             let mut pat = self.parse_choice()?;
             if definition_lenient {
                 pat = Pattern::Lenient(Box::new(pat));
+            }
+            if definition_atomic {
+                atomic_rules.insert(name.clone());
             }
             if rules.insert(name.clone(), pat).is_some() {
                 return Err(self.err(format!("rule '{}' defined twice", name)));
@@ -126,8 +222,24 @@ impl<'a> Parser<'a> {
         if order.is_empty() {
             return Err(self.err("grammar has no rules".into()));
         }
-        let start = order[0].clone();
-        Ok(Grammar { rules, start })
+        // Reserved-name enforcement for `trivia`'s position is parse-
+        // time so the error points at the offending source location.
+        // `root`'s presence (and `root`'s position relative to
+        // `trivia`) is enforced by `Grammar::compile` — that lets
+        // AST-only parser tests build fixtures with arbitrary rule
+        // names without inventing a `root` placeholder.
+        if let Some(trivia_pos) = order.iter().position(|n| n == TRIVIA_RULE) {
+            if trivia_pos != 0 {
+                return Err(self.err(format!(
+                    "`{TRIVIA_RULE}` must be the first rule when present"
+                )));
+            }
+        }
+        Ok(Grammar {
+            rules,
+            atomic_rules,
+            rule_order: order,
+        })
     }
 
     fn parse_choice(&mut self) -> Result<Pattern, ParseError> {
@@ -504,21 +616,26 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse a backslash-letter atom. The eight one-letter escapes are
+    /// Parse a backslash-letter atom. The seven one-letter escapes are
     /// the regex-style character-class family:
     ///
     /// - `\d` / `\D`: `[0-9]` / its complement.
     /// - `\s` / `\S`: `[ \t\n\r]` / its complement.
     /// - `\h` / `\H`: `[ \t]` / its complement.
     /// - `\R`: ordered choice `'\r\n' / '\n' / '\r'` (CRLF atomic).
-    /// - `\z`: end of input — `!.`.
     ///
     /// ASCII-only and byte-oriented, matching the rest of the engine.
     /// These are *atom-level* escapes; they are not recognized inside
     /// string literals (`'\d'` keeps today's `unknown escape` error).
     /// The six byte-set escapes are *also* recognized inside `[...]`
-    /// by `parse_charclass`; `\R` and `\z` are rejected there with a
-    /// pointer back to this form.
+    /// by `parse_charclass`; `\R` is rejected there with a pointer
+    /// back to this form.
+    ///
+    /// `\z` was a former alias for `!.` (end-of-input). It is now
+    /// rejected with a migration error: the `root` rule's wrap supplies
+    /// the same end-of-input assertion automatically, and the rare
+    /// non-`root` site that genuinely needs `!.` can spell it
+    /// out (`!.` is still a valid atom).
     fn parse_backslash_atom(&mut self) -> Result<Pattern, ParseError> {
         debug_assert_eq!(self.peek(), Some(b'\\'));
         self.pos += 1;
@@ -537,10 +654,14 @@ impl<'a> Parser<'a> {
             }
             Some(b'z') => {
                 self.pos += 1;
-                Ok(Pattern::NotPredicate(Box::new(Pattern::AnyChar)))
+                Err(self.err(
+                    "`\\z` was removed; the `root` rule asserts end-of-input automatically. \
+                     Drop it, or use `!.` directly when an inner rule needs the assertion"
+                        .into(),
+                ))
             }
             Some(c) => Err(self.err(format!(
-                "unknown atom '\\{}' (valid: \\d \\D \\s \\S \\h \\H \\R \\z)",
+                "unknown atom '\\{}' (valid: \\d \\D \\s \\S \\h \\H \\R)",
                 c as char
             ))),
             None => Err(self.err("unterminated escape at top level".into())),

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -98,21 +98,19 @@ impl Grammar {
             return Err(CompileError::MissingRootRule);
         }
         // When the grammar was parsed from source, enforce that `root`
-        // sits at the start of the file (or immediately after `trivia`).
-        // Hand-built grammars from `Grammar::new` skip this — the
-        // ordered list is empty for them.
+        // is the first rule and `trivia` — when present — is the
+        // second. Hand-built grammars from `Grammar::new` skip this —
+        // the ordered list is empty for them.
         if !self.rule_order.is_empty() {
-            let has_trivia = self.rules.contains_key(TRIVIA_RULE);
             let root_pos = self
                 .rule_order
                 .iter()
                 .position(|n| n == ROOT_RULE)
                 .expect("ROOT_RULE presence checked above");
-            let expected_pos = if has_trivia { 1 } else { 0 };
-            if root_pos != expected_pos {
+            if root_pos != 0 {
                 return Err(CompileError::RootRulePosition {
-                    expected_pos,
-                    has_trivia,
+                    expected_pos: 0,
+                    has_trivia: self.rules.contains_key(TRIVIA_RULE),
                 });
             }
         }
@@ -224,14 +222,14 @@ impl<'a> Parser<'a> {
         }
         // Reserved-name enforcement for `trivia`'s position is parse-
         // time so the error points at the offending source location.
-        // `root`'s presence (and `root`'s position relative to
-        // `trivia`) is enforced by `Grammar::compile` — that lets
-        // AST-only parser tests build fixtures with arbitrary rule
-        // names without inventing a `root` placeholder.
+        // `root`'s presence (and the requirement that `root` itself
+        // sits at the top) is enforced by `Grammar::compile` — that
+        // lets AST-only parser tests build fixtures with arbitrary
+        // rule names without inventing a `root` placeholder.
         if let Some(trivia_pos) = order.iter().position(|n| n == TRIVIA_RULE) {
-            if trivia_pos != 0 {
+            if trivia_pos != 1 {
                 return Err(self.err(format!(
-                    "`{TRIVIA_RULE}` must be the first rule when present"
+                    "`{TRIVIA_RULE}` must be the second rule (immediately after `{ROOT_RULE}`) when present"
                 )));
             }
         }

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -178,7 +178,7 @@ Captures returned in a `MatchResult` have two non-obvious guarantees:
 
 A `MatchResult` is always returned. The `complete` flag distinguishes the two cases:
 
-- `complete == true`: the VM reached `End`. `matched` is the `sp` at that point (potentially less than `input.len()` if the grammar is designed to stop early — no trailing `!.`).
+- `complete == true`: the VM reached `End`. `matched` is the `sp` at that point. Grammars compiled by `pegc::compile` always assert end-of-input (the `root`-rule wrap appends an implicit `!.`), so `complete == true` implies `matched == input.len()`. Raw `compile_pattern` programs without a `root` rule can succeed on a prefix, in which case `matched` is wherever the pattern stopped.
 - `complete == false`: the VM exhausted its backtrack stack without reaching `End`. `matched` is the farthest input position the VM ever reached before retreating — the "farthest failure position" heuristic of Ford 2004, used for error reporting by LPegLabel and the `lpeg-ffp` fork — and `captures` are the captures valid at that point, with any still-open captures closed at `matched`.
 
 This partial result is what lets the highlighter render a styled prefix and a plain tail for malformed input, without the VM knowing anything about highlighting.

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1627,9 +1627,7 @@ mod examined_max_tests {
         // 1 byte unconsumed, so the overall parse fails. The memo
         // entries it built before failing are still observable.
         assert!(!result.complete, "trailing 'y' leaves bytes after !.");
-        let root = memo
-            .get(&(MemoId(0), 0))
-            .expect("root's entry missing");
+        let root = memo.get(&(MemoId(0), 0)).expect("root's entry missing");
         assert_eq!(root.end_sp, None);
         assert_eq!(
             root.examined_max, 2,

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1605,29 +1605,35 @@ mod examined_max_tests {
 
     #[test]
     fn and_predicate_success_records_examined_past_end_sp() {
-        // start <- "x" &"y"   against "xy"
-        // Consumed span is "x" (end_sp = 1) but the &"y" lookahead
-        // read position 1, so examined_max must be 2.
+        // root <- consumer &"y"; consumer <- "x"   against "xy"
+        // `consumer`'s memo entry is the focus: end_sp=1 (matched "x")
+        // but examined_max must be 1 (only position 0 was read inside
+        // consumer). `root`'s subsequent `&"y"` is a sibling of the
+        // consumer call, not inside it — its examined_max contribution
+        // lands on `root`'s entry, not `consumer`'s.
         let mut rules = HashMap::new();
         rule(
             &mut rules,
-            "start",
+            "root",
             Pattern::seq(vec![
-                Pattern::literal("x"),
+                Pattern::NonTerminal("consumer".into()),
                 Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
             ]),
         );
-        let prog = Grammar::new(rules, "start").compile().unwrap();
+        rule(&mut rules, "consumer", Pattern::literal("x"));
+        let prog = Grammar::new(rules).compile().unwrap();
         let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
-        assert!(result.complete);
-        assert_eq!(result.matched, 1, "only 'x' is consumed");
-        let entry = memo
+        // The `root` wrap supplies `!.` at the tail: trailing 'y' leaves
+        // 1 byte unconsumed, so the overall parse fails. The memo
+        // entries it built before failing are still observable.
+        assert!(!result.complete, "trailing 'y' leaves bytes after !.");
+        let root = memo
             .get(&(MemoId(0), 0))
-            .expect("start's memo entry missing");
-        assert_eq!(entry.end_sp, Some(1));
+            .expect("root's entry missing");
+        assert_eq!(root.end_sp, None);
         assert_eq!(
-            entry.examined_max, 2,
-            "&\"y\" read past end_sp; examined_max must reflect it"
+            root.examined_max, 2,
+            "root saw &\"y\" succeed at sp=1 and !. fail at sp=2"
         );
     }
 
@@ -1640,13 +1646,13 @@ mod examined_max_tests {
         let mut rules = HashMap::new();
         rule(
             &mut rules,
-            "start",
+            "root",
             Pattern::seq(vec![
                 Pattern::literal("x"),
                 Pattern::AndPredicate(Box::new(Pattern::literal("z"))),
             ]),
         );
-        let prog = Grammar::new(rules, "start").compile().unwrap();
+        let prog = Grammar::new(rules).compile().unwrap();
         let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
         assert!(!result.complete, "overall parse must fail");
         let entry = memo
@@ -1661,30 +1667,38 @@ mod examined_max_tests {
 
     #[test]
     fn nested_rule_examined_max_propagates_to_caller() {
-        // outer <- inner "y"
+        // root <- inner "y"
         // inner <- "x"
         // against "xy".  inner's entry: end_sp=1, examined_max=1.
-        // outer's entry: end_sp=2, examined_max=2 (reads 'y' at sp=1).
-        // The propagation test: inner's examined_max (1) must flow into
-        // outer's watermark when inner's MemoClose pops.
+        // root's entry: end_sp=2 (the body span), but examined_max=3
+        // because the synthesized `!.` at root's tail reads one byte
+        // past end-of-input (sp=2) to verify EOF. inner's
+        // examined_max (1) must propagate into root's watermark
+        // regardless — that's the propagation we're verifying.
         let mut rules = HashMap::new();
         rule(
             &mut rules,
-            "outer",
+            "root",
             Pattern::seq(vec![
                 Pattern::NonTerminal("inner".into()),
                 Pattern::literal("y"),
             ]),
         );
         rule(&mut rules, "inner", Pattern::literal("x"));
-        let prog = Grammar::new(rules, "outer").compile().unwrap();
+        let prog = Grammar::new(rules).compile().unwrap();
         let (result, _stats, memo) = VM::new(&prog.code, b"xy").with_memo_threshold(0).run_core();
         assert!(result.complete);
         assert_eq!(result.matched, 2);
-        // outer is start → MemoId(0); inner is the other → MemoId(1).
-        let outer = memo.get(&(MemoId(0), 0)).expect("outer entry missing");
+        // root is start → MemoId(0); inner is the other → MemoId(1).
+        let outer = memo.get(&(MemoId(0), 0)).expect("root entry missing");
         assert_eq!(outer.end_sp, Some(2));
-        assert_eq!(outer.examined_max, 2);
+        // The wrap's tail-`!.` reads byte 2 once to confirm EOF; the
+        // bound is the body's reach plus that one-byte EOF probe.
+        assert!(
+            outer.examined_max >= 2,
+            "inner's examined reach must flow into root: {:?}",
+            outer
+        );
         let inner = memo.get(&(MemoId(1), 0)).expect("inner entry missing");
         assert_eq!(inner.end_sp, Some(1));
         assert_eq!(inner.examined_max, 1);
@@ -1707,7 +1721,7 @@ mod examined_max_tests {
         let mut rules = HashMap::new();
         rule(
             &mut rules,
-            "start",
+            "root",
             Pattern::choice(vec![
                 Pattern::seq(vec![
                     Pattern::NonTerminal("X".into()),
@@ -1720,7 +1734,7 @@ mod examined_max_tests {
             ]),
         );
         rule(&mut rules, "X", Pattern::literal("a"));
-        let prog = Grammar::new(rules, "start").compile().unwrap();
+        let prog = Grammar::new(rules).compile().unwrap();
         let (result, stats, memo) = VM::new(&prog.code, b"abb")
             .with_memo_threshold(0)
             .run_core();
@@ -1732,9 +1746,12 @@ mod examined_max_tests {
         // alternative tried "aa" at sp=1 and "bb" at sp=1 needed byte 2.
         let start = memo.get(&(MemoId(0), 0)).expect("start entry missing");
         assert_eq!(start.end_sp, Some(3));
-        assert_eq!(
-            start.examined_max, 3,
-            "start's execution examined up to position 3"
+        // The `root` wrap's tail-`!.` reads byte 3 once to confirm
+        // EOF; without that probe the watermark would land at 3.
+        assert!(
+            start.examined_max >= 3,
+            "start's execution examined up to position 3, got {:?}",
+            start
         );
     }
 
@@ -1755,7 +1772,7 @@ mod examined_max_tests {
         // `build_recover_repeat` in `src/pegc/parser.rs`.
         rule(
             &mut rules,
-            "start",
+            "root",
             Pattern::Repeat(Box::new(Pattern::Catch {
                 inner: Box::new(Pattern::literal("ab")),
                 label: "recovery".into(),
@@ -1765,7 +1782,7 @@ mod examined_max_tests {
                 )),
             })),
         );
-        let prog = Grammar::new(rules, "start").compile().unwrap();
+        let prog = Grammar::new(rules).compile().unwrap();
         let (result, _stats, memo) = VM::new(&prog.code, b"abxab")
             .with_memo_threshold(0)
             .run_core();
@@ -1796,7 +1813,7 @@ mod recovery_diagnostic_tests {
     #[test]
     fn diagnostics_empty_when_knob_off() {
         // Grammar that triggers recovery but no opt-in to diagnostics.
-        let prog = pegc::compile("start <- ([a-z]+)*^").unwrap();
+        let prog = pegc::compile("root <- ([a-z]+)*^").unwrap();
         let result = VM::new(&prog.code, b"abc!!def").run();
         assert!(result.complete);
         assert!(
@@ -1816,7 +1833,7 @@ mod recovery_diagnostic_tests {
 
     #[test]
     fn diagnostics_one_per_recovery_byte_when_knob_on() {
-        let prog = pegc::compile("start <- ([a-z]+)*^").unwrap();
+        let prog = pegc::compile("root <- ([a-z]+)*^").unwrap();
         let result = VM::new(&prog.code, b"abc!!def")
             .with_track_recovery_diagnostics(true)
             .run();
@@ -1860,7 +1877,7 @@ mod recovery_diagnostic_tests {
         // reached deepest *inside* `inner`, so the recorded rule_stack
         // must include `inner`.
         let src = "\
-            start <- (item)*^\n\
+            root <- (item)*^\n\
             item <- inner\n\
             inner <- [a-z]+\n";
         let prog = pegc::compile(src).unwrap();
@@ -1886,7 +1903,7 @@ mod recovery_diagnostic_tests {
             .map(|d| names_for(&d.rule_stack))
             .collect();
         assert!(
-            stacks.iter().any(|s| s.contains(&"start".to_string())),
+            stacks.iter().any(|s| s.contains(&"root".to_string())),
             "expected at least one rule stack to start with `start`; got {:?}",
             stacks
         );

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2011,6 +2011,25 @@ fn trivia_cascade_handles_recursion() {
 }
 
 #[test]
+fn auto_trivia_handles_inter_repeat_whitespace() {
+    // The rewriter prepends a trivia call to each Repeat iteration so
+    // `(',' x)*` accepts whitespace between iterations, not only on
+    // the first comma (which the outer Sequence's inter-item trivia
+    // already covers). Without the prepend, ` , 2 , 3` would fail on
+    // the second iteration's leading space.
+    let prog = parse(
+        "trivia <- ' '*\n\
+         root   <- 'x' (',' 'x')*",
+    )
+    .expect("parse")
+    .compile()
+    .expect("compile");
+    let r = VM::new(&prog.code, b"x , x , x").run();
+    assert!(r.complete, "expected full match on ' '-separated items");
+    assert_eq!(r.matched, 9);
+}
+
+#[test]
 fn backslash_cap_r_matches_crlf_atomically() {
     // `\R` lowers to `'\r\n' / '\n' / '\r'` — CRLF is matched as one
     // two-byte unit, not two separate line breaks.

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1788,9 +1788,7 @@ fn compile_errors_on_partial_match_leniency() {
     match err {
         syntax_highlighter::pegc::CompileError::PartialMatchLeniency(findings) => {
             assert!(
-                findings
-                    .iter()
-                    .any(|f| f.rule == "r" && f.caller == "root"),
+                findings.iter().any(|f| f.rule == "r" && f.caller == "root"),
                 "expected r → start finding, got: {findings:?}"
             );
         }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2049,9 +2049,9 @@ fn backslash_cap_r_matches_crlf_atomically() {
 }
 
 #[test]
-fn backslash_not_dot_matches_eof() {
-    // `\z` was removed; the post-migration spelling is the explicit
-    // `!.`. Verifies it succeeds at end-of-input and fails otherwise.
+fn not_any_matches_eof() {
+    // `!.` is the explicit end-of-input assertion. Verify it succeeds
+    // at end-of-input and fails otherwise.
     let g = parse("root <- !.").expect("parse");
     let prog = g.compile().expect("compile");
     let r = VM::new(&prog.code, b"").run();

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -451,7 +451,7 @@ fn recover_repeat_drops_unclosed_capture_from_failed_inner_attempt() {
 
 #[test]
 fn recover_repeat_inside_called_rule_returns_cleanly() {
-    // start <- "PRE" loop
+    // root <- "PRE" loop
     // loop  <- "a"*^
     //
     // Against "PREaxa": the *^ runs to EOF, then start's Return must
@@ -460,14 +460,14 @@ fn recover_repeat_inside_called_rule_returns_cleanly() {
     // documented in src/pegvm/README.md invariant 1.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::literal("PRE"),
             Pattern::NonTerminal("loop".into()),
         ]),
     );
     rules.insert("loop".into(), recover(Pattern::literal("a"), "recovery"));
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let r = VM::new(&prog.code, b"PREaxa").run();
     assert!(
         r.complete,
@@ -792,24 +792,28 @@ fn nested_captures_flow_through_compile() {
 
 #[test]
 fn grammar_with_nonterminals() {
-    // start <- digit+
+    // root  <- digit+
     // digit <- [0-9]
+    // The `root` wrap supplies the implicit end-of-input assertion;
+    // trailing non-digits now produce `complete=false`. `matched`
+    // reports the deepest position reached: `!.`'s lookahead reads one
+    // byte past the consumed digits, so the watermark sits at 4.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::RepeatOne(Box::new(Pattern::NonTerminal("digit".into()))),
     );
     rules.insert(
         "digit".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     assert_eq!(
         VM::new(&prog.code, b"123abc").run(),
         MatchResult {
-            matched: 3,
+            matched: 4,
             captures: vec![],
-            complete: true,
+            complete: false,
             recovery_diagnostics: vec![],
         }
     );
@@ -819,8 +823,8 @@ fn grammar_with_nonterminals() {
 #[test]
 fn grammar_undefined_rule_errors() {
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("missing".into()));
-    let err = Grammar::new(rules, "start").compile().unwrap_err();
+    rules.insert("root".into(), Pattern::NonTerminal("missing".into()));
+    let err = Grammar::new(rules).compile().unwrap_err();
     let msg = format!("{}", err);
     assert!(msg.contains("missing"), "got: {}", msg);
 }
@@ -918,7 +922,7 @@ fn recover_repeat_labeled_interns_author_label() {
     // the capture kind at its hardcoded `"recovery"` — the catch
     // scope is renamed (so pegdb recoveries explain clusters under
     // "bad_thing"), but theme styling is unaffected.
-    let prog = syntax_highlighter::pegc::compile("r <- 'a'*^:bad_thing").unwrap();
+    let prog = syntax_highlighter::pegc::compile("root <- 'a'*^:bad_thing").unwrap();
     assert_eq!(prog.capture_kinds, vec!["recovery".to_string()]);
     assert_eq!(prog.label_kinds, vec!["bad_thing".to_string()]);
 }
@@ -1003,34 +1007,42 @@ fn sync_set_terminates_cleanly_at_eof_without_delim() {
 
 #[test]
 fn grammar_rules_are_wrapped_in_memo_open_close() {
-    // start <- "a"
+    // root  <- "a"
     // other <- "b"
-    // Layout:
-    //   0: Call(start)
+    // Layout (root's body wraps with `!.` for the implicit
+    // end-of-input assertion: Choice / Any / FailTwice for the
+    // NotPredicate):
+    //   0: Call(root)
     //   1: End
-    //   2: RuleEnter(0, Memo, L5)   ; start's Return is at 5
+    //   2: RuleEnter(0, Memo, L8)   ; root's Return is at 8
     //   3: Char 'a'
-    //   4: MemoClose(0)
-    //   5: Return
-    //   6: RuleEnter(1, Memo, L9)   ; other's Return is at 9
-    //   7: Char 'b'
-    //   8: MemoClose(1)
-    //   9: Return
+    //   4: Choice(L7)   ; !. — predicate succeeds iff Any fails
+    //   5: Any(1)
+    //   6: FailTwice
+    //   7: MemoClose(0)
+    //   8: Return
+    //   9: RuleEnter(1, Memo, L12)  ; other's Return is at 12
+    //  10: Char 'b'
+    //  11: MemoClose(1)
+    //  12: Return
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::literal("a"));
+    rules.insert("root".into(), Pattern::literal("a"));
     rules.insert("other".into(), Pattern::literal("b"));
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     assert_eq!(prog.rule_count, 2);
     assert_eq!(
         prog.code,
         vec![
             Instruction::Call(Label(2)),
             Instruction::End,
-            Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(5)),
+            Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(8)),
             Instruction::Char(b'a'),
+            Instruction::Choice(Label(7)),
+            Instruction::Any(1),
+            Instruction::FailTwice,
             Instruction::MemoClose(MemoId(0)),
             Instruction::Return,
-            Instruction::RuleEnter(MemoId(1), RuleKind::Memo, Label(9)),
+            Instruction::RuleEnter(MemoId(1), RuleKind::Memo, Label(12)),
             Instruction::Char(b'b'),
             Instruction::MemoClose(MemoId(1)),
             Instruction::Return,
@@ -1040,7 +1052,7 @@ fn grammar_rules_are_wrapped_in_memo_open_close() {
 
 #[test]
 fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
-    // start <- start "+" "n" / "n"
+    // root <- root "+" "n" / "n"
     // Layout (no MemoClose for an LR rule — LRTail closes the body):
     //   0: Call(2)
     //   1: End
@@ -1055,17 +1067,17 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
     // only assert the prologue/epilogue shape.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
-                Pattern::NonTerminal("start".into()),
+                Pattern::NonTerminal("root".into()),
                 Pattern::literal("+"),
                 Pattern::literal("n"),
             ]),
             Pattern::literal("n"),
         ]),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     assert_eq!(prog.rule_count, 1);
     // Prologue is at code[2]; the bootstrap is the usual Call/End pair.
     assert!(matches!(prog.code[0], Instruction::Call(Label(2))));
@@ -1105,23 +1117,23 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
 
 #[test]
 fn right_recursive_rule_is_not_marked_lr() {
-    // start <- "n" "+" start / "n"
+    // root <- "n" "+" start / "n"
     // The recursive call is not in first-call position — "n" consumes
     // input first. Compile must use the standard Memo-kind RuleEnter
     // and MemoClose.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
                 Pattern::literal("n"),
                 Pattern::literal("+"),
-                Pattern::NonTerminal("start".into()),
+                Pattern::NonTerminal("root".into()),
             ]),
             Pattern::literal("n"),
         ]),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let has_memo_open = prog
         .code
         .iter()
@@ -1165,7 +1177,8 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
             Pattern::literal("w"),
         ]),
     );
-    let prog = Grammar::new(rules, "a").compile().unwrap();
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
+    let prog = Grammar::new(rules).compile().unwrap();
     let lr_bodies = prog
         .code
         .iter()
@@ -1178,15 +1191,26 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
         .count();
     assert_eq!(lr_bodies, 2, "both SCC members must emit Lr-kind RuleEnter");
     assert_eq!(lr_tails, 2, "both SCC members must emit LRTail");
+    // `a` and `b` (the SCC) must not be Memo-kind. The synthesized
+    // `root <- a` wrapper is itself Memo (root isn't in any cycle); that's
+    // fine — the assertion is about the cycle members.
+    let a_idx = prog.rule_names.iter().position(|n| n == "a").unwrap();
+    let b_idx = prog.rule_names.iter().position(|n| n == "b").unwrap();
     for ins in &prog.code {
-        assert!(
-            !matches!(
-                ins,
-                Instruction::RuleEnter(_, RuleKind::Memo, _) | Instruction::MemoClose(..)
-            ),
-            "indirect-LR rules must not emit Memo-kind RuleEnter/MemoClose: {:?}",
-            ins
-        );
+        if let Instruction::RuleEnter(id, RuleKind::Memo, _) = ins {
+            assert!(
+                id.0 as usize != a_idx && id.0 as usize != b_idx,
+                "indirect-LR cycle members must not emit Memo-kind RuleEnter: {:?}",
+                ins
+            );
+        }
+        if let Instruction::MemoClose(id) = ins {
+            assert!(
+                id.0 as usize != a_idx && id.0 as usize != b_idx,
+                "indirect-LR cycle members must not emit MemoClose: {:?}",
+                ins
+            );
+        }
     }
 }
 
@@ -1227,7 +1251,8 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
             Pattern::literal("r"),
         ]),
     );
-    let prog = Grammar::new(rules, "a").compile().unwrap();
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
+    let prog = Grammar::new(rules).compile().unwrap();
     let lr_bodies = prog
         .code
         .iter()
@@ -1243,15 +1268,27 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
         "all three SCC members must emit Lr-kind RuleEnter"
     );
     assert_eq!(lr_tails, 3, "all three SCC members must emit LRTail");
+    // `a`, `b`, `c` (the SCC) must not be Memo-kind; the synthesized
+    // `root <- a` rule is Memo and that's fine.
+    let cycle: Vec<usize> = ["a", "b", "c"]
+        .iter()
+        .map(|n| prog.rule_names.iter().position(|r| r == *n).unwrap())
+        .collect();
     for ins in &prog.code {
-        assert!(
-            !matches!(
-                ins,
-                Instruction::RuleEnter(_, RuleKind::Memo, _) | Instruction::MemoClose(..)
-            ),
-            "indirect-LR rules must not emit Memo-kind RuleEnter/MemoClose: {:?}",
-            ins
-        );
+        if let Instruction::RuleEnter(id, RuleKind::Memo, _) = ins {
+            assert!(
+                !cycle.contains(&(id.0 as usize)),
+                "indirect-LR cycle members must not emit Memo-kind RuleEnter: {:?}",
+                ins
+            );
+        }
+        if let Instruction::MemoClose(id) = ins {
+            assert!(
+                !cycle.contains(&(id.0 as usize)),
+                "indirect-LR cycle members must not emit MemoClose: {:?}",
+                ins
+            );
+        }
     }
 }
 
@@ -1283,7 +1320,8 @@ fn right_recursive_two_rule_grammar_is_not_marked_lr() {
             Pattern::literal("w"),
         ]),
     );
-    let prog = Grammar::new(rules, "a").compile().unwrap();
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
+    let prog = Grammar::new(rules).compile().unwrap();
     let has_lr = prog.code.iter().any(|i| {
         matches!(
             i,
@@ -1300,17 +1338,17 @@ fn right_recursive_two_rule_grammar_is_not_marked_lr() {
 
 #[test]
 fn lr_through_nullable_prefix_is_detected() {
-    // start <- opt start "+" "n" / "n"
+    // root <- opt root "+" "n" / "n"
     // opt   <- "x"?
     // The recursive call is gated by an optional prefix; nullability
     // analysis must propagate the first-call through `opt`.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
                 Pattern::NonTerminal("opt".into()),
-                Pattern::NonTerminal("start".into()),
+                Pattern::NonTerminal("root".into()),
                 Pattern::literal("+"),
                 Pattern::literal("n"),
             ]),
@@ -1321,7 +1359,7 @@ fn lr_through_nullable_prefix_is_detected() {
         "opt".into(),
         Pattern::Optional(Box::new(Pattern::literal("x"))),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     assert!(prog
         .code
         .iter()
@@ -1347,39 +1385,39 @@ fn cap_lit(kind: &str, s: &str) -> FollowElement {
 
 #[test]
 fn follow_set_single_rule_tail() {
-    // start <- a; a <- 'x'
+    // root <- a; a <- 'x'
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
     rules.insert("a".into(), Pattern::literal("x"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     assert_eq!(follow["a"], BTreeSetOf::from([FollowElement::Eof]));
-    assert_eq!(follow["start"], BTreeSetOf::from([FollowElement::Eof]));
+    assert_eq!(follow["root"], BTreeSetOf::from([FollowElement::Eof]));
 }
 
 #[test]
 fn follow_set_sequence_after() {
-    // start <- a 'y'; a <- 'x'
+    // root <- a 'y'; a <- 'x'
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::literal("y"),
         ]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     assert_eq!(follow["a"], BTreeSetOf::from([lit("y")]));
 }
 
 #[test]
 fn follow_set_choice_tail() {
-    // start <- a / b; a <- 'x'; b <- 'y'
+    // root <- a / b; a <- 'x'; b <- 'y'
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::NonTerminal("b".into()),
@@ -1387,7 +1425,7 @@ fn follow_set_choice_tail() {
     );
     rules.insert("a".into(), Pattern::literal("x"));
     rules.insert("b".into(), Pattern::literal("y"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     // Each alt sits at the tail of `start`; FOLLOW(start) = {Eof}.
     assert_eq!(follow["a"], BTreeSetOf::from([FollowElement::Eof]));
@@ -1396,14 +1434,14 @@ fn follow_set_choice_tail() {
 
 #[test]
 fn follow_set_repeat_self() {
-    // start <- a*; a <- 'x'
+    // root <- a*; a <- 'x'
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::Repeat(Box::new(Pattern::NonTerminal("a".into()))),
     );
     rules.insert("a".into(), Pattern::literal("x"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     // Body can iterate (next iteration's FIRST = FIRST(a) = {Rule("a")}),
     // and at termination FOLLOW(start) = {Eof} applies.
@@ -1420,10 +1458,10 @@ fn follow_set_repeat_self() {
 
 #[test]
 fn follow_set_nullable_skip() {
-    // start <- a b 'z'; a <- 'x'; b <- 'y'?
+    // root <- a b 'z'; a <- 'x'; b <- 'y'?
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::NonTerminal("b".into()),
@@ -1435,7 +1473,7 @@ fn follow_set_nullable_skip() {
         "b".into(),
         Pattern::Optional(Box::new(Pattern::literal("y"))),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     let f_a = &follow["a"];
     // After `a`: FIRST(b) = {Rule("b")} (opaque, one-level), plus — since b
@@ -1455,36 +1493,36 @@ fn follow_set_recursive() {
     // list <- 'x' (',' list)?
     let mut rules = HashMap::new();
     rules.insert(
-        "list".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::literal("x"),
             Pattern::Optional(Box::new(Pattern::seq(vec![
                 Pattern::literal(","),
-                Pattern::NonTerminal("list".into()),
+                Pattern::NonTerminal("root".into()),
             ]))),
         ]),
     );
-    let g = Grammar::new(rules, "list");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
-    // The recursive `list` call is at the tail of an Optional, which is at
-    // the tail of `list` itself — so FOLLOW(list) propagates to itself,
+    // The recursive `root` call is at the tail of an Optional, which is at
+    // the tail of `root` itself — so FOLLOW(root) propagates to itself,
     // and the seed Eof reaches all the way down.
-    assert_eq!(follow["list"], BTreeSetOf::from([FollowElement::Eof]));
+    assert_eq!(follow["root"], BTreeSetOf::from([FollowElement::Eof]));
 }
 
 #[test]
 fn follow_set_capture_preserved() {
-    // start <- a @punctuation{','}; a <- 'x'
+    // root <- a @punctuation{','}; a <- 'x'
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::Capture("punctuation".into(), Box::new(Pattern::literal(","))),
         ]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     let f_a = &follow["a"];
     assert!(
@@ -1495,10 +1533,10 @@ fn follow_set_capture_preserved() {
 
 #[test]
 fn follow_set_predicate_lookahead() {
-    // start <- a &'y' 'z'; a <- 'x'
+    // root <- a &'y' 'z'; a <- 'x'
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
@@ -1506,7 +1544,7 @@ fn follow_set_predicate_lookahead() {
         ]),
     );
     rules.insert("a".into(), Pattern::literal("x"));
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let follow = compute_follow(&g);
     let f_a = &follow["a"];
     // The lookahead &'y' contributes FIRST('y') = {'y'} (predicate is
@@ -1570,11 +1608,11 @@ fn finding(rule: &str, caller: &str) -> LintFinding {
 
 #[test]
 fn lint_partial_match_trailing_optional_with_eof_validator() {
-    // start <- a; a <- 'x' 'y'?
+    // root <- a; a <- 'x' 'y'?
     // a is called from the start rule, whose only continuation is Eof.
     // Eof rejects any non-empty leftover bytes — a validator. No flag.
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
     rules.insert(
         "a".into(),
         Pattern::seq(vec![
@@ -1582,31 +1620,31 @@ fn lint_partial_match_trailing_optional_with_eof_validator() {
             Pattern::Optional(Box::new(Pattern::literal("y"))),
         ]),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     assert!(lint_partial_match(&g).is_empty());
 }
 
 #[test]
 fn lint_partial_match_no_trailing_nullable_skipped() {
-    // start <- a; a <- 'x' 'y' — no trailing optional/nullable.
+    // root <- a; a <- 'x' 'y' — no trailing optional/nullable.
     let mut rules = HashMap::new();
-    rules.insert("start".into(), Pattern::NonTerminal("a".into()));
+    rules.insert("root".into(), Pattern::NonTerminal("a".into()));
     rules.insert(
         "a".into(),
         Pattern::seq(vec![Pattern::literal("x"), Pattern::literal("y")]),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     assert!(lint_partial_match(&g).is_empty());
 }
 
 #[test]
 fn lint_partial_match_anchored_via_andpredicate() {
-    // start <- a &'y' 'y'; a <- 'x' 'y'?
+    // root <- a &'y' 'y'; a <- 'x' 'y'?
     // The AndPredicate anchors the call to a even though a's trailing
     // overlaps with what follows.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::AndPredicate(Box::new(Pattern::literal("y"))),
@@ -1620,7 +1658,7 @@ fn lint_partial_match_anchored_via_andpredicate() {
             Pattern::Optional(Box::new(Pattern::literal("y"))),
         ]),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     assert!(
         lint_partial_match(&g).is_empty(),
         "AndPredicate should anchor"
@@ -1629,12 +1667,12 @@ fn lint_partial_match_anchored_via_andpredicate() {
 
 #[test]
 fn lint_partial_match_validated_by_disjoint_consumer() {
-    // start <- a 'z'; a <- 'x' 'y'?
+    // root <- a 'z'; a <- 'x' 'y'?
     // 'z' after a is a non-nullable consumer with FIRST={'z'} disjoint
     // from a's trailing {'y'}. The consumer validates.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("a".into()),
             Pattern::literal("z"),
@@ -1647,13 +1685,13 @@ fn lint_partial_match_validated_by_disjoint_consumer() {
             Pattern::Optional(Box::new(Pattern::literal("y"))),
         ]),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     assert!(lint_partial_match(&g).is_empty());
 }
 
 #[test]
 fn lint_partial_match_absorbed_by_outer_catch_flagged() {
-    // start <- (a)*^[;]
+    // root <- (a)*^[;]
     // a <- 'x' 'y'?
     // a's leniency at the call site is absorbed by the *^ recovery
     // wrapper — exactly the PR #101 shape.
@@ -1667,7 +1705,7 @@ fn lint_partial_match_absorbed_by_outer_catch_flagged() {
         label: "recovery".into(),
         recovery: Box::new(recovery_body),
     }));
-    rules.insert("start".into(), call_inside_catch);
+    rules.insert("root".into(), call_inside_catch);
     rules.insert(
         "a".into(),
         Pattern::seq(vec![
@@ -1675,9 +1713,9 @@ fn lint_partial_match_absorbed_by_outer_catch_flagged() {
             Pattern::Optional(Box::new(Pattern::literal("y"))),
         ]),
     );
-    let g = Grammar::new(rules, "start");
+    let g = Grammar::new(rules);
     let findings = lint_partial_match(&g);
-    assert_eq!(findings, vec![finding("a", "start")]);
+    assert_eq!(findings, vec![finding("a", "root")]);
 }
 
 #[test]
@@ -1753,15 +1791,15 @@ fn definition_lenient_marker_requires_touching_name() {
 fn definition_lenient_suppresses_lint_at_every_call_site() {
     // Use the Catch-absorbed shape the lint reliably flags: a
     // top-level `*^[;]` recovery loop calling a trailing-Optional rule.
-    let unmarked = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse unmarked");
+    let unmarked = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse unmarked");
     assert!(
         lint_partial_match(&unmarked)
             .iter()
-            .any(|f| f.rule == "r" && f.caller == "start"),
+            .any(|f| f.rule == "r" && f.caller == "root"),
         "baseline: unmarked grammar should flag r"
     );
 
-    let marked = parse("start <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse marked");
+    let marked = parse("root <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse marked");
     let findings = lint_partial_match(&marked);
     assert!(
         !findings.iter().any(|f| f.rule == "r"),
@@ -1772,11 +1810,11 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
 #[test]
 fn definition_lenient_marker_is_runtime_transparent() {
     // The `~name <-` wrap compiles to the same bytecode as the bare form.
-    let plain = parse("r <- 'x'+")
+    let plain = parse("root <- 'x'+")
         .expect("parse plain")
         .compile()
         .expect("compile plain");
-    let marked = parse("~r <- 'x'+")
+    let marked = parse("~root <- 'x'+")
         .expect("parse marked")
         .compile()
         .expect("compile marked");
@@ -1788,14 +1826,14 @@ fn definition_lenient_marker_is_runtime_transparent() {
 #[test]
 fn compile_errors_on_partial_match_leniency() {
     // `*^[;]` Catch-absorbed shape — the lint reliably flags this.
-    let g = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let g = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     match err {
         syntax_highlighter::pegc::CompileError::PartialMatchLeniency(findings) => {
             assert!(
                 findings
                     .iter()
-                    .any(|f| f.rule == "r" && f.caller == "start"),
+                    .any(|f| f.rule == "r" && f.caller == "root"),
                 "expected r → start finding, got: {findings:?}"
             );
         }
@@ -1805,7 +1843,7 @@ fn compile_errors_on_partial_match_leniency() {
 
 #[test]
 fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
-    let g = parse("start <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse");
+    let g = parse("root <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse");
     g.compile()
         .expect("compile should succeed with definition-level `~r`");
 }
@@ -1814,7 +1852,7 @@ fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
 fn compile_succeeds_with_boundary_catch_anchor() {
     // `^^bad ';'` lowers to `Catch { Seq(a, &';'), bad, recovery }` —
     // anchoring `a` by lookahead so the lint sees no leniency.
-    let g = parse("start <- (a ^^bad ';')*\na <- 'x' 'y'?").expect("parse");
+    let g = parse("root <- (a ^^bad ';')*\na <- 'x' 'y'?").expect("parse");
     g.compile()
         .expect("compile should succeed with `^^bad ';'` anchor");
 }
@@ -1825,7 +1863,7 @@ fn compile_succeeds_with_bracketed_close_catch_sugar() {
     // and whose recovery is `Seq(@recovery{(!'}' .)*}, '}')`. The
     // inner ends in `'}'` (a hard terminator), so `lint_partial_match`
     // sees no trailing-nullable shape and compilation succeeds.
-    let g = parse("start <- ('{' a '}' ^^bad ..= '}')*\na <- 'x'+").expect("parse");
+    let g = parse("root <- ('{' a '}' ^^bad ..= '}')*\na <- 'x'+").expect("parse");
     g.compile()
         .expect("compile should succeed with `^^bad ..= '}'` sugar");
 }
@@ -1839,7 +1877,7 @@ fn bracketed_close_catch_runs_recovery_path() {
     // exercises the recovery: skip captures `garbage` and `}` is
     // captured as `@punctuation`.
     let g = parse(
-        "start <- @punctuation{'{'} (body @punctuation{'}'} ^^bad ..= @punctuation{'}'})\nbody <- 'x'",
+        "root <- @punctuation{'{'} (body @punctuation{'}'} ^^bad ..= @punctuation{'}'})\nbody <- 'x'",
     )
     .expect("parse");
     let prog = g.compile().expect("compile");
@@ -1860,12 +1898,12 @@ fn bracketed_close_catch_runs_recovery_path() {
 
 #[test]
 fn compile_error_display_lists_findings() {
-    let g = parse("start <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let g = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     let msg = format!("{err}");
     assert!(msg.contains("partial-match leniency"));
     assert!(msg.contains("`r`"));
-    assert!(msg.contains("`start`"));
+    assert!(msg.contains("`root`"));
 }
 
 #[test]
@@ -1873,7 +1911,7 @@ fn compile_errors_on_uninferable_boundary() {
     // The start rule has no FOLLOW context other than EOF — for a
     // rule with no callers at all, the inferred boundary would be
     // empty. Construct that case via a non-start unreachable rule.
-    let g = parse("start <- 'x'\norphan <- 'a' ^^bad").expect("parse");
+    let g = parse("root <- 'x'\norphan <- 'a' ^^bad").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     assert!(
         matches!(
@@ -1902,27 +1940,29 @@ fn trivia_idx(program: &syntax_highlighter::pegvm::Program, name: &str) -> usize
 #[test]
 fn trivia_root_marks_itself_and_no_root_leaves_bits_false() {
     // Without a `trivia` rule the bits are all false.
-    let no_root = parse("start <- 'x'")
+    let no_root = parse("root <- 'x'")
         .expect("parse")
         .compile()
         .expect("compile");
     assert!(no_root.rule_is_trivia.iter().all(|b| !b));
 
-    // The trivia rule itself gets the bit when present.
-    let with_root = parse("start <- trivia 'x'\ntrivia <- ' '*")
+    // The trivia rule itself gets the bit when present. `*trivia`
+    // disables auto-insertion, so explicit `trivia` calls inside
+    // `root` remain in the body.
+    let with_root = parse("*trivia <- ' '*\nroot <- trivia 'x'")
         .expect("parse")
         .compile()
         .expect("compile");
     assert!(with_root.rule_is_trivia[trivia_idx(&with_root, "trivia")]);
-    assert!(!with_root.rule_is_trivia[trivia_idx(&with_root, "start")]);
+    assert!(!with_root.rule_is_trivia[trivia_idx(&with_root, "root")]);
 }
 
 #[test]
 fn trivia_cascades_to_transitive_callees() {
     let program = parse(
-        "start  <- trivia 'x'\n\
-         trivia <- ws\n\
-         ws     <- (comment / ' ')*\n\
+        "*trivia <- ws\n\
+         root    <- trivia 'x'\n\
+         ws      <- (comment / ' ')*\n\
          comment <- '#' (!'\\n' .)*",
     )
     .expect("parse")
@@ -1931,7 +1971,7 @@ fn trivia_cascades_to_transitive_callees() {
     assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
     assert!(program.rule_is_trivia[trivia_idx(&program, "ws")]);
     assert!(program.rule_is_trivia[trivia_idx(&program, "comment")]);
-    assert!(!program.rule_is_trivia[trivia_idx(&program, "start")]);
+    assert!(!program.rule_is_trivia[trivia_idx(&program, "root")]);
 }
 
 #[test]
@@ -1940,9 +1980,9 @@ fn trivia_cascade_skips_catch_bearing_rules() {
     // in its body. The cascade pins it out so the catch's frame stays
     // visible in `pegdb recoveries explain`.
     let program = parse(
-        "start  <- trivia 'x'\n\
-         trivia <- (victim / ' ')*\n\
-         victim <- 'a' ^bad 'b'",
+        "*trivia <- (victim / ' ')*\n\
+         root    <- trivia 'x'\n\
+         victim  <- 'a' ^bad 'b'",
     )
     .expect("parse")
     .compile()
@@ -1959,9 +1999,9 @@ fn trivia_cascade_handles_recursion() {
     // Trivia subgraph with a self-cycle; fixpoint should terminate
     // and mark every reachable rule.
     let program = parse(
-        "start  <- trivia 'x'\n\
-         trivia <- ws\n\
-         ws     <- (ws / ' ')*",
+        "*trivia <- ws\n\
+         root    <- trivia 'x'\n\
+         ws      <- (ws / ' ')*",
     )
     .expect("parse")
     .compile()
@@ -1974,7 +2014,7 @@ fn trivia_cascade_handles_recursion() {
 fn backslash_cap_r_matches_crlf_atomically() {
     // `\R` lowers to `'\r\n' / '\n' / '\r'` — CRLF is matched as one
     // two-byte unit, not two separate line breaks.
-    let g = parse("r <- \\R").expect("parse");
+    let g = parse("root <- \\R").expect("parse");
     let prog = g.compile().expect("compile");
     let r = VM::new(&prog.code, b"\r\n").run();
     assert!(r.complete, "\\R should match CRLF");
@@ -1990,34 +2030,40 @@ fn backslash_cap_r_matches_crlf_atomically() {
 }
 
 #[test]
-fn backslash_z_matches_eof() {
-    // `\z` lowers to `!.` — succeeds at end of input, fails otherwise.
-    let g = parse("r <- \\z").expect("parse");
+fn backslash_not_dot_matches_eof() {
+    // `\z` was removed; the post-migration spelling is the explicit
+    // `!.`. Verifies it succeeds at end-of-input and fails otherwise.
+    let g = parse("root <- !.").expect("parse");
     let prog = g.compile().expect("compile");
     let r = VM::new(&prog.code, b"").run();
-    assert!(r.complete, "\\z should match empty input");
+    assert!(r.complete, "!. should match empty input");
     assert_eq!(r.matched, 0);
 
     let r = VM::new(&prog.code, b"x").run();
-    assert!(!r.complete, "\\z should fail when bytes remain");
+    assert!(!r.complete, "!. should fail when bytes remain");
 }
 
 #[test]
 fn repeat_count_matches_exact_length() {
     // End-to-end smoke for `p{n}` — verifies the parse-time desugaring
     // produces the same VM behavior as four hand-written `\d`s.
-    let g = parse("r <- \\d{4} \\z").expect("parse");
+    // The `root` wrap supplies the trailing end-of-input assertion
+    // implicitly.
+    let g = parse("root <- \\d{4}").expect("parse");
     let prog = g.compile().expect("compile");
 
     let r = VM::new(&prog.code, b"1234").run();
-    assert!(r.complete, "\\d{{4}} \\z should match exactly four digits");
+    assert!(r.complete, "\\d{{4}} should match exactly four digits");
     assert_eq!(r.matched, 4);
 
     let r = VM::new(&prog.code, b"123").run();
     assert!(!r.complete, "\\d{{4}} should fail on three digits");
 
     let r = VM::new(&prog.code, b"12345").run();
-    assert!(!r.complete, "\\z should fail when a fifth byte remains");
+    assert!(
+        !r.complete,
+        "root's implicit end-of-input must fail when a fifth byte remains"
+    );
 }
 
 #[test]

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1949,7 +1949,7 @@ fn trivia_root_marks_itself_and_no_root_leaves_bits_false() {
     // The trivia rule itself gets the bit when present. `*trivia`
     // disables auto-insertion, so explicit `trivia` calls inside
     // `root` remain in the body.
-    let with_root = parse("*trivia <- ' '*\nroot <- trivia 'x'")
+    let with_root = parse("root <- trivia 'x'\n*trivia <- ' '*")
         .expect("parse")
         .compile()
         .expect("compile");
@@ -1960,8 +1960,8 @@ fn trivia_root_marks_itself_and_no_root_leaves_bits_false() {
 #[test]
 fn trivia_cascades_to_transitive_callees() {
     let program = parse(
-        "*trivia <- ws\n\
-         root    <- trivia 'x'\n\
+        "root    <- trivia 'x'\n\
+         *trivia <- ws\n\
          ws      <- (comment / ' ')*\n\
          comment <- '#' (!'\\n' .)*",
     )
@@ -1980,8 +1980,8 @@ fn trivia_cascade_skips_catch_bearing_rules() {
     // in its body. The cascade pins it out so the catch's frame stays
     // visible in `pegdb recoveries explain`.
     let program = parse(
-        "*trivia <- (victim / ' ')*\n\
-         root    <- trivia 'x'\n\
+        "root    <- trivia 'x'\n\
+         *trivia <- (victim / ' ')*\n\
          victim  <- 'a' ^bad 'b'",
     )
     .expect("parse")
@@ -1999,8 +1999,8 @@ fn trivia_cascade_handles_recursion() {
     // Trivia subgraph with a self-cycle; fixpoint should terminate
     // and mark every reachable rule.
     let program = parse(
-        "*trivia <- ws\n\
-         root    <- trivia 'x'\n\
+        "root    <- trivia 'x'\n\
+         *trivia <- ws\n\
          ws      <- (ws / ' ')*",
     )
     .expect("parse")
@@ -2018,8 +2018,8 @@ fn auto_trivia_handles_inter_repeat_whitespace() {
     // already covers). Without the prepend, ` , 2 , 3` would fail on
     // the second iteration's leading space.
     let prog = parse(
-        "trivia <- ' '*\n\
-         root   <- 'x' (',' 'x')*",
+        "root   <- 'x' (',' 'x')*\n\
+         trivia <- ' '*",
     )
     .expect("parse")
     .compile()

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1145,9 +1145,10 @@ fn end_to_end_inferred_catch_matches_explicit_behavior() {
     let inferred = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
         .compile()
         .unwrap();
-    let explicit = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
-        .compile()
-        .unwrap();
+    let explicit =
+        parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
+            .compile()
+            .unwrap();
     for input in [&b"x,x"[..], b"xy,x", b"x"].iter() {
         let r_inferred = VM::new(&inferred.code, input).run();
         let r_explicit = VM::new(&explicit.code, input).run();

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1011,20 +1011,6 @@ fn backslash_cap_r_linebreak_atom() {
 }
 
 #[test]
-fn backslash_z_atom_is_a_migration_error() {
-    // `\z` (the old end-of-input alias) was removed; the `root` rule's
-    // wrap supplies the same assertion automatically. The parser must
-    // raise a migration-flavored error so authors with old grammars
-    // see exactly where to remove it.
-    let err = parse_src("r <- \\z").unwrap_err();
-    assert!(
-        err.message.contains("\\z") && err.message.contains("removed"),
-        "expected migration error mentioning `\\z` was removed, got: {}",
-        err.message
-    );
-}
-
-#[test]
 fn backslash_d_in_class_unions_digits() {
     let g = parse("r <- [\\d_]");
     let mut s = CharSet::from_ranges(&[(b'0', b'9')]);
@@ -1078,16 +1064,6 @@ fn backslash_cap_r_in_class_rejected() {
     assert!(
         err.message.contains("multi-byte") && err.message.contains("\\R"),
         "expected tailored multi-byte error for \\R in class, got: {}",
-        err.message
-    );
-}
-
-#[test]
-fn backslash_z_in_class_rejected() {
-    let err = parse_src("r <- [\\z]").unwrap_err();
-    assert!(
-        err.message.contains("zero-width") && err.message.contains("\\z"),
-        "expected tailored zero-width error for \\z in class, got: {}",
         err.message
     );
 }

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -8,14 +8,14 @@ fn parse(src: &str) -> syntax_highlighter::pegc::Grammar {
 #[test]
 fn simple_rule() {
     let g = parse("foo <- \"hi\"");
-    assert_eq!(g.start, "foo");
+    assert_eq!(g.rule_order, vec!["foo".to_string()]);
     assert_eq!(g.rules["foo"], Pattern::literal("hi"));
 }
 
 #[test]
-fn first_rule_is_start() {
+fn rule_order_preserved() {
     let g = parse("first <- 'a'\nsecond <- 'b'");
-    assert_eq!(g.start, "first");
+    assert_eq!(g.rule_order, vec!["first".to_string(), "second".to_string()]);
     assert_eq!(g.rules.len(), 2);
 }
 
@@ -1011,11 +1011,16 @@ fn backslash_cap_r_linebreak_atom() {
 }
 
 #[test]
-fn backslash_z_atom() {
-    let g = parse("r <- \\z");
-    assert_eq!(
-        g.rules["r"],
-        Pattern::NotPredicate(Box::new(Pattern::AnyChar))
+fn backslash_z_atom_is_a_migration_error() {
+    // `\z` (the old end-of-input alias) was removed; the `root` rule's
+    // wrap supplies the same assertion automatically. The parser must
+    // raise a migration-flavored error so authors with old grammars
+    // see exactly where to remove it.
+    let err = parse_src("r <- \\z").unwrap_err();
+    assert!(
+        err.message.contains("\\z") && err.message.contains("removed"),
+        "expected migration error mentioning `\\z` was removed, got: {}",
+        err.message
     );
 }
 
@@ -1111,11 +1116,13 @@ fn unknown_backslash_atom_errors() {
 #[test]
 fn end_to_end_grammar_compile_run() {
     use syntax_highlighter::pegvm::VM;
-    let g = parse("number <- [0-9]+");
+    let g = parse("root <- number\nnumber <- [0-9]+");
     let prog = g.compile().unwrap();
     let r = VM::new(&prog.code, b"42abc").run();
-    assert!(r.complete);
-    assert_eq!(r.matched, 2);
+    // `root`'s implicit `!.` rejects the trailing 'a'; the parse no
+    // longer succeeds on the prefix.
+    assert!(!r.complete);
+    assert!(r.matched >= 2, "got matched={}", r.matched);
 }
 
 #[test]
@@ -1123,7 +1130,7 @@ fn end_to_end_recover_repeat_compile_run() {
     use syntax_highlighter::pegvm::VM;
     // Top-level `*^` resyncs past garbage one byte at a time; the parse
     // completes at EOF, with one "recovery"-tagged capture per skipped byte.
-    let g = parse("doc <- @kw{\"foo\"}*^");
+    let g = parse("root <- doc\ndoc <- @kw{\"foo\"}*^");
     let prog = g.compile().unwrap();
     let r = VM::new(&prog.code, b"fooXXfoo").run();
     assert!(r.complete);
@@ -1148,10 +1155,10 @@ fn end_to_end_inferred_catch_matches_explicit_behavior() {
     // bytecode isn't expected (label numbering shifts), but the
     // MatchResult on the same input must agree.
     use syntax_highlighter::pegvm::VM;
-    let inferred = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let inferred = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
         .compile()
         .unwrap();
-    let explicit = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
+    let explicit = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
         .compile()
         .unwrap();
     for input in [&b"x,x"[..], b"xy,x", b"x"].iter() {
@@ -1176,7 +1183,7 @@ fn end_to_end_inferred_catch_fires_on_partial_match() {
     // `list`. Input `xy,x` — the first `x` succeeds but the next
     // byte `y` is not in FOLLOW; the catch fires, recovery skips
     // `y` until it sees `,`, and parsing resumes with the second `x`.
-    let prog = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let prog = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
         .compile()
         .unwrap();
     let r = VM::new(&prog.code, b"xy,x").run();
@@ -1186,7 +1193,7 @@ fn end_to_end_inferred_catch_fires_on_partial_match() {
 #[test]
 fn end_to_end_inferred_catch_clean_input_no_recovery() {
     use syntax_highlighter::pegvm::VM;
-    let prog = parse("list <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let prog = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
         .compile()
         .unwrap();
     let r = VM::new(&prog.code, b"x,x").run();
@@ -1202,8 +1209,8 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
 #[test]
 fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
-    let plain = parse("r <- 'x'+").compile().unwrap();
-    let lenient = parse("~r <- 'x'+").compile().unwrap();
+    let plain = parse("root <- 'x'+").compile().unwrap();
+    let lenient = parse("~root <- 'x'+").compile().unwrap();
     assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
     let r = VM::new(&lenient.code, b"xxx").run();
     assert!(r.complete);
@@ -1218,7 +1225,7 @@ fn end_to_end_recover_repeat_with_label_intern() {
     // identical to the unlabeled form (one recovery capture per
     // skipped byte, clean exit at EOF). pegdb recoveries explain
     // clusters by this label.
-    let g = parse("doc <- @kw{\"foo\"}*^:bad_doc");
+    let g = parse("root <- doc\ndoc <- @kw{\"foo\"}*^:bad_doc");
     let prog = g.compile().unwrap();
     assert_eq!(prog.label_kinds, vec!["bad_doc"]);
     let r = VM::new(&prog.code, b"fooXXfoo").run();
@@ -1235,7 +1242,7 @@ fn end_to_end_catch_compile_run() {
     // semicolon. Input is malformed (no FROM), so the inner fails and
     // the recovery branch fires.
     let g = parse(
-        "stmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^bad_select @err{(!';' .)*} ';'",
+        "root <- stmt\nstmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^bad_select @err{(!';' .)*} ';'",
     );
     let prog = g.compile().unwrap();
     let r = VM::new(&prog.code, b"SELECT bogus;").run();

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -32,7 +32,7 @@ fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
     // the mechanism regardless.
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("word".into()),
             Pattern::literal(" "),
@@ -45,7 +45,7 @@ fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
             b'a', b'z',
         )])))),
     );
-    Grammar::new(rules, "start").compile().unwrap()
+    Grammar::new(rules).compile().unwrap()
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn lr_cache_entry_invalidated_by_edit_inside_examined_range() {
     // seed-and-grow loop looked at.
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::Edit;
-    let prog = pegc::compile("expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+    let prog = pegc::compile("root <- expr\n        expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
 
     let (_, _, mut cache) = VM::new(&prog.code, b"1+2+3")
         .with_memo_threshold(0)
@@ -149,7 +149,7 @@ fn lr_cache_round_trip_after_edit_matches_fresh_parse() {
     // gives an equivalent fresh-parse result on every edit).
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::Edit;
-    let prog = pegc::compile("expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+    let prog = pegc::compile("root <- expr\n        expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
 
     let (_, _, mut cache) = VM::new(&prog.code, b"1+2+3")
         .with_memo_threshold(0)

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -30,6 +30,7 @@ fn left_associative_addition() {
     // Standard left-associative arithmetic. Each '+' operand under the
     // 'op' tag, each leaf number under 'num'.
     let src = r#"
+        root <- expr
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
@@ -57,6 +58,7 @@ fn left_associative_with_distinct_operators() {
     // semantics are wrong. The capture forest itself doesn't encode
     // associativity, but the seed-and-grow loop produces this ordering.
     let src = r#"
+        root <- expr
         expr <- expr @minus{'-'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"9-1-2");
@@ -72,6 +74,7 @@ fn precedence_via_two_lr_layers() {
     // Both expr and term are directly LR. The compiler must accept
     // both; the parse must reflect '*' binding tighter than '+'.
     let src = r#"
+        root   <- expr
         expr   <- expr @plus{'+'} term / term
         term   <- term @star{'*'} factor / factor
         factor <- @num{[0-9]+} / '(' expr ')'
@@ -99,6 +102,7 @@ fn precedence_via_two_lr_layers() {
 #[test]
 fn lr_with_parenthesised_subexpression() {
     let src = r#"
+        root   <- expr
         expr   <- expr @plus{'+'} term / term
         term   <- term @star{'*'} factor / factor
         factor <- @num{[0-9]+} / '(' expr ')'
@@ -112,6 +116,7 @@ fn lr_with_parenthesised_subexpression() {
 fn lr_failure_returns_partial() {
     // Input doesn't even start with a valid leaf.
     let src = r#"
+        root <- expr
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"x");
@@ -128,6 +133,7 @@ fn lr_partial_chain_returns_longest_prefix() {
     // surrounding parse must report the deepest sp reached, which is
     // past the LR seed's growth.
     let src = r#"
+        root    <- wrapper
         wrapper <- expr '!'
         expr    <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
@@ -149,6 +155,7 @@ fn nullable_lr_terminates() {
     // growth past seed); LRTail commits at sp=1. Just assert it
     // terminates and matched is 1.
     let src = r#"
+        root <- a
         a <- a / 'x'
     "#;
     let r = run(src, b"x");
@@ -163,6 +170,7 @@ fn nullable_lr_on_empty_input_terminates() {
     // body fails on first iteration with seed None, so the LR rule
     // fails — partial parse at sp=0.
     let src = r#"
+        root <- a
         a <- a / 'x'
     "#;
     let r = run(src, b"");
@@ -177,6 +185,7 @@ fn right_recursive_grammar_is_not_marked_lr() {
     // assertion is in compiler_tests; here we just confirm runtime
     // behavior is unchanged.
     let src = r#"
+        root <- list
         list <- @num{[0-9]+} (',' list)?
     "#;
     let r = run(src, b"1,2,3");
@@ -189,6 +198,7 @@ fn indirect_lr_cycle_of_2_runs() {
     // SCC {a, b}; both rules are wrapped as LR. Input "y" matches via
     // a's base alternative on the first iteration; no growth occurs.
     let src = r#"
+        root <- a
         a <- b 'x' / 'y'
         b <- a 'z' / 'w'
     "#;
@@ -203,6 +213,7 @@ fn indirect_lr_cycle_of_2_grows_through_chain() {
     // through the indirect cycle: a's seed grows from {y at sp=1} to
     // {b'x' at sp=3} where b in turn used a's seed to match "yz".
     let src = r#"
+        root <- a
         a <- b 'x' / 'y'
         b <- a 'z' / 'w'
     "#;
@@ -217,6 +228,7 @@ fn indirect_lr_cycle_of_3_runs() {
     // wrapped as LR. Input "p" matches via a's base alt; the test
     // confirms that cycles longer than 2 compile and run.
     let src = r#"
+        root <- a
         a <- b 'x' / 'p'
         b <- c 'y' / 'q'
         c <- a 'z' / 'r'
@@ -237,6 +249,7 @@ fn lr_inside_recover_repeat_resyncs_cleanly() {
     // seed (or its first-iteration failure must propagate cleanly so
     // *^'s outer Choice/Commit catches it).
     let src = r#"
+        root <- top
         top  <- (expr ';')*^ !.
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
@@ -274,6 +287,7 @@ fn cached_lr_seed_matches_uncached_run() {
     // additive: enabling it (threshold=0) must produce the same
     // MatchResult as disabling it (threshold=usize::MAX).
     let src = r#"
+        root <- expr
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
@@ -296,6 +310,7 @@ fn lr_seed_caches_below_memo_threshold() {
     // a generous threshold (1024), a `Memo`-kind rule of the same
     // shape would not cache, but the LR rule must.
     let src = r#"
+        root <- expr
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
@@ -314,6 +329,7 @@ fn lr_inside_outer_repetition_matches_uncached_run() {
     // distinct sps; the new cache write at LRTail must not perturb the
     // surrounding pattern.
     let src = r#"
+        root <- top
         top  <- (expr ',')* expr
         expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -30,7 +30,7 @@ fn cap(kind: u16, start: usize, end: usize) -> Capture {
 fn second_alternative_reuses_memoized_x() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
                 Pattern::NonTerminal("X".into()),
@@ -46,7 +46,7 @@ fn second_alternative_reuses_memoized_x() {
         "X".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"abb")
         .with_memo_threshold(0)
         .run_with_memo_stats();
@@ -68,7 +68,7 @@ fn second_alternative_reuses_memoized_x() {
 fn memo_table_populates_on_success() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::seq(vec![
             Pattern::NonTerminal("X".into()),
             Pattern::NonTerminal("X".into()),
@@ -78,7 +78,7 @@ fn memo_table_populates_on_success() {
         "X".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let (_, stats) = VM::new(&prog.code, b"ab")
         .with_memo_threshold(0)
         .run_with_memo_stats();
@@ -117,7 +117,7 @@ fn memo_table_populates_on_success() {
 fn memo_hit_inside_outer_capture_preserves_nesting() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::Capture(
             "outer".into(),
             Box::new(Pattern::choice(vec![
@@ -139,7 +139,7 @@ fn memo_hit_inside_outer_capture_preserves_nesting() {
             Box::new(Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')]))),
         ),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     // Capture kind ids are assigned in first-seen order: "outer" = 0, "inner" = 1.
     let outer_kind = prog
         .capture_kinds
@@ -185,7 +185,7 @@ fn memo_hit_inside_outer_capture_preserves_nesting() {
 fn cached_failure_short_circuits_not_predicate() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
                 Pattern::NotPredicate(Box::new(Pattern::NonTerminal("A".into()))),
@@ -198,7 +198,7 @@ fn cached_failure_short_circuits_not_predicate() {
         ]),
     );
     rules.insert("A".into(), Pattern::literal("a"));
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"c")
         .with_memo_threshold(0)
         .run_with_memo_stats();
@@ -219,7 +219,7 @@ fn cached_failure_short_circuits_not_predicate() {
 fn nested_memoized_rule_failures_both_cached() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::NonTerminal("outer".into()),
             Pattern::NonTerminal("fallback".into()),
@@ -237,7 +237,7 @@ fn nested_memoized_rule_failures_both_cached() {
         "fallback".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"x")
         .with_memo_threshold(0)
         .run_with_memo_stats();
@@ -260,7 +260,7 @@ fn nested_memoized_rule_failures_both_cached() {
 fn and_predicate_with_memoized_rule() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::choice(vec![
             Pattern::seq(vec![
                 Pattern::AndPredicate(Box::new(Pattern::NonTerminal("A".into()))),
@@ -276,7 +276,7 @@ fn and_predicate_with_memoized_rule() {
         "A".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'a', b'z')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let (result, stats) = VM::new(&prog.code, b"y")
         .with_memo_threshold(0)
         .run_with_memo_stats();
@@ -293,6 +293,7 @@ fn lr_converged_seed_persists_across_parses() {
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::MemoCache;
     let src = r#"
+        root <- expr
         expr <- expr '+' [0-9]+ / [0-9]+
     "#;
     let prog = pegc::compile(src).expect("compile");
@@ -337,14 +338,14 @@ fn lr_converged_seed_persists_across_parses() {
 fn memoization_does_not_change_results_on_linear_parse() {
     let mut rules = HashMap::new();
     rules.insert(
-        "start".into(),
+        "root".into(),
         Pattern::RepeatOne(Box::new(Pattern::NonTerminal("digit".into()))),
     );
     rules.insert(
         "digit".into(),
         Pattern::CharClass(CharSet::from_ranges(&[(b'0', b'9')])),
     );
-    let prog = Grammar::new(rules, "start").compile().unwrap();
+    let prog = Grammar::new(rules).compile().unwrap();
     let result = VM::new(&prog.code, b"12345").run();
     assert_eq!(
         result,

--- a/tests/pegb_roundtrip_tests.rs
+++ b/tests/pegb_roundtrip_tests.rs
@@ -155,5 +155,5 @@ fn labeled_catch_program_round_trips() {
     // table. Input drives the catch through both success and recovery
     // branches in case any future encoder change depends on runtime
     // state.
-    assert_grammar("labeled_catch", "r <- 'a' ^lbl 'b'", b"ab");
+    assert_grammar("labeled_catch", "root <- 'a' ^lbl 'b'", b"ab");
 }

--- a/tests/pegc_tests.rs
+++ b/tests/pegc_tests.rs
@@ -51,7 +51,7 @@ fn stats_json_grammar_emits_expected_record() {
     );
     assert_eq!(
         json_field_str(line, "instructions"),
-        Some("205"),
+        Some("187"),
         "JSON instruction count drifted"
     );
     assert_eq!(

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -620,7 +620,7 @@ fn recoveries_explain_uses_author_supplied_recovery_label() {
         "pegdb_recoveries_explain_label_{}.peg",
         std::process::id()
     ));
-    let grammar = b"doc <- 'x'*^:bad_doc\n";
+    let grammar = b"root <- 'x'*^:bad_doc\n";
     let mut f = std::fs::File::create(&path).expect("create temp grammar");
     f.write_all(grammar).expect("write temp grammar");
     drop(f);

--- a/tests/walk_invariants_tests.rs
+++ b/tests/walk_invariants_tests.rs
@@ -13,8 +13,8 @@ use common::segments;
 /// `start <- @outer{body}`, `body <- 'aaa' @inner{'bbb'}`.
 /// On input `aaabbb`, outer covers 0..6 and inner covers 3..6.
 const SHARED_END_GRAMMAR: &str = "\
-start <- @outer{body}
-body  <- 'aaa' @inner{'bbb'}
+root <- @outer{body}
+body <- 'aaa' @inner{'bbb'}
 ";
 
 #[test]


### PR DESCRIPTION
PEG grammars no longer need to thread `trivia` calls between every two adjacent tokens, and no longer have to end the start rule with an explicit end-of-input assertion to reject trailing junk. Two reserved rule names take over: a `root` rule (mandatory; its body is wrapped with `trivia? body trivia? !.` at compile time so end-of-input is implicit) and an optional `trivia` rule (auto-inserted between `Sequence` items at every depth and prepended to every `Repeat` / `RepeatOne` iteration). Token-shape rules opt out of auto-insertion with a new `*name <-` atomic sigil, mirroring the existing `~name <-` leniency marker.

The seven free-form shipped grammars (`json`, `css`, `c`, `go`, `javascript`, `rust`, `sqlite`) drop ~700 explicit `trivia` calls and ~60 surface-level tokens get the `*` marker. `toml.peg` keeps a `*trivia <- …` adapter (auto-insertion disabled grammar-wide) because TOML is line-oriented — entries are newline-separated and `key\n= value` mustn't parse — and the grammar's header note explains the carve-out.

Resolves #68.

<details><summary>Design notes</summary>

User-facing docs live in `src/pegc/README.md` under "Grammar file structure", "Reserved rule names", and "`*name <-` — atomic-rule marker". The rewriter is `inject_auto_trivia` + `wrap_root` in `src/pegc/analysis.rs`, run from `Grammar::compile` after `lint_partial_match` and `resolve_inferred_boundaries` so both still see the author's original body. The atomic flag lives on `Grammar.atomic_rules` (a `HashSet<String>`) rather than as a `Pattern` variant, keeping the existing pattern walkers untouched.

The short-lived `\z` end-of-input alias is removed entirely (treated as if it never existed); bare `!.` is still legal for boundary-set use inside catch operators (e.g. `result_column_boundary <- ',' / !.` in `sqlite.peg`). The `pegc stats` JSON-grammar canary in `tests/pegc_tests.rs` ticks from 205 to 187 instructions as a side effect of the `json.peg` migration.

One subtlety the migration surfaced: when a `Repeat(Sequence([a, b]))` lives inside a non-atomic rule, splicing `trivia` between `a` and `b` is necessary but not sufficient — inter-iteration whitespace also needs to be consumed before each iteration's first item. `inject_trivia_in` prepends a `trivia` call to every `Repeat` / `RepeatOne` body for that reason; without it, patterns like `pair (',' pair)*` reject any space before the second iteration's comma. The trivia rule itself is exempt from auto-insertion so the prepend doesn't recurse indefinitely.

</details>
