### PR TITLE
Synthesize reserved/preferred word sets; fix keyword ordering

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -62,7 +62,7 @@ for f in /tmp/grammar-refactor/*.ndjson; do
 done
 ```
 
-`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. A `%`-marked rule (`%name <-`) is also off-limits to inlining: see the *Atomicity check* below.
+`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. `reserved` and `preferred` are compiler-*synthesized* (from the `%` / `%?` rules) and can't be defined at all. A `%`- or `%?`-marked rule is also off-limits to inlining: see the *Atomicity check* below.
 
 ### 3. For each candidate, evaluate
 
@@ -86,7 +86,7 @@ Safe shapes regardless of atomicity:
 
 When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `*` sigil on both rule headers before changing anything.
 
-**`%` reserved-word rules are never inline candidates.** A `%name <-` rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. Leave `%` rules (and the `wb` rule itself) alone.
+**`%` / `%?` reserved-word rules are never inline candidates.** A `%name <-` (or `%?name <-`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `%` / `%?` rules (and the `wb` rule itself) alone.
 
 ### 5. Report
 
@@ -109,8 +109,8 @@ The applied edit is mechanical at this point — the judgment was the previous s
 - **Bulk-inlining all refs=1 rules.** Most refs=1 rules are spec-significant cascade entries (every binary-precedence level, every statement form, every type-position-specific entry). Inlining them produces an unreadable wall of alternation.
 - **Inlining across atomicity boundaries without checking.** Will silently change parsing behavior — usually in a way that's not caught by the unit tests but shows up in the highlighter fixtures or recovery baselines.
 - **Forgetting to update the grammar header comment** when removing a rule that's named there.
-- **Touching `root`, `trivia`, `wb`, or any `%` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `%` rules carry an invisible trailing `wb` boundary that inlining would drop. Filter all of these out before evaluating.
-- **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention — `*_body` is used both by `kw_*` (in `@keyword{...}` capture) and by `keyword_word` (for the no-keyword-as-identifier lookahead). Don't sweep these.
+- **Touching `root`, `trivia`, `wb`, `reserved`, `preferred`, or any `%` / `%?` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `reserved` / `preferred` are compiler-synthesized (defining them is a parse error); `%` / `%?` rules carry an invisible trailing `wb` boundary that inlining would drop *and* feed the synthesized sets. Filter all of these out before evaluating.
+- **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention. The `%kw_*` literals are also the source of the synthesized `reserved` set (the no-keyword-as-identifier lookahead, `!reserved`); window-vocabulary keywords are `%?kw_*` so they stay usable as identifiers. Don't sweep these.
 
 ## Reference PRs
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -118,7 +118,7 @@ predef_type   <- @type{predef_type_name}
 # greedy `ident_body*` would swallow the trailing `_t`.
 *typedef_name <- [A-Z] ident_body*
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-%typedef_t_end <- '_t'
+*typedef_t_end <- '_t' wb
 
 struct_or_union_spec <- (kw_struct / kw_union)
                        (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
@@ -279,9 +279,9 @@ expr_primary  <- string_lit
                / lit_const
                / @variable{ident}
 
-# Boolean / null constants as a `%` reserved-word alternation so the
+# Boolean / null constants as a `%?` preferred-word alternation so the
 # `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
-%lit_const    <- @constant{'true'}
+%?lit_const   <- @constant{'true'}
                / @constant{'false'}
                / @constant{'NULL'}
 
@@ -330,17 +330,6 @@ float_suffix  <- [fFlL]
 *ident        <- !reserved ([\p{L}_] / ucn) ident_body*
 ident_body    <- [\p{L}\p{Nd}_] / ucn
 ucn           <- '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
-
-# Reserved keywords that must not be matched as identifiers.
-%reserved     <- reserved_word
-reserved_word <- 'auto' / 'break' / 'case' / 'char' / 'const' / 'continue'
-               / 'default' / 'do' / 'double' / 'else' / 'enum' / 'extern'
-               / 'float' / 'for' / 'goto' / 'if' / 'inline' / 'int'
-               / 'long long' / 'long' / 'register' / 'restrict' / 'return'
-               / 'short' / 'signed' / 'sizeof' / 'static' / 'struct'
-               / 'switch' / 'typedef' / 'union' / 'unsigned' / 'void'
-               / 'volatile' / 'while' / '_Alignof' / '_Atomic' / '_Bool'
-               / '_Complex' / '_Imaginary' / '_Noreturn' / '_Thread_local'
 
 # --- Whitespace / comments ------------------------------------------
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -363,9 +363,9 @@ expr_no_compound_list <- expr_no_compound (@punctuation{','} expr_no_compound)*
 
 literal       <- string_lit / number_lit / rune_lit / lit_const
 
-# Predeclared constants as a `%` reserved-word alternation so the `wb`
+# Predeclared constants as a `%?` preferred-word alternation so the `wb`
 # boundary keeps `trueish` / `nilish` from matching the prefix.
-%lit_const    <- @constant{'true'} / @constant{'false'}
+%?lit_const   <- @constant{'true'} / @constant{'false'}
                / @constant{'nil'} / @constant{'iota'}
 
 string_lit    <- @string{raw_string / interp_string}
@@ -404,24 +404,16 @@ number_lit    <- @number{num_body}
 *lower_ident  <- !reserved [a-z_] ident_body*
 ident_body    <- [\p{L}\p{Nd}_]
 
-# Reserved keywords blocking identifier capture.
-%reserved     <- reserved_word
-reserved_word <- 'break' / 'case' / 'chan' / 'const' / 'continue'
-               / 'defer' / 'default' / 'else' / 'fallthrough' / 'for'
-               / 'func' / 'go' / 'goto' / 'if' / 'import' / 'interface'
-               / 'map' / 'package' / 'range' / 'return' / 'select'
-               / 'struct' / 'switch' / 'type' / 'var'
-
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-%predeclared_const <- 'true' / 'false' / 'nil' / 'iota'
-%predeclared_type <- 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+%?predeclared_const <- 'true' / 'false' / 'nil' / 'iota'
+%?predeclared_type <- 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
                    / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
                    / 'float32' / 'float64' / 'complex64' / 'complex128'
                    / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
                    / 'error' / 'any' / 'comparable'
-%predeclared_fn <- 'append' / 'cap' / 'close' / 'complex' / 'copy'
+%?predeclared_fn <- 'append' / 'cap' / 'close' / 'complex' / 'copy'
                  / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
                  / 'print' / 'println' / 'real' / 'recover'
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -46,26 +46,26 @@ wb             <- !ident_body
 # `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
 # must stay one method name.
 %kw_import     <- @keyword{'import'}
-%kw_from       <- @keyword{'from'}
-%kw_as         <- @keyword{'as'}
+%?kw_from      <- @keyword{'from'}
+%?kw_as        <- @keyword{'as'}
 %kw_export     <- @keyword{'export'}
 %kw_default    <- @keyword{'default'}
-%kw_async      <- @keyword{'async'}
+%?kw_async     <- @keyword{'async'}
 %kw_function   <- @keyword{'function'}
 %kw_class      <- @keyword{'class'}
 %kw_extends    <- @keyword{'extends'}
-%kw_static     <- @keyword{'static'}
-%kw_get        <- @keyword{'get'}
-%kw_set        <- @keyword{'set'}
+%?kw_static    <- @keyword{'static'}
+%?kw_get       <- @keyword{'get'}
+%?kw_set       <- @keyword{'set'}
 %kw_var        <- @keyword{'var'}
-%kw_let        <- @keyword{'let'}
+%?kw_let       <- @keyword{'let'}
 %kw_const      <- @keyword{'const'}
 %kw_if         <- @keyword{'if'}
 %kw_else       <- @keyword{'else'}
 %kw_for        <- @keyword{'for'}
-%kw_await      <- @keyword{'await'}
+%?kw_await     <- @keyword{'await'}
 %kw_in         <- @keyword{'in'}
-%kw_of         <- @keyword{'of'}
+%?kw_of        <- @keyword{'of'}
 %kw_while      <- @keyword{'while'}
 %kw_do         <- @keyword{'do'}
 %kw_switch     <- @keyword{'switch'}
@@ -364,12 +364,12 @@ literal        <- template_lit
                 / string_lit
                 / number_lit
                 / lit_const
+                / lit_undefined
 
-# Boolean / null / undefined constants as a `%` reserved-word
-# alternation so the `wb` boundary keeps `trueish` / `nullish` from
-# matching the prefix.
-%lit_const     <- @constant{'true'} / @constant{'false'}
-                / @constant{'null'} / @constant{'undefined'}
+# Boolean / null / undefined constants; the `wb` boundary keeps
+# `trueish` / `nullish` from matching the prefix.
+%lit_const     <- @constant{'true'} / @constant{'false'} / @constant{'null'}
+%?lit_undefined <- @constant{'undefined'}
 
 string_lit     <- @string{sq_string / dq_string}
 *sq_string     <- "'" ('\\' . / !"'" !'\n' .)* "'"
@@ -424,21 +424,6 @@ number_lit     <- @number{num_body}
 *lower_ident   <- !reserved [a-z_$] ident_body_part*
 ident_body_part <- ident_body / js_uesc
 ident_body     <- [\p{ID_Continue}$\u{200C}\u{200D}]
-
-# Reserved words that must not appear as identifiers. The grammar uses
-# explicit `@keyword{...}` at each call site, so this list only blocks
-# accidental ident capture. Contextual keywords (`async`, `await`,
-# `of`, `from`, `as`, `get`, `set`, `static`, `yield` outside
-# generators) are intentionally omitted so they can still be used as
-# identifiers where the language allows.
-%reserved      <- reserved_word
-reserved_word  <- 'break' / 'case' / 'catch' / 'class' / 'const' / 'continue'
-                / 'debugger' / 'default' / 'delete' / 'do' / 'else'
-                / 'export' / 'extends' / 'false' / 'finally' / 'for'
-                / 'function' / 'if' / 'import' / 'instanceof' / 'in'
-                / 'new' / 'null' / 'return' / 'super' / 'switch'
-                / 'this' / 'throw' / 'true' / 'try' / 'typeof' / 'var'
-                / 'void' / 'while' / 'with' / 'yield'
 
 # --- Whitespace / comments --------------------------------------------
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -547,7 +547,7 @@ number_body <- hex_body / float_body / int_body
 # names and CTE heads where a keyword like INTEGER is actually the
 # content we want to capture as @type).
 
-*bare_ident_nonkw  <- quoted_ident / !keyword_word bare_raw
+*bare_ident_nonkw  <- quoted_ident / !reserved bare_raw
 *bare_ident        <- quoted_ident / bare_raw
 *quoted_ident      <- double_quoted_id / backtick_id / bracket_id
 
@@ -567,11 +567,6 @@ number_body <- hex_body / float_body / int_body
 # boundary call inside the @keyword capture so `SELECT` doesn't match
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.
-# `keyword_word` is also a `%` rule. It has no capture (it's a pure
-# negative-lookahead helper), so the compiler appends a single trailing
-# `wb` after the whole alternation rather than one per branch — one
-# check on the hot identifier-exclusion path, same as a hand-written
-# `!ident_cont`.
 
 %kw_select    <- @keyword{i"select"}
 %kw_from      <- @keyword{i"from"}
@@ -624,22 +619,22 @@ number_body <- hex_body / float_body / int_body
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-%kw_recursive <- @keyword{i"recursive"}
+%?kw_recursive<- @keyword{i"recursive"}
 %kw_window    <- @keyword{i"window"}
 %kw_over      <- @keyword{i"over"}
-%kw_filter    <- @keyword{i"filter"}
-%kw_partition <- @keyword{i"partition"}
-%kw_range     <- @keyword{i"range"}
-%kw_rows      <- @keyword{i"rows"}
-%kw_groups    <- @keyword{i"groups"}
-%kw_unbounded <- @keyword{i"unbounded"}
-%kw_preceding <- @keyword{i"preceding"}
-%kw_following <- @keyword{i"following"}
-%kw_current   <- @keyword{i"current"}
-%kw_row       <- @keyword{i"row"}
-%kw_exclude   <- @keyword{i"exclude"}
-%kw_ties      <- @keyword{i"ties"}
-%kw_others    <- @keyword{i"others"}
+%?kw_filter   <- @keyword{i"filter"}
+%?kw_partition<- @keyword{i"partition"}
+%?kw_range    <- @keyword{i"range"}
+%?kw_rows     <- @keyword{i"rows"}
+%?kw_groups   <- @keyword{i"groups"}
+%?kw_unbounded<- @keyword{i"unbounded"}
+%?kw_preceding<- @keyword{i"preceding"}
+%?kw_following<- @keyword{i"following"}
+%?kw_current  <- @keyword{i"current"}
+%?kw_row      <- @keyword{i"row"}
+%?kw_exclude  <- @keyword{i"exclude"}
+%?kw_ties     <- @keyword{i"ties"}
+%?kw_others   <- @keyword{i"others"}
 %kw_no        <- @keyword{i"no"}
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
@@ -650,7 +645,7 @@ number_body <- hex_body / float_body / int_body
 %kw_values    <- @keyword{i"values"}
 %kw_default   <- @keyword{i"default"}
 %kw_conflict  <- @keyword{i"conflict"}
-%kw_do        <- @keyword{i"do"}
+%?kw_do       <- @keyword{i"do"}
 %kw_nothing   <- @keyword{i"nothing"}
 %kw_rollback  <- @keyword{i"rollback"}
 %kw_abort     <- @keyword{i"abort"}
@@ -673,7 +668,7 @@ number_body <- hex_body / float_body / int_body
 %kw_temp      <- @keyword{i"temp"}
 %kw_temporary <- @keyword{i"temporary"}
 %kw_primary   <- @keyword{i"primary"}
-%kw_key       <- @keyword{i"key"}
+%?kw_key      <- @keyword{i"key"}
 %kw_unique    <- @keyword{i"unique"}
 %kw_check     <- @keyword{i"check"}
 %kw_null      <- @keyword{i"null"}
@@ -721,151 +716,6 @@ number_body <- hex_body / float_body / int_body
 %kw_explain   <- @keyword{i"explain"}
 %kw_query     <- @keyword{i"query"}
 %kw_plan      <- @keyword{i"plan"}
-
-# Keyword negative-lookahead for the identifier rule.
-#
-# Invariant: among alternatives that share a prefix, the longer body
-# must come first so PEG first-match doesn't accept a shorter keyword
-# when a longer one also matches (e.g. INTERSECT before IN). We enforce
-# it by sorting the whole list strictly length-descending, then
-# alphabetically within each length tier. New keywords slot in by
-# length alone — no per-cluster reasoning needed. The known shared-
-# prefix clusters (all satisfied by length-descending ordering):
-#
-#   INTERSECT > IN / IS             (I-prefix)
-#   DISTINCT > DESC                 (D-prefix)
-#   NATURAL > NULL > NOT            (N-prefix)
-#   OFFSET > ORDER / OUTER > ON / OR (O-prefix)
-#
-# The `%` marker appends one `wb` boundary after the whole alternation
-# (this rule has no capture, so it isn't distributed per branch), which
-# keeps each body boundary-free.
-%keyword_word <-
-    ( i"autoincrement"  # 13
-    / i"transaction"    # 11
-    / i"constraint"     # 10
-    / i"deferrable"     # 10
-    / i"references"     # 10
-    / i"exclusive"      # 9
-    / i"generated"      # 9
-    / i"immediate"      # 9
-    / i"initially"      # 9
-    / i"intersect"      # 9
-    / i"returning"      # 9
-    / i"savepoint"      # 9
-    / i"temporary"      # 9
-    / i"conflict"       # 8
-    / i"database"       # 8
-    / i"deferred"       # 8
-    / i"distinct"       # 8
-    / i"restrict"       # 8
-    / i"rollback"       # 8
-    / i"analyze"        # 7
-    / i"between"        # 7
-    / i"cascade"        # 7
-    / i"collate"        # 7
-    / i"default"        # 7
-    / i"explain"        # 7
-    / i"foreign"        # 7
-    / i"instead"        # 7
-    / i"natural"        # 7
-    / i"nothing"        # 7
-    / i"primary"        # 7
-    / i"reindex"        # 7
-    / i"release"        # 7
-    / i"replace"        # 7
-    / i"trigger"        # 7
-    / i"virtual"        # 7
-    / i"without"        # 7
-    / i"action"         # 6
-    / i"always"         # 6
-    / i"attach"         # 6
-    / i"before"         # 6
-    / i"column"         # 6
-    / i"commit"         # 6
-    / i"create"         # 6
-    / i"delete"         # 6
-    / i"detach"         # 6
-    / i"escape"         # 6
-    / i"except"         # 6
-    / i"exists"         # 6
-    / i"having"         # 6
-    / i"ignore"         # 6
-    / i"insert"         # 6
-    / i"offset"         # 6
-    / i"pragma"         # 6
-    / i"regexp"         # 6
-    / i"rename"         # 6
-    / i"select"         # 6 (SELECT)
-    / i"stored"         # 6
-    / i"strict"         # 6
-    / i"unique"         # 6
-    / i"update"         # 6
-    / i"vacuum"         # 6
-    / i"values"         # 6
-    / i"window"         # 6
-    / i"abort"          # 5
-    / i"after"          # 5
-    / i"alter"          # 5
-    / i"begin"          # 5
-    / bool_body         # 5 (FALSE) / 4 (TRUE); alternation handles both
-    / i"check"          # 5
-    / i"cross"          # 5
-    / i"group"          # 5
-    / i"index"          # 5
-    / i"inner"          # 5
-    / i"limit"          # 5
-    / i"match"          # 5
-    / i"order"          # 5
-    / i"outer"          # 5
-    / i"query"          # 5
-    / i"right"          # 5
-    / i"rowid"          # 5
-    / i"table"          # 5
-    / i"union"          # 5
-    / i"using"          # 5
-    / i"where"          # 5
-    / i"case"           # 4
-    / i"cast"           # 4
-    / i"desc"           # 4
-    / i"drop"           # 4
-    / i"each"           # 4
-    / i"else"           # 4
-    / i"fail"           # 4
-    / i"from"           # 4
-    / i"full"           # 4
-    / i"glob"           # 4
-    / i"into"           # 4
-    / i"join"           # 4
-    / i"left"           # 4
-    / i"like"           # 4
-    / null_body         # 4
-    / i"over"           # 4
-    / i"plan"           # 4
-    / i"temp"           # 4
-    / i"then"           # 4
-    / i"view"           # 4
-    / i"when"           # 4
-    / i"with"           # 4
-    / i"add"            # 3
-    / i"all"            # 3
-    / i"and"            # 3
-    / i"asc"            # 3
-    / i"end"            # 3
-    / i"for"            # 3
-    / i"not"            # 3
-    / i"set"            # 3
-    / i"as"             # 2
-    / i"by"             # 2
-    / i"if"             # 2
-    / i"in"             # 2
-    / i"is"             # 2
-    / i"no"             # 2
-    / i"of"             # 2
-    / i"on"             # 2
-    / i"or"             # 2
-    / i"to"             # 2
-    )
 
 # --- Whitespace & comments -------------------------------------------
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -38,12 +38,17 @@ name2 <-  body2
   it is only required when the grammar has at least one `%` rule.
 - Rules may carry **prefix sigils**: `~name <-` for the intentional
   leniency marker, `*name <-` for the atomic marker (no `trivia`
-  injected inside this rule's body), and `%name <-` for the
-  reserved-word marker (atomic *and* appends a trailing `wb` call
-  inside the rule's terminal captures). `~` composes with either of
-  `*` / `%` (`~*name`, `%~name`, …); `*` and `%` are mutually
-  exclusive — both make a rule atomic. `*trivia <- …` is the special
-  case that disables auto-insertion grammar-wide.
+  injected inside this rule's body), `%name <-` for the reserved-word
+  marker (atomic *and* appends a trailing `wb` call inside the rule's
+  terminal captures), and `%?name <-` for the preferred-word marker (a
+  sibling of `%` for identifier-eligible distinguished tokens). `~`
+  composes with `*` / `%` / `%?` (`~*name`, `%~name`, …); `*` and
+  `%` / `%?` are mutually exclusive — both make a rule atomic.
+  `*trivia <- …` is the special case that disables auto-insertion
+  grammar-wide.
+- Two special rules, **`reserved`** and **`preferred`**, are
+  *synthesized* by the compiler from the `%` / `%?` rules (see below) —
+  a grammar references them (`!reserved`) but never defines them.
 - **Position constraint:** `root` is always the first rule. The
   optional special rules `trivia` and `wb` occupy the contiguous slots
   immediately after `root` (positions 1..2, in either order). Other
@@ -576,12 +581,12 @@ Three rule names get compile-time treatment:
   pair`, and each iteration begins by consuming whatever
   inter-iteration whitespace is sitting in front of it.
 
-- **`wb`** — the optional word-boundary target for `%` rules. Its
-  body is a bare boundary predicate (typically `wb <- !ident_body`,
+- **`wb`** — the optional word-boundary target for `%` / `%?` rules.
+  Its body is a bare boundary predicate (typically `wb <- !ident_body`,
   or `!ident_cont` for a Unicode-aware continuation class). The
   compiler appends a `wb` call inside the terminal captures of every
-  `%` rule (see [`%name <-`](#name----reserved-word-marker)); it is
-  required only when the grammar has at least one `%` rule. Like
+  `%` / `%?` rule (see [`%name <-`](#name----reserved-word-marker)); it
+  is required only when the grammar has at least one such rule. Like
   `trivia`, `wb` is exempt from trivia auto-insertion and must sit in
   the reserved slots immediately after `root`. It is **not** part of
   the trivia diagnostic cascade.
@@ -635,11 +640,66 @@ the boundary holds, so a rejected keyword leaves no stray capture for
 top-level `*^` recovery to surface. Because the rule is atomic, no
 `trivia` is spliced between the literal and the appended `wb` call.
 
+When a `%` / `%?` rule's body is a **capture-less alternation of plain
+literals**, the compiler prefix-factors it into a longest-match **trie**
+(with `wb` at each accepting leaf) instead of a flat alternation. The
+trie is order-independent, so a shorter keyword can't shadow a longer
+one that extends it — `do` / `double`, `go` / `goto`, `int` / `int8`
+all match maximally regardless of source order. (Case-insensitive
+`i"…"` keyword sets lower to char-class sequences, not plain literals,
+so they keep the flat form — the synthesizer below emits those
+longest-first so maximal munch still holds.)
+
 - Requires a `wb` rule; with none defined, the synthesized
   `NonTerminal("wb")` surfaces as `CompileError::UndefinedRule("wb")`.
 - Composes with `~` (`%~name` / `~%name`); mutually exclusive with `*`
   (combining them is a parse error).
 - Rejected on the reserved rules `root` / `trivia` / `wb`.
+
+### `%?name <-` — preferred-word marker
+
+A `%?` prefix (the `?` touches the `%`) is the sibling of `%` for
+**preferred words**: identifier-eligible distinguished tokens such as
+Go's predeclared `int` / `len` / `true` or JavaScript's contextual
+`async` / `let`. It behaves exactly like `%` — atomic, with the same
+`wb` boundary and the same trie treatment — and differs only in *which
+synthesized set the rule's literals feed*: a `%?` rule's words go into
+`preferred` and are **excluded** from `reserved`, so they stay usable as
+identifiers.
+
+```peg
+%?predeclared_type <- 'int8' / 'int16' / 'int'   # Go: shadowable
+%?kw_async         <- @keyword{'async'}          # JS: contextual
+```
+
+- Same requirements / composition / rejections as `%`.
+- A word reachable from both a `%` and a `%?` rule is a contradiction
+  (it can't be both barred from and allowed in identifier position) and
+  raises `CompileError::ReservedPreferredConflict`.
+
+### `reserved` / `preferred` — synthesized word sets
+
+The compiler synthesizes two rules from the `%` / `%?` rules above:
+
+- **`reserved`** — every literal of a `%` rule that is **not** `%?`.
+  Reference it as `!reserved` in an identifier rule to bar keywords from
+  identifier position without hand-maintaining a list:
+
+  ```peg
+  *ident <- !reserved [A-Za-z_] [A-Za-z0-9_]*
+  ```
+
+- **`preferred`** — every literal of a `%?` rule. Materialized for
+  symmetry / inspection (e.g. `pegdb`); a grammar usually doesn't
+  reference it.
+
+Both are emitted as `%` rules (trie + `wb`), so `!reserved` does correct
+maximal-munch: `int` is reserved, but `integer` — a longer word that
+merely starts with it — is not. A rule whose body isn't a fixed keyword
+shape (it has a quantifier / wildcard / predicate, e.g. a number body
+like `'0x' [\da-fA-F]+`) contributes nothing; keep such boundary-only
+helpers as `*name <- … wb` rather than `%`. Authors **reference** these
+two names but never **define** them (a definition is a parse error).
 
 ### Reserved syntax
 

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -5,7 +5,7 @@
 //! the rest (FIRST/FOLLOW) for grammar inspection — see the
 //! `pegc follow-set` subcommand.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use super::compiler::CompileError;
 use super::parser::Grammar;
@@ -1666,6 +1666,23 @@ fn append_wb_in(pat: &mut Pattern) {
     // choice is equivalent to — and leaner than — one per branch. Only
     // distribute when there is a capture to keep the boundary inside of.
     if matches!(pat, Pattern::OrderedChoice { .. }) && !contains_capture(pat) {
+        // When every branch is a plain literal, prefix-factor the set
+        // into a longest-match trie (with `wb` at each accept) instead of
+        // a flat alternation under one trailing `wb`. The trie makes
+        // source ordering irrelevant — a shorter keyword can no longer
+        // shadow a longer one that shares its prefix (#13: `do`/`double`,
+        // `go`/`goto`, `int`/`int8`) — and turns the hot
+        // identifier-exclusion scan into a prefix walk. Non-literal
+        // capture-less choices (e.g. the case-insensitive `i"…"` keyword
+        // sets, which lower to char-class sequences) keep the flat
+        // single-trailing-`wb` form; `synthesize_reserved_preferred`
+        // emits those longest-first so the flat form is still correct.
+        if let Pattern::OrderedChoice { alts, .. } = pat {
+            if let Some(literals) = all_plain_literals(alts) {
+                *pat = factor_literal_trie(literals);
+                return;
+            }
+        }
         let taken = std::mem::replace(pat, Pattern::any_char());
         *pat = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
         return;
@@ -1715,6 +1732,254 @@ fn contains_capture(pat: &Pattern) -> bool {
     }
 }
 
+/// If every alternative of a choice is a plain [`Pattern::Literal`],
+/// return their raw byte-strings; otherwise `None`. The all-or-nothing
+/// gate keeps [`append_wb_in`] on the flat single-`wb` path for choices
+/// that mix literals with char classes / sub-rules (e.g. the
+/// case-insensitive `i"…"` keyword sets).
+fn all_plain_literals(alts: &[Pattern]) -> Option<Vec<Vec<u8>>> {
+    let mut out = Vec::with_capacity(alts.len());
+    for a in alts {
+        match a {
+            Pattern::Literal { bytes, .. } => out.push(bytes.clone()),
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+/// Prefix-factor a set of literal byte-strings into a longest-match trie
+/// with a [`WB_RULE`](super::parser::WB_RULE) call at every accepting
+/// node. Replaces a flat capture-less literal alternation: the trie is
+/// order-independent (a shorter keyword can't shadow a longer one that
+/// extends it) and walks the input once instead of re-scanning every
+/// alternative.
+fn factor_literal_trie(mut literals: Vec<Vec<u8>>) -> Pattern {
+    literals.sort();
+    literals.dedup();
+    build_trie(literals)
+}
+
+/// Build one trie node from the suffixes that reach it. An empty suffix
+/// means "a keyword ends here" → emit `wb`. Distinct continuation bytes
+/// become sibling branches; a single-child, no-accept chain is coalesced
+/// into one multi-byte literal. The accept (`wb`) branch is emitted
+/// *last* so maximal munch wins: with `long` and `long long` in the set,
+/// trying ` long` before accepting `long` is what stops `long long` from
+/// matching only its `long` prefix (the space is a valid boundary, so a
+/// `wb`-first order would accept the short form).
+fn build_trie(entries: Vec<Vec<u8>>) -> Pattern {
+    let mut accept = false;
+    let mut groups: BTreeMap<u8, Vec<Vec<u8>>> = BTreeMap::new();
+    for e in entries {
+        match e.split_first() {
+            None => accept = true,
+            Some((&b, rest)) => groups.entry(b).or_default().push(rest.to_vec()),
+        }
+    }
+    let mut branches: Vec<Pattern> = Vec::with_capacity(groups.len() + 1);
+    for (b, subs) in groups {
+        let mut prefix = vec![b];
+        let mut cur = subs;
+        loop {
+            if cur.iter().any(|e| e.is_empty()) {
+                break;
+            }
+            let firsts: BTreeSet<u8> = cur.iter().filter_map(|e| e.first().copied()).collect();
+            if firsts.len() != 1 {
+                break;
+            }
+            let only = *firsts.iter().next().unwrap();
+            prefix.push(only);
+            cur = cur.into_iter().map(|e| e[1..].to_vec()).collect();
+        }
+        let sub = build_trie(cur);
+        branches.push(Pattern::seq(vec![Pattern::literal_bytes(prefix), sub]));
+    }
+    if accept {
+        branches.push(Pattern::nt(super::parser::WB_RULE));
+    }
+    Pattern::choice(branches)
+}
+
+/// Synthesize the compiler-generated `reserved` and `preferred` rules
+/// from the literals reachable through the grammar's `%` / `%?` rules.
+///
+/// `reserved` collects every literal of a `%` rule that is *not* `%?`;
+/// `preferred` collects every literal of a `%?` rule. A rule whose body
+/// isn't a fixed keyword shape (it has a quantifier, wildcard, predicate,
+/// or an unresolvable reference — e.g. a number body like
+/// `'0x' [\da-fA-F]+`) contributes nothing. Both rules are emitted as a
+/// flat alternation ordered longest-first and registered as `%` rules, so
+/// the following [`append_wb_check`] gives them the same trie + `wb`
+/// treatment as any author-written keyword set.
+///
+/// A literal reachable from both a `%` and a `%?` rule is a contradiction
+/// (it can't be both barred from and allowed in identifier position) and
+/// raises [`CompileError::ReservedPreferredConflict`].
+pub fn synthesize_reserved_preferred(grammar: &mut Grammar) -> Result<(), CompileError> {
+    let mut reserved: BTreeSet<Vec<CharSet>> = BTreeSet::new();
+    let mut preferred: BTreeSet<Vec<CharSet>> = BTreeSet::new();
+
+    let mut percent: Vec<String> = grammar.percent_rules.iter().cloned().collect();
+    percent.sort();
+    for name in &percent {
+        let Some(body) = grammar.rules.get(name) else {
+            continue;
+        };
+        let mut visiting = vec![name.clone()];
+        let Some(entries) = keyword_entries(body, &grammar.rules, &mut visiting) else {
+            continue;
+        };
+        let target = if grammar.preferred_rules.contains(name) {
+            &mut preferred
+        } else {
+            &mut reserved
+        };
+        target.extend(entries);
+    }
+
+    let overlap: Vec<&Vec<CharSet>> = reserved.intersection(&preferred).collect();
+    if !overlap.is_empty() {
+        let mut words: Vec<String> = overlap.iter().map(|e| entry_display(e)).collect();
+        words.sort();
+        return Err(CompileError::ReservedPreferredConflict(words));
+    }
+
+    if !reserved.is_empty() {
+        let rule = build_word_set_rule(reserved);
+        grammar
+            .rules
+            .insert(super::parser::RESERVED_RULE.to_string(), rule);
+        grammar
+            .percent_rules
+            .insert(super::parser::RESERVED_RULE.to_string());
+        grammar
+            .atomic_rules
+            .insert(super::parser::RESERVED_RULE.to_string());
+    }
+    if !preferred.is_empty() {
+        let rule = build_word_set_rule(preferred);
+        grammar
+            .rules
+            .insert(super::parser::PREFERRED_RULE.to_string(), rule);
+        grammar
+            .percent_rules
+            .insert(super::parser::PREFERRED_RULE.to_string());
+        grammar
+            .atomic_rules
+            .insert(super::parser::PREFERRED_RULE.to_string());
+    }
+    Ok(())
+}
+
+/// Extract the fixed keyword strings a pattern can match, as one
+/// `Vec<CharSet>` per string (each `CharSet` matching one code point — a
+/// singleton for a case-sensitive byte, a two-element set for an `i"…"`
+/// case-folded letter). Returns `None` for anything that isn't a fixed
+/// shape: a quantifier, wildcard, predicate, catch, or a reference that
+/// cycles or escapes the keyword shape. `NonTerminal`s are resolved
+/// through `rules` (with a `visiting` cycle guard) so wrappers like
+/// `%bool_lit <- @constant{bool_body}` reach their literals.
+fn keyword_entries(
+    pat: &Pattern,
+    rules: &HashMap<String, Pattern>,
+    visiting: &mut Vec<String>,
+) -> Option<Vec<Vec<CharSet>>> {
+    match pat {
+        Pattern::Literal { bytes, .. } => {
+            let s = std::str::from_utf8(bytes).ok()?;
+            Some(vec![s.chars().map(CharSet::singleton).collect()])
+        }
+        Pattern::CharClass { set, .. } => Some(vec![vec![set.clone()]]),
+        Pattern::Capture { inner, .. } | Pattern::Lenient { inner, .. } => {
+            keyword_entries(inner, rules, visiting)
+        }
+        Pattern::OrderedChoice { alts, .. } => {
+            let mut out = Vec::new();
+            for a in alts {
+                out.extend(keyword_entries(a, rules, visiting)?);
+            }
+            Some(out)
+        }
+        Pattern::Sequence { items, .. } => {
+            // A sequence is one keyword: concatenate the pieces. Each
+            // piece must contribute exactly one fixed string; a choice
+            // inside the sequence would be a product we don't expand, so
+            // reject the whole rule.
+            let mut acc: Vec<CharSet> = Vec::new();
+            for it in items {
+                let sub = keyword_entries(it, rules, visiting)?;
+                let [one] = &sub[..] else {
+                    return None;
+                };
+                acc.extend(one.iter().cloned());
+            }
+            Some(vec![acc])
+        }
+        Pattern::NonTerminal { name, .. } => {
+            if visiting.iter().any(|n| n == name) {
+                return None;
+            }
+            let body = rules.get(name)?;
+            visiting.push(name.clone());
+            let r = keyword_entries(body, rules, visiting);
+            visiting.pop();
+            r
+        }
+        _ => None,
+    }
+}
+
+/// Build a `reserved` / `preferred` rule body from its keyword set: a
+/// flat alternation ordered longest-first. All-singleton-ASCII entries
+/// become byte literals (so [`append_wb_in`] folds them into a trie);
+/// case-folded entries stay sequences of char classes.
+fn build_word_set_rule(set: BTreeSet<Vec<CharSet>>) -> Pattern {
+    let mut entries: Vec<Vec<CharSet>> = set.into_iter().collect();
+    entries.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    let alts: Vec<Pattern> = entries.iter().map(|e| entry_to_pattern(e)).collect();
+    Pattern::choice(alts)
+}
+
+/// Lower one keyword entry to a pattern: a byte literal when every code
+/// point is a singleton ASCII set, otherwise a sequence of char classes.
+fn entry_to_pattern(entry: &[CharSet]) -> Pattern {
+    if let Some(bytes) = entry
+        .iter()
+        .map(charset_singleton_ascii)
+        .collect::<Option<Vec<u8>>>()
+    {
+        return Pattern::literal_bytes(bytes);
+    }
+    let items: Vec<Pattern> = entry
+        .iter()
+        .map(|s| Pattern::char_class(s.clone()))
+        .collect();
+    Pattern::seq(items)
+}
+
+/// The single ASCII byte a char set matches, or `None` if it isn't a
+/// singleton ASCII set.
+fn charset_singleton_ascii(set: &CharSet) -> Option<u8> {
+    let ranges = set.ranges();
+    if ranges.len() == 1 && ranges[0].0 == ranges[0].1 && ranges[0].0.is_ascii() {
+        Some(ranges[0].0 as u8)
+    } else {
+        None
+    }
+}
+
+/// Best-effort rendering of a keyword entry for diagnostics: one
+/// representative code point per position (the highest, so a case-folded
+/// `{a, A}` shows as `a`).
+fn entry_display(entry: &[CharSet]) -> String {
+    entry
+        .iter()
+        .map(|s| s.ranges().last().map(|r| r.0).unwrap_or('\u{FFFD}'))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1754,15 +2019,32 @@ mod tests {
     }
 
     #[test]
-    fn capture_less_choice_gets_one_trailing_wb() {
-        // `%t <- 'a' / 'b' / 'c'` — no capture to leak, so a single
-        // trailing `wb` after the choice, not one per branch.
+    fn capture_less_charclass_choice_gets_one_trailing_wb() {
+        // `%t <- [ab] / [cd]` — capture-less but not all-literal, so the
+        // trie path is skipped and a single trailing `wb` follows the
+        // whole choice, not one per branch.
         let body = Pattern::choice(vec![
-            Pattern::literal("a"),
-            Pattern::literal("b"),
-            Pattern::literal("c"),
+            Pattern::char_class(CharSet::from_chars(&['a', 'b'])),
+            Pattern::char_class(CharSet::from_chars(&['c', 'd'])),
         ]);
         assert_eq!(count_wb(&append_to(body)), 1);
+    }
+
+    #[test]
+    fn capture_less_literal_choice_factors_into_trie() {
+        // `%t <- 'do' / 'double'` — all-literal, so it folds into a
+        // longest-match trie: `do` shared, then `uble` accept vs the bare
+        // `do` accept. Two accepts → two `wb`s.
+        let body = Pattern::choice(vec![Pattern::literal("do"), Pattern::literal("double")]);
+        let trie = append_to(body);
+        assert_eq!(count_wb(&trie), 2);
+        // Source order must not matter: the scrambled set factors to the
+        // identical trie (this is the structural #13 fix).
+        let scrambled = append_to(Pattern::choice(vec![
+            Pattern::literal("double"),
+            Pattern::literal("do"),
+        ]));
+        assert_eq!(trie.strip_spans(), scrambled.strip_spans());
     }
 
     #[test]

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -38,6 +38,12 @@ pub enum CompileError {
     /// [`LintFinding`] carries the call-site's span so the rendered
     /// message points directly at the unanchored call.
     PartialMatchLeniency(Vec<LintFinding>),
+    /// One or more literals are reachable from both a `%` rule and a
+    /// `%?` rule, so the synthesized `reserved` and `preferred` sets
+    /// would overlap — a word can't be both barred from and allowed in
+    /// identifier position. Emitted by `synthesize_reserved_preferred`.
+    /// The payload is the offending literals (UTF-8 lossy), sorted.
+    ReservedPreferredConflict(Vec<String>),
 }
 
 impl std::fmt::Display for CompileError {
@@ -69,6 +75,12 @@ impl std::fmt::Display for CompileError {
                 }
                 Ok(())
             }
+            CompileError::ReservedPreferredConflict(words) => write!(
+                f,
+                "the following word(s) are marked both `%` (reserved) and `%?` (preferred), \
+                 so the synthesized `reserved` / `preferred` sets would overlap: {}",
+                words.join(", ")
+            ),
         }
     }
 }

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use super::analysis::{
-    append_wb_check, inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries, wrap_root,
+    append_wb_check, inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries,
+    synthesize_reserved_preferred, wrap_root,
 };
 use super::compiler::{compile_rules, CompileError};
 use super::pattern::{Pattern, Span};
@@ -52,6 +53,20 @@ pub const TRIVIA_RULE: &str = "trivia";
 /// it must sit in the reserved slots immediately after [`ROOT_RULE`].
 pub const WB_RULE: &str = "wb";
 
+/// Compiler-generated rule name for the reserved-word set. Synthesized
+/// by [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred)
+/// from the literals of every `%` rule minus every `%?` rule, so a
+/// grammar can write `!reserved` to bar keywords from identifier
+/// position without hand-maintaining the list. Authors may *reference*
+/// it but not *define* it — the parser rejects a definition.
+pub const RESERVED_RULE: &str = "reserved";
+
+/// Compiler-generated rule name for the preferred-word set: the union
+/// of every `%?` rule's literals (identifier-eligible distinguished
+/// tokens, e.g. Go predeclared `int` / `len`). Synthesized alongside
+/// [`RESERVED_RULE`]; like it, authors may reference but not define it.
+pub const PREFERRED_RULE: &str = "preferred";
+
 /// Cap for the `p{n}` exact-count quantifier. Conservative typo guard:
 /// the largest plausible corpus site is `hex{8}`. Above this the parser
 /// rejects with a clear error instead of expanding a malformed grammar
@@ -69,11 +84,21 @@ pub struct Grammar {
     /// grammar-wide.
     pub atomic_rules: HashSet<String>,
     /// Names of rules marked with the `%name <- body` reserved-word
-    /// sigil. Each such rule is also in `atomic_rules` (so trivia is not
-    /// auto-inserted inside it); membership here additionally drives
+    /// sigil (and the `%?name <- body` preferred-word sigil, which is a
+    /// subset — every `%?` rule is also here so it still gets a
+    /// boundary). Each such rule is also in `atomic_rules` (so trivia is
+    /// not auto-inserted inside it); membership here additionally drives
     /// [`append_wb_check`](super::analysis::append_wb_check), which
     /// appends a [`WB_RULE`] call inside the rule's terminal captures.
     pub percent_rules: HashSet<String>,
+    /// Names of rules marked with the `%?name <- body` preferred-word
+    /// sigil — identifier-eligible distinguished tokens (Go predeclared
+    /// `int` / `len`, JS contextual `async` / `let`). A strict subset of
+    /// `percent_rules`: a `%?` rule still gets the [`WB_RULE`] boundary,
+    /// but its literals are *excluded* from the synthesized
+    /// [`RESERVED_RULE`] and instead collected into [`PREFERRED_RULE`] by
+    /// [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred).
+    pub preferred_rules: HashSet<String>,
     /// Per-rule source ranges, in declaration order. Populated by
     /// [`parse`]; empty for grammars built via [`Grammar::new`] (which
     /// has no source text). `pegc stats` uses these to slice the
@@ -110,6 +135,7 @@ impl Grammar {
             rules,
             atomic_rules: HashSet::new(),
             percent_rules: HashSet::new(),
+            preferred_rules: HashSet::new(),
             rule_headers: Vec::new(),
         }
     }
@@ -122,6 +148,7 @@ impl Grammar {
             rules,
             atomic_rules,
             percent_rules: HashSet::new(),
+            preferred_rules: HashSet::new(),
             rule_headers: Vec::new(),
         }
     }
@@ -175,6 +202,7 @@ impl Grammar {
             rules: self.rules.clone(),
             atomic_rules: self.atomic_rules.clone(),
             percent_rules: self.percent_rules.clone(),
+            preferred_rules: self.preferred_rules.clone(),
             rule_headers: self.rule_headers.clone(),
         };
         resolve_inferred_boundaries(&mut resolved)?;
@@ -183,6 +211,13 @@ impl Grammar {
             return Err(CompileError::PartialMatchLeniency(findings));
         }
         inject_auto_trivia(&mut resolved);
+        // Synthesize the `reserved` / `preferred` rules from the literals
+        // of the `%` / `%?` rules. Runs after trivia injection (so the
+        // synthesized atomic rules aren't walked) and before
+        // `append_wb_check` (so the synthesized rules pick up the trie +
+        // `wb` like any other `%` rule, and exist before `compile_rules`'
+        // reference check).
+        synthesize_reserved_preferred(&mut resolved)?;
         // After trivia injection (which skips the atomic `%` rules) and
         // before the root wrap: append the `wb` boundary call inside each
         // `%` rule's terminal captures. An undefined `wb` surfaces as
@@ -271,6 +306,7 @@ impl<'a> Parser<'a> {
         let mut rules = HashMap::new();
         let mut atomic_rules: HashSet<String> = HashSet::new();
         let mut percent_rules: HashSet<String> = HashSet::new();
+        let mut preferred_rules: HashSet<String> = HashSet::new();
         let mut rule_headers: Vec<RuleHeader> = Vec::new();
         while self.pos < self.src.len() {
             // Definition-level lenient marker: `~name <- body` declares
@@ -291,9 +327,17 @@ impl<'a> Parser<'a> {
             // terminal captures (see `append_wb_check`). `%` composes with
             // `~` but is mutually exclusive with `*` — both make a rule
             // atomic, so combining them is always a mistake.
+            //
+            // The preferred-word marker `%?name <- body` (the `?` touches
+            // the `%`) is a sibling of `%`: same atomic + `wb` behavior,
+            // but the rule's literals are *excluded* from the synthesized
+            // `reserved` set and collected into `preferred` instead, so a
+            // predeclared / contextual name (`int`, `async`) stays usable
+            // as an identifier. `%?` is also mutually exclusive with `*`.
             let mut lenient_span: Option<Span> = None;
             let mut definition_atomic = false;
             let mut definition_percent = false;
+            let mut definition_preferred = false;
             loop {
                 match self.peek() {
                     Some(b'~') if lenient_span.is_none() => {
@@ -307,6 +351,12 @@ impl<'a> Parser<'a> {
                     Some(b'%') if !definition_percent && !definition_atomic => {
                         self.pos += 1;
                         definition_percent = true;
+                        // `%?` — the optional preferred-word discriminator.
+                        // The `?` must touch the `%` (no whitespace).
+                        if self.peek() == Some(b'?') {
+                            self.pos += 1;
+                            definition_preferred = true;
+                        }
                     }
                     _ => break,
                 }
@@ -334,13 +384,26 @@ impl<'a> Parser<'a> {
                     span,
                 };
             }
+            // `reserved` and `preferred` are compiler-generated (see
+            // `synthesize_reserved_preferred`); an author definition would
+            // be silently overwritten, so reject it outright. Grammars may
+            // still *reference* them (`!reserved`).
+            if name == RESERVED_RULE || name == PREFERRED_RULE {
+                return Err(self.err(format!(
+                    "`{name}` is a compiler-generated rule (synthesized from the `%` / `%?` rules) \
+                     and cannot be defined explicitly; reference it (e.g. `!{name}`) instead"
+                )));
+            }
             if definition_percent {
                 if name == ROOT_RULE || name == TRIVIA_RULE || name == WB_RULE {
                     return Err(self.err(format!(
-                        "the `%` reserved-word qualifier cannot be applied to the reserved rule `{name}`"
+                        "the `%` / `%?` reserved-word qualifier cannot be applied to the reserved rule `{name}`"
                     )));
                 }
                 percent_rules.insert(name.clone());
+            }
+            if definition_preferred {
+                preferred_rules.insert(name.clone());
             }
             if definition_atomic || definition_percent {
                 atomic_rules.insert(name.clone());
@@ -392,6 +455,7 @@ impl<'a> Parser<'a> {
             rules,
             atomic_rules,
             percent_rules,
+            preferred_rules,
             rule_headers,
         })
     }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2315,3 +2315,106 @@ fn wb_without_trivia_is_valid() {
         .compile()
         .expect("compile");
 }
+
+// ---- `%?` preferred-word sigil + synthesized reserved / preferred ---
+
+#[test]
+fn preferred_sigil_populates_preferred_and_percent_sets() {
+    // `%?r` is a preferred-word rule: it lands in `preferred_rules`, and
+    // also in `percent_rules` + `atomic_rules` (it still gets the `wb`
+    // boundary; it differs from `%` only in which synthesized set it
+    // feeds).
+    let g =
+        parse("root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%?r <- @keyword{'async'}").expect("parse");
+    assert!(g.preferred_rules.contains("r"), "`%?r` should be preferred");
+    assert!(
+        g.percent_rules.contains("r"),
+        "`%?r` is still a percent rule (gets `wb`)"
+    );
+    assert!(g.atomic_rules.contains("r"), "`%?r` is also atomic");
+}
+
+#[test]
+fn preferred_and_atomic_combined_is_parse_error() {
+    for src in ["%?*r <- 'a'", "*%?r <- 'a'"] {
+        let err = parse(src).expect_err("combining `%?` and `*` must error");
+        assert!(
+            err.message.contains("cannot be combined"),
+            "{src:?} unexpected error: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn preferred_on_reserved_rule_is_parse_error() {
+    for name in ["root", "trivia", "wb"] {
+        let src = format!("%?{name} <- 'a'");
+        let err = parse(&src).expect_err("`%?` on a reserved rule must error");
+        assert!(
+            err.message.contains("reserved rule"),
+            "{src:?} unexpected error: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn defining_synthesized_rule_is_parse_error() {
+    // `reserved` / `preferred` are compiler-generated; an explicit
+    // definition (with or without a sigil) is rejected.
+    for src in [
+        "reserved <- 'a'",
+        "%reserved <- 'a'",
+        "preferred <- 'a'",
+        "%?preferred <- 'a'",
+    ] {
+        let err = parse(src).expect_err("defining a synthesized rule must error");
+        assert!(
+            err.message.contains("compiler-generated"),
+            "{src:?} unexpected error: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn reserved_preferred_conflict_errors() {
+    // The same literal marked `%` (reserved) in one rule and `%?`
+    // (preferred) in another is a contradiction — compile rejects it.
+    let err = parse("root <- 'x'\nwb <- !'y'\n%a <- 'int'\n%?b <- 'int'")
+        .expect("parse")
+        .compile()
+        .expect_err("conflicting reserved/preferred must error");
+    match err {
+        syntax_highlighter::pegc::CompileError::ReservedPreferredConflict(words) => {
+            assert!(words.iter().any(|w| w == "int"), "got: {words:?}");
+        }
+        other => panic!("expected ReservedPreferredConflict, got: {other:?}"),
+    }
+}
+
+#[test]
+fn synthesized_reserved_trie_and_preferred_membership() {
+    // `%kw_word` is reserved with a deliberately wrong source order
+    // (`int` before `int8`); the synthesized `reserved` / keyword trie
+    // still matches `int8` maximally (#13 fixed structurally). `%?pre`
+    // (`len`) is preferred, so it is excluded from `reserved` and stays
+    // usable as an identifier.
+    let src = "root <- (token)*^\n\
+               trivia <- (\\s)*\n\
+               wb <- !ident_body\n\
+               token <- @keyword{kw_word} / @variable{ident}\n\
+               %kw_word <- 'int' / 'int8'\n\
+               %?pre <- 'len'\n\
+               *ident <- !reserved [a-z] ident_body*\n\
+               ident_body <- [a-z0-9]";
+    assert_eq!(
+        run_grammar(src, "int8 len int"),
+        vec![
+            ("keyword".to_string(), "int8"),
+            ("variable".to_string(), "len"),
+            ("keyword".to_string(), "int"),
+        ]
+    );
+}

--- a/tests/grammar_go_tests.rs
+++ b/tests/grammar_go_tests.rs
@@ -429,3 +429,26 @@ fn non_ascii_identifier_in_short_var_decl() {
         "expected non-ASCII identifier `世界` as variable; got {var_spans:?}"
     );
 }
+
+#[test]
+fn bound_predeclared_name_is_always_a_variable() {
+    // Predeclared names are `%?` (preferred), not reserved, so `int`
+    // shadows as an identifier wherever a binding identifier is expected
+    // — `var` / param / `:=` LHS all flow through `ident_list`
+    // (= @variable). #13's headline: the compiler no longer bars
+    // predeclared names from identifier position. Every `int` token in a
+    // binding slot must be a variable, never a type or keyword. (In
+    // *expression* position `int` is still @type by design — the
+    // predeclared-type colouring, exercised elsewhere.)
+    let input = "package p\n\nvar int = 5\n\nfunc f(int int8) {\n\tint := 6\n}\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let ints: Vec<(&str, &str)> = captures_with_text(input, &caps, &kinds)
+        .into_iter()
+        .filter(|(_, text)| *text == "int")
+        .collect();
+    assert_eq!(ints.len(), 3, "expected three bound `int` tokens: {ints:?}");
+    assert!(
+        ints.iter().all(|(kind, _)| *kind == "variable"),
+        "every bound `int` must be a variable, never a type/keyword: {ints:?}"
+    );
+}

--- a/tests/grammar_javascript_tests.rs
+++ b/tests/grammar_javascript_tests.rs
@@ -709,3 +709,18 @@ fn unicode_brace_escape_in_identifier() {
         "expected \\u{{}}-bearing identifier to capture; got {var_spans:?}"
     );
 }
+
+#[test]
+fn contextual_keyword_is_identifier_eligible() {
+    // Contextual keywords (`async`, `let`, `as`, …) are `%?` (preferred),
+    // not reserved, so they can be bound as ordinary variable names —
+    // the property the old hand-maintained `reserved_word` list encoded
+    // by omission, now expressed structurally.
+    let input = "const async = 1;\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let pairs = captures_with_text(input, &caps, &kinds);
+    assert!(
+        pairs.contains(&("variable", "async")),
+        "`async` should bind as a variable (contextual, not reserved): {pairs:?}"
+    );
+}

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -549,9 +549,10 @@ fn quoted_identifiers() {
 
 #[test]
 fn non_reserved_words_parse_as_identifiers() {
-    // Guards the longest-first invariant in `keyword_word`: words that
-    // look like dialect vocabulary but are not reserved in SQLite must
-    // still parse as bare identifiers in column/table position.
+    // Guards the synthesized `reserved` set: words that look like
+    // dialect vocabulary but are `%?` (window vocab, KEY, DO) — not
+    // reserved in SQLite — must still parse as bare identifiers in
+    // column/table position.
     assert_complete_full("SELECT integer FROM t");
     assert_complete_full("SELECT recursive FROM t");
     assert_complete_full("SELECT partition FROM t WHERE following = 1");


### PR DESCRIPTION
Grammar authors no longer hand-maintain the reserved-word list or its fragile length-descending ordering. A new `%?` sigil marks identifier-eligible "preferred" words (Go predeclared `int`/`len`, JS contextual `async`/`let`), and the compiler synthesizes `reserved` (every `%` literal minus every `%?` literal) and `preferred` from the `%`/`%?` rules — so a grammar writes `!reserved` and the set maintains itself.

Capture-less literal keyword alternations now prefix-factor into a longest-match trie (`wb` at each leaf), so a shorter keyword can't shadow a longer one that extends it — `do`/`double`, `go`/`goto`, `int`/`int8` munch maximally regardless of source order. That is the structural fix for the ordering hazard.

The c/go/javascript/sqlite grammars drop their `reserved_word`/`keyword_word` lists. The `%?name <-` and `reserved`/`preferred` sections of `src/pegc/README.md` document the surface.

One behavior change: JS `with` has no token rule and no other source, so it is no longer reserved (a bare `with` highlights as an identifier); the grammar does not model `with`-statements.

<details>
<summary>Per-grammar %? derivation (non-obvious)</summary>

`%?` is not just "contextual keywords" — it is "every `%` literal that the old reserved list deliberately omitted", derived by diffing each grammar's `%kw_*` tokens against its old `reserved_word`/`keyword_word`:

- **Go** — `predeclared_const`/`type`/`fn` and `lit_const` (predeclared names are shadowable).
- **C** — `lit_const` (`true`/`false`/`NULL` are library macros, not keywords); the boundary-only `_t` helper moves from `%` to `*… wb`.
- **JS** — the 9 contextual `kw_*` (`async`, `await`, `of`, `as`, `from`, `get`, `set`, `static`, `let`) plus `undefined` (split out of `lit_const`, which keeps `true`/`false`/`null` reserved).
- **SQLite** — the window-function vocabulary (`partition`, `range`, `rows`, `groups`, `preceding`, …) plus `key`, `do`, `recursive`; the boundary-only `0x` hex helper moves from `%` to `*… wb`.
</details>

Closes #13.
