### PR TITLE
pegc: forbid qualifiers on the trivia rule

### DIFF
--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -43,9 +43,9 @@ name2 <-  body2
   terminal captures), and `%?name <-` for the preferred-word marker (a
   sibling of `%` for identifier-eligible distinguished tokens). `~`
   composes with `*` / `%` / `%?` (`~*name`, `%~name`, …); `*` and
-  `%` / `%?` are mutually exclusive — both make a rule atomic.
-  `*trivia <- …` is the special case that disables auto-insertion
-  grammar-wide.
+  `%` / `%?` are mutually exclusive — both make a rule atomic. The
+  `trivia` rule carries no qualifiers; auto-insertion is disabled by
+  omitting `trivia`, not by marking it.
 - Two special rules, **`reserved`** and **`preferred`**, are
   *synthesized* by the compiler from the `%` / `%?` rules (see below) —
   a grammar references them (`!reserved`) but never defines them.
@@ -530,13 +530,13 @@ Three rule names get compile-time treatment:
 
 - **`root`** — the start rule (mandatory). The compiler wraps its
   body as `trivia? root_body trivia? !.` so end-of-input is always
-  asserted, and a `trivia` rule (when present and non-atomic) pads
-  the leading and trailing whitespace. The wrap means a grammar
+  asserted, and a `trivia` rule (when present) pads the leading and
+  trailing whitespace. The wrap means a grammar
   source like `root <- value` parses whole inputs, not just longest
   prefixes — the implicit `!.` rejects trailing junk.
 
-- **`trivia`** — the optional auto-insertion target. When defined
-  *and* non-atomic, the compiler injects a call to `trivia` between
+- **`trivia`** — the optional auto-insertion target. When defined,
+  the compiler injects a call to `trivia` between
   every pair of consecutive items in every non-atomic rule's
   `Sequence`, plus prepends one to each iteration of `*` / `+`.
   This replaces the explicit `ws` / `spacing` calls that used to
@@ -560,10 +560,12 @@ Three rule names get compile-time treatment:
 
   Grammars without a `trivia` rule (e.g. indent-sensitive shapes)
   get no auto-insertion and no trivia-padding wrap on `root`; the
-  EOF assertion is still applied. `*trivia <- …` disables
-  auto-insertion grammar-wide without removing the rule — useful
-  when the diagnostic cascade is still wanted but the trivia rule's
-  shape (e.g. line-sensitive newline handling) can't be auto-spliced.
+  EOF assertion is still applied. To keep a callable whitespace rule
+  while leaving auto-insertion off, name it anything other than
+  `trivia` and thread it by hand — the `trivia` rule carries no
+  qualifiers, so its mere presence turns auto-insertion on. Such a
+  hand-threaded rule sits outside the diagnostic cascade, which is
+  keyed on the name `trivia`.
 
   *Why the per-iteration prepend matters.* The auto-insertion
   splices `trivia` at every inter-item boundary of a `Sequence`, but

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1490,12 +1490,12 @@ fn body_contains_catch(pat: &Pattern) -> bool {
 }
 
 /// True iff the grammar has an active auto-insertion target: a rule
-/// named `trivia` that isn't marked atomic. Both
-/// [`inject_auto_trivia`] and [`wrap_root`] consult this; on `false`
-/// they no-op (no inter-Sequence splicing, no `trivia?` siblings in the
-/// root wrap).
+/// named `trivia`. Both [`inject_auto_trivia`] and [`wrap_root`]
+/// consult this; on `false` they no-op (no inter-Sequence splicing, no
+/// `trivia?` siblings in the root wrap). The `trivia` rule carries no
+/// qualifiers, so omitting it is the only way to disable auto-insertion.
 fn auto_insertion_active(grammar: &Grammar) -> bool {
-    grammar.rules.contains_key(TRIVIA_ROOT_RULE) && !grammar.atomic_rules.contains(TRIVIA_ROOT_RULE)
+    grammar.rules.contains_key(TRIVIA_ROOT_RULE)
 }
 
 /// AST-level rewrite: in every non-atomic rule's body, splice a
