### PR TITLE
TOOLS.md: clarify that pegc stats references is static call sites only

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -101,6 +101,8 @@ every rule appears, including unreferenced ones):
 | `references` | Total occurrences of `<rule>` as a `NonTerminal` across every rule's body.   |
 | `body_chars` | Source character count of the rule's body (after `<-`), trimmed.             |
 
+`references` counts **author-written** `NonTerminal` calls in rule bodies. The auto-injected `trivia` calls produced by `src/pegc/analysis.rs::inject_auto_trivia` are not counted, so the reserved `trivia` rule typically reports `references: 0` even though it is the most-invoked rule at runtime. Use the count to find dead or single-use rules in *authored* grammar source; do not read it as runtime call frequency.
+
 **Stdin:** not accepted — `stats` always takes a `<grammar.peg>` path.
 
 **Exit codes:** 0 success, 2 usage error, 3 grammar-compile error.


### PR DESCRIPTION
A reader looking at `pegc stats` output sees `{"rule":"trivia","references":0,...}` and reasonably concludes the rule is unused — but `trivia` is auto-injected between Sequence elements (`src/pegc/analysis.rs::inject_auto_trivia`) and is in fact the most-invoked rule at runtime. The `references` field counts author-written `NonTerminal` occurrences only.

This adds one paragraph after the per-rule field table in `TOOLS.md` calling that out, so consumers — agents auditing for dead code, humans reading the JSONL — don't misread the count as runtime call frequency.
