### PR TITLE
pegc: per-rule reference counts in stats

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -75,11 +75,14 @@ need a CLI surface.
 
 ## `stats <grammar.peg>`
 
-Compile a PEG grammar file and print its bytecode size.
+Compile a PEG grammar file and print its bytecode size plus a per-rule
+call-graph summary.
 
 **Synopsis:** `pegc stats <grammar.peg>`
 
-**Output:** one JSON object on a single line.
+**Output:** a JSON header line followed by one NDJSON record per rule.
+
+Header fields:
 
 | Field                 | Meaning                                                  |
 |-----------------------|----------------------------------------------------------|
@@ -89,6 +92,15 @@ Compile a PEG grammar file and print its bytecode size.
 | `capture_kinds_count` | Number of distinct capture kinds the grammar declares.   |
 | `capture_kinds`       | Array of capture-kind names, in declaration order.       |
 
+Per-rule record fields (one object per rule, sorted alphabetically by `rule`;
+every rule appears, including unreferenced ones):
+
+| Field        | Meaning                                                                      |
+|--------------|------------------------------------------------------------------------------|
+| `rule`       | Rule name.                                                                   |
+| `references` | Total occurrences of `<rule>` as a `NonTerminal` across every rule's body.   |
+| `body_chars` | Source character count of the rule's body (after `<-`), trimmed.             |
+
 **Stdin:** not accepted — `stats` always takes a `<grammar.peg>` path.
 
 **Exit codes:** 0 success, 2 usage error, 3 grammar-compile error.
@@ -97,12 +109,26 @@ Compile a PEG grammar file and print its bytecode size.
 
 ```
 $ pegc stats grammars/json.peg
-{"path":"grammars/json.peg","instructions":197,"rules":16,"capture_kinds_count":5,"capture_kinds":["punctuation","property","string","number","constant"]}
+{"path":"grammars/json.peg","instructions":205,"rules":12,"capture_kinds_count":5,"capture_kinds":["punctuation","property","string","number","constant"]}
+{"rule":"array","references":1,"body_chars":117}
+{"rule":"exp","references":1,"body_chars":15}
+...
 
-# Compare across all shipped grammars (each file emits one line; jq tabulates):
-$ for g in grammars/*.peg; do pegc stats "$g"; done \
+# Compare bytecode size across all shipped grammars (use jq to drop the
+# per-rule lines; the header is always the first line):
+$ for g in grammars/*.peg; do pegc stats "$g" | head -1; done \
     | jq -r '[.path, .instructions, .rules, .capture_kinds_count] | @tsv' \
     | column -t
+
+# Inlining-audit recipe: list rules referenced exactly once (the per-rule
+# stream lives after the header line, so skip line 1):
+$ pegc stats grammars/sqlite.peg | tail -n +2 \
+    | jq -r 'select(.references==1) | .rule'
+
+# Dead-code recipe: rules that nothing calls (excluding the start rule,
+# which is invoked by the runtime entry point rather than a NonTerminal):
+$ pegc stats grammars/sqlite.peg | tail -n +2 \
+    | jq -r 'select(.references==0) | .rule'
 ```
 
 ---

--- a/src/bin/pegc.rs
+++ b/src/bin/pegc.rs
@@ -7,12 +7,14 @@
 //! `pegdb`, which is the parse-time / debug-time toolchain. See
 //! `TOOLS.md` at the repo root for the full contract.
 
+use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::Write;
 use std::process::ExitCode;
 
 use syntax_highlighter::pegc;
 use syntax_highlighter::pegc::analysis::{compute_follow, FollowElement};
+use syntax_highlighter::pegc::tally_non_terminal_refs;
 
 const TOP_HELP: &str = "\
 pegc — PEG compiler-side toolchain for syntax-highlighter
@@ -21,7 +23,7 @@ Usage:
     pegc <subcommand> [options] [args]
 
 Subcommands:
-    stats <grammar.peg>              Print bytecode counts as one JSON object on stdout.
+    stats <grammar.peg>              Print bytecode counts as JSON header + per-rule NDJSON on stdout.
     follow-set <grammar.peg> [rule]  Print FOLLOW sets as NDJSON; one rule per line.
 
 Options:
@@ -33,9 +35,12 @@ See TOOLS.md for the full contract.
 const STATS_HELP: &str = "\
 Usage: pegc stats <grammar.peg>
 
