### PR TITLE
pegc: reject every qualifier on root, trivia, and wb

### DIFF
--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -44,8 +44,9 @@ name2 <-  body2
   sibling of `%` for identifier-eligible distinguished tokens). `~`
   composes with `*` / `%` / `%?` (`~*name`, `%~name`, …); `*` and
   `%` / `%?` are mutually exclusive — both make a rule atomic. The
-  `trivia` rule carries no qualifiers; auto-insertion is disabled by
-  omitting `trivia`, not by marking it.
+  three special rules `root`, `trivia`, and `wb` carry no qualifiers at
+  all (any sigil on them is a parse error); whitespace auto-insertion is
+  disabled by omitting `trivia`, not by marking it.
 - Two special rules, **`reserved`** and **`preferred`**, are
   *synthesized* by the compiler from the `%` / `%?` rules (see below) —
   a grammar references them (`!reserved`) but never defines them.
@@ -526,7 +527,10 @@ recorded in adjacent comments and unenforced by the lint; see
 
 ### Reserved rule names
 
-Three rule names get compile-time treatment:
+Three rule names get compile-time treatment. All three are structural
+slots the compiler wraps or injects, not lexable tokens, so none of
+them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
+`trivia`, or `wb` is a parse error.
 
 - **`root`** — the start rule (mandatory). The compiler wraps its
   body as `trivia? root_body trivia? !.` so end-of-input is always

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -394,29 +394,30 @@ impl<'a> Parser<'a> {
                      and cannot be defined explicitly; reference it (e.g. `!{name}`) instead"
                 )));
             }
