### PR TITLE
grammars: inline four more trivial single-use aliases

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: grammar-refactor
+description: Audit the eight shipped grammars (`grammars/*.peg`) for inlining and dead-code cleanup opportunities, in the spirit of PRs #123 and #136. Use when the user wants to sweep grammars for thin aliases, single-use rules, name-longer-than-body rules, character-class re-aliases, or duplicate-body rules. The skill *surfaces and classifies* candidates — apply step is a separate human/agent decision, because the keep-or-inline call is judgment-heavy.
+---
+
+# grammar-refactor
+
+A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a small, finite number of trivial-alias / thin-wrapper rules and then runs dry until the grammars accumulate more boilerplate. PRs #123 (the big sweep) and #136 (the small follow-up) are the reference shape.
+
+## When to run
+
+- After landing several grammar PRs that introduced new helper rules.
+- When the user explicitly asks to "clean up grammars", "refactor grammars", "find unused rules", "inline thin aliases", or anything in that neighbourhood.
+- As a periodic hygiene check — but expect diminishing returns: a sweep that finds zero candidates is a normal outcome.
+
+## What it does NOT do
+
+- It does not apply changes. The "evaluate" step is judgment-heavy (spec terminology, parallel structure, in-file rationale, atomicity constraints) and doesn't compress into a rule. The skill produces a classified candidate list and stops there. Applying is a follow-up.
+- It does not consider semantic refactors (rule restructuring, FOLLOW boundary changes, capture-kind retagging). Pure surface-level inlining only.
+
+## The four signals
+
+Each candidate falls into one of four categories. The first two are mechanical, the next two are judgment calls.
+
+1. **Char-class re-aliases (mechanical).** A rule whose body is just `[...]` (one or two character classes in sequence), and the rule name doesn't carry documentary intent beyond "this char class." Inline the class at use sites unless the name appears at many sites — a high-ref alias *is* the documentation.
+2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. `sqlite.peg` has `*ident_cont <- [a-zA-Z\d_]` and `*ident_char <- [a-zA-Z\d_]`. Merge to one name unless the dual naming documents a future divergence.
+3. **Refs=1 single-use rules (judgment).** Many rules are referenced once. Most are NOT inline candidates — they exist to name a multi-line cascade entry, an alternation, or a spec-significant phrase. Only inline when the body is a single `name+` / `name*` / `name` / `[...]` / literal — i.e. a textbook thin wrapper.
+4. **Name ≥ body (judgment).** When the rule name is at least as long as the body string, the indirection isn't paying its way. Same evaluation as refs=1: only inline trivial wrappers.
+
+## Workflow
+
+### 1. Generate stats
+
+`pegc stats <grammar.peg>` prints a one-line JSON header plus NDJSON, one row per rule with `references` and `body_chars`. Loop over `grammars/*.peg`:
+
+```bash
+mkdir -p /tmp/grammar-refactor
+for g in grammars/*.peg; do
+  cargo run --bin pegc --quiet -- stats "$g" \
+    > "/tmp/grammar-refactor/$(basename "$g" .peg).ndjson"
+done
+```
+
+The first line of each file is the header (with `instructions` and `rules` totals); the rest are per-rule rows. `tail -n +2` skips the header for per-rule queries.
+
+### 2. List candidates per category
+
+**Char-class bodies (single class as the entire rule body):**
+
+```bash
+grep -n -E '^\s*\*?[a-z_]+\s*<-\s*\[[^]]+\]\s*$' grammars/*.peg
+```
+
+**Duplicate atomic-rule bodies (same body, different names):**
+
+Walk each grammar, normalize the body source (strip leading `*` and the `<-`), group by body string, flag groups of size > 1.
+
+**Refs=1 (single-use) and name ≥ body:**
+
+```bash
+for f in /tmp/grammar-refactor/*.ndjson; do
+  g=$(basename "$f" .ndjson)
+  echo "=== $g ==="
+  echo "-- single-use, excluding reserved --"
+  tail -n +2 "$f" | jq -r 'select(.references==1 and .rule!="trivia" and .rule!="root") | "\(.rule) (\(.body_chars) chars)"'
+  echo "-- name length >= body chars, excluding reserved --"
+  tail -n +2 "$f" | jq -r 'select((.rule|length) >= .body_chars and .rule!="trivia" and .rule!="root") | "\(.rule) (name=\(.rule|length), body=\(.body_chars), refs=\(.references))"'
+done
+```
+
+`trivia` and `root` are reserved (`src/pegc/parser.rs` enforces) — never candidates.
+
+### 3. For each candidate, evaluate
+
+Open the grammar, read the rule, read its callers, and read any comments above the rule or the call sites. Classify into one of:
+
+- **Mechanical inline:** body is `name+` / `name*` / `name` / `[...]` / a single literal; refs=1 (or refs≤5 and the name carries no documentary weight beyond the body itself); no comment above the rule explaining its purpose; **atomicity matches at every callsite** (see *Atomicity check* below).
+- **Judgment-call keep:** the rule name names a spec phrase (e.g. `compound_selector` = CSS Selectors L4 term; `decl_spec_list` = C99 standard naming; `type_constraint` = Go spec name; `expr_no_comma` = JS spec `AssignmentExpression`'s comma-free position) — the alias documents which production this is.
+- **Documented keep:** there's an explanatory comment above the rule (e.g. `rust.peg`'s `type_expr_suffix_marker` — "Split from the cascade so the type_expr stays attached") that argues for the indirection. Don't inline these without explicit human review.
+- **Parallel-structure keep:** the rule is one of a sibling group whose names line up at use sites (e.g. `toml.peg`'s `local_date`/`local_time`/`local_datetime`/`full_datetime` in the value alternation, or `*hex_digits`/`*oct_digits`/`*bin_digits` in number cascades). Inlining one breaks the visual cluster.
+
+### 4. Atomicity check (correctness-critical)
+
+Inlining changes which rule the auto-trivia rewriter is walking. From `src/pegc/analysis.rs::inject_auto_trivia`:
+
+- Trivia is auto-inserted between consecutive Sequence elements *of non-atomic rules*. NonTerminal calls are leaves from the rewriter's POV.
+- Inlining an **atomic** rule body into a **non-atomic** caller exposes the body to auto-injection — trivia will now appear between its elements where it didn't before.
+- Inlining a **non-atomic** rule body into an **atomic** caller suppresses auto-injection where it used to fire.
+
+Safe shapes regardless of atomicity:
+- Body is a single char class, single literal, single NonTerminal, or single Repeat-of-NonTerminal — no internal Sequence, so no internal trivia injection to gain or lose.
+
+When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `*` sigil on both rule headers before changing anything.
+
+### 5. Report
+
+Produce a table grouped by category:
+
+| grammar | rule | body | refs | classification | reason |
+|---|---|---|---|---|---|
+| ... | ... | ... | ... | mechanical / spec-name / documented / parallel / reserved | one-line note |
+
+Lead with the "mechanical" rows (the actionable ones); fold the "keep" rows into a `<details>` block when the report goes into a PR description.
+
+### 6. Hand off
+
+If the user wants to apply: spin up a worktree, edit each candidate, run `cargo check && cargo test && cargo fmt --check && cargo clippy --all-targets -- -D warnings`, re-run `pegc stats` to confirm bytecode shape (rules should drop by N, instructions should drop modestly), open a PR in the spirit of #136 with a pre/post bytecode table.
+
+The applied edit is mechanical at this point — the judgment was the previous step. Don't conflate the two.
+
+## Anti-patterns
+
+- **Bulk-inlining all refs=1 rules.** Most refs=1 rules are spec-significant cascade entries (every binary-precedence level, every statement form, every type-position-specific entry). Inlining them produces an unreadable wall of alternation.
+- **Inlining across atomicity boundaries without checking.** Will silently change parsing behavior — usually in a way that's not caught by the unit tests but shows up in the highlighter fixtures or recovery baselines.
+- **Forgetting to update the grammar header comment** when removing a rule that's named there.
+- **Touching `root` or `trivia`.** Reserved; the parser will reject any grammar that mangles them. Filter these out before evaluating.
+- **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention — `*_body` is used both by `kw_*` (in `@keyword{...}` capture) and by `keyword_word` (for the no-keyword-as-identifier lookahead). Don't sweep these.
+
+## Reference PRs
+
+- #123 — the big sweep across all eight grammars (post-#86 / #87 cleanup; collapsed `trivia <- ws`, inlined thin aliases, folded block-comment patterns into `..=`).
+- #136 — the small follow-up (four trivial single-use aliases left after #123 and the implicit-`root`/`trivia` PR #132).

--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: grammar-refactor
-description: Audit the eight shipped grammars (`grammars/*.peg`) for inlining and dead-code cleanup opportunities, in the spirit of PRs #123 and #136. Use when the user wants to sweep grammars for thin aliases, single-use rules, name-longer-than-body rules, character-class re-aliases, or duplicate-body rules. The skill *surfaces and classifies* candidates — apply step is a separate human/agent decision, because the keep-or-inline call is judgment-heavy.
+description: Audit the shipped grammars (`grammars/*.peg`) for inlining and dead-code cleanup opportunities, in the spirit of PRs #123 and #136. Surfaces and classifies candidates — thin aliases, single-use rules, name-longer-than-body rules, character-class re-aliases, duplicate-body rules — without applying changes, because the keep-or-inline call is judgment-heavy. Invoke explicitly.
 ---
 
 # grammar-refactor
 
-A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a small, finite number of trivial-alias / thin-wrapper rules and then runs dry until the grammars accumulate more boilerplate. PRs #123 (the big sweep) and #136 (the small follow-up) are the reference shape.
-
-## When to run
-
-- After landing several grammar PRs that introduced new helper rules.
-- When the user explicitly asks to "clean up grammars", "refactor grammars", "find unused rules", "inline thin aliases", or anything in that neighbourhood.
-- As a periodic hygiene check — but expect diminishing returns: a sweep that finds zero candidates is a normal outcome.
+A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a small, finite number of trivial-alias / thin-wrapper rules and then runs dry until the grammars accumulate more boilerplate. PRs #123 (the big sweep) and #136 (the small follow-up) are the reference shape. A sweep that finds zero candidates is a normal outcome.
 
 ## What it does NOT do
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -267,8 +267,7 @@ call_ident    <- @function{ident} &(@punctuation{'('})
 
 # --- Literals --------------------------------------------------------
 
-string_lit    <- @string{string_pieces}
-string_pieces <- string_piece+
+string_lit    <- @string{string_piece+}
 *string_piece <- ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
 char_lit      <- @string{char_body}

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -56,7 +56,7 @@ stmt           <- import_decl
                 / continue_stmt
                 / debugger_stmt
                 / labeled_stmt
-                / block_stmt
+                / block
                 / empty_stmt
                 / expr opt_semi
 
@@ -158,7 +158,6 @@ throw_stmt     <- @keyword{'throw'} expr opt_semi
 ~continue_stmt <- @keyword{'continue'} (@variable{ident})? opt_semi
 debugger_stmt  <- @keyword{'debugger'} opt_semi
 labeled_stmt   <- @variable{ident} @punctuation{':'} stmt
-block_stmt     <- block
 block          <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -70,9 +70,8 @@ use_seg       <- @keyword{'self'}
                / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       <- vis? fn_qualifiers @keyword{'fn'} @function{ident} generic_params?
+fn_item       <- vis? fn_qualifier* @keyword{'fn'} @function{ident} generic_params?
                  fn_params fn_return? where_clause? (block / @punctuation{';'})
-fn_qualifiers <- fn_qualifier*
 fn_qualifier  <- @keyword{'const'}
                / @keyword{'async'}
                / @keyword{'unsafe'}
@@ -393,8 +392,7 @@ struct_init_base   <- @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         <- @punctuation{'{'} (block_body @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_body    <- stmt*
+block         <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 stmt          <- let_stmt
                / expr @punctuation{';'}


### PR DESCRIPTION
Follow-up to #123. Four more `name <- ...` aliases that fit the same pattern (single-use, body is a trivial wrapper) and survived the earlier sweep:

| grammar | alias | one-line body | site |
|---|---|---|---|
| `c.peg` | `string_pieces` | `string_piece+` | `string_lit` |
| `javascript.peg` | `block_stmt` | `block` | `stmt` |
| `rust.peg` | `block_body` | `stmt*` | `block` |
| `rust.peg` | `fn_qualifiers` | `fn_qualifier*` | `fn_item` |

Bytecode shape (pre → post): c.peg 2633→2629, javascript.peg 3115→3111, rust.peg 3672→3664 instructions.

<details><summary>Candidates evaluated but kept</summary>

- `go.peg` `type_constraint <- type_union` (refs=1) — matches the Go spec's TypeConstraint = TypeElem identity.
- `rust.peg` `type_expr_suffix_marker <- type_expr` (refs=1) — comment at the rule documents an LR-cascade attachment role.
- `rust.peg` `pattern_no_or <- pattern_atom` (refs=2) — disambiguator with a positional usage comment.
- `javascript.peg` `expr_no_comma <- expr_assign` (refs=17) and `go.peg` `expr_no_compound <- expr_lor_nc` (refs=13) — document a "no top-level comma / composite-literal" position used across the cascade.
- `toml.peg` `local_date <- date`, `local_time <- time`, `basic_multiline`/`literal_multiline`, `inline_space` — parallel structure / line-sensitive convention motivated in the file header.
- `c.peg` `decl_spec_list <- decl_spec+` (refs=5) and `css.peg` `compound_selector <- selector_atom+` (refs=5) — match the C99 / CSS Selectors L4 spec names.

</details>
