### PR TITLE
Fix keyword/identifier word boundaries (wb + % sigil)

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -17,7 +17,7 @@ A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a sm
 Each candidate falls into one of four categories. The first two are mechanical, the next two are judgment calls.
 
 1. **Char-class re-aliases (mechanical).** A rule whose body is just `[...]` (one or two character classes in sequence), and the rule name doesn't carry documentary intent beyond "this char class." Inline the class at use sites unless the name appears at many sites — a high-ref alias *is* the documentation.
-2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. `sqlite.peg` has `*ident_cont <- [a-zA-Z\d_]` and `*ident_char <- [a-zA-Z\d_]`. Merge to one name unless the dual naming documents a future divergence.
+2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. a grammar carrying both `*ident_cont <- [a-zA-Z\d_]` and a separate `*ident_char <- [a-zA-Z\d_]` boundary class. Merge to one name unless the dual naming documents a future divergence.
 3. **Refs=1 single-use rules (judgment).** Many rules are referenced once. Most are NOT inline candidates — they exist to name a multi-line cascade entry, an alternation, or a spec-significant phrase. Only inline when the body is a single `name+` / `name*` / `name` / `[...]` / literal — i.e. a textbook thin wrapper.
 4. **Name ≥ body (judgment).** When the rule name is at least as long as the body string, the indirection isn't paying its way. Same evaluation as refs=1: only inline trivial wrappers.
 