-            // The auto-insertion target carries no qualifiers: `*`, `~`,
-            // `%`, and `%?` on `trivia` are all rejected. To disable
-            // auto-insertion, omit the `trivia` rule and thread whitespace
-            // through a plainly-named rule instead.
-            if name == TRIVIA_RULE
-                && (definition_atomic
-                    || definition_percent
-                    || definition_preferred
-                    || definition_lenient)
+            // The three special rules — the start rule `root` and the two
+            // auto-insertion targets `trivia` (whitespace) and `wb` (word
+            // boundary) — are structural slots wrapped or injected by the
+            // compiler, not lexable tokens, so every qualifier (`*`, `~`,
+            // `%`, `%?`) is meaningless on them and rejected. Disabling
+            // whitespace auto-insertion is done by omitting `trivia`, not
+            // by qualifying it.
+            if (definition_atomic
+                || definition_percent
+                || definition_preferred
+                || definition_lenient)
+                && (name == ROOT_RULE || name == TRIVIA_RULE || name == WB_RULE)
             {
-                return Err(self.err(
-                    "the `trivia` rule cannot carry a qualifier (`*`, `~`, `%`, `%?`); to \
-                     disable auto-insertion, omit `trivia` and thread whitespace through a \
-                     plainly-named rule"
-                        .into(),
-                ));
+                let disable_hint = if name == TRIVIA_RULE {
+                    "; to disable auto-insertion, omit `trivia` and thread \
+                     whitespace through a plainly-named rule"
+                } else {
+                    ""
+                };
+                return Err(self.err(format!(
+                    "the `{name}` rule cannot carry a qualifier (`*`, `~`, `%`, `%?`){disable_hint}"
+                )));
             }
             if definition_percent {
-                if name == ROOT_RULE || name == WB_RULE {
-                    return Err(self.err(format!(
-                        "the `%` / `%?` reserved-word qualifier cannot be applied to the reserved rule `{name}`"
-                    )));
-                }
                 percent_rules.insert(name.clone());
             }
             if definition_preferred {

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1769,12 +1769,14 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
 
 #[test]
 fn definition_lenient_marker_is_runtime_transparent() {
-    // The `~name <-` wrap compiles to the same bytecode as the bare form.
-    let plain = parse("root <- 'x'+")
+    // The `~name <-` wrap compiles to the same bytecode as the bare
+    // form. The marker rides a non-special helper rule — `root` (like
+    // `trivia` / `wb`) rejects every qualifier.
+    let plain = parse("root <- r\nr <- 'x'+")
         .expect("parse plain")
         .compile()
         .expect("compile plain");
-    let marked = parse("~root <- 'x'+")
+    let marked = parse("root <- r\n~r <- 'x'+")
         .expect("parse marked")
         .compile()
         .expect("compile marked");
@@ -2129,25 +2131,29 @@ fn percent_sigil_populates_percent_and_atomic_sets() {
 }
 
 #[test]
-fn qualifier_on_trivia_is_rejected() {
-    // `trivia` is the auto-insertion target and carries no qualifiers;
-    // disabling auto-insertion is done by omitting the rule.
-    for src in [
-        "root <- trivia\n*trivia <- (\\s)*",
-        "root <- trivia\n~trivia <- (\\s)*",
-        "root <- trivia\n%trivia <- (\\s)*",
-        "root <- trivia\n%?trivia <- (\\s)*",
-    ] {
-        let err = match parse(src) {
-            Ok(_) => panic!("{src:?} should be rejected"),
-            Err(e) => e,
-        };
-        assert!(
-            err.message
-                .contains("the `trivia` rule cannot carry a qualifier"),
-            "{src:?}: unexpected error {:?}",
-            err.message
-        );
+fn qualifier_on_special_rule_is_rejected() {
+    // The three special rules — the start rule `root` and the two
+    // auto-insertion targets `trivia` (whitespace) and `wb` (word
+    // boundary) — are structural slots, not lexable tokens: every
+    // qualifier (`*`, `~`, `%`, `%?`) is rejected on all of them.
+    // Disabling whitespace auto-insertion is done by omitting `trivia`,
+    // not by qualifying it.
+    for name in ["root", "trivia", "wb"] {
+        for qual in ["*", "~", "%", "%?"] {
+            let src = format!("{qual}{name} <- 'a'");
+            let err = parse(&src).expect_err("a qualifier on a special rule must error");
+            assert!(
+                err.message.contains("cannot carry a qualifier"),
+                "{src:?}: unexpected error {:?}",
+                err.message
+            );
+            // Only `trivia` carries the auto-insertion-disable hint.
+            assert_eq!(
+                err.message.contains("omit `trivia`"),
+                name == "trivia",
+                "{src:?}: hint presence should track the `trivia` name"
+            );
+        }
     }
 }
 
@@ -2212,21 +2218,6 @@ fn percent_and_atomic_combined_is_parse_error() {
 }
 
 #[test]
-fn percent_on_reserved_rule_is_parse_error() {
-    // `trivia` is covered by `qualifier_on_trivia_is_rejected` (it has
-    // its own all-qualifier rejection with a distinct message).
-    for name in ["root", "wb"] {
-        let src = format!("%{name} <- 'a'");
-        let err = parse(&src).expect_err("`%` on a reserved rule must error");
-        assert!(
-            err.message.contains("reserved rule"),
-            "{src:?} unexpected error: {}",
-            err.message
-        );
-    }
-}
-
-#[test]
 fn wb_must_sit_in_the_reserved_slots() {
     // `wb` after a non-reserved rule (not contiguous with `root`) errors.
     let err = parse("root <- r\nr <- 'a'\nwb <- !'x'").expect_err("misplaced wb must error");
@@ -2277,21 +2268,6 @@ fn preferred_and_atomic_combined_is_parse_error() {
         let err = parse(src).expect_err("combining `%?` and `*` must error");
         assert!(
             err.message.contains("cannot be combined"),
-            "{src:?} unexpected error: {}",
-            err.message
-        );
-    }
-}
-
-#[test]
-fn preferred_on_reserved_rule_is_parse_error() {
-    // `trivia` is covered by `qualifier_on_trivia_is_rejected` (it has
-    // its own all-qualifier rejection with a distinct message).
-    for name in ["root", "wb"] {
-        let src = format!("%?{name} <- 'a'");
-        let err = parse(&src).expect_err("`%?` on a reserved rule must error");
-        assert!(
-            err.message.contains("reserved rule"),
             "{src:?} unexpected error: {}",
             err.message
         );

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1178,8 +1178,10 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
 #[test]
 fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
-    let plain = parse("root <- 'x'+").compile().unwrap();
-    let lenient = parse("~root <- 'x'+").compile().unwrap();
+    // The marker rides a non-special helper rule — `root` (like
+    // `trivia` / `wb`) rejects every qualifier.
+    let plain = parse("root <- r\nr <- 'x'+").compile().unwrap();
+    let lenient = parse("root <- r\n~r <- 'x'+").compile().unwrap();
     assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
     let r = VM::new(&lenient.code, b"xxx").run();
     assert!(r.complete);


### PR DESCRIPTION
The root item and the two auto-insertion targets `trivia` (whitespace) and `wb` (word boundary) are structural slots the compiler wraps or injects, not lexable tokens, so a prefix sigil on any of them is always meaningless. `trivia` already rejected all four qualifiers (`*`, `~`, `%`, `%?`), but `root` and `wb` only rejected `%` / `%?`. This unifies the rule: all four sigils are now a parse error on `root`, `trivia`, and `wb`, with `trivia` keeping its distinct auto-insertion-disable hint.

The qualifier-rejection logic in `Parser::parse_grammar` collapses to a single guard; the `%`-only `root`/`wb` check is gone. Tests fold into one `qualifier_on_special_rule_is_rejected` covering 3 names × 4 sigils, and the two `~root` fixtures (`definition_lenient_marker_is_runtime_transparent`, `end_to_end_lenient_marker_is_runtime_transparent`) move the marker onto a non-special helper rule.

This lands the end-state the grammar-language redesign settled on, where the root item, `ignore`, and `boundary` all carry no ascriptions.