@@ -1505,10 +1505,10 @@ fn auto_insertion_active(grammar: &Grammar) -> bool {
 /// `lint_partial_match` and the FOLLOW-driven `^^lbl` resolver so both
 /// still see the author's original body.
 ///
-/// No-op when the grammar has no `trivia` rule, or when `trivia` itself
-/// is marked atomic (the `*trivia <- …` grammar-wide opt-out). The
-/// `trivia` rule itself is also exempt — injecting trivia inside its
-/// own body would recurse the runtime indefinitely.
+/// No-op when the grammar has no `trivia` rule (the grammar-wide
+/// opt-out — `trivia` carries no qualifiers). The `trivia` rule itself
+/// is exempt from injection: splicing trivia inside its own body would
+/// recurse the runtime indefinitely.
 ///
 /// The walker descends transparently through `Choice`, `Optional`,
 /// `Capture`, `Catch`, `Lenient`, `AndPredicate`, `NotPredicate`, and
@@ -1608,8 +1608,8 @@ fn inject_trivia_in(pat: &mut Pattern) {
 /// pick up trivia injection.
 ///
 /// `trivia?` is included iff auto-insertion is active. With no `trivia`
-/// rule (or with `*trivia`), the wrap collapses to `body !.` — still
-/// supplying the EOF assertion uniformly.
+/// rule the wrap collapses to `body !.` — still supplying the EOF
+/// assertion uniformly.
 pub fn wrap_root(grammar: &mut Grammar) {
     let active = auto_insertion_active(grammar);
     let Some(body) = grammar.rules.remove(super::parser::ROOT_RULE) else {
@@ -1984,6 +1984,65 @@ fn entry_display(entry: &[CharSet]) -> String {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    // ---- trivia cascade (compute_trivia_rules) -----------------------
+    //
+    // Exercised directly on the parsed (pre-injection) rule map: the
+    // cascade is forward reachability from `trivia`, independent of
+    // auto-insertion, so a plain `trivia` rule is the faithful fixture.
+
+    fn trivia_bits(src: &str) -> HashMap<String, bool> {
+        compute_trivia_rules(&super::super::parser::parse(src).expect("parse").rules)
+    }
+
+    #[test]
+    fn no_trivia_rule_leaves_all_bits_false() {
+        let bits = trivia_bits("root <- 'x'");
+        assert!(bits.values().all(|&b| !b));
+    }
+
+    #[test]
+    fn trivia_rule_marks_itself_not_root() {
+        let bits = trivia_bits("root <- trivia 'x'\ntrivia <- ' '*");
+        assert!(bits["trivia"]);
+        assert!(!bits["root"]);
+    }
+
+    #[test]
+    fn trivia_cascade_reaches_transitive_callees() {
+        let bits = trivia_bits(
+            "root <- trivia 'x'\n\
+             trivia <- ws\n\
+             ws <- (comment / ' ')*\n\
+             comment <- '#' (!'\\n' .)*",
+        );
+        assert!(bits["trivia"] && bits["ws"] && bits["comment"]);
+        assert!(!bits["root"]);
+    }
+
+    #[test]
+    fn trivia_cascade_skips_catch_bearing_rules() {
+        // `victim` is reachable from trivia but carries a catch, so it
+        // is pinned out of the cascade — keeping its frame visible in
+        // `pegdb recoveries explain`.
+        let bits = trivia_bits(
+            "root <- trivia 'x'\n\
+             trivia <- (victim / ' ')*\n\
+             victim <- 'a' ^bad 'b'",
+        );
+        assert!(bits["trivia"]);
+        assert!(!bits["victim"], "catch-bearing rule must not cascade");
+    }
+
+    #[test]
+    fn trivia_cascade_terminates_on_recursion() {
+        let bits = trivia_bits(
+            "root <- trivia 'x'\n\
+             trivia <- ws\n\
+             ws <- (ws / ' ')*",
+        );
+        assert!(bits["trivia"] && bits["ws"]);
+    }
 
     fn count_wb(pat: &Pattern) -> usize {
         match pat {

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -40,8 +40,8 @@ pub const ROOT_RULE: &str = "root";
 /// Reserved rule name for the (optional) auto-insertion target. When a
 /// grammar defines a rule named [`TRIVIA_RULE`], the compiler injects a
 /// call to it between consecutive `Sequence` items in every non-atomic
-/// rule's body. Marking the rule atomic (`*trivia <- …`) keeps the
-/// definition but disables auto-insertion grammar-wide.
+/// rule's body. The rule carries no qualifiers; auto-insertion is
+/// disabled grammar-wide by omitting `trivia`, not by marking it.
 pub const TRIVIA_RULE: &str = "trivia";
 
 /// Reserved rule name for the (optional) word-boundary target. A rule
@@ -79,9 +79,9 @@ pub struct Grammar {
     /// Names of rules marked atomic with the `*name <- body` sigil. The
     /// auto-insertion rewriter skips these rules: `Sequence` items inside
     /// an atomic body don't get a synthesized `trivia` call spliced
-    /// between them. `*trivia <- …` (the auto-insertion target itself
-    /// being atomic) is the special case that disables auto-insertion
-    /// grammar-wide.
+    /// between them. The `trivia` rule itself never appears here — it
+    /// carries no qualifiers; auto-insertion is disabled by omitting
+    /// the rule, not by marking it.
     pub atomic_rules: HashSet<String>,
     /// Names of rules marked with the `%name <- body` reserved-word
     /// sigil (and the `%?name <- body` preferred-word sigil, which is a
@@ -167,8 +167,7 @@ impl Grammar {
     ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with `~`
     ///    at the call site or `~name <- body` at the rule definition.
     /// 3. Inject auto-trivia calls into every non-atomic rule's body
-    ///    (no-op when the grammar has no `trivia` rule or when
-    ///    `trivia` itself is atomic).
+    ///    (no-op when the grammar has no `trivia` rule).
     /// 4. Wrap `root`'s body with `trivia? body trivia? !.` (the
     ///    `trivia?` calls are present iff auto-insertion is active).
     /// 5. Emit bytecode via `compile_rules`.
@@ -319,8 +318,8 @@ impl<'a> Parser<'a> {
             // The atomic marker `*name <- body` (sibling of `~`) opts
             // the rule out of trivia auto-insertion: the rewriter walks
             // the body but does not splice `trivia` between `Sequence`
-            // items. `*trivia <- …` is the special case that disables
-            // auto-insertion grammar-wide.
+            // items. The `trivia` rule carries no qualifiers; omitting it
+            // (not marking it) is what disables auto-insertion.
             //
             // The reserved-word marker `%name <- body` implies atomic and
             // additionally appends a `wb` boundary call inside the rule's
@@ -370,6 +369,7 @@ impl<'a> Parser<'a> {
                         .into(),
                 ));
             }
+            let definition_lenient = lenient_span.is_some();
             let name_byte = self.pos;
             let name = self.parse_ident()?;
             self.skip_ws();
@@ -394,8 +394,25 @@ impl<'a> Parser<'a> {
                      and cannot be defined explicitly; reference it (e.g. `!{name}`) instead"
                 )));
             }
+            // The auto-insertion target carries no qualifiers: `*`, `~`,
+            // `%`, and `%?` on `trivia` are all rejected. To disable
+            // auto-insertion, omit the `trivia` rule and thread whitespace
+            // through a plainly-named rule instead.
+            if name == TRIVIA_RULE
+                && (definition_atomic
+                    || definition_percent
+                    || definition_preferred
+                    || definition_lenient)
+            {
+                return Err(self.err(
+                    "the `trivia` rule cannot carry a qualifier (`*`, `~`, `%`, `%?`); to \
+                     disable auto-insertion, omit `trivia` and thread whitespace through a \
+                     plainly-named rule"
+                        .into(),
+                ));
+            }
             if definition_percent {
-                if name == ROOT_RULE || name == TRIVIA_RULE || name == WB_RULE {
+                if name == ROOT_RULE || name == WB_RULE {
                     return Err(self.err(format!(
                         "the `%` / `%?` reserved-word qualifier cannot be applied to the reserved rule `{name}`"
                     )));

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1880,94 +1880,6 @@ fn compile_errors_on_uninferable_boundary() {
     );
 }
 
-// ---- Trivia reserved-rule cascade --------------------------------
-
-fn trivia_idx(program: &syntax_highlighter::pegvm::Program, name: &str) -> usize {
-    program
-        .rule_names
-        .iter()
-        .position(|n| n == name)
-        .unwrap_or_else(|| {
-            panic!(
-                "rule `{name}` not indexed; rule_names = {:?}",
-                program.rule_names
-            )
-        })
-}
-
-#[test]
-fn trivia_root_marks_itself_and_no_root_leaves_bits_false() {
-    // Without a `trivia` rule the bits are all false.
-    let no_root = parse("root <- 'x'")
-        .expect("parse")
-        .compile()
-        .expect("compile");
-    assert!(no_root.rule_is_trivia.iter().all(|b| !b));
-
-    // The trivia rule itself gets the bit when present. `*trivia`
-    // disables auto-insertion, so explicit `trivia` calls inside
-    // `root` remain in the body.
-    let with_root = parse("root <- trivia 'x'\n*trivia <- ' '*")
-        .expect("parse")
-        .compile()
-        .expect("compile");
-    assert!(with_root.rule_is_trivia[trivia_idx(&with_root, "trivia")]);
-    assert!(!with_root.rule_is_trivia[trivia_idx(&with_root, "root")]);
-}
-
-#[test]
-fn trivia_cascades_to_transitive_callees() {
-    let program = parse(
-        "root    <- trivia 'x'\n\
-         *trivia <- ws\n\
-         ws      <- (comment / ' ')*\n\
-         comment <- '#' (!'\\n' .)*",
-    )
-    .expect("parse")
-    .compile()
-    .expect("compile");
-    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
-    assert!(program.rule_is_trivia[trivia_idx(&program, "ws")]);
-    assert!(program.rule_is_trivia[trivia_idx(&program, "comment")]);
-    assert!(!program.rule_is_trivia[trivia_idx(&program, "root")]);
-}
-
-#[test]
-fn trivia_cascade_skips_catch_bearing_rules() {
-    // `victim` is reached from the trivia subgraph but has a catch
-    // in its body. The cascade pins it out so the catch's frame stays
-    // visible in `pegdb recoveries explain`.
-    let program = parse(
-        "root    <- trivia 'x'\n\
-         *trivia <- (victim / ' ')*\n\
-         victim  <- 'a' ^bad 'b'",
-    )
-    .expect("parse")
-    .compile()
-    .expect("compile");
-    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
-    assert!(
-        !program.rule_is_trivia[trivia_idx(&program, "victim")],
-        "rules containing a catch must not cascade to trivia"
-    );
-}
-
-#[test]
-fn trivia_cascade_handles_recursion() {
-    // Trivia subgraph with a self-cycle; fixpoint should terminate
-    // and mark every reachable rule.
-    let program = parse(
-        "root    <- trivia 'x'\n\
-         *trivia <- ws\n\
-         ws      <- (ws / ' ')*",
-    )
-    .expect("parse")
-    .compile()
-    .expect("compile");
-    assert!(program.rule_is_trivia[trivia_idx(&program, "trivia")]);
-    assert!(program.rule_is_trivia[trivia_idx(&program, "ws")]);
-}
-
 #[test]
 fn auto_trivia_handles_inter_repeat_whitespace() {
     // The rewriter prepends a trivia call to each Repeat iteration so
@@ -2217,6 +2129,29 @@ fn percent_sigil_populates_percent_and_atomic_sets() {
 }
 
 #[test]
+fn qualifier_on_trivia_is_rejected() {
+    // `trivia` is the auto-insertion target and carries no qualifiers;
+    // disabling auto-insertion is done by omitting the rule.
+    for src in [
+        "root <- trivia\n*trivia <- (\\s)*",
+        "root <- trivia\n~trivia <- (\\s)*",
+        "root <- trivia\n%trivia <- (\\s)*",
+        "root <- trivia\n%?trivia <- (\\s)*",
+    ] {
+        let err = match parse(src) {
+            Ok(_) => panic!("{src:?} should be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.message
+                .contains("the `trivia` rule cannot carry a qualifier"),
+            "{src:?}: unexpected error {:?}",
+            err.message
+        );
+    }
+}
+
+#[test]
 fn percent_composes_with_lenient() {
     // `~%name` and `%~name` both parse: `~` (lenient) and `%`
     // (reserved-word) are independent markers.
@@ -2278,7 +2213,9 @@ fn percent_and_atomic_combined_is_parse_error() {
 
 #[test]
 fn percent_on_reserved_rule_is_parse_error() {
-    for name in ["root", "trivia", "wb"] {
+    // `trivia` is covered by `qualifier_on_trivia_is_rejected` (it has
+    // its own all-qualifier rejection with a distinct message).
+    for name in ["root", "wb"] {
         let src = format!("%{name} <- 'a'");
         let err = parse(&src).expect_err("`%` on a reserved rule must error");
         assert!(
@@ -2348,7 +2285,9 @@ fn preferred_and_atomic_combined_is_parse_error() {
 
 #[test]
 fn preferred_on_reserved_rule_is_parse_error() {
-    for name in ["root", "trivia", "wb"] {
+    // `trivia` is covered by `qualifier_on_trivia_is_rejected` (it has
+    // its own all-qualifier rejection with a distinct message).
+    for name in ["root", "wb"] {
         let src = format!("%?{name} <- 'a'");
         let err = parse(&src).expect_err("`%?` on a reserved rule must error");
         assert!(


### PR DESCRIPTION
The `trivia` auto-insertion target had a redundant second control surface: `*trivia` disabled auto-insertion grammar-wide, reaching exactly the same state as not defining a `trivia` rule at all. It also made `atomic` mean something different on `trivia` (a global off-switch) than on every other rule (no trivia spliced inside the body) — an overload with no upside.

This rejects every qualifier (`*`, `~`, `%`, `%?`) on `trivia`, so the rule has a single shape and `auto_insertion_active` collapses to a plain presence check. Auto-insertion is disabled by omitting `trivia`; a hand-threaded whitespace rule simply takes any other name (TOML now does this with `blank`).

One capability is dropped: keeping a rule literally named `trivia` for the diagnostic cascade while suppressing injection — the former `*trivia`. No shipped grammar uses it: TOML, the only line-sensitive grammar, has no recovery catches and so needs no cascade, and a hand-threaded rule sits outside the cascade (which is keyed on the name `trivia`).

The four `compute_trivia_rules` cascade tests used `*trivia` only to dodge that injection; they move to `src/pegc/analysis.rs` as direct unit tests of the reachability function.