@@ -56,13 +56,13 @@ for f in /tmp/grammar-refactor/*.ndjson; do
   g=$(basename "$f" .ndjson)
   echo "=== $g ==="
   echo "-- single-use, excluding reserved --"
-  tail -n +2 "$f" | jq -r 'select(.references==1 and .rule!="trivia" and .rule!="root") | "\(.rule) (\(.body_chars) chars)"'
+  tail -n +2 "$f" | jq -r 'select(.references==1 and .rule!="trivia" and .rule!="root" and .rule!="wb") | "\(.rule) (\(.body_chars) chars)"'
   echo "-- name length >= body chars, excluding reserved --"
-  tail -n +2 "$f" | jq -r 'select((.rule|length) >= .body_chars and .rule!="trivia" and .rule!="root") | "\(.rule) (name=\(.rule|length), body=\(.body_chars), refs=\(.references))"'
+  tail -n +2 "$f" | jq -r 'select((.rule|length) >= .body_chars and .rule!="trivia" and .rule!="root" and .rule!="wb") | "\(.rule) (name=\(.rule|length), body=\(.body_chars), refs=\(.references))"'
 done
 ```
 
-`trivia` and `root` are reserved (`src/pegc/parser.rs` enforces) — never candidates.
+`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. A `%`-marked rule (`%name <-`) is also off-limits to inlining: see the *Atomicity check* below.
 
 ### 3. For each candidate, evaluate
 
@@ -86,6 +86,8 @@ Safe shapes regardless of atomicity:
 
 When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `*` sigil on both rule headers before changing anything.
 
+**`%` reserved-word rules are never inline candidates.** A `%name <-` rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. Leave `%` rules (and the `wb` rule itself) alone.
+
 ### 5. Report
 
 Produce a table grouped by category:
@@ -107,7 +109,7 @@ The applied edit is mechanical at this point — the judgment was the previous s
 - **Bulk-inlining all refs=1 rules.** Most refs=1 rules are spec-significant cascade entries (every binary-precedence level, every statement form, every type-position-specific entry). Inlining them produces an unreadable wall of alternation.
 - **Inlining across atomicity boundaries without checking.** Will silently change parsing behavior — usually in a way that's not caught by the unit tests but shows up in the highlighter fixtures or recovery baselines.
 - **Forgetting to update the grammar header comment** when removing a rule that's named there.
-- **Touching `root` or `trivia`.** Reserved; the parser will reject any grammar that mangles them. Filter these out before evaluating.
+- **Touching `root`, `trivia`, `wb`, or any `%` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `%` rules carry an invisible trailing `wb` boundary that inlining would drop. Filter all of these out before evaluating.
 - **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention — `*_body` is used both by `kw_*` (in `@keyword{...}` capture) and by `keyword_word` (for the no-keyword-as-identifier lookahead). Don't sweep these.
 
 ## Reference PRs

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -60,18 +60,47 @@ decl_spec     <- storage_spec
                / type_spec
                / fn_spec
 
-storage_spec  <- @keyword{'typedef'}
-               / @keyword{'extern'}
-               / @keyword{'static'}
-               / @keyword{'auto'}
-               / @keyword{'register'}
-               / @keyword{'_Thread_local'}
-type_qualifier <- @keyword{'const'}
-                / @keyword{'volatile'}
-                / @keyword{'restrict'}
-                / @keyword{'_Atomic'}
-fn_spec       <- @keyword{'inline'}
-               / @keyword{'_Noreturn'}
+# Keyword rules are atomic and place the `!ident_body` word boundary
+# *inside* the capture. Atomicity stops auto-trivia from splicing
+# between the literal and the boundary (otherwise `static MyType` would
+# match `static`, consume the space, then fail the boundary on
+# `MyType`). Inside-capture placement means the `@keyword` capture only
+# commits when the boundary holds, so a rejected keyword (`typedefx`)
+# leaves no stray capture for top-level recovery to surface.
+*storage_spec  <- @keyword{'typedef' !ident_body}
+                / @keyword{'extern' !ident_body}
+                / @keyword{'static' !ident_body}
+                / @keyword{'auto' !ident_body}
+                / @keyword{'register' !ident_body}
+                / @keyword{'_Thread_local' !ident_body}
+*type_qualifier <- @keyword{'const' !ident_body}
+                 / @keyword{'volatile' !ident_body}
+                 / @keyword{'restrict' !ident_body}
+                 / @keyword{'_Atomic' !ident_body}
+*fn_spec       <- @keyword{'inline' !ident_body}
+                / @keyword{'_Noreturn' !ident_body}
+
+# Embedded keyword tokens. Each is an atomic rule with the keyword and
+# its `!ident_body` boundary inside the capture, so a keyword can't fire
+# on a longer identifier that merely starts with it (`structx`,
+# `returny`) and a rejected keyword leaves no stray capture behind.
+*kw_struct    <- @keyword{'struct' !ident_body}
+*kw_union     <- @keyword{'union' !ident_body}
+*kw_enum      <- @keyword{'enum' !ident_body}
+*kw_case      <- @keyword{'case' !ident_body}
+*kw_default   <- @keyword{'default' !ident_body}
+*kw_if        <- @keyword{'if' !ident_body}
+*kw_else      <- @keyword{'else' !ident_body}
+*kw_for       <- @keyword{'for' !ident_body}
+*kw_while     <- @keyword{'while' !ident_body}
+*kw_do        <- @keyword{'do' !ident_body}
+*kw_switch    <- @keyword{'switch' !ident_body}
+*kw_return    <- @keyword{'return' !ident_body}
+*kw_break     <- @keyword{'break' !ident_body}
+*kw_continue  <- @keyword{'continue' !ident_body}
+*kw_goto      <- @keyword{'goto' !ident_body}
+*kw_sizeof    <- @keyword{'sizeof' !ident_body}
+*kw_alignof   <- @keyword{'_Alignof' !ident_body}
 
 type_spec     <- struct_or_union_spec
                / enum_spec
@@ -92,7 +121,7 @@ predef_type   <- @type{predef_type_name}
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
 *typedef_t_end <- '_t' !ident_body
 
-struct_or_union_spec <- (@keyword{'struct'} / @keyword{'union'})
+struct_or_union_spec <- (kw_struct / kw_union)
                        (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
 struct_decl   <- decl_spec_list struct_declarator_list? @punctuation{';'}
                / pp_line
@@ -105,7 +134,7 @@ struct_field_direct <- @property{ident} struct_field_tail*
 struct_field_tail <- @punctuation{'['} (expr / '')? @punctuation{']'}
                    / @punctuation{'('} param_list? @punctuation{')'}
 
-enum_spec     <- @keyword{'enum'} (@type{ident})?
+enum_spec     <- kw_enum (@type{ident})?
                  (@punctuation{'{'} enum_list? @punctuation{'}'})?
 enum_list     <- enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
 enum_item     <- @constant{ident} (@operator{'='} expr_cond)?
@@ -164,21 +193,21 @@ stmt          <- labeled_stmt
                / expr_stmt
 
 labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
-               / @keyword{'case'} expr_cond @punctuation{':'} stmt
-               / @keyword{'default'} @punctuation{':'} stmt
+               / kw_case expr_cond @punctuation{':'} stmt
+               / kw_default @punctuation{':'} stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt      <- @keyword{'if'} @punctuation{'('} expr @punctuation{')'} stmt
-                 (@keyword{'else'} stmt)?
-for_stmt      <- @keyword{'for'} @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
+~if_stmt      <- kw_if @punctuation{'('} expr @punctuation{')'} stmt
+                 (kw_else stmt)?
+for_stmt      <- kw_for @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
 for_init      <- decl
                / expr? @punctuation{';'}
-while_stmt    <- @keyword{'while'} @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt <- @keyword{'do'} stmt @keyword{'while'} @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
-switch_stmt   <- @keyword{'switch'} @punctuation{'('} expr @punctuation{')'} stmt
-return_stmt   <- @keyword{'return'} expr? @punctuation{';'}
-break_stmt    <- @keyword{'break'} @punctuation{';'}
-continue_stmt <- @keyword{'continue'} @punctuation{';'}
-goto_stmt     <- @keyword{'goto'} @variable{ident} @punctuation{';'}
+while_stmt    <- kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt <- kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
+switch_stmt   <- kw_switch @punctuation{'('} expr @punctuation{')'} stmt
+return_stmt   <- kw_return expr? @punctuation{';'}
+break_stmt    <- kw_break @punctuation{';'}
+continue_stmt <- kw_continue @punctuation{';'}
+goto_stmt     <- kw_goto @variable{ident} @punctuation{';'}
 empty_stmt    <- @punctuation{';'}
 expr_stmt     <- expr @punctuation{';'}
 
@@ -228,8 +257,8 @@ expr_unary    <- sizeof_type
 unary_prefix  <- @operator{'++'} / @operator{'--'}
                / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
                / @operator{'*'} / @operator{'&'}
-               / @keyword{'sizeof'} &(@punctuation{'('} / [A-Za-z_])
-               / @keyword{'_Alignof'}
+               / kw_sizeof &(@punctuation{'('} / [A-Za-z_])
+               / kw_alignof
 
 expr_postfix  <- expr_primary postfix_op*
 postfix_op    <- @operator{'++'} / @operator{'--'}
@@ -254,7 +283,7 @@ expr_primary  <- string_lit
                / @variable{ident}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
-sizeof_type   <- @keyword{'sizeof'} @punctuation{'('} type_name @punctuation{')'}
+sizeof_type   <- kw_sizeof @punctuation{'('} type_name @punctuation{')'}
 type_name     <- decl_spec_list abstract_declarator?
 
 # `(T)expr` vs `(expr)` — try cast first (uses decl_spec which

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -33,6 +33,10 @@ root          <- (external_decl)*^
 
 trivia        <- (comment / \s)*
 
+# Word boundary for `%` reserved-word rules: a keyword can't be the
+# prefix of a longer identifier. Per C11 §6.4.2.1 identifier-continue.
+wb            <- !ident_body
+
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
 pp_line       <- @keyword{pp_body}
@@ -60,47 +64,42 @@ decl_spec     <- storage_spec
                / type_spec
                / fn_spec
 
-# Keyword rules are atomic and place the `!ident_body` word boundary
-# *inside* the capture. Atomicity stops auto-trivia from splicing
-# between the literal and the boundary (otherwise `static MyType` would
-# match `static`, consume the space, then fail the boundary on
-# `MyType`). Inside-capture placement means the `@keyword` capture only
-# commits when the boundary holds, so a rejected keyword (`typedefx`)
-# leaves no stray capture for top-level recovery to surface.
-*storage_spec  <- @keyword{'typedef' !ident_body}
-                / @keyword{'extern' !ident_body}
-                / @keyword{'static' !ident_body}
-                / @keyword{'auto' !ident_body}
-                / @keyword{'register' !ident_body}
-                / @keyword{'_Thread_local' !ident_body}
-*type_qualifier <- @keyword{'const' !ident_body}
-                 / @keyword{'volatile' !ident_body}
-                 / @keyword{'restrict' !ident_body}
-                 / @keyword{'_Atomic' !ident_body}
-*fn_spec       <- @keyword{'inline' !ident_body}
-                / @keyword{'_Noreturn' !ident_body}
+# `%` reserved-word rules: compiled atomic, with a `wb` boundary call
+# appended inside each keyword capture. A keyword can't fire on a longer
+# identifier that merely starts with it (`static MyType`, `typedefx`),
+# and a rejected keyword leaves no stray capture for recovery to surface.
+%storage_spec  <- @keyword{'typedef'}
+                / @keyword{'extern'}
+                / @keyword{'static'}
+                / @keyword{'auto'}
+                / @keyword{'register'}
+                / @keyword{'_Thread_local'}
+%type_qualifier <- @keyword{'const'}
+                 / @keyword{'volatile'}
+                 / @keyword{'restrict'}
+                 / @keyword{'_Atomic'}
+%fn_spec       <- @keyword{'inline'}
+                / @keyword{'_Noreturn'}
 
-# Embedded keyword tokens. Each is an atomic rule with the keyword and
-# its `!ident_body` boundary inside the capture, so a keyword can't fire
-# on a longer identifier that merely starts with it (`structx`,
-# `returny`) and a rejected keyword leaves no stray capture behind.
-*kw_struct    <- @keyword{'struct' !ident_body}
-*kw_union     <- @keyword{'union' !ident_body}
-*kw_enum      <- @keyword{'enum' !ident_body}
-*kw_case      <- @keyword{'case' !ident_body}
-*kw_default   <- @keyword{'default' !ident_body}
-*kw_if        <- @keyword{'if' !ident_body}
-*kw_else      <- @keyword{'else' !ident_body}
-*kw_for       <- @keyword{'for' !ident_body}
-*kw_while     <- @keyword{'while' !ident_body}
-*kw_do        <- @keyword{'do' !ident_body}
-*kw_switch    <- @keyword{'switch' !ident_body}
-*kw_return    <- @keyword{'return' !ident_body}
-*kw_break     <- @keyword{'break' !ident_body}
-*kw_continue  <- @keyword{'continue' !ident_body}
-*kw_goto      <- @keyword{'goto' !ident_body}
-*kw_sizeof    <- @keyword{'sizeof' !ident_body}
-*kw_alignof   <- @keyword{'_Alignof' !ident_body}
+# Embedded keyword tokens: one `%` rule per keyword, referenced wherever
+# the keyword appears so the `wb` boundary is applied uniformly.
+%kw_struct    <- @keyword{'struct'}
+%kw_union     <- @keyword{'union'}
+%kw_enum      <- @keyword{'enum'}
+%kw_case      <- @keyword{'case'}
+%kw_default   <- @keyword{'default'}
+%kw_if        <- @keyword{'if'}
+%kw_else      <- @keyword{'else'}
+%kw_for       <- @keyword{'for'}
+%kw_while     <- @keyword{'while'}
+%kw_do        <- @keyword{'do'}
+%kw_switch    <- @keyword{'switch'}
+%kw_return    <- @keyword{'return'}
+%kw_break     <- @keyword{'break'}
+%kw_continue  <- @keyword{'continue'}
+%kw_goto      <- @keyword{'goto'}
+%kw_sizeof    <- @keyword{'sizeof'}
+%kw_alignof   <- @keyword{'_Alignof'}
 
 type_spec     <- struct_or_union_spec
                / enum_spec
@@ -108,9 +107,9 @@ type_spec     <- struct_or_union_spec
                / @type{typedef_name}
 
 predef_type   <- @type{predef_type_name}
-*predef_type_name <- ('void' / 'char' / 'short' / 'long long' / 'long'
+%predef_type_name <- 'void' / 'char' / 'short' / 'long long' / 'long'
                    / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
-                   / '_Bool' / '_Complex' / '_Imaginary') !ident_body
+                   / '_Bool' / '_Complex' / '_Imaginary'
 
 # Heuristic typedef-name: PascalCase or `*_t` tail. If this mismatches
 # an actual declaration, the decl path will fail and we fall back to
@@ -119,7 +118,7 @@ predef_type   <- @type{predef_type_name}
 # greedy `ident_body*` would swallow the trailing `_t`.
 *typedef_name <- [A-Z] ident_body*
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-*typedef_t_end <- '_t' !ident_body
+%typedef_t_end <- '_t'
 
 struct_or_union_spec <- (kw_struct / kw_union)
                        (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
@@ -277,10 +276,14 @@ expr_primary  <- string_lit
                / cast_or_paren
                / call_ident
                / @type{predef_type_name}
-               / @constant{'true' !ident_body}
-               / @constant{'false' !ident_body}
-               / @constant{'NULL' !ident_body}
+               / lit_const
                / @variable{ident}
+
+# Boolean / null constants as a `%` reserved-word alternation so the
+# `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
+%lit_const    <- @constant{'true'}
+               / @constant{'false'}
+               / @constant{'NULL'}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
 sizeof_type   <- kw_sizeof @punctuation{'('} type_name @punctuation{')'}
@@ -329,7 +332,7 @@ ident_body    <- [\p{L}\p{Nd}_] / ucn
 ucn           <- '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
 
 # Reserved keywords that must not be matched as identifiers.
-*reserved     <- reserved_word !ident_body
+%reserved     <- reserved_word
 reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
                / 'default' / 'do' / 'double' / 'else' / 'enum' / 'extern'
                / 'float' / 'for' / 'goto' / 'if' / 'inline' / 'int'

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -28,38 +28,40 @@ root          <- package_clause import_decl* (top_decl)*^
 
 trivia        <- (comment / \s)*
 
+# Word boundary for `%` reserved-word rules: a keyword can't be the
+# prefix of a longer identifier (Go spec identifier-continue).
+wb            <- !ident_body
+
 # --- Keyword tokens --------------------------------------------------
 #
-# Each keyword is an atomic rule with the literal and its `!ident_body`
-# word boundary inside the capture, so a keyword can't fire on a longer
-# identifier that merely starts with it (`funcx`, `ranger`) and a
-# rejected keyword leaves no stray capture for recovery to surface.
-# Atomicity keeps the boundary adjacent to the literal (no auto-trivia).
-*kw_package   <- @keyword{'package' !ident_body}
-*kw_import    <- @keyword{'import' !ident_body}
-*kw_var       <- @keyword{'var' !ident_body}
-*kw_const     <- @keyword{'const' !ident_body}
-*kw_type      <- @keyword{'type' !ident_body}
-*kw_map       <- @keyword{'map' !ident_body}
-*kw_chan      <- @keyword{'chan' !ident_body}
-*kw_func      <- @keyword{'func' !ident_body}
-*kw_struct    <- @keyword{'struct' !ident_body}
-*kw_interface <- @keyword{'interface' !ident_body}
-*kw_if        <- @keyword{'if' !ident_body}
-*kw_else      <- @keyword{'else' !ident_body}
-*kw_for       <- @keyword{'for' !ident_body}
-*kw_range     <- @keyword{'range' !ident_body}
-*kw_switch    <- @keyword{'switch' !ident_body}
-*kw_case      <- @keyword{'case' !ident_body}
-*kw_default   <- @keyword{'default' !ident_body}
-*kw_select    <- @keyword{'select' !ident_body}
-*kw_go        <- @keyword{'go' !ident_body}
-*kw_defer     <- @keyword{'defer' !ident_body}
-*kw_return    <- @keyword{'return' !ident_body}
-*kw_break     <- @keyword{'break' !ident_body}
-*kw_continue  <- @keyword{'continue' !ident_body}
-*kw_goto      <- @keyword{'goto' !ident_body}
-*kw_fallthrough <- @keyword{'fallthrough' !ident_body}
+# One `%` reserved-word rule per keyword, referenced wherever the
+# keyword appears so the `wb` boundary is applied uniformly: a keyword
+# can't fire on a longer identifier that starts with it (`funcx`).
+%kw_package   <- @keyword{'package'}
+%kw_import    <- @keyword{'import'}
+%kw_var       <- @keyword{'var'}
+%kw_const     <- @keyword{'const'}
+%kw_type      <- @keyword{'type'}
+%kw_map       <- @keyword{'map'}
+%kw_chan      <- @keyword{'chan'}
+%kw_func      <- @keyword{'func'}
+%kw_struct    <- @keyword{'struct'}
+%kw_interface <- @keyword{'interface'}
+%kw_if        <- @keyword{'if'}
+%kw_else      <- @keyword{'else'}
+%kw_for       <- @keyword{'for'}
+%kw_range     <- @keyword{'range'}
+%kw_switch    <- @keyword{'switch'}
+%kw_case      <- @keyword{'case'}
+%kw_default   <- @keyword{'default'}
+%kw_select    <- @keyword{'select'}
+%kw_go        <- @keyword{'go'}
+%kw_defer     <- @keyword{'defer'}
+%kw_return    <- @keyword{'return'}
+%kw_break     <- @keyword{'break'}
+%kw_continue  <- @keyword{'continue'}
+%kw_goto      <- @keyword{'goto'}
+%kw_fallthrough <- @keyword{'fallthrough'}
 
 # --- Package / imports ----------------------------------------------
 
@@ -359,10 +361,12 @@ expr_no_compound_list <- expr_no_compound (@punctuation{','} expr_no_compound)*
 
 # --- Literals -------------------------------------------------------
 
-literal       <- string_lit / number_lit / rune_lit
-               / @constant{'true' !ident_body / 'false' !ident_body}
-               / @constant{'nil' !ident_body}
-               / @constant{'iota' !ident_body}
+literal       <- string_lit / number_lit / rune_lit / lit_const
+
+# Predeclared constants as a `%` reserved-word alternation so the `wb`
+# boundary keeps `trueish` / `nilish` from matching the prefix.
+%lit_const    <- @constant{'true'} / @constant{'false'}
+               / @constant{'nil'} / @constant{'iota'}
 
 string_lit    <- @string{raw_string / interp_string}
 *raw_string   <- '`' ..= '`'
@@ -401,7 +405,7 @@ number_lit    <- @number{num_body}
 ident_body    <- [\p{L}\p{Nd}_]
 
 # Reserved keywords blocking identifier capture.
-*reserved     <- reserved_word !ident_body
+%reserved     <- reserved_word
 reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
                / 'defer' / 'default' / 'else' / 'fallthrough' / 'for'
                / 'func' / 'go' / 'goto' / 'if' / 'import' / 'interface'
@@ -411,15 +415,15 @@ reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-*predeclared_const <- ('true' / 'false' / 'nil' / 'iota') !ident_body
-*predeclared_type <- ('uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+%predeclared_const <- 'true' / 'false' / 'nil' / 'iota'
+%predeclared_type <- 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
                    / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
                    / 'float32' / 'float64' / 'complex64' / 'complex128'
                    / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
-                   / 'error' / 'any' / 'comparable') !ident_body
-*predeclared_fn <- ('append' / 'cap' / 'close' / 'complex' / 'copy'
+                   / 'error' / 'any' / 'comparable'
+%predeclared_fn <- 'append' / 'cap' / 'close' / 'complex' / 'copy'
                  / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
-                 / 'print' / 'println' / 'real' / 'recover') !ident_body
+                 / 'print' / 'println' / 'real' / 'recover'
 
 # --- Whitespace / comments / semicolon handling ----------------------
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -28,12 +28,45 @@ root          <- package_clause import_decl* (top_decl)*^
 
 trivia        <- (comment / \s)*
 
+# --- Keyword tokens --------------------------------------------------
+#
+# Each keyword is an atomic rule with the literal and its `!ident_body`
+# word boundary inside the capture, so a keyword can't fire on a longer
+# identifier that merely starts with it (`funcx`, `ranger`) and a
+# rejected keyword leaves no stray capture for recovery to surface.
+# Atomicity keeps the boundary adjacent to the literal (no auto-trivia).
+*kw_package   <- @keyword{'package' !ident_body}
+*kw_import    <- @keyword{'import' !ident_body}
+*kw_var       <- @keyword{'var' !ident_body}
+*kw_const     <- @keyword{'const' !ident_body}
+*kw_type      <- @keyword{'type' !ident_body}
+*kw_map       <- @keyword{'map' !ident_body}
+*kw_chan      <- @keyword{'chan' !ident_body}
+*kw_func      <- @keyword{'func' !ident_body}
+*kw_struct    <- @keyword{'struct' !ident_body}
+*kw_interface <- @keyword{'interface' !ident_body}
+*kw_if        <- @keyword{'if' !ident_body}
+*kw_else      <- @keyword{'else' !ident_body}
+*kw_for       <- @keyword{'for' !ident_body}
+*kw_range     <- @keyword{'range' !ident_body}
+*kw_switch    <- @keyword{'switch' !ident_body}
+*kw_case      <- @keyword{'case' !ident_body}
+*kw_default   <- @keyword{'default' !ident_body}
+*kw_select    <- @keyword{'select' !ident_body}
+*kw_go        <- @keyword{'go' !ident_body}
+*kw_defer     <- @keyword{'defer' !ident_body}
+*kw_return    <- @keyword{'return' !ident_body}
+*kw_break     <- @keyword{'break' !ident_body}
+*kw_continue  <- @keyword{'continue' !ident_body}
+*kw_goto      <- @keyword{'goto' !ident_body}
+*kw_fallthrough <- @keyword{'fallthrough' !ident_body}
+
 # --- Package / imports ----------------------------------------------
 
-package_clause <- @keyword{'package'} @variable{ident} opt_semi
+package_clause <- kw_package @variable{ident} opt_semi
 
-import_decl   <- @keyword{'import'} import_spec_group opt_semi
-               / @keyword{'import'} import_spec opt_semi
+import_decl   <- kw_import import_spec_group opt_semi
+               / kw_import import_spec opt_semi
 import_spec_group <- @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
 import_spec   <- import_alias? string_lit
 import_alias  <- @punctuation{'.'}
@@ -47,12 +80,12 @@ top_decl      <- decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl         <- @keyword{'var'} var_spec_group
-               / @keyword{'var'} var_spec opt_semi
-               / @keyword{'const'} const_spec_group
-               / @keyword{'const'} const_spec opt_semi
-               / @keyword{'type'} type_spec_group
-               / @keyword{'type'} type_spec opt_semi
+~decl         <- kw_var var_spec_group
+               / kw_var var_spec opt_semi
+               / kw_const const_spec_group
+               / kw_const const_spec opt_semi
+               / kw_type type_spec_group
+               / kw_type type_spec opt_semi
 
 var_spec_group <- @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
 var_spec      <- ident_list type_expr @operator{'='} expr_list
@@ -67,8 +100,8 @@ type_spec_group <- @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
 type_spec     <- @type{ident} type_params? @operator{'='}? type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl    <- @keyword{'func'} @function{ident} type_params? fn_signature block?
-~method_decl  <- @keyword{'func'} method_receiver @function{ident} fn_signature block?
+~func_decl    <- kw_func @function{ident} type_params? fn_signature block?
+~method_decl  <- kw_func method_receiver @function{ident} fn_signature block?
 method_receiver <- @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
@@ -103,16 +136,16 @@ type_expr     <- type_ptr
 
 type_ptr      <- @operator{'*'} type_expr
 type_slice_or_array <- @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
-type_map      <- @keyword{'map'} @punctuation{'['} type_expr @punctuation{']'} type_expr
-type_chan     <- @operator{'<-'} @keyword{'chan'} type_expr
-               / @keyword{'chan'} @operator{'<-'} type_expr
-               / @keyword{'chan'} type_expr
-type_func     <- @keyword{'func'} fn_signature
-type_struct   <- @keyword{'struct'} @punctuation{'{'} struct_field_list? @punctuation{'}'}
+type_map      <- kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr
+type_chan     <- @operator{'<-'} kw_chan type_expr
+               / kw_chan @operator{'<-'} type_expr
+               / kw_chan type_expr
+type_func     <- kw_func fn_signature
+type_struct   <- kw_struct @punctuation{'{'} struct_field_list? @punctuation{'}'}
 struct_field_list <- struct_field (opt_semi struct_field)* opt_semi?
 struct_field  <- @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
                / @operator{'*'}? type_name string_lit?       # embedded field
-type_interface <- @keyword{'interface'} @punctuation{'{'} interface_members? @punctuation{'}'}
+type_interface <- kw_interface @punctuation{'{'} interface_members? @punctuation{'}'}
 interface_members <- interface_member (opt_semi interface_member)* opt_semi?
 interface_member <- @function{ident} fn_signature
                   / type_term
@@ -169,42 +202,42 @@ assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator
 labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt      <- @keyword{'if'} (simple_stmt @punctuation{';'})? expr_no_compound block
-                 (@keyword{'else'} (if_stmt / block))?
-for_stmt      <- @keyword{'for'} for_header? block
+~if_stmt      <- kw_if (simple_stmt @punctuation{';'})? expr_no_compound block
+                 (kw_else (if_stmt / block))?
+for_stmt      <- kw_for for_header? block
 for_header    <- for_range
                / for_c_style
                / expr_no_compound
-for_range     <- (ident_list (@operator{'='} / @operator{':='}))? @keyword{'range'} expr_no_compound
+for_range     <- (ident_list (@operator{'='} / @operator{':='}))? kw_range expr_no_compound
 for_c_style   <- simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
 
-switch_stmt   <- @keyword{'switch'} type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
-               / @keyword{'switch'} expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
+switch_stmt   <- kw_switch type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
+               / kw_switch expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
 expr_switch_header <- (simple_stmt @punctuation{';'})? expr_no_compound?
                / ''
 type_switch_header <- (simple_stmt @punctuation{';'})? type_switch_guard
-type_switch_guard  <- (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} @keyword{'type'} @punctuation{')'}
-expr_case     <- @keyword{'case'} expr_list @punctuation{':'} stmt*
-               / @keyword{'default'} @punctuation{':'} stmt*
-type_case     <- @keyword{'case'} type_list @punctuation{':'} stmt*
-               / @keyword{'default'} @punctuation{':'} stmt*
+type_switch_guard  <- (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} kw_type @punctuation{')'}
+expr_case     <- kw_case expr_list @punctuation{':'} stmt*
+               / kw_default @punctuation{':'} stmt*
+type_case     <- kw_case type_list @punctuation{':'} stmt*
+               / kw_default @punctuation{':'} stmt*
 type_list     <- type_expr (@punctuation{','} type_expr)*
 
-select_stmt   <- @keyword{'select'} @punctuation{'{'} comm_case* @punctuation{'}'}
-comm_case     <- @keyword{'case'} comm_clause @punctuation{':'} stmt*
-               / @keyword{'default'} @punctuation{':'} stmt*
+select_stmt   <- kw_select @punctuation{'{'} comm_case* @punctuation{'}'}
+comm_case     <- kw_case comm_clause @punctuation{':'} stmt*
+               / kw_default @punctuation{':'} stmt*
 comm_clause   <- send_stmt
                / recv_stmt
 recv_stmt     <- (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
 
-go_stmt       <- @keyword{'go'} expr
-defer_stmt    <- @keyword{'defer'} expr
+go_stmt       <- kw_go expr
+defer_stmt    <- kw_defer expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt  <- @keyword{'return'} expr_list?
-~break_stmt   <- @keyword{'break'} (@variable{ident})?
-~continue_stmt <- @keyword{'continue'} (@variable{ident})?
-goto_stmt     <- @keyword{'goto'} @variable{ident}
-fallthrough_stmt <- @keyword{'fallthrough'}
+~return_stmt  <- kw_return expr_list?
+~break_stmt   <- kw_break (@variable{ident})?
+~continue_stmt <- kw_continue (@variable{ident})?
+goto_stmt     <- kw_goto @variable{ident}
+fallthrough_stmt <- kw_fallthrough
 
 # --- Expressions -----------------------------------------------------
 #
@@ -305,9 +338,9 @@ paren_expr    <- @punctuation{'('} expr @punctuation{')'}
 
 # Composite literal: `T{...}` where T is a named/qualified type.
 composite_lit <- @type{qualified_ident} composite_body
-               / @keyword{'map'} @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
+               / kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
                / @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr composite_body
-               / @keyword{'struct'} type_struct_body composite_body
+               / kw_struct type_struct_body composite_body
 type_struct_body <- @punctuation{'{'} struct_field_list? @punctuation{'}'}
 
 # Type conversion: `T(x)` where T is a named type — only triggers if
@@ -315,7 +348,7 @@ type_struct_body <- @punctuation{'{'} struct_field_list? @punctuation{'}'}
 type_conv     <- @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
 
 # Function literal.
-fn_lit        <- @keyword{'func'} fn_signature block
+fn_lit        <- kw_func fn_signature block
 
 call_ident    <- @function{ident} &(@punctuation{'('})
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -33,6 +33,59 @@ root           <- (stmt)*^
 
 trivia         <- (comment / \s)*
 
+# --- Keyword tokens ---------------------------------------------------
+#
+# Each keyword is an atomic rule with the literal and its `!ident_body`
+# word boundary inside the capture, so a keyword can't fire on a longer
+# identifier that merely starts with it. This matters most for the
+# contextual keywords (`async`, `as`, `of`, `from`, `get`, `set`,
+# `static`, `yield`) deliberately kept out of `reserved` so they remain
+# usable as identifiers: `{ asyncFoo() {} }` must stay one method name.
+# Atomicity keeps the boundary adjacent to the literal (no auto-trivia);
+# inside-capture placement means a rejected keyword leaves no stray
+# capture for recovery to surface.
+*kw_import     <- @keyword{'import' !ident_body}
+*kw_from       <- @keyword{'from' !ident_body}
+*kw_as         <- @keyword{'as' !ident_body}
+*kw_export     <- @keyword{'export' !ident_body}
+*kw_default    <- @keyword{'default' !ident_body}
+*kw_async      <- @keyword{'async' !ident_body}
+*kw_function   <- @keyword{'function' !ident_body}
+*kw_class      <- @keyword{'class' !ident_body}
+*kw_extends    <- @keyword{'extends' !ident_body}
+*kw_static     <- @keyword{'static' !ident_body}
+*kw_get        <- @keyword{'get' !ident_body}
+*kw_set        <- @keyword{'set' !ident_body}
+*kw_var        <- @keyword{'var' !ident_body}
+*kw_let        <- @keyword{'let' !ident_body}
+*kw_const      <- @keyword{'const' !ident_body}
+*kw_if         <- @keyword{'if' !ident_body}
+*kw_else       <- @keyword{'else' !ident_body}
+*kw_for        <- @keyword{'for' !ident_body}
+*kw_await      <- @keyword{'await' !ident_body}
+*kw_in         <- @keyword{'in' !ident_body}
+*kw_of         <- @keyword{'of' !ident_body}
+*kw_while      <- @keyword{'while' !ident_body}
+*kw_do         <- @keyword{'do' !ident_body}
+*kw_switch     <- @keyword{'switch' !ident_body}
+*kw_case       <- @keyword{'case' !ident_body}
+*kw_try        <- @keyword{'try' !ident_body}
+*kw_catch      <- @keyword{'catch' !ident_body}
+*kw_finally    <- @keyword{'finally' !ident_body}
+*kw_throw      <- @keyword{'throw' !ident_body}
+*kw_return     <- @keyword{'return' !ident_body}
+*kw_break      <- @keyword{'break' !ident_body}
+*kw_continue   <- @keyword{'continue' !ident_body}
+*kw_debugger   <- @keyword{'debugger' !ident_body}
+*kw_yield      <- @keyword{'yield' !ident_body}
+*kw_instanceof <- @keyword{'instanceof' !ident_body}
+*kw_typeof     <- @keyword{'typeof' !ident_body}
+*kw_void       <- @keyword{'void' !ident_body}
+*kw_delete     <- @keyword{'delete' !ident_body}
+*kw_new        <- @keyword{'new' !ident_body}
+*kw_this       <- @keyword{'this' !ident_body}
+*kw_super      <- @keyword{'super' !ident_body}
+
 # --- Statements -------------------------------------------------------
 #
 # Order matters (PEG first-match). Declaration-shaped items precede
@@ -69,49 +122,49 @@ empty_stmt     <- @punctuation{';'}
 
 # --- Imports / exports ------------------------------------------------
 
-import_decl    <- @keyword{'import'} import_body opt_semi
-import_body    <- import_clause @keyword{'from'} string_lit
+import_decl    <- kw_import import_body opt_semi
+import_body    <- import_clause kw_from string_lit
                 / string_lit
 import_clause  <- import_default @punctuation{','} import_ns_or_named
                 / import_default
                 / import_ns_or_named
 import_default <- @variable{ident}
 import_ns_or_named <- import_namespace / import_named
-import_namespace <- @operator{'*'} @keyword{'as'} @variable{ident}
+import_namespace <- @operator{'*'} kw_as @variable{ident}
 import_named   <- @punctuation{'{'} import_specifier_list? @punctuation{'}'}
 import_specifier_list <- import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
-import_specifier <- @variable{ident_name} @keyword{'as'} @variable{ident}
+import_specifier <- @variable{ident_name} kw_as @variable{ident}
                   / @variable{ident}
 
-export_decl    <- @keyword{'export'} @keyword{'default'} export_default_body
-                / @keyword{'export'} @operator{'*'} (@keyword{'as'} @variable{ident_name})? @keyword{'from'} string_lit opt_semi
-                / @keyword{'export'} export_named
-                / @keyword{'export'} fn_decl
-                / @keyword{'export'} class_decl
-                / @keyword{'export'} var_decl opt_semi
+export_decl    <- kw_export kw_default export_default_body
+                / kw_export @operator{'*'} (kw_as @variable{ident_name})? kw_from string_lit opt_semi
+                / kw_export export_named
+                / kw_export fn_decl
+                / kw_export class_decl
+                / kw_export var_decl opt_semi
 export_default_body <- fn_decl
                      / class_decl
                      / expr opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named  <- @punctuation{'{'} export_specifier_list? @punctuation{'}'} (@keyword{'from'} string_lit)? opt_semi
+~export_named  <- @punctuation{'{'} export_specifier_list? @punctuation{'}'} (kw_from string_lit)? opt_semi
 export_specifier_list <- export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
-export_specifier <- @variable{ident_name} @keyword{'as'} @variable{ident_name}
+export_specifier <- @variable{ident_name} kw_as @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
 
-fn_decl        <- @keyword{'async'} fn_decl_core
+fn_decl        <- kw_async fn_decl_core
                 / fn_decl_core
-fn_decl_core   <- @keyword{'function'} @operator{'*'}? @function{ident} fn_params block
+fn_decl_core   <- kw_function @operator{'*'}? @function{ident} fn_params block
 
-class_decl     <- @keyword{'class'} @type{ident} class_heritage? class_body
-class_heritage <- @keyword{'extends'} expr_lhs
+class_decl     <- kw_class @type{ident} class_heritage? class_body
+class_heritage <- kw_extends expr_lhs
 class_body     <- @punctuation{'{'} class_member* @punctuation{'}'}
 class_member   <- @punctuation{';'}
                 / class_method_or_field
-class_method_or_field <- @keyword{'static'}? (class_method / class_field)
-class_method   <- @keyword{'async'}? @operator{'*'}? method_head fn_params block
-                / (@keyword{'get'} / @keyword{'set'}) method_head fn_params block
+class_method_or_field <- kw_static? (class_method / class_field)
+class_method   <- kw_async? @operator{'*'}? method_head fn_params block
+                / (kw_get / kw_set) method_head fn_params block
 method_head    <- computed_prop
                 / @function{ident_name}
                 / string_lit
@@ -120,7 +173,7 @@ class_field    <- (computed_prop / @property{ident_name}) (@operator{'='} expr_n
 
 # --- Variable declarations -------------------------------------------
 
-var_decl       <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) var_declarator_list
+var_decl       <- (kw_var / kw_let / kw_const) var_declarator_list
 var_declarator_list <- var_declarator (@punctuation{','} var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
 ~var_declarator <- pattern (@operator{'='} expr_no_comma)?
@@ -128,35 +181,35 @@ var_declarator_list <- var_declarator (@punctuation{','} var_declarator)*
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt       <- @keyword{'if'} @punctuation{'('} expr @punctuation{')'} stmt
-                  (@keyword{'else'} stmt)?
-for_stmt       <- @keyword{'for'} @keyword{'await'}? @punctuation{'('} for_head @punctuation{')'} stmt
+~if_stmt       <- kw_if @punctuation{'('} expr @punctuation{')'} stmt
+                  (kw_else stmt)?
+for_stmt       <- kw_for kw_await? @punctuation{'('} for_head @punctuation{')'} stmt
 for_head       <- for_c_style
                 / for_in_of
 for_c_style    <- for_init? @punctuation{';'} expr? @punctuation{';'} expr?
-for_in_of      <- for_binding (@keyword{'in'} / @keyword{'of'}) expr
+for_in_of      <- for_binding (kw_in / kw_of) expr
 for_init       <- var_decl
                 / expr
-for_binding    <- (@keyword{'var'} / @keyword{'let'} / @keyword{'const'}) pattern
+for_binding    <- (kw_var / kw_let / kw_const) pattern
                 / pattern
 
-while_stmt     <- @keyword{'while'} @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt  <- @keyword{'do'} stmt @keyword{'while'} @punctuation{'('} expr @punctuation{')'} opt_semi
-switch_stmt    <- @keyword{'switch'} @punctuation{'('} expr @punctuation{')'}
+while_stmt     <- kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt  <- kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} opt_semi
+switch_stmt    <- kw_switch @punctuation{'('} expr @punctuation{')'}
                   @punctuation{'{'} switch_case* @punctuation{'}'}
-switch_case    <- @keyword{'case'} expr @punctuation{':'} (!switch_case_term stmt)*
-                / @keyword{'default'} @punctuation{':'} (!switch_case_term stmt)*
-switch_case_term <- @keyword{'case'} / @keyword{'default'} / @punctuation{'}'}
+switch_case    <- kw_case expr @punctuation{':'} (!switch_case_term stmt)*
+                / kw_default @punctuation{':'} (!switch_case_term stmt)*
+switch_case_term <- kw_case / kw_default / @punctuation{'}'}
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt      <- @keyword{'try'} block catch_clause? finally_clause?
-catch_clause   <- @keyword{'catch'} (@punctuation{'('} pattern @punctuation{')'})? block
-finally_clause <- @keyword{'finally'} block
-throw_stmt     <- @keyword{'throw'} expr opt_semi
+~try_stmt      <- kw_try block catch_clause? finally_clause?
+catch_clause   <- kw_catch (@punctuation{'('} pattern @punctuation{')'})? block
+finally_clause <- kw_finally block
+throw_stmt     <- kw_throw expr opt_semi
 # Trailing `expr?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt   <- @keyword{'return'} expr? opt_semi
-~break_stmt    <- @keyword{'break'} (@variable{ident})? opt_semi
-~continue_stmt <- @keyword{'continue'} (@variable{ident})? opt_semi
-debugger_stmt  <- @keyword{'debugger'} opt_semi
+~return_stmt   <- kw_return expr? opt_semi
+~break_stmt    <- kw_break (@variable{ident})? opt_semi
+~continue_stmt <- kw_continue (@variable{ident})? opt_semi
+debugger_stmt  <- kw_debugger opt_semi
 labeled_stmt   <- @variable{ident} @punctuation{':'} stmt
 block          <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
@@ -201,7 +254,7 @@ assign_op      <- @operator{'**='}
 # Arrow functions tried first. `async x => ...`, `x => ...`,
 # `(a, b) => ...`, `() => ...`.
 expr_arrow     <- arrow_head @operator{'=>'} arrow_body
-arrow_head     <- @keyword{'async'} arrow_params
+arrow_head     <- kw_async arrow_params
                 / arrow_params
 arrow_params   <- @variable{ident}
                 / arrow_paren_params
@@ -210,7 +263,7 @@ arrow_body     <- block
                 / expr_no_comma
 
 # Trailing `(*)? (expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield    <- @keyword{'yield'} @operator{'*'}? expr_assign?
+~expr_yield    <- kw_yield @operator{'*'}? expr_assign?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
@@ -228,7 +281,7 @@ expr_bor       <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
 expr_bxor      <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
 expr_band      <- expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
 expr_eq        <- expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
-expr_rel       <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / @keyword{'instanceof'} / @keyword{'in'}) expr_shift / expr_shift
+expr_rel       <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / kw_instanceof / kw_in) expr_shift / expr_shift
 expr_shift     <- expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
 expr_add       <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
 expr_mul       <- expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
@@ -237,10 +290,10 @@ expr_mul       <- expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @op
 expr_pow       <- expr_unary @operator{'**'} !'=' expr_pow / expr_unary
 
 expr_unary     <- unary_op* expr_postfix
-unary_op       <- @keyword{'typeof'}
-                / @keyword{'void'}
-                / @keyword{'delete'}
-                / @keyword{'await'}
+unary_op       <- kw_typeof
+                / kw_void
+                / kw_delete
+                / kw_await
                 / @operator{'++'} / @operator{'--'}
                 / @operator{'+'} / @operator{'-'}
                 / @operator{'!'} / @operator{'~'}
@@ -265,7 +318,7 @@ arg            <- @operator{'...'} expr_no_comma
                 / expr_no_comma
 
 expr_lhs       <- expr_new / expr_primary
-expr_new       <- @keyword{'new'} expr_new_target
+expr_new       <- kw_new expr_new_target
 expr_new_target <- @type{upper_ident} new_tail?
                  / @variable{lower_ident} new_tail?
                  / expr_primary new_tail?
@@ -285,10 +338,10 @@ expr_primary   <- literal
 
 call_ident     <- @function{ident} &(@punctuation{'('})
 
-expr_this      <- @keyword{'this'}
-expr_super     <- @keyword{'super'}
-expr_fn        <- @keyword{'async'}? @keyword{'function'} @operator{'*'}? @function{ident}? fn_params block
-expr_class     <- @keyword{'class'} @type{ident}? class_heritage? class_body
+expr_this      <- kw_this
+expr_super     <- kw_super
+expr_fn        <- kw_async? kw_function @operator{'*'}? @function{ident}? fn_params block
+expr_class     <- kw_class @type{ident}? class_heritage? class_body
 expr_array     <- @punctuation{'['} array_elem_list? @punctuation{']'}
 array_elem_list <- array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
 array_elem     <- @operator{'...'} expr_no_comma
@@ -300,8 +353,8 @@ object_prop    <- @operator{'...'} expr_no_comma
                 / object_method
                 / (computed_prop / string_lit / number_lit / @property{ident_name}) @punctuation{':'} expr_no_comma
                 / @property{ident}
-object_method  <- @keyword{'async'}? @operator{'*'}? method_head fn_params block
-                / (@keyword{'get'} / @keyword{'set'}) method_head fn_params block
+object_method  <- kw_async? @operator{'*'}? method_head fn_params block
+                / (kw_get / kw_set) method_head fn_params block
 expr_paren     <- @punctuation{'('} expr @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -33,58 +33,59 @@ root           <- (stmt)*^
 
 trivia         <- (comment / \s)*
 
+# Word boundary for `%` reserved-word rules: a keyword can't be the
+# prefix of a longer identifier (ECMAScript IdentifierPartChar).
+wb             <- !ident_body
+
 # --- Keyword tokens ---------------------------------------------------
 #
-# Each keyword is an atomic rule with the literal and its `!ident_body`
-# word boundary inside the capture, so a keyword can't fire on a longer
-# identifier that merely starts with it. This matters most for the
-# contextual keywords (`async`, `as`, `of`, `from`, `get`, `set`,
-# `static`, `yield`) deliberately kept out of `reserved` so they remain
-# usable as identifiers: `{ asyncFoo() {} }` must stay one method name.
-# Atomicity keeps the boundary adjacent to the literal (no auto-trivia);
-# inside-capture placement means a rejected keyword leaves no stray
-# capture for recovery to surface.
-*kw_import     <- @keyword{'import' !ident_body}
-*kw_from       <- @keyword{'from' !ident_body}
-*kw_as         <- @keyword{'as' !ident_body}
-*kw_export     <- @keyword{'export' !ident_body}
-*kw_default    <- @keyword{'default' !ident_body}
-*kw_async      <- @keyword{'async' !ident_body}
-*kw_function   <- @keyword{'function' !ident_body}
-*kw_class      <- @keyword{'class' !ident_body}
-*kw_extends    <- @keyword{'extends' !ident_body}
-*kw_static     <- @keyword{'static' !ident_body}
-*kw_get        <- @keyword{'get' !ident_body}
-*kw_set        <- @keyword{'set' !ident_body}
-*kw_var        <- @keyword{'var' !ident_body}
-*kw_let        <- @keyword{'let' !ident_body}
-*kw_const      <- @keyword{'const' !ident_body}
-*kw_if         <- @keyword{'if' !ident_body}
-*kw_else       <- @keyword{'else' !ident_body}
-*kw_for        <- @keyword{'for' !ident_body}
-*kw_await      <- @keyword{'await' !ident_body}
-*kw_in         <- @keyword{'in' !ident_body}
-*kw_of         <- @keyword{'of' !ident_body}
-*kw_while      <- @keyword{'while' !ident_body}
-*kw_do         <- @keyword{'do' !ident_body}
-*kw_switch     <- @keyword{'switch' !ident_body}
-*kw_case       <- @keyword{'case' !ident_body}
-*kw_try        <- @keyword{'try' !ident_body}
-*kw_catch      <- @keyword{'catch' !ident_body}
-*kw_finally    <- @keyword{'finally' !ident_body}
-*kw_throw      <- @keyword{'throw' !ident_body}
-*kw_return     <- @keyword{'return' !ident_body}
-*kw_break      <- @keyword{'break' !ident_body}
-*kw_continue   <- @keyword{'continue' !ident_body}
-*kw_debugger   <- @keyword{'debugger' !ident_body}
-*kw_yield      <- @keyword{'yield' !ident_body}
-*kw_instanceof <- @keyword{'instanceof' !ident_body}
-*kw_typeof     <- @keyword{'typeof' !ident_body}
-*kw_void       <- @keyword{'void' !ident_body}
-*kw_delete     <- @keyword{'delete' !ident_body}
-*kw_new        <- @keyword{'new' !ident_body}
-*kw_this       <- @keyword{'this' !ident_body}
-*kw_super      <- @keyword{'super' !ident_body}
+# One `%` reserved-word rule per keyword, referenced wherever the
+# keyword appears so the `wb` boundary is applied uniformly. This
+# matters most for the contextual keywords (`async`, `as`, `of`,
+# `from`, `get`, `set`, `static`, `yield`) deliberately kept out of
+# `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
+# must stay one method name.
+%kw_import     <- @keyword{'import'}
+%kw_from       <- @keyword{'from'}
+%kw_as         <- @keyword{'as'}
+%kw_export     <- @keyword{'export'}
+%kw_default    <- @keyword{'default'}
+%kw_async      <- @keyword{'async'}
+%kw_function   <- @keyword{'function'}
+%kw_class      <- @keyword{'class'}
+%kw_extends    <- @keyword{'extends'}
+%kw_static     <- @keyword{'static'}
+%kw_get        <- @keyword{'get'}
+%kw_set        <- @keyword{'set'}
+%kw_var        <- @keyword{'var'}
+%kw_let        <- @keyword{'let'}
+%kw_const      <- @keyword{'const'}
+%kw_if         <- @keyword{'if'}
+%kw_else       <- @keyword{'else'}
+%kw_for        <- @keyword{'for'}
+%kw_await      <- @keyword{'await'}
+%kw_in         <- @keyword{'in'}
+%kw_of         <- @keyword{'of'}
+%kw_while      <- @keyword{'while'}
+%kw_do         <- @keyword{'do'}
+%kw_switch     <- @keyword{'switch'}
+%kw_case       <- @keyword{'case'}
+%kw_try        <- @keyword{'try'}
+%kw_catch      <- @keyword{'catch'}
+%kw_finally    <- @keyword{'finally'}
+%kw_throw      <- @keyword{'throw'}
+%kw_return     <- @keyword{'return'}
+%kw_break      <- @keyword{'break'}
+%kw_continue   <- @keyword{'continue'}
+%kw_debugger   <- @keyword{'debugger'}
+%kw_yield      <- @keyword{'yield'}
+%kw_instanceof <- @keyword{'instanceof'}
+%kw_typeof     <- @keyword{'typeof'}
+%kw_void       <- @keyword{'void'}
+%kw_delete     <- @keyword{'delete'}
+%kw_new        <- @keyword{'new'}
+%kw_this       <- @keyword{'this'}
+%kw_super      <- @keyword{'super'}
 
 # --- Statements -------------------------------------------------------
 #
@@ -362,9 +363,13 @@ expr_paren     <- @punctuation{'('} expr @punctuation{')'}
 literal        <- template_lit
                 / string_lit
                 / number_lit
-                / @constant{'true' !ident_body / 'false' !ident_body}
-                / @constant{'null' !ident_body}
-                / @constant{'undefined' !ident_body}
+                / lit_const
+
+# Boolean / null / undefined constants as a `%` reserved-word
+# alternation so the `wb` boundary keeps `trueish` / `nullish` from
+# matching the prefix.
+%lit_const     <- @constant{'true'} / @constant{'false'}
+                / @constant{'null'} / @constant{'undefined'}
 
 string_lit     <- @string{sq_string / dq_string}
 *sq_string     <- "'" ('\\' . / !"'" !'\n' .)* "'"
@@ -426,7 +431,7 @@ ident_body     <- [\p{ID_Continue}$\u{200C}\u{200D}]
 # `of`, `from`, `as`, `get`, `set`, `static`, `yield` outside
 # generators) are intentionally omitted so they can still be used as
 # identifiers where the language allows.
-*reserved      <- reserved_word !ident_body
+%reserved      <- reserved_word
 reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
                 / 'debugger' / 'default' / 'delete' / 'do' / 'else'
                 / 'export' / 'extends' / 'false' / 'finally' / 'for'

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -28,6 +28,51 @@ root          <- (item)*^
 
 trivia        <- (comment / \s)*
 
+# --- Keyword tokens ----------------------------------------------------
+#
+# Each keyword is an atomic rule with the literal and its `!ident_body`
+# word boundary inside the capture, so a keyword can't fire on a longer
+# identifier that merely starts with it (`fnfoo`, `asyncx`) and a
+# rejected keyword leaves no stray capture for recovery to surface.
+# Atomicity keeps the boundary adjacent to the literal (no auto-trivia).
+*kw_use       <- @keyword{'use' !ident_body}
+*kw_as        <- @keyword{'as' !ident_body}
+*kw_self      <- @keyword{'self' !ident_body}
+*kw_self_ty   <- @keyword{'Self' !ident_body}
+*kw_super     <- @keyword{'super' !ident_body}
+*kw_crate     <- @keyword{'crate' !ident_body}
+*kw_fn        <- @keyword{'fn' !ident_body}
+*kw_const     <- @keyword{'const' !ident_body}
+*kw_static    <- @keyword{'static' !ident_body}
+*kw_type      <- @keyword{'type' !ident_body}
+*kw_async     <- @keyword{'async' !ident_body}
+*kw_unsafe    <- @keyword{'unsafe' !ident_body}
+*kw_extern    <- @keyword{'extern' !ident_body}
+*kw_mut       <- @keyword{'mut' !ident_body}
+*kw_struct    <- @keyword{'struct' !ident_body}
+*kw_enum      <- @keyword{'enum' !ident_body}
+*kw_impl      <- @keyword{'impl' !ident_body}
+*kw_for       <- @keyword{'for' !ident_body}
+*kw_trait     <- @keyword{'trait' !ident_body}
+*kw_mod       <- @keyword{'mod' !ident_body}
+*kw_pub       <- @keyword{'pub' !ident_body}
+*kw_in        <- @keyword{'in' !ident_body}
+*kw_where     <- @keyword{'where' !ident_body}
+*kw_dyn       <- @keyword{'dyn' !ident_body}
+*kw_box       <- @keyword{'box' !ident_body}
+*kw_ref       <- @keyword{'ref' !ident_body}
+*kw_if        <- @keyword{'if' !ident_body}
+*kw_let       <- @keyword{'let' !ident_body}
+*kw_else      <- @keyword{'else' !ident_body}
+*kw_match     <- @keyword{'match' !ident_body}
+*kw_while     <- @keyword{'while' !ident_body}
+*kw_loop      <- @keyword{'loop' !ident_body}
+*kw_return    <- @keyword{'return' !ident_body}
+*kw_break     <- @keyword{'break' !ident_body}
+*kw_continue  <- @keyword{'continue' !ident_body}
+*kw_move      <- @keyword{'move' !ident_body}
+*kw_await     <- @keyword{'await' !ident_body}
+
 # --- Items -------------------------------------------------------------
 #
 # Order matters (PEG first-match). Attributes / inner-attributes must
@@ -56,39 +101,39 @@ item          <- attr_outer
 *attr_body    <- .. ']'
 
 # `use foo::bar::{baz, qux as q};`
-use_item      <- @keyword{'use'} use_tree @punctuation{';'}
+use_item      <- kw_use use_tree @punctuation{';'}
 use_tree      <- use_path use_tail?
-use_tail      <- @keyword{'as'} ident_any
+use_tail      <- kw_as ident_any
                / @punctuation{'::'} @punctuation{'*'}
                / @punctuation{'::'} @punctuation{'{'} use_tree_list? @punctuation{'}'}
 use_tree_list <- use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
 use_path      <- use_seg (@punctuation{'::'} use_seg)*
-use_seg       <- @keyword{'self'}
-               / @keyword{'super'}
-               / @keyword{'crate'}
+use_seg       <- kw_self
+               / kw_super
+               / kw_crate
                / @type{upper_ident}
                / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       <- vis? fn_qualifier* @keyword{'fn'} @function{ident} generic_params?
+fn_item       <- vis? fn_qualifier* kw_fn @function{ident} generic_params?
                  fn_params fn_return? where_clause? (block / @punctuation{';'})
-fn_qualifier  <- @keyword{'const'}
-               / @keyword{'async'}
-               / @keyword{'unsafe'}
-               / @keyword{'extern'} string_lit?
+fn_qualifier  <- kw_const
+               / kw_async
+               / kw_unsafe
+               / kw_extern string_lit?
 fn_params     <- @punctuation{'('} fn_param_list? @punctuation{')'}
 fn_param_list <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
 fn_param      <- attr_outer? self_param
                / attr_outer? fn_param_named
 fn_param_named <- pattern_no_or @punctuation{':'} type_expr
-self_param    <- ref_marker? @keyword{'mut'}? @keyword{'self'}
-               / @keyword{'mut'} @keyword{'self'}
-               / @keyword{'self'} @punctuation{':'} type_expr
+self_param    <- ref_marker? kw_mut? kw_self
+               / kw_mut kw_self
+               / kw_self @punctuation{':'} type_expr
 ref_marker    <- @punctuation{'&'} lifetime?
 fn_return     <- @punctuation{'->'} type_expr
 
 # `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
-struct_item   <- vis? @keyword{'struct'} @type{ident} generic_params?
+struct_item   <- vis? kw_struct @type{ident} generic_params?
                  (struct_body_named / struct_body_tuple / @punctuation{';'})
 struct_body_named <- where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
 struct_body_tuple <- @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
@@ -98,7 +143,7 @@ tuple_fields  <- tuple_field (@punctuation{','} tuple_field)* (@punctuation{','}
 tuple_field   <- attr_outer* vis? type_expr
 
 # `enum E { A, B(T), C { x: T } }`
-enum_item     <- vis? @keyword{'enum'} @type{ident} generic_params? where_clause?
+enum_item     <- vis? kw_enum @type{ident} generic_params? where_clause?
                  @punctuation{'{'} enum_variants? @punctuation{'}'}
 enum_variants <- enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
 enum_variant  <- attr_outer* @type{ident} enum_variant_body?
@@ -107,29 +152,29 @@ enum_variant_body <- @punctuation{'('} tuple_fields? @punctuation{')'}
                    / @punctuation{'='} expr
 
 # `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
-impl_item     <- @keyword{'impl'} generic_params? impl_head where_clause?
+impl_item     <- kw_impl generic_params? impl_head where_clause?
                  @punctuation{'{'} impl_body @punctuation{'}'}
-impl_head     <- type_expr (@keyword{'for'} type_expr)?
+impl_head     <- type_expr (kw_for type_expr)?
 impl_body     <- item*
 
 # `trait T<U>: Bound { ... }`
-trait_item    <- vis? @keyword{'unsafe'}? @keyword{'trait'} @type{ident}
+trait_item    <- vis? kw_unsafe? kw_trait @type{ident}
                  generic_params? trait_bounds? where_clause?
                  @punctuation{'{'} impl_body @punctuation{'}'}
 trait_bounds  <- @punctuation{':'} bound_list
 
 # `mod name;` / `mod name { ... }`
-mod_item      <- vis? @keyword{'mod'} @variable{ident}
+mod_item      <- vis? kw_mod @variable{ident}
                  (@punctuation{';'} / @punctuation{'{'} item* @punctuation{'}'})
 
 # `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
-extern_item   <- @keyword{'extern'} string_lit? @punctuation{'{'} item* @punctuation{'}'}
+extern_item   <- kw_extern string_lit? @punctuation{'{'} item* @punctuation{'}'}
 
-const_item    <- vis? @keyword{'const'} @constant{ident} @punctuation{':'} type_expr
+const_item    <- vis? kw_const @constant{ident} @punctuation{':'} type_expr
                  @punctuation{'='} expr @punctuation{';'}
-static_item   <- vis? @keyword{'static'} @keyword{'mut'}? @constant{ident} @punctuation{':'} type_expr
+static_item   <- vis? kw_static kw_mut? @constant{ident} @punctuation{':'} type_expr
                  @punctuation{'='} expr @punctuation{';'}
-type_alias_item <- vis? @keyword{'type'} @type{ident} generic_params? where_clause?
+type_alias_item <- vis? kw_type @type{ident} generic_params? where_clause?
                    @punctuation{'='} type_expr @punctuation{';'}
 
 # `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
@@ -144,9 +189,9 @@ macro_args    <- paren_group
                / bracket_group
 
 # Visibility modifier.
-vis           <- @keyword{'pub'} (@punctuation{'('} vis_scope @punctuation{')'})?
-vis_scope     <- @keyword{'crate'} / @keyword{'self'} / @keyword{'super'}
-               / @keyword{'in'} use_path
+vis           <- kw_pub (@punctuation{'('} vis_scope @punctuation{')'})?
+vis_scope     <- kw_crate / kw_self / kw_super
+               / kw_in use_path
 
 # --- Generic parameters and where-clauses ----------------------------
 
@@ -158,9 +203,9 @@ generic_param <- lifetime_param
 lifetime_param <- lifetime (@punctuation{':'} lifetime_bounds)?
 lifetime_bounds <- lifetime (@punctuation{'+'} lifetime)*
 type_param    <- @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
-const_param   <- @keyword{'const'} @constant{ident} @punctuation{':'} type_expr
+const_param   <- kw_const @constant{ident} @punctuation{':'} type_expr
 
-where_clause  <- @keyword{'where'} where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
+where_clause  <- kw_where where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
 where_pred    <- lifetime @punctuation{':'} lifetime_bounds
                / type_expr @punctuation{':'} bound_list
 
@@ -184,17 +229,17 @@ type_expr     <- type_fn
                / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn      <- type_fn_qualifier* @keyword{'fn'} @punctuation{'('} type_list? @punctuation{')'}
+~type_fn      <- type_fn_qualifier* kw_fn @punctuation{'('} type_list? @punctuation{')'}
                  (@punctuation{'->'} type_expr)?
-type_fn_qualifier <- @keyword{'unsafe'}
-                   / @keyword{'extern'} string_lit?
+type_fn_qualifier <- kw_unsafe
+                   / kw_extern string_lit?
 type_list     <- type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
-type_impl     <- @keyword{'impl'} bound_list
-type_dyn      <- @keyword{'dyn'} bound_list
+type_impl     <- kw_impl bound_list
+type_dyn      <- kw_dyn bound_list
 
-type_ref      <- @punctuation{'&'} lifetime? @keyword{'mut'}? type_expr
-type_ptr      <- @punctuation{'*'} (@keyword{'mut'} / @keyword{'const'}) type_expr
+type_ref      <- @punctuation{'&'} lifetime? kw_mut? type_expr
+type_ptr      <- @punctuation{'*'} (kw_mut / kw_const) type_expr
 
 type_array_or_slice <- @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
 type_tuple_or_group <- @punctuation{'('} type_list? @punctuation{')'}
@@ -204,10 +249,10 @@ type_never    <- @punctuation{'!'}
 type_path     <- type_path_seg (@punctuation{'::'} type_path_seg)*
 type_path_seg <- @type{upper_ident} path_tail?
                / @variable{lower_ident} path_tail?
-               / @keyword{'self'}
-               / @keyword{'Self'}
-               / @keyword{'super'}
-               / @keyword{'crate'}
+               / kw_self
+               / kw_self_ty
+               / kw_super
+               / kw_crate
 
 # Either angle-bracket generics (`Foo<T>`) or paren-sugar for Fn-traits
 # (`Fn(T) -> U`); Rust's reference grammar splits these as
@@ -246,8 +291,8 @@ pattern_atom  <- pattern_ref
                / pattern_wild
                / pattern_rest
                / pattern_binding
-pattern_ref   <- @punctuation{'&'} @keyword{'mut'}? pattern_atom
-pattern_box   <- @keyword{'box'} pattern_atom
+pattern_ref   <- @punctuation{'&'} kw_mut? pattern_atom
+pattern_box   <- kw_box pattern_atom
 pattern_tuple <- @punctuation{'('} pattern_list? @punctuation{')'}
 pattern_list  <- pattern (@punctuation{','} pattern)* (@punctuation{','})?
 # Trailing `::` chain leniency absorbed by outer recovery.
@@ -264,7 +309,7 @@ pattern_literal <- string_lit / char_lit / number_lit / @constant{'true' / 'fals
 pattern_wild  <- @punctuation{'_'}
 pattern_rest  <- @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding <- @keyword{'ref'}? @keyword{'mut'}? @variable{ident}
+~pattern_binding <- kw_ref? kw_mut? @variable{ident}
                    (@punctuation{'@'} pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
@@ -303,14 +348,14 @@ expr_band     <- expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
 expr_shift    <- expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
 expr_add      <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
 expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
-expr_as       <- expr_as @keyword{'as'} type_expr_suffix_marker / expr_unary
+expr_as       <- expr_as kw_as type_expr_suffix_marker / expr_unary
 
 # A marker rule: when `as` matches, consume the following type. Split
 # from the cascade so the type_expr stays attached.
 type_expr_suffix_marker <- type_expr
 
 expr_unary    <- unary_op* expr_postfix
-unary_op      <- @operator{'&'} lifetime? @keyword{'mut'}?
+unary_op      <- @operator{'&'} lifetime? kw_mut?
                / @operator{'*'}
                / @operator{'-'}
                / @operator{'!'}
@@ -318,7 +363,7 @@ unary_op      <- @operator{'&'} lifetime? @keyword{'mut'}?
 # Postfix chain: calls, indexing, field access, try `?`.
 expr_postfix  <- expr_primary postfix_op*
 postfix_op    <- @punctuation{'?'}
-               / @punctuation{'.'} @keyword{'await'}
+               / @punctuation{'.'} kw_await
                / @punctuation{'.'} postfix_member
                / @punctuation{'('} expr_list? @punctuation{')'}
                / @punctuation{'['} expr @punctuation{']'}
@@ -347,31 +392,31 @@ expr_primary  <- literal
                / expr_keyword
 
 # Trailing `(else (if | block))?` leniency absorbed by `root`'s `*^` and `block`'s `^block_close`.
-~expr_if      <- @keyword{'if'} (@keyword{'let'} pattern @operator{'='})? expr block
-                 (@keyword{'else'} (expr_if / block))?
-expr_match    <- @keyword{'match'} expr @punctuation{'{'} match_arms? @punctuation{'}'}
+~expr_if      <- kw_if (kw_let pattern @operator{'='})? expr block
+                 (kw_else (expr_if / block))?
+expr_match    <- kw_match expr @punctuation{'{'} match_arms? @punctuation{'}'}
 match_arms    <- match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
-match_arm     <- attr_outer* pattern (@keyword{'if'} expr)? @punctuation{'=>'} expr
-expr_while    <- @keyword{'while'} (@keyword{'let'} pattern @operator{'='})? expr block
-expr_loop     <- loop_label? @keyword{'loop'} block
-expr_for      <- @keyword{'for'} pattern @keyword{'in'} expr block
+match_arm     <- attr_outer* pattern (kw_if expr)? @punctuation{'=>'} expr
+expr_while    <- kw_while (kw_let pattern @operator{'='})? expr block
+expr_loop     <- loop_label? kw_loop block
+expr_for      <- kw_for pattern kw_in expr block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return  <- @keyword{'return'} expr?
-~expr_break   <- @keyword{'break'} loop_label? expr?
-~expr_continue <- @keyword{'continue'} loop_label?
-expr_unsafe   <- @keyword{'unsafe'} block
-expr_closure  <- @keyword{'move'}? @punctuation{'|'} closure_params? @punctuation{'|'}
+~expr_return  <- kw_return expr?
+~expr_break   <- kw_break loop_label? expr?
+~expr_continue <- kw_continue loop_label?
+expr_unsafe   <- kw_unsafe block
+expr_closure  <- kw_move? @punctuation{'|'} closure_params? @punctuation{'|'}
                  (@punctuation{'->'} type_expr)? expr
 closure_params <- closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
 closure_param <- pattern_no_or (@punctuation{':'} type_expr)?
 expr_block    <- block
-expr_async_block <- @keyword{'async'} @keyword{'move'}? block
+expr_async_block <- kw_async kw_move? block
 expr_tuple_or_paren <- @punctuation{'('} expr_list? @punctuation{')'}
 expr_array    <- @punctuation{'['} expr_array_body? @punctuation{']'}
 expr_array_body <- expr @punctuation{';'} expr
                  / expr (@punctuation{','} expr)* (@punctuation{','})?
 expr_list     <- expr (@punctuation{','} expr)* (@punctuation{','})?
-expr_keyword  <- @keyword{'self'} / @keyword{'Self'} / @keyword{'super'} / @keyword{'crate'}
+expr_keyword  <- kw_self / kw_self_ty / kw_super / kw_crate
 
 *loop_label   <- @punctuation{'\''} @variable{ident} @punctuation{':'}
 
@@ -398,8 +443,8 @@ stmt          <- let_stmt
                / expr @punctuation{';'}
                / expr                                    # trailing expression (block-valued)
 
-let_stmt      <- @keyword{'let'} pattern (@punctuation{':'} type_expr)?
-                 (@punctuation{'='} expr)? (@keyword{'else'} block)? @punctuation{';'}
+let_stmt      <- kw_let pattern (@punctuation{':'} type_expr)?
+                 (@punctuation{'='} expr)? (kw_else block)? @punctuation{';'}
 
 # --- Balanced-bracket helpers (used for macro bodies) -----------------
 #

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -28,50 +28,52 @@ root          <- (item)*^
 
 trivia        <- (comment / \s)*
 
+# Word boundary for `%` reserved-word rules: a keyword can't be the
+# prefix of a longer identifier (Rust Reference XID_Continue).
+wb            <- !ident_body
+
 # --- Keyword tokens ----------------------------------------------------
 #
-# Each keyword is an atomic rule with the literal and its `!ident_body`
-# word boundary inside the capture, so a keyword can't fire on a longer
-# identifier that merely starts with it (`fnfoo`, `asyncx`) and a
-# rejected keyword leaves no stray capture for recovery to surface.
-# Atomicity keeps the boundary adjacent to the literal (no auto-trivia).
-*kw_use       <- @keyword{'use' !ident_body}
-*kw_as        <- @keyword{'as' !ident_body}
-*kw_self      <- @keyword{'self' !ident_body}
-*kw_self_ty   <- @keyword{'Self' !ident_body}
-*kw_super     <- @keyword{'super' !ident_body}
-*kw_crate     <- @keyword{'crate' !ident_body}
-*kw_fn        <- @keyword{'fn' !ident_body}
-*kw_const     <- @keyword{'const' !ident_body}
-*kw_static    <- @keyword{'static' !ident_body}
-*kw_type      <- @keyword{'type' !ident_body}
-*kw_async     <- @keyword{'async' !ident_body}
-*kw_unsafe    <- @keyword{'unsafe' !ident_body}
-*kw_extern    <- @keyword{'extern' !ident_body}
-*kw_mut       <- @keyword{'mut' !ident_body}
-*kw_struct    <- @keyword{'struct' !ident_body}
-*kw_enum      <- @keyword{'enum' !ident_body}
-*kw_impl      <- @keyword{'impl' !ident_body}
-*kw_for       <- @keyword{'for' !ident_body}
-*kw_trait     <- @keyword{'trait' !ident_body}
-*kw_mod       <- @keyword{'mod' !ident_body}
-*kw_pub       <- @keyword{'pub' !ident_body}
-*kw_in        <- @keyword{'in' !ident_body}
-*kw_where     <- @keyword{'where' !ident_body}
-*kw_dyn       <- @keyword{'dyn' !ident_body}
-*kw_box       <- @keyword{'box' !ident_body}
-*kw_ref       <- @keyword{'ref' !ident_body}
-*kw_if        <- @keyword{'if' !ident_body}
-*kw_let       <- @keyword{'let' !ident_body}
-*kw_else      <- @keyword{'else' !ident_body}
-*kw_match     <- @keyword{'match' !ident_body}
-*kw_while     <- @keyword{'while' !ident_body}
-*kw_loop      <- @keyword{'loop' !ident_body}
-*kw_return    <- @keyword{'return' !ident_body}
-*kw_break     <- @keyword{'break' !ident_body}
-*kw_continue  <- @keyword{'continue' !ident_body}
-*kw_move      <- @keyword{'move' !ident_body}
-*kw_await     <- @keyword{'await' !ident_body}
+# One `%` reserved-word rule per keyword, referenced wherever the
+# keyword appears so the `wb` boundary is applied uniformly: a keyword
+# can't fire on a longer identifier that starts with it (`fnfoo`).
+%kw_use       <- @keyword{'use'}
+%kw_as        <- @keyword{'as'}
+%kw_self      <- @keyword{'self'}
+%kw_self_ty   <- @keyword{'Self'}
+%kw_super     <- @keyword{'super'}
+%kw_crate     <- @keyword{'crate'}
+%kw_fn        <- @keyword{'fn'}
+%kw_const     <- @keyword{'const'}
+%kw_static    <- @keyword{'static'}
+%kw_type      <- @keyword{'type'}
+%kw_async     <- @keyword{'async'}
+%kw_unsafe    <- @keyword{'unsafe'}
+%kw_extern    <- @keyword{'extern'}
+%kw_mut       <- @keyword{'mut'}
+%kw_struct    <- @keyword{'struct'}
+%kw_enum      <- @keyword{'enum'}
+%kw_impl      <- @keyword{'impl'}
+%kw_for       <- @keyword{'for'}
+%kw_trait     <- @keyword{'trait'}
+%kw_mod       <- @keyword{'mod'}
+%kw_pub       <- @keyword{'pub'}
+%kw_in        <- @keyword{'in'}
+%kw_where     <- @keyword{'where'}
+%kw_dyn       <- @keyword{'dyn'}
+%kw_box       <- @keyword{'box'}
+%kw_ref       <- @keyword{'ref'}
+%kw_if        <- @keyword{'if'}
+%kw_let       <- @keyword{'let'}
+%kw_else      <- @keyword{'else'}
+%kw_match     <- @keyword{'match'}
+%kw_while     <- @keyword{'while'}
+%kw_loop      <- @keyword{'loop'}
+%kw_return    <- @keyword{'return'}
+%kw_break     <- @keyword{'break'}
+%kw_continue  <- @keyword{'continue'}
+%kw_move      <- @keyword{'move'}
+%kw_await     <- @keyword{'await'}
 
 # --- Items -------------------------------------------------------------
 #
@@ -305,7 +307,7 @@ pattern_struct_field  <- @property{ident} @punctuation{':'} pattern
                        / @punctuation{'..'}
 pattern_slice <- @punctuation{'['} pattern_list? @punctuation{']'}
 pattern_range <- pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
-pattern_literal <- string_lit / char_lit / number_lit / @constant{'true' / 'false'}
+pattern_literal <- string_lit / char_lit / number_lit / lit_const
 pattern_wild  <- @punctuation{'_'}
 pattern_rest  <- @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
@@ -470,7 +472,11 @@ balanced_atom <- brace_block
 
 # --- Literals ----------------------------------------------------------
 
-literal       <- string_lit / char_lit / number_lit / @constant{'true' / 'false'}
+literal       <- string_lit / char_lit / number_lit / lit_const
+
+# Boolean constants as a `%` reserved-word alternation so the `wb`
+# boundary keeps `trueish` from matching the `true` prefix.
+%lit_const    <- @constant{'true'} / @constant{'false'}
 
 # Raw strings first (longer prefix), then regular.
 string_lit    <- @string{raw_string / byte_string / regular_string}

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -550,7 +550,11 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
 # `$` (continuation only), plus any code point above U+007F.
 *ident_start       <- [a-zA-Z_\u{80}-\u{10FFFF}]
 *ident_cont        <- [a-zA-Z\d_$\u{80}-\u{10FFFF}]
-*ident_char        <- [a-zA-Z\d_$]
+# Word-boundary negative-lookahead class. Must match `ident_cont` (the
+# full continuation class, Unicode included) so a keyword can't fire on
+# the prefix of an identifier that continues with a non-ASCII code
+# point — `SELECT€` is one identifier, not `SELECT` + `€`.
+*ident_char        <- [a-zA-Z\d_$\u{80}-\u{10FFFF}]
 
 *double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
 *backtick_id       <- '`' ('``' / !'`' !\R .)* '`'

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -523,12 +523,15 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
 *string_lit  <- @string{string_body}
 *string_body <- "'" ("''" / !"'" .)* "'"
 
-*number_body <- '0x' [\da-fA-F]+ wb
-             / float_body
-             / int_body
-*float_body  <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
-             / \d+ [eE] [+\-]? \d+
-*int_body    <- \d+
+# Hex is a `%` rule so the compiler appends the `wb` boundary: hex
+# digits include a-f, so a hex run can butt against identifier chars
+# (`0x1Fg` must fall back to `0` + `x1Fg`, not lex `0x1F`). float/int
+# use `\d`, which can't, so they carry no boundary.
+number_body <- hex_body / float_body / int_body
+%hex_body   <- '0x' [\da-fA-F]+
+*float_body <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
+            / \d+ [eE] [+\-]? \d+
+*int_body   <- \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -567,9 +567,11 @@ number_body <- hex_body / float_body / int_body
 # boundary call inside the @keyword capture so `SELECT` doesn't match
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.
-# `keyword_word` keeps an explicit `!ident_cont` boundary: it is a pure
-# negative-lookahead helper (no capture), so it has nothing to leak and
-# stays a single trailing check on the hot identifier-exclusion path.
+# `keyword_word` is also a `%` rule. It has no capture (it's a pure
+# negative-lookahead helper), so the compiler appends a single trailing
+# `wb` after the whole alternation rather than one per branch — one
+# check on the hot identifier-exclusion path, same as a hand-written
+# `!ident_cont`.
 
 %kw_select    <- @keyword{i"select"}
 %kw_from      <- @keyword{i"from"}
@@ -735,9 +737,10 @@ number_body <- hex_body / float_body / int_body
 #   NATURAL > NULL > NOT            (N-prefix)
 #   OFFSET > ORDER / OUTER > ON / OR (O-prefix)
 #
-# `!ident_cont` is applied once on the outside so each body stays
-# boundary-free.
-*keyword_word <-
+# The `%` marker appends one `wb` boundary after the whole alternation
+# (this rule has no capture, so it isn't distributed per branch), which
+# keeps each body boundary-free.
+%keyword_word <-
     ( i"autoincrement"  # 13
     / i"transaction"    # 11
     / i"constraint"     # 10
@@ -862,7 +865,7 @@ number_body <- hex_body / float_body / int_body
     / i"on"             # 2
     / i"or"             # 2
     / i"to"             # 2
-    ) !ident_cont
+    )
 
 # --- Whitespace & comments -------------------------------------------
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -56,6 +56,10 @@
 root       <- (statement stmt_sep?)*^[;]
 
 trivia    <- (comment / \s)*
+# Word boundary for `%` reserved-word rules: a keyword can't be the
+# prefix of a longer identifier. Matches the full identifier-continue
+# class (`ident_cont`, Unicode included).
+wb        <- !ident_cont
 stmt_sep   <- @punctuation{';'}
 statement       <- explain_stmt / statement_body
 statement_body  <- select_stmt
@@ -509,8 +513,8 @@ exists_expr <- kw_exists @punctuation{'('} select_stmt @punctuation{')'}
 
 literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
 
-*null_lit    <- @constant{null_body !ident_char}
-*bool_lit    <- @constant{bool_body !ident_char}
+%null_lit    <- @constant{null_body}
+%bool_lit    <- @constant{bool_body}
 *null_body   <- i"null"
 *bool_body   <- i"true" / i"false"
 
@@ -519,7 +523,7 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
 *string_lit  <- @string{string_body}
 *string_body <- "'" ("''" / !"'" .)* "'"
 
-*number_body <- '0x' [\da-fA-F]+ !ident_char
+*number_body <- '0x' [\da-fA-F]+ wb
              / float_body
              / int_body
 *float_body  <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
@@ -550,171 +554,168 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
 # `$` (continuation only), plus any code point above U+007F.
 *ident_start       <- [a-zA-Z_\u{80}-\u{10FFFF}]
 *ident_cont        <- [a-zA-Z\d_$\u{80}-\u{10FFFF}]
-# Word-boundary negative-lookahead class. Must match `ident_cont` (the
-# full continuation class, Unicode included) so a keyword can't fire on
-# the prefix of an identifier that continues with a non-ASCII code
-# point — `SELECT€` is one identifier, not `SELECT` + `€`.
-*ident_char        <- [a-zA-Z\d_$\u{80}-\u{10FFFF}]
 
 *double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
 *backtick_id       <- '`' ('``' / !'`' !\R .)* '`'
 *bracket_id        <- '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
-# Every kw_* wraps its body in @keyword{...} and appends the
-# `!ident_char` boundary so `SELECT` doesn't match the prefix of
-# `SELECTED`. The `i"…"` literal sugar gives case-insensitive matching
-# at the parser level — see src/pegc/README.md. `keyword_word` reuses
-# the same boundary for the identifier-exclusion negative lookahead.
+# Each kw_* is a `%` reserved-word rule: the compiler appends a `wb`
+# boundary call inside the @keyword capture so `SELECT` doesn't match
+# the prefix of `SELECTED`. The `i"…"` literal sugar gives
+# case-insensitive matching at the parser level — see src/pegc/README.md.
+# `keyword_word` keeps an explicit `!ident_cont` boundary: it is a pure
+# negative-lookahead helper (no capture), so it has nothing to leak and
+# stays a single trailing check on the hot identifier-exclusion path.
 
-*kw_select    <- @keyword{i"select" !ident_char}
-*kw_from      <- @keyword{i"from" !ident_char}
-*kw_where     <- @keyword{i"where" !ident_char}
-*kw_group     <- @keyword{i"group" !ident_char}
-*kw_by        <- @keyword{i"by" !ident_char}
-*kw_having    <- @keyword{i"having" !ident_char}
-*kw_order     <- @keyword{i"order" !ident_char}
-*kw_asc       <- @keyword{i"asc" !ident_char}
-*kw_desc      <- @keyword{i"desc" !ident_char}
-*kw_limit     <- @keyword{i"limit" !ident_char}
-*kw_offset    <- @keyword{i"offset" !ident_char}
-*kw_join      <- @keyword{i"join" !ident_char}
-*kw_inner     <- @keyword{i"inner" !ident_char}
-*kw_left      <- @keyword{i"left" !ident_char}
-*kw_right     <- @keyword{i"right" !ident_char}
-*kw_full      <- @keyword{i"full" !ident_char}
-*kw_outer     <- @keyword{i"outer" !ident_char}
-*kw_cross     <- @keyword{i"cross" !ident_char}
-*kw_natural   <- @keyword{i"natural" !ident_char}
-*kw_on        <- @keyword{i"on" !ident_char}
-*kw_using     <- @keyword{i"using" !ident_char}
-*kw_as        <- @keyword{i"as" !ident_char}
-*kw_distinct  <- @keyword{i"distinct" !ident_char}
-*kw_all       <- @keyword{i"all" !ident_char}
-*kw_union     <- @keyword{i"union" !ident_char}
-*kw_intersect <- @keyword{i"intersect" !ident_char}
-*kw_except    <- @keyword{i"except" !ident_char}
-*kw_with      <- @keyword{i"with" !ident_char}
-*kw_and       <- @keyword{i"and" !ident_char}
-*kw_or        <- @keyword{i"or" !ident_char}
-*kw_not       <- @keyword{i"not" !ident_char}
-*kw_is        <- @keyword{i"is" !ident_char}
-*kw_in        <- @keyword{i"in" !ident_char}
-*kw_like      <- @keyword{i"like" !ident_char}
-*kw_glob      <- @keyword{i"glob" !ident_char}
-*kw_match     <- @keyword{i"match" !ident_char}
-*kw_regexp    <- @keyword{i"regexp" !ident_char}
-*kw_between   <- @keyword{i"between" !ident_char}
-*kw_escape    <- @keyword{i"escape" !ident_char}
-*kw_case      <- @keyword{i"case" !ident_char}
-*kw_when      <- @keyword{i"when" !ident_char}
-*kw_then      <- @keyword{i"then" !ident_char}
-*kw_else      <- @keyword{i"else" !ident_char}
-*kw_end       <- @keyword{i"end" !ident_char}
-*kw_cast      <- @keyword{i"cast" !ident_char}
-*kw_exists    <- @keyword{i"exists" !ident_char}
-*kw_collate   <- @keyword{i"collate" !ident_char}
+%kw_select    <- @keyword{i"select"}
+%kw_from      <- @keyword{i"from"}
+%kw_where     <- @keyword{i"where"}
+%kw_group     <- @keyword{i"group"}
+%kw_by        <- @keyword{i"by"}
+%kw_having    <- @keyword{i"having"}
+%kw_order     <- @keyword{i"order"}
+%kw_asc       <- @keyword{i"asc"}
+%kw_desc      <- @keyword{i"desc"}
+%kw_limit     <- @keyword{i"limit"}
+%kw_offset    <- @keyword{i"offset"}
+%kw_join      <- @keyword{i"join"}
+%kw_inner     <- @keyword{i"inner"}
+%kw_left      <- @keyword{i"left"}
+%kw_right     <- @keyword{i"right"}
+%kw_full      <- @keyword{i"full"}
+%kw_outer     <- @keyword{i"outer"}
+%kw_cross     <- @keyword{i"cross"}
+%kw_natural   <- @keyword{i"natural"}
+%kw_on        <- @keyword{i"on"}
+%kw_using     <- @keyword{i"using"}
+%kw_as        <- @keyword{i"as"}
+%kw_distinct  <- @keyword{i"distinct"}
+%kw_all       <- @keyword{i"all"}
+%kw_union     <- @keyword{i"union"}
+%kw_intersect <- @keyword{i"intersect"}
+%kw_except    <- @keyword{i"except"}
+%kw_with      <- @keyword{i"with"}
+%kw_and       <- @keyword{i"and"}
+%kw_or        <- @keyword{i"or"}
+%kw_not       <- @keyword{i"not"}
+%kw_is        <- @keyword{i"is"}
+%kw_in        <- @keyword{i"in"}
+%kw_like      <- @keyword{i"like"}
+%kw_glob      <- @keyword{i"glob"}
+%kw_match     <- @keyword{i"match"}
+%kw_regexp    <- @keyword{i"regexp"}
+%kw_between   <- @keyword{i"between"}
+%kw_escape    <- @keyword{i"escape"}
+%kw_case      <- @keyword{i"case"}
+%kw_when      <- @keyword{i"when"}
+%kw_then      <- @keyword{i"then"}
+%kw_else      <- @keyword{i"else"}
+%kw_end       <- @keyword{i"end"}
+%kw_cast      <- @keyword{i"cast"}
+%kw_exists    <- @keyword{i"exists"}
+%kw_collate   <- @keyword{i"collate"}
 
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-*kw_recursive <- @keyword{i"recursive" !ident_char}
-*kw_window    <- @keyword{i"window" !ident_char}
-*kw_over      <- @keyword{i"over" !ident_char}
-*kw_filter    <- @keyword{i"filter" !ident_char}
-*kw_partition <- @keyword{i"partition" !ident_char}
-*kw_range     <- @keyword{i"range" !ident_char}
-*kw_rows      <- @keyword{i"rows" !ident_char}
-*kw_groups    <- @keyword{i"groups" !ident_char}
-*kw_unbounded <- @keyword{i"unbounded" !ident_char}
-*kw_preceding <- @keyword{i"preceding" !ident_char}
-*kw_following <- @keyword{i"following" !ident_char}
-*kw_current   <- @keyword{i"current" !ident_char}
-*kw_row       <- @keyword{i"row" !ident_char}
-*kw_exclude   <- @keyword{i"exclude" !ident_char}
-*kw_ties      <- @keyword{i"ties" !ident_char}
-*kw_others    <- @keyword{i"others" !ident_char}
-*kw_no        <- @keyword{i"no" !ident_char}
+%kw_recursive <- @keyword{i"recursive"}
+%kw_window    <- @keyword{i"window"}
+%kw_over      <- @keyword{i"over"}
+%kw_filter    <- @keyword{i"filter"}
+%kw_partition <- @keyword{i"partition"}
+%kw_range     <- @keyword{i"range"}
+%kw_rows      <- @keyword{i"rows"}
+%kw_groups    <- @keyword{i"groups"}
+%kw_unbounded <- @keyword{i"unbounded"}
+%kw_preceding <- @keyword{i"preceding"}
+%kw_following <- @keyword{i"following"}
+%kw_current   <- @keyword{i"current"}
+%kw_row       <- @keyword{i"row"}
+%kw_exclude   <- @keyword{i"exclude"}
+%kw_ties      <- @keyword{i"ties"}
+%kw_others    <- @keyword{i"others"}
+%kw_no        <- @keyword{i"no"}
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
 # rule goes here so UPSERT's DO UPDATE path can use it now.
-*kw_insert    <- @keyword{i"insert" !ident_char}
-*kw_replace   <- @keyword{i"replace" !ident_char}
-*kw_into      <- @keyword{i"into" !ident_char}
-*kw_values    <- @keyword{i"values" !ident_char}
-*kw_default   <- @keyword{i"default" !ident_char}
-*kw_conflict  <- @keyword{i"conflict" !ident_char}
-*kw_do        <- @keyword{i"do" !ident_char}
-*kw_nothing   <- @keyword{i"nothing" !ident_char}
-*kw_rollback  <- @keyword{i"rollback" !ident_char}
-*kw_abort     <- @keyword{i"abort" !ident_char}
-*kw_fail      <- @keyword{i"fail" !ident_char}
-*kw_ignore    <- @keyword{i"ignore" !ident_char}
-*kw_set       <- @keyword{i"set" !ident_char}
-*kw_returning <- @keyword{i"returning" !ident_char}
-*kw_update    <- @keyword{i"update" !ident_char}
-*kw_delete    <- @keyword{i"delete" !ident_char}
+%kw_insert    <- @keyword{i"insert"}
+%kw_replace   <- @keyword{i"replace"}
+%kw_into      <- @keyword{i"into"}
+%kw_values    <- @keyword{i"values"}
+%kw_default   <- @keyword{i"default"}
+%kw_conflict  <- @keyword{i"conflict"}
+%kw_do        <- @keyword{i"do"}
+%kw_nothing   <- @keyword{i"nothing"}
+%kw_rollback  <- @keyword{i"rollback"}
+%kw_abort     <- @keyword{i"abort"}
+%kw_fail      <- @keyword{i"fail"}
+%kw_ignore    <- @keyword{i"ignore"}
+%kw_set       <- @keyword{i"set"}
+%kw_returning <- @keyword{i"returning"}
+%kw_update    <- @keyword{i"update"}
+%kw_delete    <- @keyword{i"delete"}
 
 # DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
-*kw_create    <- @keyword{i"create" !ident_char}
-*kw_table     <- @keyword{i"table" !ident_char}
-*kw_alter     <- @keyword{i"alter" !ident_char}
-*kw_drop      <- @keyword{i"drop" !ident_char}
-*kw_rename    <- @keyword{i"rename" !ident_char}
-*kw_add       <- @keyword{i"add" !ident_char}
-*kw_column    <- @keyword{i"column" !ident_char}
-*kw_if        <- @keyword{i"if" !ident_char}
-*kw_temp      <- @keyword{i"temp" !ident_char}
-*kw_temporary <- @keyword{i"temporary" !ident_char}
-*kw_primary   <- @keyword{i"primary" !ident_char}
-*kw_key       <- @keyword{i"key" !ident_char}
-*kw_unique    <- @keyword{i"unique" !ident_char}
-*kw_check     <- @keyword{i"check" !ident_char}
-*kw_null      <- @keyword{i"null" !ident_char}
-*kw_references <- @keyword{i"references" !ident_char}
-*kw_generated <- @keyword{i"generated" !ident_char}
-*kw_always    <- @keyword{i"always" !ident_char}
-*kw_stored    <- @keyword{i"stored" !ident_char}
-*kw_virtual   <- @keyword{i"virtual" !ident_char}
-*kw_constraint<- @keyword{i"constraint" !ident_char}
-*kw_foreign   <- @keyword{i"foreign" !ident_char}
-*kw_action    <- @keyword{i"action" !ident_char}
-*kw_cascade   <- @keyword{i"cascade" !ident_char}
-*kw_restrict  <- @keyword{i"restrict" !ident_char}
-*kw_deferrable<- @keyword{i"deferrable" !ident_char}
-*kw_initially <- @keyword{i"initially" !ident_char}
-*kw_immediate <- @keyword{i"immediate" !ident_char}
-*kw_deferred  <- @keyword{i"deferred" !ident_char}
-*kw_autoincrement <- @keyword{i"autoincrement" !ident_char}
-*kw_rowid     <- @keyword{i"rowid" !ident_char}
-*kw_strict    <- @keyword{i"strict" !ident_char}
-*kw_without   <- @keyword{i"without" !ident_char}
-*kw_to        <- @keyword{i"to" !ident_char}
-*kw_index     <- @keyword{i"index" !ident_char}
-*kw_view      <- @keyword{i"view" !ident_char}
-*kw_trigger   <- @keyword{i"trigger" !ident_char}
-*kw_before    <- @keyword{i"before" !ident_char}
-*kw_after     <- @keyword{i"after" !ident_char}
-*kw_instead   <- @keyword{i"instead" !ident_char}
-*kw_of        <- @keyword{i"of" !ident_char}
-*kw_for       <- @keyword{i"for" !ident_char}
-*kw_each      <- @keyword{i"each" !ident_char}
-*kw_begin     <- @keyword{i"begin" !ident_char}
-*kw_commit    <- @keyword{i"commit" !ident_char}
-*kw_transaction <- @keyword{i"transaction" !ident_char}
-*kw_savepoint <- @keyword{i"savepoint" !ident_char}
-*kw_release   <- @keyword{i"release" !ident_char}
-*kw_exclusive <- @keyword{i"exclusive" !ident_char}
-*kw_pragma    <- @keyword{i"pragma" !ident_char}
-*kw_vacuum    <- @keyword{i"vacuum" !ident_char}
-*kw_attach    <- @keyword{i"attach" !ident_char}
-*kw_detach    <- @keyword{i"detach" !ident_char}
-*kw_database  <- @keyword{i"database" !ident_char}
-*kw_reindex   <- @keyword{i"reindex" !ident_char}
-*kw_analyze   <- @keyword{i"analyze" !ident_char}
-*kw_explain   <- @keyword{i"explain" !ident_char}
-*kw_query     <- @keyword{i"query" !ident_char}
-*kw_plan      <- @keyword{i"plan" !ident_char}
+%kw_create    <- @keyword{i"create"}
+%kw_table     <- @keyword{i"table"}
+%kw_alter     <- @keyword{i"alter"}
+%kw_drop      <- @keyword{i"drop"}
+%kw_rename    <- @keyword{i"rename"}
+%kw_add       <- @keyword{i"add"}
+%kw_column    <- @keyword{i"column"}
+%kw_if        <- @keyword{i"if"}
+%kw_temp      <- @keyword{i"temp"}
+%kw_temporary <- @keyword{i"temporary"}
+%kw_primary   <- @keyword{i"primary"}
+%kw_key       <- @keyword{i"key"}
+%kw_unique    <- @keyword{i"unique"}
+%kw_check     <- @keyword{i"check"}
+%kw_null      <- @keyword{i"null"}
+%kw_references <- @keyword{i"references"}
+%kw_generated <- @keyword{i"generated"}
+%kw_always    <- @keyword{i"always"}
+%kw_stored    <- @keyword{i"stored"}
+%kw_virtual   <- @keyword{i"virtual"}
+%kw_constraint<- @keyword{i"constraint"}
+%kw_foreign   <- @keyword{i"foreign"}
+%kw_action    <- @keyword{i"action"}
+%kw_cascade   <- @keyword{i"cascade"}
+%kw_restrict  <- @keyword{i"restrict"}
+%kw_deferrable<- @keyword{i"deferrable"}
+%kw_initially <- @keyword{i"initially"}
+%kw_immediate <- @keyword{i"immediate"}
+%kw_deferred  <- @keyword{i"deferred"}
+%kw_autoincrement <- @keyword{i"autoincrement"}
+%kw_rowid     <- @keyword{i"rowid"}
+%kw_strict    <- @keyword{i"strict"}
+%kw_without   <- @keyword{i"without"}
+%kw_to        <- @keyword{i"to"}
+%kw_index     <- @keyword{i"index"}
+%kw_view      <- @keyword{i"view"}
+%kw_trigger   <- @keyword{i"trigger"}
+%kw_before    <- @keyword{i"before"}
+%kw_after     <- @keyword{i"after"}
+%kw_instead   <- @keyword{i"instead"}
+%kw_of        <- @keyword{i"of"}
+%kw_for       <- @keyword{i"for"}
+%kw_each      <- @keyword{i"each"}
+%kw_begin     <- @keyword{i"begin"}
+%kw_commit    <- @keyword{i"commit"}
+%kw_transaction <- @keyword{i"transaction"}
+%kw_savepoint <- @keyword{i"savepoint"}
+%kw_release   <- @keyword{i"release"}
+%kw_exclusive <- @keyword{i"exclusive"}
+%kw_pragma    <- @keyword{i"pragma"}
+%kw_vacuum    <- @keyword{i"vacuum"}
+%kw_attach    <- @keyword{i"attach"}
+%kw_detach    <- @keyword{i"detach"}
+%kw_database  <- @keyword{i"database"}
+%kw_reindex   <- @keyword{i"reindex"}
+%kw_analyze   <- @keyword{i"analyze"}
+%kw_explain   <- @keyword{i"explain"}
+%kw_query     <- @keyword{i"query"}
+%kw_plan      <- @keyword{i"plan"}
 
 # Keyword negative-lookahead for the identifier rule.
 #
@@ -731,7 +732,7 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
 #   NATURAL > NULL > NOT            (N-prefix)
 #   OFFSET > ORDER / OUTER > ON / OR (O-prefix)
 #
-# `!ident_char` is applied once on the outside so each body stays
+# `!ident_cont` is applied once on the outside so each body stays
 # boundary-free.
 *keyword_word <-
     ( i"autoincrement"  # 13
@@ -858,7 +859,7 @@ literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_li
     / i"on"             # 2
     / i"or"             # 2
     / i"to"             # 2
-    ) !ident_char
+    ) !ident_cont
 
 # --- Whitespace & comments -------------------------------------------
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -33,13 +33,20 @@ name2 <-  body2
   pair of consecutive items in non-atomic rule bodies, including
   between iterations of `*` / `+`. Without a `trivia` rule, no
   auto-insertion happens.
+- An optional **`wb` rule** is the word-boundary target consumed by
+  `%` rules (see below); it is typically `wb <- !ident_body`. Defining
+  it is only required when the grammar has at least one `%` rule.
 - Rules may carry **prefix sigils**: `~name <-` for the intentional
-  leniency marker (see below) and `*name <-` for the atomic marker
-  (no `trivia` injected inside this rule's body). The two compose:
-  `~*name` and `*~name` are equivalent. `*trivia <- …` is the
-  special case that disables auto-insertion grammar-wide.
-- **Position constraint:** `root` is always the first rule. When a
-  `trivia` rule is present it sits immediately after `root`. Other
+  leniency marker, `*name <-` for the atomic marker (no `trivia`
+  injected inside this rule's body), and `%name <-` for the
+  reserved-word marker (atomic *and* appends a trailing `wb` call
+  inside the rule's terminal captures). `~` composes with either of
+  `*` / `%` (`~*name`, `%~name`, …); `*` and `%` are mutually
+  exclusive — both make a rule atomic. `*trivia <- …` is the special
+  case that disables auto-insertion grammar-wide.
+- **Position constraint:** `root` is always the first rule. The
+  optional special rules `trivia` and `wb` occupy the contiguous slots
+  immediately after `root` (positions 1..2, in either order). Other
   rules follow in any order.
 - **Identifiers** are ASCII `[A-Za-z_][A-Za-z0-9_]*`.
 - **Whitespace** (space, tab, newline, carriage return) separates
@@ -514,7 +521,7 @@ recorded in adjacent comments and unenforced by the lint; see
 
 ### Reserved rule names
 
-Two rule names get compile-time treatment:
+Three rule names get compile-time treatment:
 
 - **`root`** — the start rule (mandatory). The compiler wraps its
   body as `trivia? root_body trivia? !.` so end-of-input is always
@@ -569,6 +576,20 @@ Two rule names get compile-time treatment:
   pair`, and each iteration begins by consuming whatever
   inter-iteration whitespace is sitting in front of it.
 
+- **`wb`** — the optional word-boundary target for `%` rules. Its
+  body is a bare boundary predicate (typically `wb <- !ident_body`,
+  or `!ident_cont` for a Unicode-aware continuation class). The
+  compiler appends a `wb` call inside the terminal captures of every
+  `%` rule (see [`%name <-`](#name----reserved-word-marker)); it is
+  required only when the grammar has at least one `%` rule. Like
+  `trivia`, `wb` is exempt from trivia auto-insertion and must sit in
+  the reserved slots immediately after `root`. It is **not** part of
+  the trivia diagnostic cascade.
+
+  ```peg
+  wb            <- !ident_body
+  ```
+
 ### `*name <-` — atomic-rule marker
 
 A `*` prefix on the rule name opts the rule out of `trivia`
@@ -588,6 +609,37 @@ between adjacent bytes would let whitespace appear inside the
 token. The atomic boundary stops at `NonTerminal` calls: a
 non-atomic rule called from inside an atomic body still gets
 auto-insertion in its own body.
+
+For a keyword rule that also needs a trailing word boundary, prefer
+the [`%name <-`](#name----reserved-word-marker) sibling below — it is
+atomic *and* supplies the boundary, so you don't hand-write `!ident_body`.
+
+### `%name <-` — reserved-word marker
+
+A `%` prefix marks a rule as a **reserved word**: it is compiled
+atomic (like `*`) *and* the compiler appends a call to the `wb` rule
+inside the rule's terminal captures, so the match must be followed by
+a word boundary. This keeps a keyword from firing on the prefix of a
+longer identifier — `if` must not match the start of `ifx`.
+
+```peg
+wb            <- !ident_body
+%kw_if        <- @keyword{'if'}
+%storage_spec <- @keyword{'typedef'} / @keyword{'extern'} / @keyword{'static'}
+```
+
+The `wb` call is pushed inside each leaf capture (and distributed
+across choice branches), not appended after the rule body. That
+placement matters: it means the `@keyword` capture only commits when
+the boundary holds, so a rejected keyword leaves no stray capture for
+top-level `*^` recovery to surface. Because the rule is atomic, no
+`trivia` is spliced between the literal and the appended `wb` call.
+
+- Requires a `wb` rule; with none defined, the synthesized
+  `NonTerminal("wb")` surfaces as `CompileError::UndefinedRule("wb")`.
+- Composes with `~` (`%~name` / `~%name`); mutually exclusive with `*`
+  (combining them is a parse error).
+- Rejected on the reserved rules `root` / `trivia` / `wb`.
 
 ### Reserved syntax
 

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1661,6 +1661,15 @@ pub fn append_wb_check(grammar: &mut Grammar) {
 /// it inside the final capture and distributing across choice branches
 /// so each alternative ends in its own boundary check.
 fn append_wb_in(pat: &mut Pattern) {
+    // A choice whose branches hold no capture can't leak a committed
+    // capture through recovery, so one trailing `wb` after the whole
+    // choice is equivalent to — and leaner than — one per branch. Only
+    // distribute when there is a capture to keep the boundary inside of.
+    if matches!(pat, Pattern::OrderedChoice { .. }) && !contains_capture(pat) {
+        let taken = std::mem::replace(pat, Pattern::any_char());
+        *pat = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
+        return;
+    }
     match pat {
         Pattern::OrderedChoice { alts, .. } => {
             for alt in alts.iter_mut() {
@@ -1677,5 +1686,93 @@ fn append_wb_in(pat: &mut Pattern) {
             let taken = std::mem::replace(other, Pattern::any_char());
             *other = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
         }
+    }
+}
+
+/// Whether `pat` contains a [`Pattern::Capture`] anywhere in its tree.
+/// `NonTerminal`s are opaque (a referenced rule's captures aren't
+/// visible here) — consistent with the rest of `append_wb_in`, which
+/// appends `wb` after a `NonTerminal` call rather than inside it.
+fn contains_capture(pat: &Pattern) -> bool {
+    match pat {
+        Pattern::Capture { .. } => true,
+        Pattern::Sequence { items, .. } => items.iter().any(contains_capture),
+        Pattern::OrderedChoice { alts, .. } => alts.iter().any(contains_capture),
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Lenient { inner, .. } => contains_capture(inner),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => contains_capture(inner) || contains_capture(recovery),
+        Pattern::InferBoundaryCatch { inner, .. } => contains_capture(inner),
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::NonTerminal { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn count_wb(pat: &Pattern) -> usize {
+        match pat {
+            Pattern::NonTerminal { name, .. } if name.as_str() == super::super::parser::WB_RULE => {
+                1
+            }
+            Pattern::Sequence { items, .. } => items.iter().map(count_wb).sum(),
+            Pattern::OrderedChoice { alts, .. } => alts.iter().map(count_wb).sum(),
+            Pattern::Repeat { inner, .. }
+            | Pattern::RepeatOne { inner, .. }
+            | Pattern::Optional { inner, .. }
+            | Pattern::NotPredicate { inner, .. }
+            | Pattern::AndPredicate { inner, .. }
+            | Pattern::Capture { inner, .. }
+            | Pattern::Lenient { inner, .. } => count_wb(inner),
+            Pattern::Catch {
+                inner, recovery, ..
+            } => count_wb(inner) + count_wb(recovery),
+            Pattern::InferBoundaryCatch { inner, .. } => count_wb(inner),
+            _ => 0,
+        }
+    }
+
+    /// Mark a single rule `t` as a `%` rule, run `append_wb_check`, and
+    /// return the rewritten body.
+    fn append_to(body: Pattern) -> Pattern {
+        let mut rules = HashMap::new();
+        rules.insert("t".to_string(), body);
+        let mut g = Grammar::new(rules);
+        g.percent_rules.insert("t".to_string());
+        append_wb_check(&mut g);
+        g.rules.remove("t").unwrap()
+    }
+
+    #[test]
+    fn capture_less_choice_gets_one_trailing_wb() {
+        // `%t <- 'a' / 'b' / 'c'` — no capture to leak, so a single
+        // trailing `wb` after the choice, not one per branch.
+        let body = Pattern::choice(vec![
+            Pattern::literal("a"),
+            Pattern::literal("b"),
+            Pattern::literal("c"),
+        ]);
+        assert_eq!(count_wb(&append_to(body)), 1);
+    }
+
+    #[test]
+    fn capture_choice_distributes_wb_per_branch() {
+        // `%t <- @k{'a'} / @k{'b'}` — each capture must keep `wb` inside
+        // so a committed keyword can't leak through recovery.
+        let body = Pattern::choice(vec![
+            Pattern::capture("k", Pattern::literal("a")),
+            Pattern::capture("k", Pattern::literal("b")),
+        ]);
+        assert_eq!(count_wb(&append_to(body)), 2);
     }
 }

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1632,3 +1632,50 @@ pub fn wrap_root(grammar: &mut Grammar) {
 fn trivia_call() -> Pattern {
     Pattern::nt(TRIVIA_ROOT_RULE)
 }
+
+/// Append a `wb` word-boundary call inside the terminal captures of
+/// every `%`-marked rule (see [`Grammar::percent_rules`]).
+///
+/// The boundary is pushed to the tail of the matched region, *inside*
+/// the capture that ends the match, so the capture commits only when
+/// the boundary holds. Placing `wb` after the capture instead would let
+/// the keyword capture commit before the boundary check fails, leaking a
+/// stray keyword token through top-level `*^` recovery on inputs like
+/// `typedefx`. The rule is already atomic (the `%` sigil inserts it into
+/// `atomic_rules`), so no `trivia` is spliced between the literal and
+/// the appended call.
+///
+/// A `wb` call into a rule with no `wb` definition surfaces downstream
+/// as `CompileError::UndefinedRule("wb")` from `compile_rules`.
+pub fn append_wb_check(grammar: &mut Grammar) {
+    let names: Vec<String> = grammar.percent_rules.iter().cloned().collect();
+    for name in names {
+        if let Some(mut body) = grammar.rules.remove(&name) {
+            append_wb_in(&mut body);
+            grammar.rules.insert(name, body);
+        }
+    }
+}
+
+/// Recursively append a `wb` call at the tail of `pat`'s match, pushing
+/// it inside the final capture and distributing across choice branches
+/// so each alternative ends in its own boundary check.
+fn append_wb_in(pat: &mut Pattern) {
+    match pat {
+        Pattern::OrderedChoice { alts, .. } => {
+            for alt in alts.iter_mut() {
+                append_wb_in(alt);
+            }
+        }
+        Pattern::Sequence { items, .. } => {
+            if let Some(last) = items.last_mut() {
+                append_wb_in(last);
+            }
+        }
+        Pattern::Capture { inner, .. } => append_wb_in(inner),
+        other => {
+            let taken = std::mem::replace(other, Pattern::any_char());
+            *other = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
+        }
+    }
+}

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::analysis::{
-    inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries, wrap_root,
+    append_wb_check, inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries, wrap_root,
 };
 use super::compiler::{compile_rules, CompileError};
 use super::pattern::{Pattern, Span};
@@ -43,6 +43,15 @@ pub const ROOT_RULE: &str = "root";
 /// definition but disables auto-insertion grammar-wide.
 pub const TRIVIA_RULE: &str = "trivia";
 
+/// Reserved rule name for the (optional) word-boundary target. A rule
+/// marked with the `%name <- …` sigil is compiled atomic and has a
+/// trailing call to [`WB_RULE`] appended inside its terminal captures by
+/// [`append_wb_check`](super::analysis::append_wb_check), so a keyword
+/// can't fire on the prefix of a longer identifier. Defining `wb` is
+/// only required when at least one `%` rule exists; like [`TRIVIA_RULE`]
+/// it must sit in the reserved slots immediately after [`ROOT_RULE`].
+pub const WB_RULE: &str = "wb";
+
 /// Cap for the `p{n}` exact-count quantifier. Conservative typo guard:
 /// the largest plausible corpus site is `hex{8}`. Above this the parser
 /// rejects with a clear error instead of expanding a malformed grammar
@@ -59,6 +68,12 @@ pub struct Grammar {
     /// being atomic) is the special case that disables auto-insertion
     /// grammar-wide.
     pub atomic_rules: HashSet<String>,
+    /// Names of rules marked with the `%name <- body` reserved-word
+    /// sigil. Each such rule is also in `atomic_rules` (so trivia is not
+    /// auto-inserted inside it); membership here additionally drives
+    /// [`append_wb_check`](super::analysis::append_wb_check), which
+    /// appends a [`WB_RULE`] call inside the rule's terminal captures.
+    pub percent_rules: HashSet<String>,
     /// Per-rule source ranges, in declaration order. Populated by
     /// [`parse`]; empty for grammars built via [`Grammar::new`] (which
     /// has no source text). `pegc stats` uses these to slice the
@@ -94,6 +109,7 @@ impl Grammar {
         Grammar {
             rules,
             atomic_rules: HashSet::new(),
+            percent_rules: HashSet::new(),
             rule_headers: Vec::new(),
         }
     }
@@ -105,6 +121,7 @@ impl Grammar {
         Grammar {
             rules,
             atomic_rules,
+            percent_rules: HashSet::new(),
             rule_headers: Vec::new(),
         }
     }
@@ -157,6 +174,7 @@ impl Grammar {
         let mut resolved = Grammar {
             rules: self.rules.clone(),
             atomic_rules: self.atomic_rules.clone(),
+            percent_rules: self.percent_rules.clone(),
             rule_headers: self.rule_headers.clone(),
         };
         resolve_inferred_boundaries(&mut resolved)?;
@@ -165,6 +183,11 @@ impl Grammar {
             return Err(CompileError::PartialMatchLeniency(findings));
         }
         inject_auto_trivia(&mut resolved);
+        // After trivia injection (which skips the atomic `%` rules) and
+        // before the root wrap: append the `wb` boundary call inside each
+        // `%` rule's terminal captures. An undefined `wb` surfaces as
+        // `CompileError::UndefinedRule("wb")` from `compile_rules`.
+        append_wb_check(&mut resolved);
         wrap_root(&mut resolved);
         compile_rules(&resolved.rules)
     }
@@ -247,6 +270,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let mut rules = HashMap::new();
         let mut atomic_rules: HashSet<String> = HashSet::new();
+        let mut percent_rules: HashSet<String> = HashSet::new();
         let mut rule_headers: Vec<RuleHeader> = Vec::new();
         while self.pos < self.src.len() {
             // Definition-level lenient marker: `~name <- body` declares
@@ -260,22 +284,41 @@ impl<'a> Parser<'a> {
             // the rule out of trivia auto-insertion: the rewriter walks
             // the body but does not splice `trivia` between `Sequence`
             // items. `*trivia <- …` is the special case that disables
-            // auto-insertion grammar-wide. The two prefixes compose
-            // in either order.
+            // auto-insertion grammar-wide.
+            //
+            // The reserved-word marker `%name <- body` implies atomic and
+            // additionally appends a `wb` boundary call inside the rule's
+            // terminal captures (see `append_wb_check`). `%` composes with
+            // `~` but is mutually exclusive with `*` — both make a rule
+            // atomic, so combining them is always a mistake.
             let mut lenient_span: Option<Span> = None;
             let mut definition_atomic = false;
+            let mut definition_percent = false;
             loop {
                 match self.peek() {
                     Some(b'~') if lenient_span.is_none() => {
                         lenient_span = Some(self.span());
                         self.pos += 1;
                     }
-                    Some(b'*') if !definition_atomic => {
+                    Some(b'*') if !definition_atomic && !definition_percent => {
                         self.pos += 1;
                         definition_atomic = true;
                     }
+                    Some(b'%') if !definition_percent && !definition_atomic => {
+                        self.pos += 1;
+                        definition_percent = true;
+                    }
                     _ => break,
                 }
+            }
+            // A leftover `*`/`%` here means the two were combined
+            // (`*%name`, `%*name`) or doubled — reject with a clear error
+            // instead of a confusing "expected rule name".
+            if matches!(self.peek(), Some(b'*') | Some(b'%')) {
+                return Err(self.err(
+                    "the `*` (atomic) and `%` (reserved-word) rule qualifiers cannot be combined"
+                        .into(),
+                ));
             }
             let name_byte = self.pos;
             let name = self.parse_ident()?;
@@ -291,7 +334,15 @@ impl<'a> Parser<'a> {
                     span,
                 };
             }
-            if definition_atomic {
+            if definition_percent {
+                if name == ROOT_RULE || name == TRIVIA_RULE || name == WB_RULE {
+                    return Err(self.err(format!(
+                        "the `%` reserved-word qualifier cannot be applied to the reserved rule `{name}`"
+                    )));
+                }
+                percent_rules.insert(name.clone());
+            }
+            if definition_atomic || definition_percent {
                 atomic_rules.insert(name.clone());
             }
             if rules.insert(name.clone(), pat).is_some() {
@@ -308,22 +359,39 @@ impl<'a> Parser<'a> {
         if rule_headers.is_empty() {
             return Err(self.err("grammar has no rules".into()));
         }
-        // Reserved-name enforcement for `trivia`'s position is parse-
-        // time so the error points at the offending source location.
-        // `root`'s presence (and the requirement that `root` itself
-        // sits at the top) is enforced by `Grammar::compile` — that
-        // lets AST-only parser tests build fixtures with arbitrary
+        // Reserved-name enforcement for the special rules' positions is
+        // parse-time so the error points at the offending source
+        // location. `root`'s presence (and the requirement that `root`
+        // itself sits at the top) is enforced by `Grammar::compile` —
+        // that lets AST-only parser tests build fixtures with arbitrary
         // rule names without inventing a `root` placeholder.
-        if let Some(trivia_pos) = rule_headers.iter().position(|h| h.name == TRIVIA_RULE) {
-            if trivia_pos != 1 {
+        //
+        // `trivia` and `wb`, when present, occupy the contiguous slots
+        // immediately after `root` (positions 1..=n in either order),
+        // where n is how many of them the grammar defines.
+        let specials = [TRIVIA_RULE, WB_RULE];
+        let n_special = rule_headers
+            .iter()
+            .filter(|h| specials.contains(&h.name.as_str()))
+            .count();
+        for (pos, h) in rule_headers.iter().enumerate() {
+            if specials.contains(&h.name.as_str()) && !(1..=n_special).contains(&pos) {
                 return Err(self.err(format!(
-                    "`{TRIVIA_RULE}` must be the second rule (immediately after `{ROOT_RULE}`) when present"
+                    "`{}` must appear in the reserved slots immediately after `{ROOT_RULE}` (before any other rule)",
+                    h.name
                 )));
             }
+        }
+        // `wb`, like `trivia`, is exempt from trivia auto-insertion: its
+        // body is a bare boundary predicate that must stay adjacent to
+        // the keyword it follows.
+        if rules.contains_key(WB_RULE) {
+            atomic_rules.insert(WB_RULE.to_string());
         }
         Ok(Grammar {
             rules,
             atomic_rules,
+            percent_rules,
             rule_headers,
         })
     }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2181,3 +2181,137 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     };
     assert_eq!(*lit_span, Span { line: 1, col: 12 });
 }
+
+// ---- `%` reserved-word sigil + `wb` special rule -------------------
+
+/// Compile a grammar from source and run it, returning the captures
+/// paired with their resolved kind name and matched text.
+fn run_grammar<'a>(src: &str, input: &'a str) -> Vec<(String, &'a str)> {
+    let prog = parse(src)
+        .expect("grammar parses")
+        .compile()
+        .expect("grammar compiles");
+    let r = VM::new_from_program(&prog, input.as_bytes()).run();
+    r.captures
+        .iter()
+        .map(|c| {
+            (
+                prog.capture_kinds[c.kind.0 as usize].clone(),
+                &input[c.start..c.end],
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn percent_sigil_populates_percent_and_atomic_sets() {
+    let g = parse("root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%r <- @keyword{'if'}").expect("parse");
+    assert!(
+        g.percent_rules.contains("r"),
+        "`%r` should be a percent rule"
+    );
+    assert!(
+        g.atomic_rules.contains("r"),
+        "a `%` rule is also atomic (trivia is not auto-inserted inside it)"
+    );
+}
+
+#[test]
+fn percent_composes_with_lenient() {
+    // `~%name` and `%~name` both parse: `~` (lenient) and `%`
+    // (reserved-word) are independent markers.
+    for src in [
+        "root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n~%r <- @keyword{'if'}",
+        "root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%~r <- @keyword{'if'}",
+    ] {
+        let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
+        assert!(
+            g.percent_rules.contains("r"),
+            "{src:?} should mark r percent"
+        );
+    }
+}
+
+#[test]
+fn percent_rule_appends_wb_inside_capture() {
+    // `%kw_if` must match the keyword `if` but not fire on `ifx`, and
+    // (the leak guard) must leave no stray `if` capture behind on `ifx`.
+    let src = "root <- (token)*^\n\
+               trivia <- (\\s)*\n\
+               wb <- !ident_body\n\
+               token <- kw_if / @variable{ident}\n\
+               %kw_if <- @keyword{'if'}\n\
+               *ident <- [a-z] ident_body*\n\
+               ident_body <- [a-z0-9_]";
+    assert_eq!(
+        run_grammar(src, "if ifx if"),
+        vec![
+            ("keyword".to_string(), "if"),
+            ("variable".to_string(), "ifx"),
+            ("keyword".to_string(), "if"),
+        ]
+    );
+}
+
+#[test]
+fn percent_without_wb_errors_undefined_rule() {
+    // A `%` rule emits a `NonTerminal("wb")`; with no `wb` defined the
+    // reference surfaces as `UndefinedRule("wb")`.
+    let g = parse("root <- r\ntrivia <- (\\s)*\n%r <- @keyword{'if'}").expect("parse");
+    match g.compile().expect_err("compile should fail without wb") {
+        syntax_highlighter::pegc::CompileError::UndefinedRule(name) => assert_eq!(name, "wb"),
+        other => panic!("expected UndefinedRule(\"wb\"), got: {other:?}"),
+    }
+}
+
+#[test]
+fn percent_and_atomic_combined_is_parse_error() {
+    for src in ["%*r <- 'a'", "*%r <- 'a'"] {
+        let err = parse(src).expect_err("combining `%` and `*` must error");
+        assert!(
+            err.message.contains("cannot be combined"),
+            "{src:?} unexpected error: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn percent_on_reserved_rule_is_parse_error() {
+    for name in ["root", "trivia", "wb"] {
+        let src = format!("%{name} <- 'a'");
+        let err = parse(&src).expect_err("`%` on a reserved rule must error");
+        assert!(
+            err.message.contains("reserved rule"),
+            "{src:?} unexpected error: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn wb_must_sit_in_the_reserved_slots() {
+    // `wb` after a non-reserved rule (not contiguous with `root`) errors.
+    let err = parse("root <- r\nr <- 'a'\nwb <- !'x'").expect_err("misplaced wb must error");
+    assert!(
+        err.message.contains("reserved slots"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn wb_and_trivia_compose_in_either_order() {
+    // Both orderings of the two reserved slots after `root` are accepted.
+    parse("root <- 'a'\ntrivia <- (\\s)*\nwb <- !'x'").expect("trivia then wb");
+    parse("root <- 'a'\nwb <- !'x'\ntrivia <- (\\s)*").expect("wb then trivia");
+}
+
+#[test]
+fn wb_without_trivia_is_valid() {
+    // `wb` does not require `trivia`; a grammar may define only `wb`.
+    parse("root <- r\nwb <- !'x'\n%r <- @keyword{'if'}")
+        .expect("parse")
+        .compile()
+        .expect("compile");
+}

--- a/tests/grammar_c_tests.rs
+++ b/tests/grammar_c_tests.rs
@@ -308,6 +308,66 @@ fn sizeof_struct_type_name_parses() {
     assert_eq!(kind_at_pos(&caps, &kinds, foo_pos), Some("type"));
 }
 
+fn captures_with_text<'a>(
+    input: &'a str,
+    caps: &[Capture],
+    kinds: &'a [String],
+) -> Vec<(&'a str, &'a str)> {
+    caps.iter()
+        .map(|c| (kinds[c.kind.0 as usize].as_str(), &input[c.start..c.end]))
+        .collect()
+}
+
+// --- Word-boundary regression tests (issue #6) -----------------------
+//
+// Keywords matched inline as `@keyword{'…'}` must not fire on a longer
+// identifier that merely starts with the keyword. Without a trailing
+// boundary, `typedefiner` highlights as `typedef` + `iner`.
+
+#[test]
+fn keyword_prefix_storage_spec_not_split() {
+    // `typedefiner` is one identifier; `typedef` must not be captured.
+    let input = "typedefiner x;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "typedef")),
+        "`typedef` must not be captured as a keyword prefix of `typedefiner`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_prefix_struct_not_split() {
+    // `structx` is one word; `struct` must not be captured as a keyword.
+    let input = "structx var;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "struct")),
+        "`struct` must not be captured as a keyword prefix of `structx`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_exact_still_highlights() {
+    // No-regression: the bare keywords still highlight when standalone.
+    let input = "static int g;\nstruct P { int x; };\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("keyword", "static")),
+        "`static` should still be a keyword: {:?}",
+        pairs
+    );
+    assert!(
+        pairs.contains(&("keyword", "struct")),
+        "`struct` should still be a keyword: {:?}",
+        pairs
+    );
+}
+
 #[test]
 fn medium_fixture_parses_without_recovery() {
     let input = include_str!("../benches/fixtures/medium.c");

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -58,6 +58,62 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+fn captures_with_text<'a>(
+    input: &'a str,
+    caps: &[Capture],
+    kinds: &'a [String],
+) -> Vec<(&'a str, &'a str)> {
+    caps.iter()
+        .map(|c| (kinds[c.kind.0 as usize].as_str(), &input[c.start..c.end]))
+        .collect()
+}
+
+// --- Word-boundary regression tests (issue #6) -----------------------
+
+#[test]
+fn keyword_prefix_func_not_split() {
+    // `funcx` is one identifier; `func` must not be captured as a keyword.
+    let input = "package main\n\nfuncx F() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "func")),
+        "`func` must not be captured as a keyword prefix of `funcx`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_prefix_return_not_split() {
+    // `returnx` is one identifier; `return` must not be captured.
+    let input = "package main\n\nfunc f() { returnx() }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "return")),
+        "`return` must not be captured as a keyword prefix of `returnx`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_exact_still_highlights() {
+    // No-regression: bare keywords still highlight when standalone.
+    let input = "package main\n\nfunc f() int { return 1 }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("keyword", "func")),
+        "`func` should still be a keyword: {:?}",
+        pairs
+    );
+    assert!(
+        pairs.contains(&("keyword", "return")),
+        "`return` should still be a keyword: {:?}",
+        pairs
+    );
+}
+
 /// Collect recovery captures whose text contains anything other than ASCII
 /// whitespace. Trailing-newline recovery is a known pre-existing quirk (see
 /// #71); this filter keeps callers focused on real recovery regressions.

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -58,6 +58,63 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+fn captures_with_text<'a>(
+    input: &'a str,
+    caps: &[Capture],
+    kinds: &'a [String],
+) -> Vec<(&'a str, &'a str)> {
+    caps.iter()
+        .map(|c| (kinds[c.kind.0 as usize].as_str(), &input[c.start..c.end]))
+        .collect()
+}
+
+// --- Word-boundary regression tests (issue #6) -----------------------
+
+#[test]
+fn keyword_prefix_function_not_split() {
+    // `functionx` is one identifier; `function` must not be a keyword.
+    let input = "functionx foo() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "function")),
+        "`function` must not be captured as a keyword prefix of `functionx`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn contextual_keyword_async_method_name_not_split() {
+    // `async` is a contextual keyword: `{ asyncFoo() {} }` must keep
+    // `asyncFoo` as one method name, not `async` keyword + `Foo`.
+    let input = "let o = { asyncFoo() {} };\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "async")),
+        "`async` must not be captured as a keyword prefix of `asyncFoo`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_exact_still_highlights() {
+    // No-regression: bare keywords / contextual keywords still highlight.
+    let input = "async function f() { return 1; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("keyword", "async")),
+        "`async` should still be a keyword before `function`: {:?}",
+        pairs
+    );
+    assert!(
+        pairs.contains(&("keyword", "function")),
+        "`function` should still be a keyword: {:?}",
+        pairs
+    );
+}
+
 fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String> {
     captures
         .iter()

--- a/tests/grammar_rust_tests.rs
+++ b/tests/grammar_rust_tests.rs
@@ -58,6 +58,62 @@ fn kinds_for<'a>(captures: &[Capture], kinds: &'a [String]) -> Vec<&'a str> {
         .collect()
 }
 
+fn captures_with_text<'a>(
+    input: &'a str,
+    caps: &[Capture],
+    kinds: &'a [String],
+) -> Vec<(&'a str, &'a str)> {
+    caps.iter()
+        .map(|c| (kinds[c.kind.0 as usize].as_str(), &input[c.start..c.end]))
+        .collect()
+}
+
+// --- Word-boundary regression tests (issue #6) -----------------------
+
+#[test]
+fn keyword_prefix_fn_not_split() {
+    // `fnfoo` is one identifier; `fn` must not be captured as a keyword.
+    let input = "fnfoo bar() {}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "fn")),
+        "`fn` must not be captured as a keyword prefix of `fnfoo`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_prefix_async_not_split() {
+    // `asyncx` is one identifier; `async` must not be captured.
+    let input = "fn f() { asyncx() }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        !pairs.contains(&("keyword", "async")),
+        "`async` must not be captured as a keyword prefix of `asyncx`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_exact_still_highlights() {
+    // No-regression: bare keywords still highlight when standalone.
+    let input = "pub fn f() -> i32 { return 1; }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("keyword", "fn")),
+        "`fn` should still be a keyword: {:?}",
+        pairs
+    );
+    assert!(
+        pairs.contains(&("keyword", "return")),
+        "`return` should still be a keyword: {:?}",
+        pairs
+    );
+}
+
 fn kind_spans(captures: &[Capture], kinds: &[String], kind: &str) -> Vec<String> {
     captures
         .iter()

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -60,6 +60,60 @@ fn spans_for<'a>(
         .collect()
 }
 
+fn captures_with_text<'a>(
+    input: &'a str,
+    caps: &[Capture],
+    kinds: &'a [String],
+) -> Vec<(&'a str, &'a str)> {
+    caps.iter()
+        .map(|c| (kinds[c.kind.0 as usize].as_str(), &input[c.start..c.end]))
+        .collect()
+}
+
+// --- Word-boundary regression tests (issue #6) -----------------------
+
+#[test]
+fn keyword_prefix_unicode_identifier_not_split() {
+    // `order€` is one identifier — `€` (U+20AC) is a valid Unicode
+    // continuation char. The `order` keyword must not fire on its
+    // prefix. Regression for the ASCII-only `!ident_char` boundary,
+    // which let a keyword stop at the first non-ASCII byte.
+    let input = "SELECT order\u{20ac} FROM t;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let k = kinds_for(&caps, &kinds);
+    assert!(
+        !k.contains(&"recovery"),
+        "keyword-prefixed Unicode identifier should parse cleanly: {:?}",
+        k
+    );
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("variable", "order\u{20ac}")),
+        "`order€` should be one identifier: {:?}",
+        pairs
+    );
+    assert!(
+        !pairs
+            .iter()
+            .any(|(kind, t)| *kind == "keyword" && t.eq_ignore_ascii_case("order")),
+        "`order` must not be captured as a keyword prefix of `order€`: {:?}",
+        pairs
+    );
+}
+
+#[test]
+fn keyword_exact_still_highlights() {
+    // No-regression: ASCII keyword boundaries still hold.
+    let input = "SELECT a FROM t;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("keyword", "SELECT")),
+        "`SELECT` should still be a keyword: {:?}",
+        pairs
+    );
+}
+
 fn assert_complete_full(input: &str) -> (Vec<Capture>, Vec<String>) {
     let (matched, caps, kinds, complete) = run(input);
     assert!(

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -357,6 +357,37 @@ fn float_variants() {
 }
 
 #[test]
+fn number_literal_does_not_span_whitespace() {
+    // Numeric forms are atomic: `1 . 5` must not lex as a single number
+    // (no trivia injected inside a numeric literal).
+    let input = "SELECT 1 . 5";
+    let (_, caps, kinds, _) = run(input);
+    let nums = spans_for(&caps, &kinds, "number", input);
+    assert!(
+        nums.iter().all(|n| !n.contains(' ')),
+        "no number literal should contain whitespace: {nums:?}"
+    );
+    assert!(
+        nums.contains(&"1"),
+        "`1` should be the number literal: {nums:?}"
+    );
+}
+
+#[test]
+fn hex_literal_requires_word_boundary() {
+    // `0x1Fg` must not lex `0x1F` as a number: the hex boundary rejects the
+    // partial match (`g` is an identifier char), so it falls back to the
+    // integer `0` followed by the identifier `x1Fg`.
+    let input = "SELECT 0x1Fg";
+    let (_, caps, kinds, _) = run(input);
+    let nums = spans_for(&caps, &kinds, "number", input);
+    assert!(
+        !nums.contains(&"0x1F"),
+        "hex word boundary should reject `0x1F` before `g`: {nums:?}"
+    );
+}
+
+#[test]
 fn null_true_false_are_constants() {
     for (input, expected) in [
         ("SELECT NULL", "NULL"),


### PR DESCRIPTION
Keywords matched inline as `@keyword{'…'}` had no trailing word boundary, so a keyword fired on the prefix of a longer identifier — `typedefiner` highlit as `typedef` + `iner`, `funcx` as `func` + `x`, `{ asyncFoo() {} }` split a method name, and SQLite's `SELECT€xx` split at the first non-ASCII byte. Closes #6.

The fix arrives in three commits so correctness lands before the ergonomic syntax change:

1. **Correctness, current syntax.** Each keyword becomes an atomic token rule with `!ident_body` *inside* the `@keyword` capture; SQLite's ASCII-only `!ident_char` is widened to the full `ident_cont` class. Per-grammar regression tests cover keyword-prefixed identifiers, JS contextual keywords, and SQLite's Unicode boundary.
2. **New `%`/`wb` sigil.** `%name <-` compiles a rule atomic and appends a `wb` boundary call inside its terminal captures; `wb` is an optional special rule sitting in the reserved slots after `root`.
3. **Port + docs.** All five grammars adopt `%` rules plus one `wb` each; SQLite retires `ident_char`. Documented in `src/pegc/README.md` and the grammar-refactor skill.

<details>
<summary>Why the boundary goes <em>inside</em> the capture, not after the rule body</summary>

When a keyword rule fails its boundary under top-level `*^` recovery, an `@keyword` capture committed *before* the boundary check leaks as a stray token (e.g. `typedefx` surfacing a bare `typedef` keyword). Placing `wb` inside each leaf capture means the capture only commits when the boundary holds, so a rejected keyword leaves nothing for recovery to surface. `append_wb_check` distributes `wb` into captures and across choice branches to preserve this — it does not simply append `wb` after the rule body.
</details>