-Compile a PEG grammar file and print its bytecode size as one JSON
-object on stdout (keys: path, instructions, rules, capture_kinds_count,
-capture_kinds).
+Compile a PEG grammar file and print stats on stdout. The first line is
+a JSON header (keys: path, instructions, rules, capture_kinds_count,
+capture_kinds). Subsequent lines are NDJSON, one record per rule sorted
+alphabetically (keys: rule, references, body_chars). Every rule appears,
+including unreferenced ones (`references` is 0) — drives the inlining
+and dead-code audits.
 
 Exit 0 on success, 2 on usage error, 3 on grammar-compile error.
 See TOOLS.md for the full contract.
@@ -127,7 +132,14 @@ fn run_stats(args: &[String]) -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let prog = match pegc::compile(&source) {
+    let grammar = match pegc::parse(&source) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("pegc stats: grammar error: {}", e);
+            return ExitCode::from(3);
+        }
+    };
+    let prog = match grammar.compile() {
         Ok(p) => p,
         Err(e) => {
             eprintln!("pegc stats: grammar error: {}", e);
@@ -153,7 +165,47 @@ fn run_stats(args: &[String]) -> ExitCode {
         prog.capture_kinds.len(),
         kinds_json,
     );
+    // Per-rule NDJSON: one record per rule, sorted alphabetically.
+    // Every rule appears, including zero-reference ones — the "dead
+    // code" query is one of the target audits.
+    let mut refs: HashMap<String, usize> = HashMap::with_capacity(grammar.rule_headers.len());
+    for h in &grammar.rule_headers {
+        refs.insert(h.name.clone(), 0);
+    }
+    for body in grammar.rules.values() {
+        tally_non_terminal_refs(body, &mut refs);
+    }
+    let mut records: Vec<(&str, usize, usize)> = grammar
+        .rule_headers
+        .iter()
+        .map(|h| {
+            let body_chars = source[h.body_byte_start..h.body_byte_end]
+                .trim()
+                .chars()
+                .count();
+            let references = refs.get(&h.name).copied().unwrap_or(0);
+            (h.name.as_str(), references, body_chars)
+        })
+        .collect();
+    records.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, references, body_chars) in records {
+        let _ = writeln!(out, "{}", json_rule_record(name, references, body_chars));
+    }
     ExitCode::SUCCESS
+}
+
+/// Format one rule's stats record as a single-line JSON object.
+fn json_rule_record(name: &str, references: usize, body_chars: usize) -> String {
+    let mut s = String::new();
+    s.push('{');
+    s.push_str("\"rule\":");
+    s.push_str(&json_string(name));
+    let _ = write!(
+        s,
+        ",\"references\":{},\"body_chars\":{}}}",
+        references, body_chars
+    );
+    s
 }
 
 fn run_follow_set(args: &[String]) -> ExitCode {

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1391,6 +1391,43 @@ pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<
     trivia
 }
 
+/// Walk `pat` and bump `out[name]` for every `Pattern::NonTerminal { name }`
+/// occurrence. Unlike [`collect_non_terminal_refs`], duplicates count —
+/// `pegc stats` uses this to surface per-rule reference totals across all
+/// rule bodies.
+pub fn tally_non_terminal_refs(pat: &Pattern, out: &mut HashMap<String, usize>) {
+    match pat {
+        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Sequence { items, .. } => {
+            for it in items {
+                tally_non_terminal_refs(it, out);
+            }
+        }
+        Pattern::OrderedChoice { alts, .. } => {
+            for it in alts {
+                tally_non_terminal_refs(it, out);
+            }
+        }
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. } => tally_non_terminal_refs(inner, out),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            tally_non_terminal_refs(inner, out);
+            tally_non_terminal_refs(recovery, out);
+        }
+        Pattern::InferBoundaryCatch { inner, .. } => tally_non_terminal_refs(inner, out),
+        Pattern::NonTerminal { name, .. } => {
+            *out.entry(name.clone()).or_insert(0) += 1;
+        }
+    }
+}
+
 fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
     match pat {
         Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}

--- a/src/pegc/mod.rs
+++ b/src/pegc/mod.rs
@@ -31,9 +31,9 @@ pub mod compiler;
 pub mod parser;
 pub mod pattern;
 
-pub use analysis::{LintFinding, LintKind};
+pub use analysis::{tally_non_terminal_refs, LintFinding, LintKind};
 pub use compiler::{compile_pattern, CompileError};
-pub use parser::{parse, Grammar, ParseError};
+pub use parser::{parse, Grammar, ParseError, RuleHeader};
 pub use pattern::{Pattern, Span};
 
 use crate::pegvm::Program;

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -15,16 +15,36 @@ const MAX_REPEAT_COUNT: usize = 1024;
 pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
     pub start: String,
+    /// Per-rule source ranges, in declaration order. Populated by
+    /// [`parse`]; empty for grammars built via [`Grammar::new`] (which
+    /// has no source text). `pegc stats` uses these to slice the
+    /// grammar source for the `body_chars` field.
+    pub rule_headers: Vec<RuleHeader>,
+}
+
+/// Byte ranges of one rule's pieces in the grammar source. All offsets
+/// are into the same source string passed to [`parse`].
+#[derive(Debug, Clone)]
+pub struct RuleHeader {
+    pub name: String,
+    /// Byte offset of the rule's identifier (after any leading `~`).
+    pub name_byte: usize,
+    /// Byte offset of the first non-whitespace byte after `<-`.
+    pub body_byte_start: usize,
+    /// Byte offset just past the last byte consumed for the body.
+    pub body_byte_end: usize,
 }
 
 impl Grammar {
     /// Construct a grammar from a hand-built rule map. Useful for
     /// tests that build `Pattern` trees directly without going
-    /// through [`parse`].
+    /// through [`parse`]. `rule_headers` is left empty — hand-built
+    /// grammars have no source text to range over.
     pub fn new(rules: HashMap<String, Pattern>, start: impl Into<String>) -> Self {
         Grammar {
             rules,
             start: start.into(),
+            rule_headers: Vec::new(),
         }
     }
 
@@ -46,6 +66,7 @@ impl Grammar {
         let mut resolved = Grammar {
             rules: self.rules.clone(),
             start: self.start.clone(),
+            rule_headers: self.rule_headers.clone(),
         };
         resolve_inferred_boundaries(&mut resolved)?;
         let findings = lint_partial_match(&resolved);
@@ -132,7 +153,7 @@ impl<'a> Parser<'a> {
     fn parse_grammar(&mut self) -> Result<Grammar, ParseError> {
         self.skip_ws();
         let mut rules = HashMap::new();
-        let mut order = Vec::new();
+        let mut rule_headers: Vec<RuleHeader> = Vec::new();
         while self.pos < self.src.len() {
             // Definition-level lenient marker: `~name <- body` declares
             // that every call to `name` is intentionally lenient and
@@ -145,11 +166,14 @@ impl<'a> Parser<'a> {
                 lenient_span = Some(self.span());
                 self.pos += 1;
             }
+            let name_byte = self.pos;
             let name = self.parse_ident()?;
             self.skip_ws();
             self.expect_str("<-")?;
             self.skip_ws();
+            let body_byte_start = self.pos;
             let mut pat = self.parse_choice()?;
+            let body_byte_end = self.pos;
             if let Some(span) = lenient_span {
                 pat = Pattern::Lenient {
                     inner: Box::new(pat),
@@ -159,14 +183,23 @@ impl<'a> Parser<'a> {
             if rules.insert(name.clone(), pat).is_some() {
                 return Err(self.err(format!("rule '{}' defined twice", name)));
             }
-            order.push(name);
+            rule_headers.push(RuleHeader {
+                name,
+                name_byte,
+                body_byte_start,
+                body_byte_end,
+            });
             self.skip_ws();
         }
-        if order.is_empty() {
+        if rule_headers.is_empty() {
             return Err(self.err("grammar has no rules".into()));
         }
-        let start = order[0].clone();
-        Ok(Grammar { rules, start })
+        let start = rule_headers[0].name.clone();
+        Ok(Grammar {
+            rules,
+            start,
+            rule_headers,
+        })
     }
 
     fn parse_choice(&mut self) -> Result<Pattern, ParseError> {

--- a/tests/fixtures/stats_refs_canary.peg
+++ b/tests/fixtures/stats_refs_canary.peg
@@ -1,0 +1,3 @@
+start <- a a b
+a <- 'x'
+b <- a / 'y'

--- a/tests/pegc_tests.rs
+++ b/tests/pegc_tests.rs
@@ -81,7 +81,40 @@ fn stats_json_grammar_emits_expected_record() {
             "kind name not JSON-string-quoted: {p:?}"
         );
     }
-    assert!(lines.next().is_none(), "stats should emit one record");
+    // One NDJSON per-rule record after the header; the count matches
+    // the header's `rules` field, lines are sorted alphabetically, and
+    // each carries the documented `rule` / `references` / `body_chars`
+    // fields.
+    let per_rule: Vec<&str> = lines.collect();
+    assert_eq!(
+        per_rule.len(),
+        rules,
+        "per-rule record count mismatch: {per_rule:?}"
+    );
+    let mut prev: Option<&str> = None;
+    for r in &per_rule {
+        assert!(
+            r.starts_with('{') && r.ends_with('}'),
+            "per-rule line not a JSON object: {r:?}"
+        );
+        let name = json_field_str(r, "rule").expect("rule present");
+        assert!(
+            name.starts_with('"') && name.ends_with('"'),
+            "rule name not JSON-string-quoted: {r:?}"
+        );
+        json_field_str(r, "references")
+            .expect("references present")
+            .parse::<usize>()
+            .expect("references parses as integer");
+        json_field_str(r, "body_chars")
+            .expect("body_chars present")
+            .parse::<usize>()
+            .expect("body_chars parses as integer");
+        if let Some(p) = prev {
+            assert!(p < name, "per-rule lines not sorted: {p:?} then {name:?}");
+        }
+        prev = Some(name);
+    }
 }
 
 // `tests/fixtures/stats_canary.peg` is a deliberately tiny grammar
@@ -95,11 +128,48 @@ fn stats_emits_correct_counts_for_canary_grammar() {
     assert!(Path::new(path).exists(), "fixture missing: {path}");
     let (code, stdout, stderr) = run(&["stats", path]);
     assert_eq!(code, 0, "stderr was: {stderr}");
-    let line = stdout.lines().next().expect("at least one line");
-    assert_eq!(json_field_str(line, "instructions"), Some("11"));
-    assert_eq!(json_field_str(line, "rules"), Some("1"));
-    assert_eq!(json_field_str(line, "capture_kinds_count"), Some("1"));
-    assert_eq!(json_field_str(line, "capture_kinds"), Some("[\"keyword\"]"));
+    let mut lines = stdout.lines();
+    let header = lines.next().expect("at least one line");
+    assert_eq!(json_field_str(header, "instructions"), Some("11"));
+    assert_eq!(json_field_str(header, "rules"), Some("1"));
+    assert_eq!(json_field_str(header, "capture_kinds_count"), Some("1"));
+    assert_eq!(
+        json_field_str(header, "capture_kinds"),
+        Some("[\"keyword\"]")
+    );
+    // The lone rule has no NonTerminal references; body_chars pins the
+    // trimmed source length of `'a' / @keyword{'b'}` (19 characters).
+    let rule_line = lines.next().expect("per-rule record present");
+    assert_eq!(json_field_str(rule_line, "rule"), Some("\"r\""));
+    assert_eq!(json_field_str(rule_line, "references"), Some("0"));
+    assert_eq!(json_field_str(rule_line, "body_chars"), Some("19"));
+    assert!(lines.next().is_none(), "canary should emit one rule record");
+}
+
+// Multi-rule fixture pinning per-rule reference counting: `a` is
+// referenced three times (twice from `start`, once from `b`), `b` once
+// (from `start`), and `start` zero times.
+#[test]
+fn stats_per_rule_records_count_references() {
+    let path = "tests/fixtures/stats_refs_canary.peg";
+    assert!(Path::new(path).exists(), "fixture missing: {path}");
+    let (code, stdout, stderr) = run(&["stats", path]);
+    assert_eq!(code, 0, "stderr was: {stderr}");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 4, "expected 1 header + 3 per-rule: {lines:?}");
+    let header = lines[0];
+    assert_eq!(json_field_str(header, "rules"), Some("3"));
+    let mut by_rule: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for line in &lines[1..] {
+        let rule = json_field_str(line, "rule").expect("rule present");
+        by_rule.insert(rule, line);
+    }
+    let a = by_rule["\"a\""];
+    assert_eq!(json_field_str(a, "references"), Some("3"));
+    let b = by_rule["\"b\""];
+    assert_eq!(json_field_str(b, "references"), Some("1"));
+    let start = by_rule["\"start\""];
+    assert_eq!(json_field_str(start, "references"), Some("0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `pegc stats` follows its JSON header with one NDJSON record per rule (`{rule, references, body_chars}`), sorted alphabetically. Every rule emits a record — including unreferenced ones — so `select(.references==1)` and `select(.references==0)` answer the inlining-audit and dead-code queries from a single `pegc stats | jq` pipeline.
- `references` multi-counts every `Pattern::NonTerminal { name }` occurrence across all rule bodies. New `tally_non_terminal_refs` in `src/pegc/analysis.rs`, distinct from the existing dedup-by-HashSet `collect_non_terminal_refs`.
- `body_chars` is the trimmed source length of the body, sliced from the grammar source using a new `Grammar::rule_headers` populated by `parse` (`src/pegc/parser.rs`). Hand-built `Grammar::new` callers get an empty header vec.
- `TOOLS.md` documents the new per-rule fields and includes the audit recipes; `STATS_HELP` mentions the per-rule stream.

Closes #124.
