### PR TITLE
pegc: use = for rule definitions instead of <-

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -17,7 +17,7 @@ A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a sm
 Each candidate falls into one of four categories. The first two are mechanical, the next two are judgment calls.
 
 1. **Char-class re-aliases (mechanical).** A rule whose body is just `[...]` (one or two character classes in sequence), and the rule name doesn't carry documentary intent beyond "this char class." Inline the class at use sites unless the name appears at many sites — a high-ref alias *is* the documentation.
-2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. a grammar carrying both `*ident_cont <- [a-zA-Z\d_]` and a separate `*ident_char <- [a-zA-Z\d_]` boundary class. Merge to one name unless the dual naming documents a future divergence.
+2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. a grammar carrying both `*ident_cont = [a-zA-Z\d_]` and a separate `*ident_char = [a-zA-Z\d_]` boundary class. Merge to one name unless the dual naming documents a future divergence.
 3. **Refs=1 single-use rules (judgment).** Many rules are referenced once. Most are NOT inline candidates — they exist to name a multi-line cascade entry, an alternation, or a spec-significant phrase. Only inline when the body is a single `name+` / `name*` / `name` / `[...]` / literal — i.e. a textbook thin wrapper.
 4. **Name ≥ body (judgment).** When the rule name is at least as long as the body string, the indirection isn't paying its way. Same evaluation as refs=1: only inline trivial wrappers.
 
@@ -42,12 +42,12 @@ The first line of each file is the header (with `instructions` and `rules` total
 **Char-class bodies (single class as the entire rule body):**
 
 ```bash
-grep -n -E '^\s*\*?[a-z_]+\s*<-\s*\[[^]]+\]\s*$' grammars/*.peg
+grep -n -E '^\s*\*?[a-z_]+\s*=\s*\[[^]]+\]\s*$' grammars/*.peg
 ```
 
 **Duplicate atomic-rule bodies (same body, different names):**
 
-Walk each grammar, normalize the body source (strip leading `*` and the `<-`), group by body string, flag groups of size > 1.
+Walk each grammar, normalize the body source (strip leading `*` and the `=`), group by body string, flag groups of size > 1.
 
 **Refs=1 (single-use) and name ≥ body:**
 
@@ -86,7 +86,7 @@ Safe shapes regardless of atomicity:
 
 When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `*` sigil on both rule headers before changing anything.
 
-**`%` / `%?` reserved-word rules are never inline candidates.** A `%name <-` (or `%?name <-`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `%` / `%?` rules (and the `wb` rule itself) alone.
+**`%` / `%?` reserved-word rules are never inline candidates.** A `%name =` (or `%?name =`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `%` / `%?` rules (and the `wb` rule itself) alone.
 
 ### 5. Report
 
@@ -114,5 +114,5 @@ The applied edit is mechanical at this point — the judgment was the previous s
 
 ## Reference PRs
 
-- #123 — the big sweep across all eight grammars (post-#86 / #87 cleanup; collapsed `trivia <- ws`, inlined thin aliases, folded block-comment patterns into `..=`).
+- #123 — the big sweep across all eight grammars (post-#86 / #87 cleanup; collapsed `trivia = ws`, inlined thin aliases, folded block-comment patterns into `..=`).
 - #136 — the small follow-up (four trivial single-use aliases left after #123 and the implicit-`root`/`trivia` PR #132).

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -99,7 +99,7 @@ every rule appears, including unreferenced ones):
 |--------------|------------------------------------------------------------------------------|
 | `rule`       | Rule name.                                                                   |
 | `references` | Total occurrences of `<rule>` as a `NonTerminal` across every rule's body.   |
-| `body_chars` | Source character count of the rule's body (after `<-`), trimmed.             |
+| `body_chars` | Source character count of the rule's body (after `=`), trimmed.             |
 
 `references` counts **author-written** `NonTerminal` calls in rule bodies. The auto-injected `trivia` calls produced by `src/pegc/analysis.rs::inject_auto_trivia` are not counted, so the reserved `trivia` rule typically reports `references: 0` even though it is the most-invoked rule at runtime. Use the count to find dead or single-use rules in *authored* grammar source; do not read it as runtime call frequency.
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -29,186 +29,186 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-root          =  (external_decl)*^
+root = (external_decl)*^
 
-trivia        =  (comment / \s)*
+trivia = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Per C11 §6.4.2.1 identifier-continue.
-wb            =  !ident_body
+wb = !ident_body
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
-pp_line       =  @keyword{pp_body}
-*pp_body      =  '#' (pp_cont / [^\n])*
-*pp_cont      =  '\\' '\n'
-                / '\\' '\r' '\n'
+pp_line = @keyword{pp_body}
+*pp_body = '#' (pp_cont / [^\n])*
+*pp_cont = '\\' '\n'
+          / '\\' '\r' '\n'
 
 # --- External declarations -------------------------------------------
 
-external_decl =  pp_line
-               / fn_def
-               / decl
+external_decl = pp_line
+              / fn_def
+              / decl
 
 # Type-specifier + declarator + block.
-fn_def        =  decl_spec_list declarator decl* compound_stmt
+fn_def = decl_spec_list declarator decl* compound_stmt
 
 # Declarations end in `;`. Must start with at least one specifier
 # (storage/qualifier/type keyword, `typedef`, `struct`, `union`,
 # `enum`) so we don't accidentally parse `a * b;` as a declaration.
-decl          =  decl_spec_list init_declarator_list? @punctuation{';'}
+decl = decl_spec_list init_declarator_list? @punctuation{';'}
 
-decl_spec_list =  decl_spec+
-decl_spec     =  storage_spec
-               / type_qualifier
-               / type_spec
-               / fn_spec
+decl_spec_list = decl_spec+
+decl_spec = storage_spec
+          / type_qualifier
+          / type_spec
+          / fn_spec
 
 # `%` reserved-word rules: compiled atomic, with a `wb` boundary call
 # appended inside each keyword capture. A keyword can't fire on a longer
 # identifier that merely starts with it (`static MyType`, `typedefx`),
 # and a rejected keyword leaves no stray capture for recovery to surface.
-%storage_spec  =  @keyword{'typedef'}
-                / @keyword{'extern'}
-                / @keyword{'static'}
-                / @keyword{'auto'}
-                / @keyword{'register'}
-                / @keyword{'_Thread_local'}
-%type_qualifier =  @keyword{'const'}
-                 / @keyword{'volatile'}
-                 / @keyword{'restrict'}
-                 / @keyword{'_Atomic'}
-%fn_spec       =  @keyword{'inline'}
-                / @keyword{'_Noreturn'}
+%storage_spec = @keyword{'typedef'}
+              / @keyword{'extern'}
+              / @keyword{'static'}
+              / @keyword{'auto'}
+              / @keyword{'register'}
+              / @keyword{'_Thread_local'}
+%type_qualifier = @keyword{'const'}
+                / @keyword{'volatile'}
+                / @keyword{'restrict'}
+                / @keyword{'_Atomic'}
+%fn_spec = @keyword{'inline'}
+         / @keyword{'_Noreturn'}
 
 # Embedded keyword tokens: one `%` rule per keyword, referenced wherever
 # the keyword appears so the `wb` boundary is applied uniformly.
-%kw_struct    =  @keyword{'struct'}
-%kw_union     =  @keyword{'union'}
-%kw_enum      =  @keyword{'enum'}
-%kw_case      =  @keyword{'case'}
-%kw_default   =  @keyword{'default'}
-%kw_if        =  @keyword{'if'}
-%kw_else      =  @keyword{'else'}
-%kw_for       =  @keyword{'for'}
-%kw_while     =  @keyword{'while'}
-%kw_do        =  @keyword{'do'}
-%kw_switch    =  @keyword{'switch'}
-%kw_return    =  @keyword{'return'}
-%kw_break     =  @keyword{'break'}
-%kw_continue  =  @keyword{'continue'}
-%kw_goto      =  @keyword{'goto'}
-%kw_sizeof    =  @keyword{'sizeof'}
-%kw_alignof   =  @keyword{'_Alignof'}
+%kw_struct = @keyword{'struct'}
+%kw_union = @keyword{'union'}
+%kw_enum = @keyword{'enum'}
+%kw_case = @keyword{'case'}
+%kw_default = @keyword{'default'}
+%kw_if = @keyword{'if'}
+%kw_else = @keyword{'else'}
+%kw_for = @keyword{'for'}
+%kw_while = @keyword{'while'}
+%kw_do = @keyword{'do'}
+%kw_switch = @keyword{'switch'}
+%kw_return = @keyword{'return'}
+%kw_break = @keyword{'break'}
+%kw_continue = @keyword{'continue'}
+%kw_goto = @keyword{'goto'}
+%kw_sizeof = @keyword{'sizeof'}
+%kw_alignof = @keyword{'_Alignof'}
 
-type_spec     =  struct_or_union_spec
-               / enum_spec
-               / predef_type
-               / @type{typedef_name}
+type_spec = struct_or_union_spec
+          / enum_spec
+          / predef_type
+          / @type{typedef_name}
 
-predef_type   =  @type{predef_type_name}
-%predef_type_name =  'void' / 'char' / 'short' / 'long long' / 'long'
-                   / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
-                   / '_Bool' / '_Complex' / '_Imaginary'
+predef_type = @type{predef_type_name}
+%predef_type_name = 'void' / 'char' / 'short' / 'long long' / 'long'
+                  / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
+                  / '_Bool' / '_Complex' / '_Imaginary'
 
 # Heuristic typedef-name: PascalCase or `*_t` tail. If this mismatches
 # an actual declaration, the decl path will fail and we fall back to
 # expression statement. The `_t` arm uses the standard PEG non-greedy
 # idiom `(!end_t ident_body)*` because PEG `*` is possessive — a
 # greedy `ident_body*` would swallow the trailing `_t`.
-*typedef_name =  [A-Z] ident_body*
-               / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-*typedef_t_end =  '_t' wb
+*typedef_name = [A-Z] ident_body*
+              / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
+*typedef_t_end = '_t' wb
 
-struct_or_union_spec =  (kw_struct / kw_union)
-                       (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
-struct_decl   =  decl_spec_list struct_declarator_list? @punctuation{';'}
-               / pp_line
-struct_declarator_list =  struct_declarator (@punctuation{','} struct_declarator)*
-struct_declarator =  struct_field_declarator (@punctuation{':'} expr_cond)?
-                   / @punctuation{':'} expr_cond
-struct_field_declarator =  pointer? struct_field_direct
-struct_field_direct =  @property{ident} struct_field_tail*
-                     / @punctuation{'('} struct_field_declarator @punctuation{')'} struct_field_tail*
-struct_field_tail =  @punctuation{'['} (expr / '')? @punctuation{']'}
-                   / @punctuation{'('} param_list? @punctuation{')'}
+struct_or_union_spec = (kw_struct / kw_union)
+                      (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
+struct_decl = decl_spec_list struct_declarator_list? @punctuation{';'}
+            / pp_line
+struct_declarator_list = struct_declarator (@punctuation{','} struct_declarator)*
+struct_declarator = struct_field_declarator (@punctuation{':'} expr_cond)?
+                  / @punctuation{':'} expr_cond
+struct_field_declarator = pointer? struct_field_direct
+struct_field_direct = @property{ident} struct_field_tail*
+                    / @punctuation{'('} struct_field_declarator @punctuation{')'} struct_field_tail*
+struct_field_tail = @punctuation{'['} (expr / '')? @punctuation{']'}
+                  / @punctuation{'('} param_list? @punctuation{')'}
 
-enum_spec     =  kw_enum (@type{ident})?
-                 (@punctuation{'{'} enum_list? @punctuation{'}'})?
-enum_list     =  enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
-enum_item     =  @constant{ident} (@operator{'='} expr_cond)?
+enum_spec = kw_enum (@type{ident})?
+            (@punctuation{'{'} enum_list? @punctuation{'}'})?
+enum_list = enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
+enum_item = @constant{ident} (@operator{'='} expr_cond)?
 
 # --- Declarators -----------------------------------------------------
 
-init_declarator_list =  init_declarator (@punctuation{','} init_declarator)*
-init_declarator =  declarator (@operator{'='} initializer)?
+init_declarator_list = init_declarator (@punctuation{','} init_declarator)*
+init_declarator = declarator (@operator{'='} initializer)?
 
-declarator    =  pointer? direct_declarator
-pointer       =  (@operator{'*'} type_qualifier*)+
-direct_declarator =  simple_declarator direct_declarator_tail*
-simple_declarator =  @function{ident} &(@punctuation{'('})
-                   / @variable{ident}
-                   / @punctuation{'('} declarator @punctuation{')'}
-direct_declarator_tail =  @punctuation{'['} (expr / '')? @punctuation{']'}
-                        / @punctuation{'('} param_list? @punctuation{')'}
-                        / @punctuation{'('} ident_list? @punctuation{')'}
+declarator = pointer? direct_declarator
+pointer = (@operator{'*'} type_qualifier*)+
+direct_declarator = simple_declarator direct_declarator_tail*
+simple_declarator = @function{ident} &(@punctuation{'('})
+                  / @variable{ident}
+                  / @punctuation{'('} declarator @punctuation{')'}
+direct_declarator_tail = @punctuation{'['} (expr / '')? @punctuation{']'}
+                       / @punctuation{'('} param_list? @punctuation{')'}
+                       / @punctuation{'('} ident_list? @punctuation{')'}
 
-param_list    =  param (@punctuation{','} param)* (@punctuation{','} @operator{'...'})?
-               / @operator{'...'}
-param         =  decl_spec_list (declarator / abstract_declarator)?
-abstract_declarator =  pointer direct_abstract_declarator?
-                     / direct_abstract_declarator
-direct_abstract_declarator =  (@punctuation{'('} abstract_declarator @punctuation{')'} / @punctuation{'['} (expr / '')? @punctuation{']'})
-                              (@punctuation{'['} (expr / '')? @punctuation{']'} / @punctuation{'('} param_list? @punctuation{')'})*
+param_list = param (@punctuation{','} param)* (@punctuation{','} @operator{'...'})?
+           / @operator{'...'}
+param = decl_spec_list (declarator / abstract_declarator)?
+abstract_declarator = pointer direct_abstract_declarator?
+                    / direct_abstract_declarator
+direct_abstract_declarator = (@punctuation{'('} abstract_declarator @punctuation{')'} / @punctuation{'['} (expr / '')? @punctuation{']'})
+                             (@punctuation{'['} (expr / '')? @punctuation{']'} / @punctuation{'('} param_list? @punctuation{')'})*
 
-ident_list    =  @variable{ident} (@punctuation{','} @variable{ident})*
+ident_list = @variable{ident} (@punctuation{','} @variable{ident})*
 
-initializer   =  @punctuation{'{'} initializer_list? @punctuation{','}? @punctuation{'}'}
-               / expr_assign
-initializer_list =  designation? initializer (@punctuation{','} designation? initializer)*
-designation   =  designator+ @operator{'='}
-designator    =  @punctuation{'['} expr_cond @punctuation{']'}
-               / @punctuation{'.'} @property{ident}
+initializer = @punctuation{'{'} initializer_list? @punctuation{','}? @punctuation{'}'}
+            / expr_assign
+initializer_list = designation? initializer (@punctuation{','} designation? initializer)*
+designation = designator+ @operator{'='}
+designator = @punctuation{'['} expr_cond @punctuation{']'}
+           / @punctuation{'.'} @property{ident}
 
 # --- Statements ------------------------------------------------------
 
-compound_stmt =  @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_item    =  pp_line
-               / decl
-               / stmt
+compound_stmt = @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block_item = pp_line
+           / decl
+           / stmt
 
-stmt          =  labeled_stmt
-               / compound_stmt
-               / if_stmt
-               / for_stmt
-               / while_stmt
-               / do_while_stmt
-               / switch_stmt
-               / return_stmt
-               / break_stmt
-               / continue_stmt
-               / goto_stmt
-               / empty_stmt
-               / expr_stmt
+stmt = labeled_stmt
+     / compound_stmt
+     / if_stmt
+     / for_stmt
+     / while_stmt
+     / do_while_stmt
+     / switch_stmt
+     / return_stmt
+     / break_stmt
+     / continue_stmt
+     / goto_stmt
+     / empty_stmt
+     / expr_stmt
 
-labeled_stmt  =  @variable{ident} @punctuation{':'} stmt
-               / kw_case expr_cond @punctuation{':'} stmt
-               / kw_default @punctuation{':'} stmt
+labeled_stmt = @variable{ident} @punctuation{':'} stmt
+             / kw_case expr_cond @punctuation{':'} stmt
+             / kw_default @punctuation{':'} stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt      =  kw_if @punctuation{'('} expr @punctuation{')'} stmt
-                 (kw_else stmt)?
-for_stmt      =  kw_for @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
-for_init      =  decl
-               / expr? @punctuation{';'}
-while_stmt    =  kw_while @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt =  kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
-switch_stmt   =  kw_switch @punctuation{'('} expr @punctuation{')'} stmt
-return_stmt   =  kw_return expr? @punctuation{';'}
-break_stmt    =  kw_break @punctuation{';'}
-continue_stmt =  kw_continue @punctuation{';'}
-goto_stmt     =  kw_goto @variable{ident} @punctuation{';'}
-empty_stmt    =  @punctuation{';'}
-expr_stmt     =  expr @punctuation{';'}
+~if_stmt = kw_if @punctuation{'('} expr @punctuation{')'} stmt
+           (kw_else stmt)?
+for_stmt = kw_for @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
+for_init = decl
+         / expr? @punctuation{';'}
+while_stmt = kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt = kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
+switch_stmt = kw_switch @punctuation{'('} expr @punctuation{')'} stmt
+return_stmt = kw_return expr? @punctuation{';'}
+break_stmt = kw_break @punctuation{';'}
+continue_stmt = kw_continue @punctuation{';'}
+goto_stmt = kw_goto @variable{ident} @punctuation{';'}
+empty_stmt = @punctuation{';'}
+expr_stmt = expr @punctuation{';'}
 
 # --- Expressions ----------------------------------------------------
 #
@@ -220,29 +220,29 @@ expr_stmt     =  expr @punctuation{';'}
 # doesn't eat a fragment of a longer operator that belongs higher up.
 # Assignment (right-associative) and ternary stay outside the LR ladder.
 
-expr          =  expr_assign (@punctuation{','} expr_assign)*
-expr_assign   =  expr_unary assign_op expr_assign
-               / expr_cond
+expr = expr_assign (@punctuation{','} expr_assign)*
+expr_assign = expr_unary assign_op expr_assign
+            / expr_cond
 
 
-assign_op     =  @operator{'<<='} / @operator{'>>='}
-               / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
-               / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
-               / @operator{'='} !'='
+assign_op = @operator{'<<='} / @operator{'>>='}
+          / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+          / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
+          / @operator{'='} !'='
 
 # Trailing ternary `?` leniency absorbed by top-level `*^`.
-~expr_cond    =  expr_lor (@operator{'?'} expr @punctuation{':'} expr_assign)?
+~expr_cond = expr_lor (@operator{'?'} expr @punctuation{':'} expr_assign)?
 
-expr_lor      =  expr_lor @operator{'||'} expr_land / expr_land
-expr_land     =  expr_land @operator{'&&'} expr_bor / expr_bor
-expr_bor      =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor     =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band     =  expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
-expr_eq       =  expr_eq (@operator{'=='} / @operator{'!='}) expr_rel / expr_rel
-expr_rel      =  expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_shift / expr_shift
-expr_shift    =  expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add      =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul      =  expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_unary / expr_unary
+expr_lor = expr_lor @operator{'||'} expr_land / expr_land
+expr_land = expr_land @operator{'&&'} expr_bor / expr_bor
+expr_bor = expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor = expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band = expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq = expr_eq (@operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel = expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_shift / expr_shift
+expr_shift = expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add = expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul = expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_unary / expr_unary
 
 # `sizeof_type` is tried before the generic prefix loop so that
 # `sizeof(struct X)` / `sizeof(union X)` / `sizeof(counter_size_t)`
@@ -251,75 +251,75 @@ expr_mul      =  expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator
 # happen to be an `expr_primary` (e.g. `sizeof(int)`). On failure we
 # fall back to the prefix path so `sizeof expr` and `sizeof(expr)`
 # still parse.
-expr_unary    =  sizeof_type
-               / unary_prefix* expr_postfix
-unary_prefix  =  @operator{'++'} / @operator{'--'}
-               / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
-               / @operator{'*'} / @operator{'&'}
-               / kw_sizeof &(@punctuation{'('} / [A-Za-z_])
-               / kw_alignof
+expr_unary = sizeof_type
+           / unary_prefix* expr_postfix
+unary_prefix = @operator{'++'} / @operator{'--'}
+             / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
+             / @operator{'*'} / @operator{'&'}
+             / kw_sizeof &(@punctuation{'('} / [A-Za-z_])
+             / kw_alignof
 
-expr_postfix  =  expr_primary postfix_op*
-postfix_op    =  @operator{'++'} / @operator{'--'}
-               / @punctuation{'('} arg_list? @punctuation{')'}
-               / @punctuation{'['} expr @punctuation{']'}
-               / @operator{'->'} postfix_member
-               / @punctuation{'.'} postfix_member
-postfix_member =  @function{ident} &(@punctuation{'('})
-                / @property{ident}
+expr_postfix = expr_primary postfix_op*
+postfix_op = @operator{'++'} / @operator{'--'}
+           / @punctuation{'('} arg_list? @punctuation{')'}
+           / @punctuation{'['} expr @punctuation{']'}
+           / @operator{'->'} postfix_member
+           / @punctuation{'.'} postfix_member
+postfix_member = @function{ident} &(@punctuation{'('})
+               / @property{ident}
 
-arg_list      =  expr_assign (@punctuation{','} expr_assign)*
+arg_list = expr_assign (@punctuation{','} expr_assign)*
 
-expr_primary  =  string_lit
-               / char_lit
-               / number_lit
-               / cast_or_paren
-               / call_ident
-               / @type{predef_type_name}
-               / lit_const
-               / @variable{ident}
+expr_primary = string_lit
+             / char_lit
+             / number_lit
+             / cast_or_paren
+             / call_ident
+             / @type{predef_type_name}
+             / lit_const
+             / @variable{ident}
 
 # Boolean / null constants as a `%?` preferred-word alternation so the
 # `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
-%?lit_const   =  @constant{'true'}
-               / @constant{'false'}
-               / @constant{'NULL'}
+%?lit_const = @constant{'true'}
+            / @constant{'false'}
+            / @constant{'NULL'}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
-sizeof_type   =  kw_sizeof @punctuation{'('} type_name @punctuation{')'}
-type_name     =  decl_spec_list abstract_declarator?
+sizeof_type = kw_sizeof @punctuation{'('} type_name @punctuation{')'}
+type_name = decl_spec_list abstract_declarator?
 
 # `(T)expr` vs `(expr)` — try cast first (uses decl_spec which
 # requires a type keyword/qualifier, making the distinction
 # unambiguous for real-world C).
-cast_or_paren =  @punctuation{'('} type_name @punctuation{')'} expr_unary
-               / @punctuation{'('} expr @punctuation{')'}
+cast_or_paren = @punctuation{'('} type_name @punctuation{')'} expr_unary
+              / @punctuation{'('} expr @punctuation{')'}
 
-call_ident    =  @function{ident} &(@punctuation{'('})
+call_ident = @function{ident} &(@punctuation{'('})
 
 # --- Literals --------------------------------------------------------
 
-string_lit    =  @string{string_piece+}
-*string_piece =  ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit = @string{string_piece+}
+*string_piece = ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
-char_lit      =  @string{char_body}
-*char_body    =  ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
+char_lit = @string{char_body}
+*char_body = ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
 
-number_lit    =  @number{num_body}
-*num_body     =  '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
-               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
-               / '0b' bin_digits int_suffix?
-               / '0' [0-7]* int_suffix?
-               / digit_seq '.' digit_seq? exp_part? float_suffix?
-               / '.' digit_seq exp_part? float_suffix?
-               / digit_seq exp_part float_suffix?
-               / digit_seq int_suffix?
-*digit_seq    =  \d [\d']*
-*hex_digits   =  [\da-fA-F] [\da-fA-F']*
-*bin_digits   =  [01] [01']*
-*exp_part     =  [eE] [+\-]? \d+
-int_suffix    =  ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
-float_suffix  =  [fFlL]
+number_lit = @number{num_body}
+*num_body = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+          / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+          / '0b' bin_digits int_suffix?
+          / '0' [0-7]* int_suffix?
+          / digit_seq '.' digit_seq? exp_part? float_suffix?
+          / '.' digit_seq exp_part? float_suffix?
+          / digit_seq exp_part float_suffix?
+          / digit_seq int_suffix?
+*digit_seq = \d [\d']*
+*hex_digits = [\da-fA-F] [\da-fA-F']*
+*bin_digits = [01] [01']*
+*exp_part = [eE] [+\-]? \d+
+int_suffix = ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
+float_suffix = [fFlL]
 
 # --- Identifiers ----------------------------------------------------
 
@@ -327,10 +327,10 @@ float_suffix  =  [fFlL]
 # | digit)*; nondigit = `_ A-Z a-z` | universal-character-name (UCN);
 # UCNs are `\uHHHH` (4 hex) or `\UHHHHHHHH` (8 hex). C23 §6.4.3 also
 # admits raw non-ASCII letters (General_Category=L) directly.
-*ident        =  !reserved ([\p{L}_] / ucn) ident_body*
-ident_body    =  [\p{L}\p{Nd}_] / ucn
-ucn           =  '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
+*ident = !reserved ([\p{L}_] / ucn) ident_body*
+ident_body = [\p{L}\p{Nd}_] / ucn
+ucn = '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
 
 # --- Whitespace / comments ------------------------------------------
 
-*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment = @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -29,37 +29,37 @@
 # `^block_close` catch so malformed function bodies resync at the
 # closing `}` instead of failing the enclosing `fn_def`.
 
-root          <- (external_decl)*^
+root          =  (external_decl)*^
 
-trivia        <- (comment / \s)*
+trivia        =  (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Per C11 §6.4.2.1 identifier-continue.
-wb            <- !ident_body
+wb            =  !ident_body
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
-pp_line       <- @keyword{pp_body}
-*pp_body      <- '#' (pp_cont / [^\n])*
-*pp_cont      <- '\\' '\n'
+pp_line       =  @keyword{pp_body}
+*pp_body      =  '#' (pp_cont / [^\n])*
+*pp_cont      =  '\\' '\n'
                 / '\\' '\r' '\n'
 
 # --- External declarations -------------------------------------------
 
-external_decl <- pp_line
+external_decl =  pp_line
                / fn_def
                / decl
 
 # Type-specifier + declarator + block.
-fn_def        <- decl_spec_list declarator decl* compound_stmt
+fn_def        =  decl_spec_list declarator decl* compound_stmt
 
 # Declarations end in `;`. Must start with at least one specifier
 # (storage/qualifier/type keyword, `typedef`, `struct`, `union`,
 # `enum`) so we don't accidentally parse `a * b;` as a declaration.
-decl          <- decl_spec_list init_declarator_list? @punctuation{';'}
+decl          =  decl_spec_list init_declarator_list? @punctuation{';'}
 
-decl_spec_list <- decl_spec+
-decl_spec     <- storage_spec
+decl_spec_list =  decl_spec+
+decl_spec     =  storage_spec
                / type_qualifier
                / type_spec
                / fn_spec
@@ -68,46 +68,46 @@ decl_spec     <- storage_spec
 # appended inside each keyword capture. A keyword can't fire on a longer
 # identifier that merely starts with it (`static MyType`, `typedefx`),
 # and a rejected keyword leaves no stray capture for recovery to surface.
-%storage_spec  <- @keyword{'typedef'}
+%storage_spec  =  @keyword{'typedef'}
                 / @keyword{'extern'}
                 / @keyword{'static'}
                 / @keyword{'auto'}
                 / @keyword{'register'}
                 / @keyword{'_Thread_local'}
-%type_qualifier <- @keyword{'const'}
+%type_qualifier =  @keyword{'const'}
                  / @keyword{'volatile'}
                  / @keyword{'restrict'}
                  / @keyword{'_Atomic'}
-%fn_spec       <- @keyword{'inline'}
+%fn_spec       =  @keyword{'inline'}
                 / @keyword{'_Noreturn'}
 
 # Embedded keyword tokens: one `%` rule per keyword, referenced wherever
 # the keyword appears so the `wb` boundary is applied uniformly.
-%kw_struct    <- @keyword{'struct'}
-%kw_union     <- @keyword{'union'}
-%kw_enum      <- @keyword{'enum'}
-%kw_case      <- @keyword{'case'}
-%kw_default   <- @keyword{'default'}
-%kw_if        <- @keyword{'if'}
-%kw_else      <- @keyword{'else'}
-%kw_for       <- @keyword{'for'}
-%kw_while     <- @keyword{'while'}
-%kw_do        <- @keyword{'do'}
-%kw_switch    <- @keyword{'switch'}
-%kw_return    <- @keyword{'return'}
-%kw_break     <- @keyword{'break'}
-%kw_continue  <- @keyword{'continue'}
-%kw_goto      <- @keyword{'goto'}
-%kw_sizeof    <- @keyword{'sizeof'}
-%kw_alignof   <- @keyword{'_Alignof'}
+%kw_struct    =  @keyword{'struct'}
+%kw_union     =  @keyword{'union'}
+%kw_enum      =  @keyword{'enum'}
+%kw_case      =  @keyword{'case'}
+%kw_default   =  @keyword{'default'}
+%kw_if        =  @keyword{'if'}
+%kw_else      =  @keyword{'else'}
+%kw_for       =  @keyword{'for'}
+%kw_while     =  @keyword{'while'}
+%kw_do        =  @keyword{'do'}
+%kw_switch    =  @keyword{'switch'}
+%kw_return    =  @keyword{'return'}
+%kw_break     =  @keyword{'break'}
+%kw_continue  =  @keyword{'continue'}
+%kw_goto      =  @keyword{'goto'}
+%kw_sizeof    =  @keyword{'sizeof'}
+%kw_alignof   =  @keyword{'_Alignof'}
 
-type_spec     <- struct_or_union_spec
+type_spec     =  struct_or_union_spec
                / enum_spec
                / predef_type
                / @type{typedef_name}
 
-predef_type   <- @type{predef_type_name}
-%predef_type_name <- 'void' / 'char' / 'short' / 'long long' / 'long'
+predef_type   =  @type{predef_type_name}
+%predef_type_name =  'void' / 'char' / 'short' / 'long long' / 'long'
                    / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
                    / '_Bool' / '_Complex' / '_Imaginary'
 
@@ -116,68 +116,68 @@ predef_type   <- @type{predef_type_name}
 # expression statement. The `_t` arm uses the standard PEG non-greedy
 # idiom `(!end_t ident_body)*` because PEG `*` is possessive — a
 # greedy `ident_body*` would swallow the trailing `_t`.
-*typedef_name <- [A-Z] ident_body*
+*typedef_name =  [A-Z] ident_body*
                / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-*typedef_t_end <- '_t' wb
+*typedef_t_end =  '_t' wb
 
-struct_or_union_spec <- (kw_struct / kw_union)
+struct_or_union_spec =  (kw_struct / kw_union)
                        (@type{ident})? (@punctuation{'{'} struct_decl* @punctuation{'}'})?
-struct_decl   <- decl_spec_list struct_declarator_list? @punctuation{';'}
+struct_decl   =  decl_spec_list struct_declarator_list? @punctuation{';'}
                / pp_line
-struct_declarator_list <- struct_declarator (@punctuation{','} struct_declarator)*
-struct_declarator <- struct_field_declarator (@punctuation{':'} expr_cond)?
+struct_declarator_list =  struct_declarator (@punctuation{','} struct_declarator)*
+struct_declarator =  struct_field_declarator (@punctuation{':'} expr_cond)?
                    / @punctuation{':'} expr_cond
-struct_field_declarator <- pointer? struct_field_direct
-struct_field_direct <- @property{ident} struct_field_tail*
+struct_field_declarator =  pointer? struct_field_direct
+struct_field_direct =  @property{ident} struct_field_tail*
                      / @punctuation{'('} struct_field_declarator @punctuation{')'} struct_field_tail*
-struct_field_tail <- @punctuation{'['} (expr / '')? @punctuation{']'}
+struct_field_tail =  @punctuation{'['} (expr / '')? @punctuation{']'}
                    / @punctuation{'('} param_list? @punctuation{')'}
 
-enum_spec     <- kw_enum (@type{ident})?
+enum_spec     =  kw_enum (@type{ident})?
                  (@punctuation{'{'} enum_list? @punctuation{'}'})?
-enum_list     <- enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
-enum_item     <- @constant{ident} (@operator{'='} expr_cond)?
+enum_list     =  enum_item (@punctuation{','} enum_item)* (@punctuation{','})?
+enum_item     =  @constant{ident} (@operator{'='} expr_cond)?
 
 # --- Declarators -----------------------------------------------------
 
-init_declarator_list <- init_declarator (@punctuation{','} init_declarator)*
-init_declarator <- declarator (@operator{'='} initializer)?
+init_declarator_list =  init_declarator (@punctuation{','} init_declarator)*
+init_declarator =  declarator (@operator{'='} initializer)?
 
-declarator    <- pointer? direct_declarator
-pointer       <- (@operator{'*'} type_qualifier*)+
-direct_declarator <- simple_declarator direct_declarator_tail*
-simple_declarator <- @function{ident} &(@punctuation{'('})
+declarator    =  pointer? direct_declarator
+pointer       =  (@operator{'*'} type_qualifier*)+
+direct_declarator =  simple_declarator direct_declarator_tail*
+simple_declarator =  @function{ident} &(@punctuation{'('})
                    / @variable{ident}
                    / @punctuation{'('} declarator @punctuation{')'}
-direct_declarator_tail <- @punctuation{'['} (expr / '')? @punctuation{']'}
+direct_declarator_tail =  @punctuation{'['} (expr / '')? @punctuation{']'}
                         / @punctuation{'('} param_list? @punctuation{')'}
                         / @punctuation{'('} ident_list? @punctuation{')'}
 
-param_list    <- param (@punctuation{','} param)* (@punctuation{','} @operator{'...'})?
+param_list    =  param (@punctuation{','} param)* (@punctuation{','} @operator{'...'})?
                / @operator{'...'}
-param         <- decl_spec_list (declarator / abstract_declarator)?
-abstract_declarator <- pointer direct_abstract_declarator?
+param         =  decl_spec_list (declarator / abstract_declarator)?
+abstract_declarator =  pointer direct_abstract_declarator?
                      / direct_abstract_declarator
-direct_abstract_declarator <- (@punctuation{'('} abstract_declarator @punctuation{')'} / @punctuation{'['} (expr / '')? @punctuation{']'})
+direct_abstract_declarator =  (@punctuation{'('} abstract_declarator @punctuation{')'} / @punctuation{'['} (expr / '')? @punctuation{']'})
                               (@punctuation{'['} (expr / '')? @punctuation{']'} / @punctuation{'('} param_list? @punctuation{')'})*
 
-ident_list    <- @variable{ident} (@punctuation{','} @variable{ident})*
+ident_list    =  @variable{ident} (@punctuation{','} @variable{ident})*
 
-initializer   <- @punctuation{'{'} initializer_list? @punctuation{','}? @punctuation{'}'}
+initializer   =  @punctuation{'{'} initializer_list? @punctuation{','}? @punctuation{'}'}
                / expr_assign
-initializer_list <- designation? initializer (@punctuation{','} designation? initializer)*
-designation   <- designator+ @operator{'='}
-designator    <- @punctuation{'['} expr_cond @punctuation{']'}
+initializer_list =  designation? initializer (@punctuation{','} designation? initializer)*
+designation   =  designator+ @operator{'='}
+designator    =  @punctuation{'['} expr_cond @punctuation{']'}
                / @punctuation{'.'} @property{ident}
 
 # --- Statements ------------------------------------------------------
 
-compound_stmt <- @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_item    <- pp_line
+compound_stmt =  @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block_item    =  pp_line
                / decl
                / stmt
 
-stmt          <- labeled_stmt
+stmt          =  labeled_stmt
                / compound_stmt
                / if_stmt
                / for_stmt
@@ -191,58 +191,58 @@ stmt          <- labeled_stmt
                / empty_stmt
                / expr_stmt
 
-labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
+labeled_stmt  =  @variable{ident} @punctuation{':'} stmt
                / kw_case expr_cond @punctuation{':'} stmt
                / kw_default @punctuation{':'} stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt      <- kw_if @punctuation{'('} expr @punctuation{')'} stmt
+~if_stmt      =  kw_if @punctuation{'('} expr @punctuation{')'} stmt
                  (kw_else stmt)?
-for_stmt      <- kw_for @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
-for_init      <- decl
+for_stmt      =  kw_for @punctuation{'('} for_init expr? @punctuation{';'} expr? @punctuation{')'} stmt
+for_init      =  decl
                / expr? @punctuation{';'}
-while_stmt    <- kw_while @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt <- kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
-switch_stmt   <- kw_switch @punctuation{'('} expr @punctuation{')'} stmt
-return_stmt   <- kw_return expr? @punctuation{';'}
-break_stmt    <- kw_break @punctuation{';'}
-continue_stmt <- kw_continue @punctuation{';'}
-goto_stmt     <- kw_goto @variable{ident} @punctuation{';'}
-empty_stmt    <- @punctuation{';'}
-expr_stmt     <- expr @punctuation{';'}
+while_stmt    =  kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt =  kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} @punctuation{';'}
+switch_stmt   =  kw_switch @punctuation{'('} expr @punctuation{')'} stmt
+return_stmt   =  kw_return expr? @punctuation{';'}
+break_stmt    =  kw_break @punctuation{';'}
+continue_stmt =  kw_continue @punctuation{';'}
+goto_stmt     =  kw_goto @variable{ident} @punctuation{';'}
+empty_stmt    =  @punctuation{';'}
+expr_stmt     =  expr @punctuation{';'}
 
 # --- Expressions ----------------------------------------------------
 #
 # Precedence is encoded by direct left recursion: each binary level is
-# `expr_LEVEL <- expr_LEVEL OP expr_NEXT / expr_NEXT`. Each level inlines
+# `expr_LEVEL =  expr_LEVEL OP expr_NEXT / expr_NEXT`. Each level inlines
 # its own operator alternation. Within a level, longer operators come
 # first; cross-level ambiguities (`<` vs `<<=`, `&` vs `&&`, `+` vs
 # `+=`, …) need explicit `!`-lookaheads so a lower-precedence level
 # doesn't eat a fragment of a longer operator that belongs higher up.
 # Assignment (right-associative) and ternary stay outside the LR ladder.
 
-expr          <- expr_assign (@punctuation{','} expr_assign)*
-expr_assign   <- expr_unary assign_op expr_assign
+expr          =  expr_assign (@punctuation{','} expr_assign)*
+expr_assign   =  expr_unary assign_op expr_assign
                / expr_cond
 
 
-assign_op     <- @operator{'<<='} / @operator{'>>='}
+assign_op     =  @operator{'<<='} / @operator{'>>='}
                / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
                / @operator{'='} !'='
 
 # Trailing ternary `?` leniency absorbed by top-level `*^`.
-~expr_cond    <- expr_lor (@operator{'?'} expr @punctuation{':'} expr_assign)?
+~expr_cond    =  expr_lor (@operator{'?'} expr @punctuation{':'} expr_assign)?
 
-expr_lor      <- expr_lor @operator{'||'} expr_land / expr_land
-expr_land     <- expr_land @operator{'&&'} expr_bor / expr_bor
-expr_bor      <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band     <- expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
-expr_eq       <- expr_eq (@operator{'=='} / @operator{'!='}) expr_rel / expr_rel
-expr_rel      <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_shift / expr_shift
-expr_shift    <- expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add      <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_unary / expr_unary
+expr_lor      =  expr_lor @operator{'||'} expr_land / expr_land
+expr_land     =  expr_land @operator{'&&'} expr_bor / expr_bor
+expr_bor      =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor     =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band     =  expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq       =  expr_eq (@operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel      =  expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_shift / expr_shift
+expr_shift    =  expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add      =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul      =  expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_unary / expr_unary
 
 # `sizeof_type` is tried before the generic prefix loop so that
 # `sizeof(struct X)` / `sizeof(union X)` / `sizeof(counter_size_t)`
@@ -251,26 +251,26 @@ expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator
 # happen to be an `expr_primary` (e.g. `sizeof(int)`). On failure we
 # fall back to the prefix path so `sizeof expr` and `sizeof(expr)`
 # still parse.
-expr_unary    <- sizeof_type
+expr_unary    =  sizeof_type
                / unary_prefix* expr_postfix
-unary_prefix  <- @operator{'++'} / @operator{'--'}
+unary_prefix  =  @operator{'++'} / @operator{'--'}
                / @operator{'+'} / @operator{'-'} / @operator{'!'} / @operator{'~'}
                / @operator{'*'} / @operator{'&'}
                / kw_sizeof &(@punctuation{'('} / [A-Za-z_])
                / kw_alignof
 
-expr_postfix  <- expr_primary postfix_op*
-postfix_op    <- @operator{'++'} / @operator{'--'}
+expr_postfix  =  expr_primary postfix_op*
+postfix_op    =  @operator{'++'} / @operator{'--'}
                / @punctuation{'('} arg_list? @punctuation{')'}
                / @punctuation{'['} expr @punctuation{']'}
                / @operator{'->'} postfix_member
                / @punctuation{'.'} postfix_member
-postfix_member <- @function{ident} &(@punctuation{'('})
+postfix_member =  @function{ident} &(@punctuation{'('})
                 / @property{ident}
 
-arg_list      <- expr_assign (@punctuation{','} expr_assign)*
+arg_list      =  expr_assign (@punctuation{','} expr_assign)*
 
-expr_primary  <- string_lit
+expr_primary  =  string_lit
                / char_lit
                / number_lit
                / cast_or_paren
@@ -281,32 +281,32 @@ expr_primary  <- string_lit
 
 # Boolean / null constants as a `%?` preferred-word alternation so the
 # `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
-%?lit_const   <- @constant{'true'}
+%?lit_const   =  @constant{'true'}
                / @constant{'false'}
                / @constant{'NULL'}
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
-sizeof_type   <- kw_sizeof @punctuation{'('} type_name @punctuation{')'}
-type_name     <- decl_spec_list abstract_declarator?
+sizeof_type   =  kw_sizeof @punctuation{'('} type_name @punctuation{')'}
+type_name     =  decl_spec_list abstract_declarator?
 
 # `(T)expr` vs `(expr)` — try cast first (uses decl_spec which
 # requires a type keyword/qualifier, making the distinction
 # unambiguous for real-world C).
-cast_or_paren <- @punctuation{'('} type_name @punctuation{')'} expr_unary
+cast_or_paren =  @punctuation{'('} type_name @punctuation{')'} expr_unary
                / @punctuation{'('} expr @punctuation{')'}
 
-call_ident    <- @function{ident} &(@punctuation{'('})
+call_ident    =  @function{ident} &(@punctuation{'('})
 
 # --- Literals --------------------------------------------------------
 
-string_lit    <- @string{string_piece+}
-*string_piece <- ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit    =  @string{string_piece+}
+*string_piece =  ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
-char_lit      <- @string{char_body}
-*char_body    <- ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
+char_lit      =  @string{char_body}
+*char_body    =  ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
 
-number_lit    <- @number{num_body}
-*num_body     <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+number_lit    =  @number{num_body}
+*num_body     =  '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
                / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
                / '0b' bin_digits int_suffix?
                / '0' [0-7]* int_suffix?
@@ -314,12 +314,12 @@ number_lit    <- @number{num_body}
                / '.' digit_seq exp_part? float_suffix?
                / digit_seq exp_part float_suffix?
                / digit_seq int_suffix?
-*digit_seq    <- \d [\d']*
-*hex_digits   <- [\da-fA-F] [\da-fA-F']*
-*bin_digits   <- [01] [01']*
-*exp_part     <- [eE] [+\-]? \d+
-int_suffix    <- ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
-float_suffix  <- [fFlL]
+*digit_seq    =  \d [\d']*
+*hex_digits   =  [\da-fA-F] [\da-fA-F']*
+*bin_digits   =  [01] [01']*
+*exp_part     =  [eE] [+\-]? \d+
+int_suffix    =  ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
+float_suffix  =  [fFlL]
 
 # --- Identifiers ----------------------------------------------------
 
@@ -327,10 +327,10 @@ float_suffix  <- [fFlL]
 # | digit)*; nondigit = `_ A-Z a-z` | universal-character-name (UCN);
 # UCNs are `\uHHHH` (4 hex) or `\UHHHHHHHH` (8 hex). C23 §6.4.3 also
 # admits raw non-ASCII letters (General_Category=L) directly.
-*ident        <- !reserved ([\p{L}_] / ucn) ident_body*
-ident_body    <- [\p{L}\p{Nd}_] / ucn
-ucn           <- '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
+*ident        =  !reserved ([\p{L}_] / ucn) ident_body*
+ident_body    =  [\p{L}\p{Nd}_] / ucn
+ucn           =  '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
 
 # --- Whitespace / comments ------------------------------------------
 
-*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -23,21 +23,21 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-root          <- (statement)*^
+root          =  (statement)*^
 
-trivia        <- (comment / \s)*
+trivia        =  (comment / \s)*
 
-statement     <- at_rule
+statement     =  at_rule
                 / rule
 
 # --- At-rules --------------------------------------------------------
 
-at_rule       <- at_name prelude (block / @punctuation{';'})
-*at_name      <- @keyword{'@' ident_body+}
+at_rule       =  at_name prelude (block / @punctuation{';'})
+*at_name      =  @keyword{'@' ident_body+}
 
 # Prelude: tokens up to `{` or `;` — sequences of value-like tokens.
-prelude       <- prelude_token*
-prelude_token <- string_lit
+prelude       =  prelude_token*
+prelude_token =  string_lit
                 / fn_call
                 / hex_color
                 / number_with_unit
@@ -55,16 +55,16 @@ prelude_token <- string_lit
 
 # --- Rules -----------------------------------------------------------
 
-rule          <- selector_list block
-selector_list <- selector (@punctuation{','} selector)*
-selector      <- compound_selector combinator_and_next*
-combinator_and_next <- @operator{'>'} compound_selector
+rule          =  selector_list block
+selector_list =  selector (@punctuation{','} selector)*
+selector      =  compound_selector combinator_and_next*
+combinator_and_next =  @operator{'>'} compound_selector
                      / @operator{'+'} compound_selector
                      / @operator{'~'} compound_selector
                      / compound_selector
 
-compound_selector <- selector_atom+
-*selector_atom <- @property{'.' ident}
+compound_selector =  selector_atom+
+*selector_atom =  @property{'.' ident}
                 / @constant{'#' ident}
                 / @function{'::' ident pseudo_args?}
                 / @function{':' ident pseudo_args?}
@@ -73,28 +73,28 @@ compound_selector <- selector_atom+
                 / @punctuation{'*'}
                 / @type{ident}
 
-*pseudo_args  <- '(' ..= ')'
+*pseudo_args  =  '(' ..= ')'
 
 # --- Blocks & declarations ------------------------------------------
 
-block         <- @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_item    <- at_rule
+block         =  @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block_item    =  at_rule
                 / declaration
                 / rule
                 / @punctuation{';'}
 
 # Trailing `important? (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
-~declaration  <- @property{prop_ident} @punctuation{':'} value_list
+~declaration  =  @property{prop_ident} @punctuation{':'} value_list
                  @keyword{'!important'}? (@punctuation{';'} / &'}')
 
-*prop_ident   <- '--' ident_body+
+*prop_ident   =  '--' ident_body+
                 / '-'? ident
 
 # --- Values ---------------------------------------------------------
 
-value_list    <- value_term (@punctuation{','} value_term)*
-value_term    <- value_factor+
-value_factor  <- string_lit
+value_list    =  value_term (@punctuation{','} value_term)*
+value_term    =  value_factor+
+value_factor  =  string_lit
                 / fn_call
                 / hex_color
                 / number_with_unit
@@ -105,29 +105,29 @@ value_factor  <- string_lit
                 / @operator{'-'}
                 / @operator{'*'}
 
-fn_call       <- @function{ident} @punctuation{'('} fn_args? @punctuation{')'}
-fn_args       <- value_term (@punctuation{','} value_term)*
+fn_call       =  @function{ident} @punctuation{'('} fn_args? @punctuation{')'}
+fn_args       =  value_term (@punctuation{','} value_term)*
 
 # Unquoted `url(...)` arg — bare text till the closing paren.
-url_unquoted  <- @function{'url'} @punctuation{'('} @string{.. ')'} @punctuation{')'}
+url_unquoted  =  @function{'url'} @punctuation{'('} @string{.. ')'} @punctuation{')'}
 
 # --- Literals -------------------------------------------------------
 
-*hex_color    <- @constant{'#' [\da-fA-F]+}
+*hex_color    =  @constant{'#' [\da-fA-F]+}
 
-number_with_unit <- @number{num_body}
+number_with_unit =  @number{num_body}
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
-*~num_body    <- [+\-]? (num_float / \d+) num_unit?
-*num_float    <- \d* '.' \d+
+*~num_body    =  [+\-]? (num_float / \d+) num_unit?
+*num_float    =  \d* '.' \d+
                 / \d+ '.' \d*
-num_unit      <- '%'
+num_unit      =  '%'
                 / ident
 
-string_lit    <- @string{dq_string / sq_string}
-*dq_string    <- '"' (str_escape / !'"' !'\n' .)* '"'
-*sq_string    <- "'" (str_escape / !"'" !'\n' .)* "'"
-*str_escape   <- '\\' .
+string_lit    =  @string{dq_string / sq_string}
+*dq_string    =  '"' (str_escape / !'"' !'\n' .)* '"'
+*sq_string    =  "'" (str_escape / !"'" !'\n' .)* "'"
+*str_escape   =  '\\' .
 
 # --- Identifiers ----------------------------------------------------
 
@@ -135,20 +135,20 @@ string_lit    <- @string{dq_string / sq_string}
 # code point (≥ U+0080) | css_escape; ident code point = ident-start |
 # digit | -. The escape is `\` followed by 1-6 hex digits and an
 # optional trailing whitespace (consumed by the escape, not the ident).
-*ident        <- (ident_start_char / css_escape) (ident_body_char / css_escape)*
-ident_start_char <- [A-Za-z_\-\u{80}-\u{10FFFF}]
-ident_body_char  <- [A-Za-z\d_\-\u{80}-\u{10FFFF}]
-ident_body    <- ident_body_char / css_escape
+*ident        =  (ident_start_char / css_escape) (ident_body_char / css_escape)*
+ident_start_char =  [A-Za-z_\-\u{80}-\u{10FFFF}]
+ident_body_char  =  [A-Za-z\d_\-\u{80}-\u{10FFFF}]
+ident_body    =  ident_body_char / css_escape
 # Per CSS Syntax Module L3 §4.6 an escape is `\\` followed by either
 # 1-6 hex digits (plus optional trailing whitespace) or any non-newline
 # code point. The broader "any non-newline byte" form covers both
 # cases for highlighter purposes; encoding the hex-digit-count
 # refinement separately would force a partial-match call site that
 # trips the lint.
-*css_escape   <- '\\' !\R .
+*css_escape   =  '\\' !\R .
 
 # --- Whitespace / comments -----------------------------------------
 #
 # CSS has only block comments.
 
-*comment      <- @comment{'/*' ..= '*/'}
+*comment      =  @comment{'/*' ..= '*/'}

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -23,111 +23,111 @@
 # malformed declarations inside a rule/at-rule body resync at the
 # closing `}` instead of failing the enclosing statement.
 
-root          =  (statement)*^
+root = (statement)*^
 
-trivia        =  (comment / \s)*
+trivia = (comment / \s)*
 
-statement     =  at_rule
-                / rule
+statement = at_rule
+           / rule
 
 # --- At-rules --------------------------------------------------------
 
-at_rule       =  at_name prelude (block / @punctuation{';'})
-*at_name      =  @keyword{'@' ident_body+}
+at_rule = at_name prelude (block / @punctuation{';'})
+*at_name = @keyword{'@' ident_body+}
 
 # Prelude: tokens up to `{` or `;` — sequences of value-like tokens.
-prelude       =  prelude_token*
-prelude_token =  string_lit
-                / fn_call
-                / hex_color
-                / number_with_unit
-                / @keyword{'!important'}
-                / @type{ident}
-                / @punctuation{'('} prelude @punctuation{')'}
-                / @punctuation{','}
-                / @punctuation{':'}
-                / @operator{'='}
-                / @operator{'+'}
-                / @operator{'-'}
-                / @operator{'*'}
-                / @operator{'/'}
-                / @operator{'>'}
+prelude = prelude_token*
+prelude_token = string_lit
+               / fn_call
+               / hex_color
+               / number_with_unit
+               / @keyword{'!important'}
+               / @type{ident}
+               / @punctuation{'('} prelude @punctuation{')'}
+               / @punctuation{','}
+               / @punctuation{':'}
+               / @operator{'='}
+               / @operator{'+'}
+               / @operator{'-'}
+               / @operator{'*'}
+               / @operator{'/'}
+               / @operator{'>'}
 
 # --- Rules -----------------------------------------------------------
 
-rule          =  selector_list block
-selector_list =  selector (@punctuation{','} selector)*
-selector      =  compound_selector combinator_and_next*
-combinator_and_next =  @operator{'>'} compound_selector
-                     / @operator{'+'} compound_selector
-                     / @operator{'~'} compound_selector
-                     / compound_selector
+rule = selector_list block
+selector_list = selector (@punctuation{','} selector)*
+selector = compound_selector combinator_and_next*
+combinator_and_next = @operator{'>'} compound_selector
+                    / @operator{'+'} compound_selector
+                    / @operator{'~'} compound_selector
+                    / compound_selector
 
-compound_selector =  selector_atom+
-*selector_atom =  @property{'.' ident}
-                / @constant{'#' ident}
-                / @function{'::' ident pseudo_args?}
-                / @function{':' ident pseudo_args?}
-                / @punctuation{'['} (.. ']') @punctuation{']'}
-                / @punctuation{'&'}
-                / @punctuation{'*'}
-                / @type{ident}
+compound_selector = selector_atom+
+*selector_atom = @property{'.' ident}
+               / @constant{'#' ident}
+               / @function{'::' ident pseudo_args?}
+               / @function{':' ident pseudo_args?}
+               / @punctuation{'['} (.. ']') @punctuation{']'}
+               / @punctuation{'&'}
+               / @punctuation{'*'}
+               / @type{ident}
 
-*pseudo_args  =  '(' ..= ')'
+*pseudo_args = '(' ..= ')'
 
 # --- Blocks & declarations ------------------------------------------
 
-block         =  @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
-block_item    =  at_rule
-                / declaration
-                / rule
-                / @punctuation{';'}
+block = @punctuation{'{'} (block_item* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block_item = at_rule
+            / declaration
+            / rule
+            / @punctuation{';'}
 
 # Trailing `important? (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
-~declaration  =  @property{prop_ident} @punctuation{':'} value_list
-                 @keyword{'!important'}? (@punctuation{';'} / &'}')
+~declaration = @property{prop_ident} @punctuation{':'} value_list
+               @keyword{'!important'}? (@punctuation{';'} / &'}')
 
-*prop_ident   =  '--' ident_body+
-                / '-'? ident
+*prop_ident = '--' ident_body+
+             / '-'? ident
 
 # --- Values ---------------------------------------------------------
 
-value_list    =  value_term (@punctuation{','} value_term)*
-value_term    =  value_factor+
-value_factor  =  string_lit
-                / fn_call
-                / hex_color
-                / number_with_unit
-                / url_unquoted
-                / @variable{ident}
-                / @operator{'/'}
-                / @operator{'+'}
-                / @operator{'-'}
-                / @operator{'*'}
+value_list = value_term (@punctuation{','} value_term)*
+value_term = value_factor+
+value_factor = string_lit
+              / fn_call
+              / hex_color
+              / number_with_unit
+              / url_unquoted
+              / @variable{ident}
+              / @operator{'/'}
+              / @operator{'+'}
+              / @operator{'-'}
+              / @operator{'*'}
 
-fn_call       =  @function{ident} @punctuation{'('} fn_args? @punctuation{')'}
-fn_args       =  value_term (@punctuation{','} value_term)*
+fn_call = @function{ident} @punctuation{'('} fn_args? @punctuation{')'}
+fn_args = value_term (@punctuation{','} value_term)*
 
 # Unquoted `url(...)` arg — bare text till the closing paren.
-url_unquoted  =  @function{'url'} @punctuation{'('} @string{.. ')'} @punctuation{')'}
+url_unquoted = @function{'url'} @punctuation{'('} @string{.. ')'} @punctuation{')'}
 
 # --- Literals -------------------------------------------------------
 
-*hex_color    =  @constant{'#' [\da-fA-F]+}
+*hex_color = @constant{'#' [\da-fA-F]+}
 
-number_with_unit =  @number{num_body}
+number_with_unit = @number{num_body}
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
-*~num_body    =  [+\-]? (num_float / \d+) num_unit?
-*num_float    =  \d* '.' \d+
-                / \d+ '.' \d*
-num_unit      =  '%'
-                / ident
+*~num_body = [+\-]? (num_float / \d+) num_unit?
+*num_float = \d* '.' \d+
+            / \d+ '.' \d*
+num_unit = '%'
+          / ident
 
-string_lit    =  @string{dq_string / sq_string}
-*dq_string    =  '"' (str_escape / !'"' !'\n' .)* '"'
-*sq_string    =  "'" (str_escape / !"'" !'\n' .)* "'"
-*str_escape   =  '\\' .
+string_lit = @string{dq_string / sq_string}
+*dq_string = '"' (str_escape / !'"' !'\n' .)* '"'
+*sq_string = "'" (str_escape / !"'" !'\n' .)* "'"
+*str_escape = '\\' .
 
 # --- Identifiers ----------------------------------------------------
 
@@ -135,20 +135,20 @@ string_lit    =  @string{dq_string / sq_string}
 # code point (≥ U+0080) | css_escape; ident code point = ident-start |
 # digit | -. The escape is `\` followed by 1-6 hex digits and an
 # optional trailing whitespace (consumed by the escape, not the ident).
-*ident        =  (ident_start_char / css_escape) (ident_body_char / css_escape)*
-ident_start_char =  [A-Za-z_\-\u{80}-\u{10FFFF}]
-ident_body_char  =  [A-Za-z\d_\-\u{80}-\u{10FFFF}]
-ident_body    =  ident_body_char / css_escape
+*ident = (ident_start_char / css_escape) (ident_body_char / css_escape)*
+ident_start_char = [A-Za-z_\-\u{80}-\u{10FFFF}]
+ident_body_char = [A-Za-z\d_\-\u{80}-\u{10FFFF}]
+ident_body = ident_body_char / css_escape
 # Per CSS Syntax Module L3 §4.6 an escape is `\\` followed by either
 # 1-6 hex digits (plus optional trailing whitespace) or any non-newline
 # code point. The broader "any non-newline byte" form covers both
 # cases for highlighter purposes; encoding the hex-digit-count
 # refinement separately would force a partial-match call site that
 # trips the lint.
-*css_escape   =  '\\' !\R .
+*css_escape = '\\' !\R .
 
 # --- Whitespace / comments -----------------------------------------
 #
 # CSS has only block comments.
 
-*comment      =  @comment{'/*' ..= '*/'}
+*comment = @comment{'/*' ..= '*/'}

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -24,222 +24,222 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-root          =  package_clause import_decl* (top_decl)*^
+root = package_clause import_decl* (top_decl)*^
 
-trivia        =  (comment / \s)*
+trivia = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Go spec identifier-continue).
-wb            =  !ident_body
+wb = !ident_body
 
 # --- Keyword tokens --------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`funcx`).
-%kw_package   =  @keyword{'package'}
-%kw_import    =  @keyword{'import'}
-%kw_var       =  @keyword{'var'}
-%kw_const     =  @keyword{'const'}
-%kw_type      =  @keyword{'type'}
-%kw_map       =  @keyword{'map'}
-%kw_chan      =  @keyword{'chan'}
-%kw_func      =  @keyword{'func'}
-%kw_struct    =  @keyword{'struct'}
-%kw_interface =  @keyword{'interface'}
-%kw_if        =  @keyword{'if'}
-%kw_else      =  @keyword{'else'}
-%kw_for       =  @keyword{'for'}
-%kw_range     =  @keyword{'range'}
-%kw_switch    =  @keyword{'switch'}
-%kw_case      =  @keyword{'case'}
-%kw_default   =  @keyword{'default'}
-%kw_select    =  @keyword{'select'}
-%kw_go        =  @keyword{'go'}
-%kw_defer     =  @keyword{'defer'}
-%kw_return    =  @keyword{'return'}
-%kw_break     =  @keyword{'break'}
-%kw_continue  =  @keyword{'continue'}
-%kw_goto      =  @keyword{'goto'}
-%kw_fallthrough =  @keyword{'fallthrough'}
+%kw_package = @keyword{'package'}
+%kw_import = @keyword{'import'}
+%kw_var = @keyword{'var'}
+%kw_const = @keyword{'const'}
+%kw_type = @keyword{'type'}
+%kw_map = @keyword{'map'}
+%kw_chan = @keyword{'chan'}
+%kw_func = @keyword{'func'}
+%kw_struct = @keyword{'struct'}
+%kw_interface = @keyword{'interface'}
+%kw_if = @keyword{'if'}
+%kw_else = @keyword{'else'}
+%kw_for = @keyword{'for'}
+%kw_range = @keyword{'range'}
+%kw_switch = @keyword{'switch'}
+%kw_case = @keyword{'case'}
+%kw_default = @keyword{'default'}
+%kw_select = @keyword{'select'}
+%kw_go = @keyword{'go'}
+%kw_defer = @keyword{'defer'}
+%kw_return = @keyword{'return'}
+%kw_break = @keyword{'break'}
+%kw_continue = @keyword{'continue'}
+%kw_goto = @keyword{'goto'}
+%kw_fallthrough = @keyword{'fallthrough'}
 
 # --- Package / imports ----------------------------------------------
 
-package_clause =  kw_package @variable{ident} opt_semi
+package_clause = kw_package @variable{ident} opt_semi
 
-import_decl   =  kw_import import_spec_group opt_semi
-               / kw_import import_spec opt_semi
-import_spec_group =  @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
-import_spec   =  import_alias? string_lit
-import_alias  =  @punctuation{'.'}
-               / @variable{ident}
+import_decl = kw_import import_spec_group opt_semi
+            / kw_import import_spec opt_semi
+import_spec_group = @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
+import_spec = import_alias? string_lit
+import_alias = @punctuation{'.'}
+             / @variable{ident}
 
 # --- Top-level declarations -----------------------------------------
 
-top_decl      =  decl
-                 / func_decl
-                 / method_decl
+top_decl = decl
+           / func_decl
+           / method_decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl         =  kw_var var_spec_group
-               / kw_var var_spec opt_semi
-               / kw_const const_spec_group
-               / kw_const const_spec opt_semi
-               / kw_type type_spec_group
-               / kw_type type_spec opt_semi
+~decl = kw_var var_spec_group
+      / kw_var var_spec opt_semi
+      / kw_const const_spec_group
+      / kw_const const_spec opt_semi
+      / kw_type type_spec_group
+      / kw_type type_spec opt_semi
 
-var_spec_group =  @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
-var_spec      =  ident_list type_expr @operator{'='} expr_list
-               / ident_list type_expr
-               / ident_list @operator{'='} expr_list
+var_spec_group = @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
+var_spec = ident_list type_expr @operator{'='} expr_list
+         / ident_list type_expr
+         / ident_list @operator{'='} expr_list
 
-const_spec_group =  @punctuation{'('} (const_spec opt_semi)* @punctuation{')'}
+const_spec_group = @punctuation{'('} (const_spec opt_semi)* @punctuation{')'}
 # Trailing `(= expr)?` absorbed by outer recovery.
-~const_spec   =  const_ident_list type_expr? (@operator{'='} expr_list)?
+~const_spec = const_ident_list type_expr? (@operator{'='} expr_list)?
 
-type_spec_group =  @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
-type_spec     =  @type{ident} type_params? @operator{'='}? type_expr
+type_spec_group = @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
+type_spec = @type{ident} type_params? @operator{'='}? type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl    =  kw_func @function{ident} type_params? fn_signature block?
-~method_decl  =  kw_func method_receiver @function{ident} fn_signature block?
-method_receiver =  @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
+~func_decl = kw_func @function{ident} type_params? fn_signature block?
+~method_decl = kw_func method_receiver @function{ident} fn_signature block?
+method_receiver = @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
-type_params   =  @punctuation{'['} type_param_list @punctuation{']'}
-type_param_list =  type_param (@punctuation{','} type_param)* (@punctuation{','})?
-type_param    =  ident_list type_constraint
-type_constraint =  type_union
-type_union    =  type_term (@operator{'|'} type_term)*
-type_term     =  @operator{'~'} type_expr
-               / type_expr
+type_params = @punctuation{'['} type_param_list @punctuation{']'}
+type_param_list = type_param (@punctuation{','} type_param)* (@punctuation{','})?
+type_param = ident_list type_constraint
+type_constraint = type_union
+type_union = type_term (@operator{'|'} type_term)*
+type_term = @operator{'~'} type_expr
+          / type_expr
 
 # Trailing `fn_result?` absorbed by outer recovery.
-~fn_signature =  fn_params fn_result?
-fn_params     =  @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param      =  ident_list @operator{'...'}? type_expr
-               / @operator{'...'}? type_expr
-fn_result     =  fn_params
-               / type_expr
+~fn_signature = fn_params fn_result?
+fn_params = @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list = fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param = ident_list @operator{'...'}? type_expr
+         / @operator{'...'}? type_expr
+fn_result = fn_params
+          / type_expr
 
 # --- Types -----------------------------------------------------------
 
-type_expr     =  type_ptr
-               / type_slice_or_array
-               / type_map
-               / type_chan
-               / type_func
-               / type_struct
-               / type_interface
-               / type_paren
-               / type_name
+type_expr = type_ptr
+          / type_slice_or_array
+          / type_map
+          / type_chan
+          / type_func
+          / type_struct
+          / type_interface
+          / type_paren
+          / type_name
 
-type_ptr      =  @operator{'*'} type_expr
-type_slice_or_array =  @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
-type_map      =  kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr
-type_chan     =  @operator{'<-'} kw_chan type_expr
-               / kw_chan @operator{'<-'} type_expr
-               / kw_chan type_expr
-type_func     =  kw_func fn_signature
-type_struct   =  kw_struct @punctuation{'{'} struct_field_list? @punctuation{'}'}
-struct_field_list =  struct_field (opt_semi struct_field)* opt_semi?
-struct_field  =  @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
-               / @operator{'*'}? type_name string_lit?       # embedded field
-type_interface =  kw_interface @punctuation{'{'} interface_members? @punctuation{'}'}
-interface_members =  interface_member (opt_semi interface_member)* opt_semi?
-interface_member =  @function{ident} fn_signature
-                  / type_term
-type_paren    =  @punctuation{'('} type_expr @punctuation{')'}
+type_ptr = @operator{'*'} type_expr
+type_slice_or_array = @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
+type_map = kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr
+type_chan = @operator{'<-'} kw_chan type_expr
+          / kw_chan @operator{'<-'} type_expr
+          / kw_chan type_expr
+type_func = kw_func fn_signature
+type_struct = kw_struct @punctuation{'{'} struct_field_list? @punctuation{'}'}
+struct_field_list = struct_field (opt_semi struct_field)* opt_semi?
+struct_field = @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
+             / @operator{'*'}? type_name string_lit?       # embedded field
+type_interface = kw_interface @punctuation{'{'} interface_members? @punctuation{'}'}
+interface_members = interface_member (opt_semi interface_member)* opt_semi?
+interface_member = @function{ident} fn_signature
+                 / type_term
+type_paren = @punctuation{'('} type_expr @punctuation{')'}
 # Trailing `type_args?` leniency absorbed by outer recovery.
-~type_name    =  @type{qualified_ident} type_args?
-type_args     =  @punctuation{'['} type_arg_list @punctuation{']'}
-type_arg_list =  type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
+~type_name = @type{qualified_ident} type_args?
+type_args = @punctuation{'['} type_arg_list @punctuation{']'}
+type_arg_list = type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
 # `pkg.Name` or `Name`.
 # Trailing `(.ident)?` leniency absorbed by outer recovery.
-~qualified_ident =  ident (@punctuation{'.'} ident)?
+~qualified_ident = ident (@punctuation{'.'} ident)?
 
 # --- Statements ------------------------------------------------------
 
-block         =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block = @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          =  decl opt_semi
-               / block
-               / labeled_stmt
-               / if_stmt
-               / for_stmt
-               / switch_stmt
-               / select_stmt
-               / go_stmt
-               / defer_stmt
-               / return_stmt
-               / break_stmt
-               / continue_stmt
-               / goto_stmt
-               / fallthrough_stmt
-               / simple_stmt opt_semi
-               / empty_stmt
+stmt = decl opt_semi
+     / block
+     / labeled_stmt
+     / if_stmt
+     / for_stmt
+     / switch_stmt
+     / select_stmt
+     / go_stmt
+     / defer_stmt
+     / return_stmt
+     / break_stmt
+     / continue_stmt
+     / goto_stmt
+     / fallthrough_stmt
+     / simple_stmt opt_semi
+     / empty_stmt
 
-empty_stmt    =  @punctuation{';'}
+empty_stmt = @punctuation{';'}
 
-simple_stmt   =  send_stmt
-               / inc_dec_stmt
-               / assignment
-               / short_var_decl
-               / expr_stmt
+simple_stmt = send_stmt
+            / inc_dec_stmt
+            / assignment
+            / short_var_decl
+            / expr_stmt
 
-send_stmt     =  expr_no_compound @operator{'<-'} expr_no_compound
-inc_dec_stmt  =  expr_no_compound (@operator{'++'} / @operator{'--'})
-short_var_decl =  ident_list @operator{':='} expr_list
-assignment    =  expr_no_compound_list assign_op expr_list
-expr_stmt     =  expr_no_compound
+send_stmt = expr_no_compound @operator{'<-'} expr_no_compound
+inc_dec_stmt = expr_no_compound (@operator{'++'} / @operator{'--'})
+short_var_decl = ident_list @operator{':='} expr_list
+assignment = expr_no_compound_list assign_op expr_list
+expr_stmt = expr_no_compound
 
-assign_op     =  @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
-               / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
-               / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
-               / @operator{'='} !'='
+assign_op = @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+          / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
+          / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
+          / @operator{'='} !'='
 
-labeled_stmt  =  @variable{ident} @punctuation{':'} stmt
+labeled_stmt = @variable{ident} @punctuation{':'} stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt      =  kw_if (simple_stmt @punctuation{';'})? expr_no_compound block
-                 (kw_else (if_stmt / block))?
-for_stmt      =  kw_for for_header? block
-for_header    =  for_range
-               / for_c_style
-               / expr_no_compound
-for_range     =  (ident_list (@operator{'='} / @operator{':='}))? kw_range expr_no_compound
-for_c_style   =  simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
+~if_stmt = kw_if (simple_stmt @punctuation{';'})? expr_no_compound block
+           (kw_else (if_stmt / block))?
+for_stmt = kw_for for_header? block
+for_header = for_range
+           / for_c_style
+           / expr_no_compound
+for_range = (ident_list (@operator{'='} / @operator{':='}))? kw_range expr_no_compound
+for_c_style = simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
 
-switch_stmt   =  kw_switch type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
-               / kw_switch expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
-expr_switch_header =  (simple_stmt @punctuation{';'})? expr_no_compound?
-               / ''
-type_switch_header =  (simple_stmt @punctuation{';'})? type_switch_guard
-type_switch_guard  =  (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} kw_type @punctuation{')'}
-expr_case     =  kw_case expr_list @punctuation{':'} stmt*
-               / kw_default @punctuation{':'} stmt*
-type_case     =  kw_case type_list @punctuation{':'} stmt*
-               / kw_default @punctuation{':'} stmt*
-type_list     =  type_expr (@punctuation{','} type_expr)*
+switch_stmt = kw_switch type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
+            / kw_switch expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
+expr_switch_header = (simple_stmt @punctuation{';'})? expr_no_compound?
+              / ''
+type_switch_header = (simple_stmt @punctuation{';'})? type_switch_guard
+type_switch_guard = (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} kw_type @punctuation{')'}
+expr_case = kw_case expr_list @punctuation{':'} stmt*
+          / kw_default @punctuation{':'} stmt*
+type_case = kw_case type_list @punctuation{':'} stmt*
+          / kw_default @punctuation{':'} stmt*
+type_list = type_expr (@punctuation{','} type_expr)*
 
-select_stmt   =  kw_select @punctuation{'{'} comm_case* @punctuation{'}'}
-comm_case     =  kw_case comm_clause @punctuation{':'} stmt*
-               / kw_default @punctuation{':'} stmt*
-comm_clause   =  send_stmt
-               / recv_stmt
-recv_stmt     =  (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
+select_stmt = kw_select @punctuation{'{'} comm_case* @punctuation{'}'}
+comm_case = kw_case comm_clause @punctuation{':'} stmt*
+          / kw_default @punctuation{':'} stmt*
+comm_clause = send_stmt
+            / recv_stmt
+recv_stmt = (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
 
-go_stmt       =  kw_go expr
-defer_stmt    =  kw_defer expr
+go_stmt = kw_go expr
+defer_stmt = kw_defer expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt  =  kw_return expr_list?
-~break_stmt   =  kw_break (@variable{ident})?
-~continue_stmt =  kw_continue (@variable{ident})?
-goto_stmt     =  kw_goto @variable{ident}
-fallthrough_stmt =  kw_fallthrough
+~return_stmt = kw_return expr_list?
+~break_stmt = kw_break (@variable{ident})?
+~continue_stmt = kw_continue (@variable{ident})?
+goto_stmt = kw_goto @variable{ident}
+fallthrough_stmt = kw_fallthrough
 
 # --- Expressions -----------------------------------------------------
 #
@@ -256,137 +256,137 @@ fallthrough_stmt =  kw_fallthrough
 # `&` vs `&^`, `|` vs `||`) need explicit `!`-lookaheads — within a
 # level, longer operators come first.
 
-expr             =  expr_lor
-expr_no_compound =  expr_lor_nc
+expr = expr_lor
+expr_no_compound = expr_lor_nc
 
-expr_lor         =  expr_lor @operator{'||'} expr_land / expr_land
-expr_land        =  expr_land @operator{'&&'} expr_rel / expr_rel
-expr_rel         =  expr_rel (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add / expr_add
-expr_add         =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul / expr_mul
-expr_mul         =  expr_mul (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary / expr_unary
+expr_lor = expr_lor @operator{'||'} expr_land / expr_land
+expr_land = expr_land @operator{'&&'} expr_rel / expr_rel
+expr_rel = expr_rel (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add / expr_add
+expr_add = expr_add (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul / expr_mul
+expr_mul = expr_mul (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary / expr_unary
 
-expr_lor_nc      =  expr_lor_nc @operator{'||'} expr_land_nc / expr_land_nc
-expr_land_nc     =  expr_land_nc @operator{'&&'} expr_rel_nc / expr_rel_nc
-expr_rel_nc      =  expr_rel_nc (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add_nc / expr_add_nc
-expr_add_nc      =  expr_add_nc (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul_nc / expr_mul_nc
-expr_mul_nc      =  expr_mul_nc (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary_nc / expr_unary_nc
+expr_lor_nc = expr_lor_nc @operator{'||'} expr_land_nc / expr_land_nc
+expr_land_nc = expr_land_nc @operator{'&&'} expr_rel_nc / expr_rel_nc
+expr_rel_nc = expr_rel_nc (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add_nc / expr_add_nc
+expr_add_nc = expr_add_nc (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul_nc / expr_mul_nc
+expr_mul_nc = expr_mul_nc (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary_nc / expr_unary_nc
 
-expr_unary    =  unary_op* expr_postfix
-expr_unary_nc =  unary_op* expr_postfix_nc
-unary_op      =  @operator{'!'} / @operator{'+'} / @operator{'-'}
-               / @operator{'^'} / @operator{'*'} / @operator{'&'}
-               / @operator{'<-'}
+expr_unary = unary_op* expr_postfix
+expr_unary_nc = unary_op* expr_postfix_nc
+unary_op = @operator{'!'} / @operator{'+'} / @operator{'-'}
+         / @operator{'^'} / @operator{'*'} / @operator{'&'}
+         / @operator{'<-'}
 
-expr_postfix  =  expr_primary postfix_op*
-expr_postfix_nc =  expr_primary_nc postfix_op_nc*
+expr_postfix = expr_primary postfix_op*
+expr_postfix_nc = expr_primary_nc postfix_op_nc*
 
-postfix_op    =  @punctuation{'.'} postfix_selector
-               / @punctuation{'['} slice_or_index @punctuation{']'}
-               / @punctuation{'('} call_args? @punctuation{')'}
-               / composite_body
-postfix_op_nc =  @punctuation{'.'} postfix_selector
-               / @punctuation{'['} slice_or_index @punctuation{']'}
-               / @punctuation{'('} call_args? @punctuation{')'}
-postfix_selector =  @punctuation{'('} type_expr @punctuation{')'}                   # x.(T) type assertion
-                  / @function{ident} &(@punctuation{'('})
-                  / @property{ident}
+postfix_op = @punctuation{'.'} postfix_selector
+           / @punctuation{'['} slice_or_index @punctuation{']'}
+           / @punctuation{'('} call_args? @punctuation{')'}
+           / composite_body
+postfix_op_nc = @punctuation{'.'} postfix_selector
+              / @punctuation{'['} slice_or_index @punctuation{']'}
+              / @punctuation{'('} call_args? @punctuation{')'}
+postfix_selector = @punctuation{'('} type_expr @punctuation{')'}                   # x.(T) type assertion
+                 / @function{ident} &(@punctuation{'('})
+                 / @property{ident}
 # `x.(type)` is intentionally not a postfix here: it is only valid inside
 # a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
 # Letting `postfix_selector` swallow it would leave nothing for the guard
 # to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
-slice_or_index =  expr? @punctuation{':'} expr? (@punctuation{':'} expr)?
-               / expr
+slice_or_index = expr? @punctuation{':'} expr? (@punctuation{':'} expr)?
+              / expr
 
-call_args     =  arg (@punctuation{','} arg)* (@punctuation{','})?
-arg           =  expr @operator{'...'}
-               / expr
-               / type_expr
+call_args = arg (@punctuation{','} arg)* (@punctuation{','})?
+arg = expr @operator{'...'}
+    / expr
+    / type_expr
 
 # Composite literal body: `{ ... }` after a type expression.
-composite_body =  @punctuation{'{'} composite_elems? @punctuation{'}'}
-composite_elems =  composite_elem (@punctuation{','} composite_elem)* (@punctuation{','})?
-composite_elem =  composite_key @punctuation{':'} composite_value
-               / composite_value
-composite_key  =  @property{ident}
-                / @punctuation{'['} expr @punctuation{']'}
-                / string_lit
-                / number_lit
-composite_value =  composite_body
-                 / expr
+composite_body = @punctuation{'{'} composite_elems? @punctuation{'}'}
+composite_elems = composite_elem (@punctuation{','} composite_elem)* (@punctuation{','})?
+composite_elem = composite_key @punctuation{':'} composite_value
+              / composite_value
+composite_key = @property{ident}
+              / @punctuation{'['} expr @punctuation{']'}
+              / string_lit
+              / number_lit
+composite_value = composite_body
+                / expr
 
-expr_primary  =  literal
-               / fn_lit
-               / composite_lit
-               / type_conv
-               / call_ident
-               / @type{upper_ident}
-               / @constant{predeclared_const}
-               / @type{predeclared_type}
-               / @function{predeclared_fn} &(@punctuation{'('})
-               / @variable{lower_ident}
-               / paren_expr
-expr_primary_nc =  literal
-                 / fn_lit
-                 / type_conv
-                 / call_ident
-                 / @type{upper_ident}
-                 / @constant{predeclared_const}
-                 / @type{predeclared_type}
-                 / @function{predeclared_fn} &(@punctuation{'('})
-                 / @variable{lower_ident}
-                 / paren_expr
+expr_primary = literal
+             / fn_lit
+             / composite_lit
+             / type_conv
+             / call_ident
+             / @type{upper_ident}
+             / @constant{predeclared_const}
+             / @type{predeclared_type}
+             / @function{predeclared_fn} &(@punctuation{'('})
+             / @variable{lower_ident}
+             / paren_expr
+expr_primary_nc = literal
+                / fn_lit
+                / type_conv
+                / call_ident
+                / @type{upper_ident}
+                / @constant{predeclared_const}
+                / @type{predeclared_type}
+                / @function{predeclared_fn} &(@punctuation{'('})
+                / @variable{lower_ident}
+                / paren_expr
 
-paren_expr    =  @punctuation{'('} expr @punctuation{')'}
+paren_expr = @punctuation{'('} expr @punctuation{')'}
 
 # Composite literal: `T{...}` where T is a named/qualified type.
-composite_lit =  @type{qualified_ident} composite_body
-               / kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
-               / @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr composite_body
-               / kw_struct type_struct_body composite_body
-type_struct_body =  @punctuation{'{'} struct_field_list? @punctuation{'}'}
+composite_lit = @type{qualified_ident} composite_body
+              / kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
+              / @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr composite_body
+              / kw_struct type_struct_body composite_body
+type_struct_body = @punctuation{'{'} struct_field_list? @punctuation{'}'}
 
 # Type conversion: `T(x)` where T is a named type — only triggers if
 # immediately followed by `(`.
-type_conv     =  @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
+type_conv = @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
 
 # Function literal.
-fn_lit        =  kw_func fn_signature block
+fn_lit = kw_func fn_signature block
 
-call_ident    =  @function{ident} &(@punctuation{'('})
+call_ident = @function{ident} &(@punctuation{'('})
 
-ident_list    =  @variable{ident} (@punctuation{','} @variable{ident})*
-const_ident_list =  @constant{ident} (@punctuation{','} @constant{ident})*
-expr_list     =  expr (@punctuation{','} expr)*
-expr_no_compound_list =  expr_no_compound (@punctuation{','} expr_no_compound)*
+ident_list = @variable{ident} (@punctuation{','} @variable{ident})*
+const_ident_list = @constant{ident} (@punctuation{','} @constant{ident})*
+expr_list = expr (@punctuation{','} expr)*
+expr_no_compound_list = expr_no_compound (@punctuation{','} expr_no_compound)*
 
 # --- Literals -------------------------------------------------------
 
-literal       =  string_lit / number_lit / rune_lit / lit_const
+literal = string_lit / number_lit / rune_lit / lit_const
 
 # Predeclared constants as a `%?` preferred-word alternation so the `wb`
 # boundary keeps `trueish` / `nilish` from matching the prefix.
-%?lit_const   =  @constant{'true'} / @constant{'false'}
-               / @constant{'nil'} / @constant{'iota'}
+%?lit_const = @constant{'true'} / @constant{'false'}
+            / @constant{'nil'} / @constant{'iota'}
 
-string_lit    =  @string{raw_string / interp_string}
-*raw_string   =  '`' ..= '`'
-*interp_string =  '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit = @string{raw_string / interp_string}
+*raw_string = '`' ..= '`'
+*interp_string = '"' ('\\' . / !'"' !'\n' .)* '"'
 
-*rune_lit     =  @string{"'" ('\\' . / !"'" .)* "'"}
+*rune_lit = @string{"'" ('\\' . / !"'" .)* "'"}
 
-number_lit    =  @number{num_body}
-*num_body     =  '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
-               / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
-               / '0o' oct_digits 'i'?
-               / '0b' bin_digits 'i'?
-               / digit_seq '.' digit_seq? exp_part? 'i'?
-               / '.' digit_seq exp_part? 'i'?
-               / digit_seq exp_part? 'i'?
-*digit_seq    =  \d ([\d_])*
-*hex_digits   =  [\da-fA-F] [\da-fA-F_]*
-*oct_digits   =  [0-7] [0-7_]*
-*bin_digits   =  [01] [01_]*
-*exp_part     =  [eE] [+\-]? \d+
+number_lit = @number{num_body}
+*num_body = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+          / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+          / '0o' oct_digits 'i'?
+          / '0b' bin_digits 'i'?
+          / digit_seq '.' digit_seq? exp_part? 'i'?
+          / '.' digit_seq exp_part? 'i'?
+          / digit_seq exp_part? 'i'?
+*digit_seq = \d ([\d_])*
+*hex_digits = [\da-fA-F] [\da-fA-F_]*
+*oct_digits = [0-7] [0-7_]*
+*bin_digits = [01] [01_]*
+*exp_part = [eE] [+\-]? \d+
 
 # --- Identifiers / predeclared names ---------------------------------
 
@@ -399,29 +399,29 @@ number_lit    =  @number{num_body}
 # (exported names start uppercase). Admitting non-ASCII letters into
 # both ranges would collapse the distinction; refine with `\p{Lu}` /
 # `\p{Ll}` in a follow-on if needed.
-*ident        =  !reserved [\p{L}_] ident_body*
-*upper_ident  =  !reserved [A-Z] ident_body*
-*lower_ident  =  !reserved [a-z_] ident_body*
-ident_body    =  [\p{L}\p{Nd}_]
+*ident = !reserved [\p{L}_] ident_body*
+*upper_ident = !reserved [A-Z] ident_body*
+*lower_ident = !reserved [a-z_] ident_body*
+ident_body = [\p{L}\p{Nd}_]
 
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-%?predeclared_const =  'true' / 'false' / 'nil' / 'iota'
-%?predeclared_type =  'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
-                   / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
-                   / 'float32' / 'float64' / 'complex64' / 'complex128'
-                   / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
-                   / 'error' / 'any' / 'comparable'
-%?predeclared_fn =  'append' / 'cap' / 'close' / 'complex' / 'copy'
-                 / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
-                 / 'print' / 'println' / 'real' / 'recover'
+%?predeclared_const = 'true' / 'false' / 'nil' / 'iota'
+%?predeclared_type = 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+                  / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
+                  / 'float32' / 'float64' / 'complex64' / 'complex128'
+                  / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
+                  / 'error' / 'any' / 'comparable'
+%?predeclared_fn = 'append' / 'cap' / 'close' / 'complex' / 'copy'
+                / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
+                / 'print' / 'println' / 'real' / 'recover'
 
 # --- Whitespace / comments / semicolon handling ----------------------
 
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
 # we accept optional explicit `;` and let `trivia` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
-~opt_semi     =  @punctuation{';'}?
+~opt_semi = @punctuation{';'}?
 
-*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment = @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -24,109 +24,109 @@
 # malformed function/control-flow bodies resync at the closing `}`
 # instead of failing the enclosing declaration.
 
-root          <- package_clause import_decl* (top_decl)*^
+root          =  package_clause import_decl* (top_decl)*^
 
-trivia        <- (comment / \s)*
+trivia        =  (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Go spec identifier-continue).
-wb            <- !ident_body
+wb            =  !ident_body
 
 # --- Keyword tokens --------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`funcx`).
-%kw_package   <- @keyword{'package'}
-%kw_import    <- @keyword{'import'}
-%kw_var       <- @keyword{'var'}
-%kw_const     <- @keyword{'const'}
-%kw_type      <- @keyword{'type'}
-%kw_map       <- @keyword{'map'}
-%kw_chan      <- @keyword{'chan'}
-%kw_func      <- @keyword{'func'}
-%kw_struct    <- @keyword{'struct'}
-%kw_interface <- @keyword{'interface'}
-%kw_if        <- @keyword{'if'}
-%kw_else      <- @keyword{'else'}
-%kw_for       <- @keyword{'for'}
-%kw_range     <- @keyword{'range'}
-%kw_switch    <- @keyword{'switch'}
-%kw_case      <- @keyword{'case'}
-%kw_default   <- @keyword{'default'}
-%kw_select    <- @keyword{'select'}
-%kw_go        <- @keyword{'go'}
-%kw_defer     <- @keyword{'defer'}
-%kw_return    <- @keyword{'return'}
-%kw_break     <- @keyword{'break'}
-%kw_continue  <- @keyword{'continue'}
-%kw_goto      <- @keyword{'goto'}
-%kw_fallthrough <- @keyword{'fallthrough'}
+%kw_package   =  @keyword{'package'}
+%kw_import    =  @keyword{'import'}
+%kw_var       =  @keyword{'var'}
+%kw_const     =  @keyword{'const'}
+%kw_type      =  @keyword{'type'}
+%kw_map       =  @keyword{'map'}
+%kw_chan      =  @keyword{'chan'}
+%kw_func      =  @keyword{'func'}
+%kw_struct    =  @keyword{'struct'}
+%kw_interface =  @keyword{'interface'}
+%kw_if        =  @keyword{'if'}
+%kw_else      =  @keyword{'else'}
+%kw_for       =  @keyword{'for'}
+%kw_range     =  @keyword{'range'}
+%kw_switch    =  @keyword{'switch'}
+%kw_case      =  @keyword{'case'}
+%kw_default   =  @keyword{'default'}
+%kw_select    =  @keyword{'select'}
+%kw_go        =  @keyword{'go'}
+%kw_defer     =  @keyword{'defer'}
+%kw_return    =  @keyword{'return'}
+%kw_break     =  @keyword{'break'}
+%kw_continue  =  @keyword{'continue'}
+%kw_goto      =  @keyword{'goto'}
+%kw_fallthrough =  @keyword{'fallthrough'}
 
 # --- Package / imports ----------------------------------------------
 
-package_clause <- kw_package @variable{ident} opt_semi
+package_clause =  kw_package @variable{ident} opt_semi
 
-import_decl   <- kw_import import_spec_group opt_semi
+import_decl   =  kw_import import_spec_group opt_semi
                / kw_import import_spec opt_semi
-import_spec_group <- @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
-import_spec   <- import_alias? string_lit
-import_alias  <- @punctuation{'.'}
+import_spec_group =  @punctuation{'('} (import_spec opt_semi)* @punctuation{')'}
+import_spec   =  import_alias? string_lit
+import_alias  =  @punctuation{'.'}
                / @variable{ident}
 
 # --- Top-level declarations -----------------------------------------
 
-top_decl      <- decl
+top_decl      =  decl
                  / func_decl
                  / method_decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl         <- kw_var var_spec_group
+~decl         =  kw_var var_spec_group
                / kw_var var_spec opt_semi
                / kw_const const_spec_group
                / kw_const const_spec opt_semi
                / kw_type type_spec_group
                / kw_type type_spec opt_semi
 
-var_spec_group <- @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
-var_spec      <- ident_list type_expr @operator{'='} expr_list
+var_spec_group =  @punctuation{'('} (var_spec opt_semi)* @punctuation{')'}
+var_spec      =  ident_list type_expr @operator{'='} expr_list
                / ident_list type_expr
                / ident_list @operator{'='} expr_list
 
-const_spec_group <- @punctuation{'('} (const_spec opt_semi)* @punctuation{')'}
+const_spec_group =  @punctuation{'('} (const_spec opt_semi)* @punctuation{')'}
 # Trailing `(= expr)?` absorbed by outer recovery.
-~const_spec   <- const_ident_list type_expr? (@operator{'='} expr_list)?
+~const_spec   =  const_ident_list type_expr? (@operator{'='} expr_list)?
 
-type_spec_group <- @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
-type_spec     <- @type{ident} type_params? @operator{'='}? type_expr
+type_spec_group =  @punctuation{'('} (type_spec opt_semi)* @punctuation{')'}
+type_spec     =  @type{ident} type_params? @operator{'='}? type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl    <- kw_func @function{ident} type_params? fn_signature block?
-~method_decl  <- kw_func method_receiver @function{ident} fn_signature block?
-method_receiver <- @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
+~func_decl    =  kw_func @function{ident} type_params? fn_signature block?
+~method_decl  =  kw_func method_receiver @function{ident} fn_signature block?
+method_receiver =  @punctuation{'('} (@variable{ident})? type_expr @punctuation{')'}
 
 # Generics type parameters: `[T any, U comparable]`.
-type_params   <- @punctuation{'['} type_param_list @punctuation{']'}
-type_param_list <- type_param (@punctuation{','} type_param)* (@punctuation{','})?
-type_param    <- ident_list type_constraint
-type_constraint <- type_union
-type_union    <- type_term (@operator{'|'} type_term)*
-type_term     <- @operator{'~'} type_expr
+type_params   =  @punctuation{'['} type_param_list @punctuation{']'}
+type_param_list =  type_param (@punctuation{','} type_param)* (@punctuation{','})?
+type_param    =  ident_list type_constraint
+type_constraint =  type_union
+type_union    =  type_term (@operator{'|'} type_term)*
+type_term     =  @operator{'~'} type_expr
                / type_expr
 
 # Trailing `fn_result?` absorbed by outer recovery.
-~fn_signature <- fn_params fn_result?
-fn_params     <- @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param      <- ident_list @operator{'...'}? type_expr
+~fn_signature =  fn_params fn_result?
+fn_params     =  @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param      =  ident_list @operator{'...'}? type_expr
                / @operator{'...'}? type_expr
-fn_result     <- fn_params
+fn_result     =  fn_params
                / type_expr
 
 # --- Types -----------------------------------------------------------
 
-type_expr     <- type_ptr
+type_expr     =  type_ptr
                / type_slice_or_array
                / type_map
                / type_chan
@@ -136,36 +136,36 @@ type_expr     <- type_ptr
                / type_paren
                / type_name
 
-type_ptr      <- @operator{'*'} type_expr
-type_slice_or_array <- @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
-type_map      <- kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr
-type_chan     <- @operator{'<-'} kw_chan type_expr
+type_ptr      =  @operator{'*'} type_expr
+type_slice_or_array =  @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr
+type_map      =  kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr
+type_chan     =  @operator{'<-'} kw_chan type_expr
                / kw_chan @operator{'<-'} type_expr
                / kw_chan type_expr
-type_func     <- kw_func fn_signature
-type_struct   <- kw_struct @punctuation{'{'} struct_field_list? @punctuation{'}'}
-struct_field_list <- struct_field (opt_semi struct_field)* opt_semi?
-struct_field  <- @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
+type_func     =  kw_func fn_signature
+type_struct   =  kw_struct @punctuation{'{'} struct_field_list? @punctuation{'}'}
+struct_field_list =  struct_field (opt_semi struct_field)* opt_semi?
+struct_field  =  @property{ident} (@punctuation{','} @property{ident})* type_expr string_lit?
                / @operator{'*'}? type_name string_lit?       # embedded field
-type_interface <- kw_interface @punctuation{'{'} interface_members? @punctuation{'}'}
-interface_members <- interface_member (opt_semi interface_member)* opt_semi?
-interface_member <- @function{ident} fn_signature
+type_interface =  kw_interface @punctuation{'{'} interface_members? @punctuation{'}'}
+interface_members =  interface_member (opt_semi interface_member)* opt_semi?
+interface_member =  @function{ident} fn_signature
                   / type_term
-type_paren    <- @punctuation{'('} type_expr @punctuation{')'}
+type_paren    =  @punctuation{'('} type_expr @punctuation{')'}
 # Trailing `type_args?` leniency absorbed by outer recovery.
-~type_name    <- @type{qualified_ident} type_args?
-type_args     <- @punctuation{'['} type_arg_list @punctuation{']'}
-type_arg_list <- type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
+~type_name    =  @type{qualified_ident} type_args?
+type_args     =  @punctuation{'['} type_arg_list @punctuation{']'}
+type_arg_list =  type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
 # `pkg.Name` or `Name`.
 # Trailing `(.ident)?` leniency absorbed by outer recovery.
-~qualified_ident <- ident (@punctuation{'.'} ident)?
+~qualified_ident =  ident (@punctuation{'.'} ident)?
 
 # --- Statements ------------------------------------------------------
 
-block         <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          <- decl opt_semi
+stmt          =  decl opt_semi
                / block
                / labeled_stmt
                / if_stmt
@@ -182,64 +182,64 @@ stmt          <- decl opt_semi
                / simple_stmt opt_semi
                / empty_stmt
 
-empty_stmt    <- @punctuation{';'}
+empty_stmt    =  @punctuation{';'}
 
-simple_stmt   <- send_stmt
+simple_stmt   =  send_stmt
                / inc_dec_stmt
                / assignment
                / short_var_decl
                / expr_stmt
 
-send_stmt     <- expr_no_compound @operator{'<-'} expr_no_compound
-inc_dec_stmt  <- expr_no_compound (@operator{'++'} / @operator{'--'})
-short_var_decl <- ident_list @operator{':='} expr_list
-assignment    <- expr_no_compound_list assign_op expr_list
-expr_stmt     <- expr_no_compound
+send_stmt     =  expr_no_compound @operator{'<-'} expr_no_compound
+inc_dec_stmt  =  expr_no_compound (@operator{'++'} / @operator{'--'})
+short_var_decl =  ident_list @operator{':='} expr_list
+assignment    =  expr_no_compound_list assign_op expr_list
+expr_stmt     =  expr_no_compound
 
-assign_op     <- @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+assign_op     =  @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
                / @operator{'<<='} / @operator{'>>='} / @operator{'&^='}
                / @operator{'='} !'='
 
-labeled_stmt  <- @variable{ident} @punctuation{':'} stmt
+labeled_stmt  =  @variable{ident} @punctuation{':'} stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt      <- kw_if (simple_stmt @punctuation{';'})? expr_no_compound block
+~if_stmt      =  kw_if (simple_stmt @punctuation{';'})? expr_no_compound block
                  (kw_else (if_stmt / block))?
-for_stmt      <- kw_for for_header? block
-for_header    <- for_range
+for_stmt      =  kw_for for_header? block
+for_header    =  for_range
                / for_c_style
                / expr_no_compound
-for_range     <- (ident_list (@operator{'='} / @operator{':='}))? kw_range expr_no_compound
-for_c_style   <- simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
+for_range     =  (ident_list (@operator{'='} / @operator{':='}))? kw_range expr_no_compound
+for_c_style   =  simple_stmt? @punctuation{';'} expr_no_compound? @punctuation{';'} simple_stmt?
 
-switch_stmt   <- kw_switch type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
+switch_stmt   =  kw_switch type_switch_header @punctuation{'{'} type_case* @punctuation{'}'}
                / kw_switch expr_switch_header @punctuation{'{'} expr_case* @punctuation{'}'}
-expr_switch_header <- (simple_stmt @punctuation{';'})? expr_no_compound?
+expr_switch_header =  (simple_stmt @punctuation{';'})? expr_no_compound?
                / ''
-type_switch_header <- (simple_stmt @punctuation{';'})? type_switch_guard
-type_switch_guard  <- (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} kw_type @punctuation{')'}
-expr_case     <- kw_case expr_list @punctuation{':'} stmt*
+type_switch_header =  (simple_stmt @punctuation{';'})? type_switch_guard
+type_switch_guard  =  (@variable{ident} @operator{':='})? expr_no_compound @punctuation{'.'} @punctuation{'('} kw_type @punctuation{')'}
+expr_case     =  kw_case expr_list @punctuation{':'} stmt*
                / kw_default @punctuation{':'} stmt*
-type_case     <- kw_case type_list @punctuation{':'} stmt*
+type_case     =  kw_case type_list @punctuation{':'} stmt*
                / kw_default @punctuation{':'} stmt*
-type_list     <- type_expr (@punctuation{','} type_expr)*
+type_list     =  type_expr (@punctuation{','} type_expr)*
 
-select_stmt   <- kw_select @punctuation{'{'} comm_case* @punctuation{'}'}
-comm_case     <- kw_case comm_clause @punctuation{':'} stmt*
+select_stmt   =  kw_select @punctuation{'{'} comm_case* @punctuation{'}'}
+comm_case     =  kw_case comm_clause @punctuation{':'} stmt*
                / kw_default @punctuation{':'} stmt*
-comm_clause   <- send_stmt
+comm_clause   =  send_stmt
                / recv_stmt
-recv_stmt     <- (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
+recv_stmt     =  (ident_list (@operator{'='} / @operator{':='}))? expr_no_compound
 
-go_stmt       <- kw_go expr
-defer_stmt    <- kw_defer expr
+go_stmt       =  kw_go expr
+defer_stmt    =  kw_defer expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt  <- kw_return expr_list?
-~break_stmt   <- kw_break (@variable{ident})?
-~continue_stmt <- kw_continue (@variable{ident})?
-goto_stmt     <- kw_goto @variable{ident}
-fallthrough_stmt <- kw_fallthrough
+~return_stmt  =  kw_return expr_list?
+~break_stmt   =  kw_break (@variable{ident})?
+~continue_stmt =  kw_continue (@variable{ident})?
+goto_stmt     =  kw_goto @variable{ident}
+fallthrough_stmt =  kw_fallthrough
 
 # --- Expressions -----------------------------------------------------
 #
@@ -249,72 +249,72 @@ fallthrough_stmt <- kw_fallthrough
 # Go's own disambiguation (see go/parser for `exprLev`).
 #
 # Precedence is encoded by direct left recursion: each binary level is
-# `expr_LEVEL <- expr_LEVEL OP expr_NEXT / expr_NEXT`, mirroring Go's
+# `expr_LEVEL =  expr_LEVEL OP expr_NEXT / expr_NEXT`, mirroring Go's
 # spec (5 levels: `||`, `&&`, comparison, additive, multiplicative).
 # The `_nc` track is a parallel ladder descending into `expr_unary_nc`
 # at the bottom. Cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # `&` vs `&^`, `|` vs `||`) need explicit `!`-lookaheads — within a
 # level, longer operators come first.
 
-expr             <- expr_lor
-expr_no_compound <- expr_lor_nc
+expr             =  expr_lor
+expr_no_compound =  expr_lor_nc
 
-expr_lor         <- expr_lor @operator{'||'} expr_land / expr_land
-expr_land        <- expr_land @operator{'&&'} expr_rel / expr_rel
-expr_rel         <- expr_rel (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add / expr_add
-expr_add         <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul / expr_mul
-expr_mul         <- expr_mul (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary / expr_unary
+expr_lor         =  expr_lor @operator{'||'} expr_land / expr_land
+expr_land        =  expr_land @operator{'&&'} expr_rel / expr_rel
+expr_rel         =  expr_rel (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add / expr_add
+expr_add         =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul / expr_mul
+expr_mul         =  expr_mul (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary / expr_unary
 
-expr_lor_nc      <- expr_lor_nc @operator{'||'} expr_land_nc / expr_land_nc
-expr_land_nc     <- expr_land_nc @operator{'&&'} expr_rel_nc / expr_rel_nc
-expr_rel_nc      <- expr_rel_nc (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add_nc / expr_add_nc
-expr_add_nc      <- expr_add_nc (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul_nc / expr_mul_nc
-expr_mul_nc      <- expr_mul_nc (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary_nc / expr_unary_nc
+expr_lor_nc      =  expr_lor_nc @operator{'||'} expr_land_nc / expr_land_nc
+expr_land_nc     =  expr_land_nc @operator{'&&'} expr_rel_nc / expr_rel_nc
+expr_rel_nc      =  expr_rel_nc (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_add_nc / expr_add_nc
+expr_add_nc      =  expr_add_nc (@operator{'+'} !'=' / @operator{'-'} !'=' / @operator{'|'} !'|' !'=' / @operator{'^'} !'=') expr_mul_nc / expr_mul_nc
+expr_mul_nc      =  expr_mul_nc (@operator{'<<'} !'=' / @operator{'>>'} !'=' / @operator{'&^'} !'=' / @operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=' / @operator{'&'} !'&' !'^' !'=') expr_unary_nc / expr_unary_nc
 
-expr_unary    <- unary_op* expr_postfix
-expr_unary_nc <- unary_op* expr_postfix_nc
-unary_op      <- @operator{'!'} / @operator{'+'} / @operator{'-'}
+expr_unary    =  unary_op* expr_postfix
+expr_unary_nc =  unary_op* expr_postfix_nc
+unary_op      =  @operator{'!'} / @operator{'+'} / @operator{'-'}
                / @operator{'^'} / @operator{'*'} / @operator{'&'}
                / @operator{'<-'}
 
-expr_postfix  <- expr_primary postfix_op*
-expr_postfix_nc <- expr_primary_nc postfix_op_nc*
+expr_postfix  =  expr_primary postfix_op*
+expr_postfix_nc =  expr_primary_nc postfix_op_nc*
 
-postfix_op    <- @punctuation{'.'} postfix_selector
+postfix_op    =  @punctuation{'.'} postfix_selector
                / @punctuation{'['} slice_or_index @punctuation{']'}
                / @punctuation{'('} call_args? @punctuation{')'}
                / composite_body
-postfix_op_nc <- @punctuation{'.'} postfix_selector
+postfix_op_nc =  @punctuation{'.'} postfix_selector
                / @punctuation{'['} slice_or_index @punctuation{']'}
                / @punctuation{'('} call_args? @punctuation{')'}
-postfix_selector <- @punctuation{'('} type_expr @punctuation{')'}                   # x.(T) type assertion
+postfix_selector =  @punctuation{'('} type_expr @punctuation{')'}                   # x.(T) type assertion
                   / @function{ident} &(@punctuation{'('})
                   / @property{ident}
 # `x.(type)` is intentionally not a postfix here: it is only valid inside
 # a `type_switch_guard`, where the `.(type)` tail is matched explicitly.
 # Letting `postfix_selector` swallow it would leave nothing for the guard
 # to match, causing the enclosing `switch_stmt` (and `func_decl`) to fail.
-slice_or_index <- expr? @punctuation{':'} expr? (@punctuation{':'} expr)?
+slice_or_index =  expr? @punctuation{':'} expr? (@punctuation{':'} expr)?
                / expr
 
-call_args     <- arg (@punctuation{','} arg)* (@punctuation{','})?
-arg           <- expr @operator{'...'}
+call_args     =  arg (@punctuation{','} arg)* (@punctuation{','})?
+arg           =  expr @operator{'...'}
                / expr
                / type_expr
 
 # Composite literal body: `{ ... }` after a type expression.
-composite_body <- @punctuation{'{'} composite_elems? @punctuation{'}'}
-composite_elems <- composite_elem (@punctuation{','} composite_elem)* (@punctuation{','})?
-composite_elem <- composite_key @punctuation{':'} composite_value
+composite_body =  @punctuation{'{'} composite_elems? @punctuation{'}'}
+composite_elems =  composite_elem (@punctuation{','} composite_elem)* (@punctuation{','})?
+composite_elem =  composite_key @punctuation{':'} composite_value
                / composite_value
-composite_key  <- @property{ident}
+composite_key  =  @property{ident}
                 / @punctuation{'['} expr @punctuation{']'}
                 / string_lit
                 / number_lit
-composite_value <- composite_body
+composite_value =  composite_body
                  / expr
 
-expr_primary  <- literal
+expr_primary  =  literal
                / fn_lit
                / composite_lit
                / type_conv
@@ -325,7 +325,7 @@ expr_primary  <- literal
                / @function{predeclared_fn} &(@punctuation{'('})
                / @variable{lower_ident}
                / paren_expr
-expr_primary_nc <- literal
+expr_primary_nc =  literal
                  / fn_lit
                  / type_conv
                  / call_ident
@@ -336,57 +336,57 @@ expr_primary_nc <- literal
                  / @variable{lower_ident}
                  / paren_expr
 
-paren_expr    <- @punctuation{'('} expr @punctuation{')'}
+paren_expr    =  @punctuation{'('} expr @punctuation{')'}
 
 # Composite literal: `T{...}` where T is a named/qualified type.
-composite_lit <- @type{qualified_ident} composite_body
+composite_lit =  @type{qualified_ident} composite_body
                / kw_map @punctuation{'['} type_expr @punctuation{']'} type_expr composite_body
                / @punctuation{'['} (@operator{'...'} / expr)? @punctuation{']'} type_expr composite_body
                / kw_struct type_struct_body composite_body
-type_struct_body <- @punctuation{'{'} struct_field_list? @punctuation{'}'}
+type_struct_body =  @punctuation{'{'} struct_field_list? @punctuation{'}'}
 
 # Type conversion: `T(x)` where T is a named type — only triggers if
 # immediately followed by `(`.
-type_conv     <- @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
+type_conv     =  @type{predeclared_type} @punctuation{'('} expr @punctuation{')'}
 
 # Function literal.
-fn_lit        <- kw_func fn_signature block
+fn_lit        =  kw_func fn_signature block
 
-call_ident    <- @function{ident} &(@punctuation{'('})
+call_ident    =  @function{ident} &(@punctuation{'('})
 
-ident_list    <- @variable{ident} (@punctuation{','} @variable{ident})*
-const_ident_list <- @constant{ident} (@punctuation{','} @constant{ident})*
-expr_list     <- expr (@punctuation{','} expr)*
-expr_no_compound_list <- expr_no_compound (@punctuation{','} expr_no_compound)*
+ident_list    =  @variable{ident} (@punctuation{','} @variable{ident})*
+const_ident_list =  @constant{ident} (@punctuation{','} @constant{ident})*
+expr_list     =  expr (@punctuation{','} expr)*
+expr_no_compound_list =  expr_no_compound (@punctuation{','} expr_no_compound)*
 
 # --- Literals -------------------------------------------------------
 
-literal       <- string_lit / number_lit / rune_lit / lit_const
+literal       =  string_lit / number_lit / rune_lit / lit_const
 
 # Predeclared constants as a `%?` preferred-word alternation so the `wb`
 # boundary keeps `trueish` / `nilish` from matching the prefix.
-%?lit_const   <- @constant{'true'} / @constant{'false'}
+%?lit_const   =  @constant{'true'} / @constant{'false'}
                / @constant{'nil'} / @constant{'iota'}
 
-string_lit    <- @string{raw_string / interp_string}
-*raw_string   <- '`' ..= '`'
-*interp_string <- '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit    =  @string{raw_string / interp_string}
+*raw_string   =  '`' ..= '`'
+*interp_string =  '"' ('\\' . / !'"' !'\n' .)* '"'
 
-*rune_lit     <- @string{"'" ('\\' . / !"'" .)* "'"}
+*rune_lit     =  @string{"'" ('\\' . / !"'" .)* "'"}
 
-number_lit    <- @number{num_body}
-*num_body     <- '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+number_lit    =  @number{num_body}
+*num_body     =  '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
                / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
                / '0o' oct_digits 'i'?
                / '0b' bin_digits 'i'?
                / digit_seq '.' digit_seq? exp_part? 'i'?
                / '.' digit_seq exp_part? 'i'?
                / digit_seq exp_part? 'i'?
-*digit_seq    <- \d ([\d_])*
-*hex_digits   <- [\da-fA-F] [\da-fA-F_]*
-*oct_digits   <- [0-7] [0-7_]*
-*bin_digits   <- [01] [01_]*
-*exp_part     <- [eE] [+\-]? \d+
+*digit_seq    =  \d ([\d_])*
+*hex_digits   =  [\da-fA-F] [\da-fA-F_]*
+*oct_digits   =  [0-7] [0-7_]*
+*bin_digits   =  [01] [01_]*
+*exp_part     =  [eE] [+\-]? \d+
 
 # --- Identifiers / predeclared names ---------------------------------
 
@@ -399,21 +399,21 @@ number_lit    <- @number{num_body}
 # (exported names start uppercase). Admitting non-ASCII letters into
 # both ranges would collapse the distinction; refine with `\p{Lu}` /
 # `\p{Ll}` in a follow-on if needed.
-*ident        <- !reserved [\p{L}_] ident_body*
-*upper_ident  <- !reserved [A-Z] ident_body*
-*lower_ident  <- !reserved [a-z_] ident_body*
-ident_body    <- [\p{L}\p{Nd}_]
+*ident        =  !reserved [\p{L}_] ident_body*
+*upper_ident  =  !reserved [A-Z] ident_body*
+*lower_ident  =  !reserved [a-z_] ident_body*
+ident_body    =  [\p{L}\p{Nd}_]
 
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-%?predeclared_const <- 'true' / 'false' / 'nil' / 'iota'
-%?predeclared_type <- 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+%?predeclared_const =  'true' / 'false' / 'nil' / 'iota'
+%?predeclared_type =  'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
                    / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
                    / 'float32' / 'float64' / 'complex64' / 'complex128'
                    / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
                    / 'error' / 'any' / 'comparable'
-%?predeclared_fn <- 'append' / 'cap' / 'close' / 'complex' / 'copy'
+%?predeclared_fn =  'append' / 'cap' / 'close' / 'complex' / 'copy'
                  / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
                  / 'print' / 'println' / 'real' / 'recover'
 
@@ -422,6 +422,6 @@ ident_body    <- [\p{L}\p{Nd}_]
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
 # we accept optional explicit `;` and let `trivia` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
-~opt_semi     <- @punctuation{';'}?
+~opt_semi     =  @punctuation{';'}?
 
-*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -29,13 +29,13 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-root           =  (stmt)*^
+root = (stmt)*^
 
-trivia         =  (comment / \s)*
+trivia = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (ECMAScript IdentifierPartChar).
-wb             =  !ident_body
+wb = !ident_body
 
 # --- Keyword tokens ---------------------------------------------------
 #
@@ -45,47 +45,47 @@ wb             =  !ident_body
 # `from`, `get`, `set`, `static`, `yield`) deliberately kept out of
 # `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
 # must stay one method name.
-%kw_import     =  @keyword{'import'}
-%?kw_from      =  @keyword{'from'}
-%?kw_as        =  @keyword{'as'}
-%kw_export     =  @keyword{'export'}
-%kw_default    =  @keyword{'default'}
-%?kw_async     =  @keyword{'async'}
-%kw_function   =  @keyword{'function'}
-%kw_class      =  @keyword{'class'}
-%kw_extends    =  @keyword{'extends'}
-%?kw_static    =  @keyword{'static'}
-%?kw_get       =  @keyword{'get'}
-%?kw_set       =  @keyword{'set'}
-%kw_var        =  @keyword{'var'}
-%?kw_let       =  @keyword{'let'}
-%kw_const      =  @keyword{'const'}
-%kw_if         =  @keyword{'if'}
-%kw_else       =  @keyword{'else'}
-%kw_for        =  @keyword{'for'}
-%?kw_await     =  @keyword{'await'}
-%kw_in         =  @keyword{'in'}
-%?kw_of        =  @keyword{'of'}
-%kw_while      =  @keyword{'while'}
-%kw_do         =  @keyword{'do'}
-%kw_switch     =  @keyword{'switch'}
-%kw_case       =  @keyword{'case'}
-%kw_try        =  @keyword{'try'}
-%kw_catch      =  @keyword{'catch'}
-%kw_finally    =  @keyword{'finally'}
-%kw_throw      =  @keyword{'throw'}
-%kw_return     =  @keyword{'return'}
-%kw_break      =  @keyword{'break'}
-%kw_continue   =  @keyword{'continue'}
-%kw_debugger   =  @keyword{'debugger'}
-%kw_yield      =  @keyword{'yield'}
-%kw_instanceof =  @keyword{'instanceof'}
-%kw_typeof     =  @keyword{'typeof'}
-%kw_void       =  @keyword{'void'}
-%kw_delete     =  @keyword{'delete'}
-%kw_new        =  @keyword{'new'}
-%kw_this       =  @keyword{'this'}
-%kw_super      =  @keyword{'super'}
+%kw_import = @keyword{'import'}
+%?kw_from = @keyword{'from'}
+%?kw_as = @keyword{'as'}
+%kw_export = @keyword{'export'}
+%kw_default = @keyword{'default'}
+%?kw_async = @keyword{'async'}
+%kw_function = @keyword{'function'}
+%kw_class = @keyword{'class'}
+%kw_extends = @keyword{'extends'}
+%?kw_static = @keyword{'static'}
+%?kw_get = @keyword{'get'}
+%?kw_set = @keyword{'set'}
+%kw_var = @keyword{'var'}
+%?kw_let = @keyword{'let'}
+%kw_const = @keyword{'const'}
+%kw_if = @keyword{'if'}
+%kw_else = @keyword{'else'}
+%kw_for = @keyword{'for'}
+%?kw_await = @keyword{'await'}
+%kw_in = @keyword{'in'}
+%?kw_of = @keyword{'of'}
+%kw_while = @keyword{'while'}
+%kw_do = @keyword{'do'}
+%kw_switch = @keyword{'switch'}
+%kw_case = @keyword{'case'}
+%kw_try = @keyword{'try'}
+%kw_catch = @keyword{'catch'}
+%kw_finally = @keyword{'finally'}
+%kw_throw = @keyword{'throw'}
+%kw_return = @keyword{'return'}
+%kw_break = @keyword{'break'}
+%kw_continue = @keyword{'continue'}
+%kw_debugger = @keyword{'debugger'}
+%kw_yield = @keyword{'yield'}
+%kw_instanceof = @keyword{'instanceof'}
+%kw_typeof = @keyword{'typeof'}
+%kw_void = @keyword{'void'}
+%kw_delete = @keyword{'delete'}
+%kw_new = @keyword{'new'}
+%kw_this = @keyword{'this'}
+%kw_super = @keyword{'super'}
 
 # --- Statements -------------------------------------------------------
 #
@@ -93,178 +93,178 @@ wb             =  !ident_body
 # expression-statements so their leading keywords aren't misparsed as
 # identifiers.
 
-stmt           =  import_decl
-                / export_decl
-                / fn_decl
-                / class_decl
-                / var_decl opt_semi
-                / if_stmt
-                / for_stmt
-                / while_stmt
-                / do_while_stmt
-                / switch_stmt
-                / try_stmt
-                / throw_stmt
-                / return_stmt
-                / break_stmt
-                / continue_stmt
-                / debugger_stmt
-                / labeled_stmt
-                / block
-                / empty_stmt
-                / expr opt_semi
+stmt = import_decl
+     / export_decl
+     / fn_decl
+     / class_decl
+     / var_decl opt_semi
+     / if_stmt
+     / for_stmt
+     / while_stmt
+     / do_while_stmt
+     / switch_stmt
+     / try_stmt
+     / throw_stmt
+     / return_stmt
+     / break_stmt
+     / continue_stmt
+     / debugger_stmt
+     / labeled_stmt
+     / block
+     / empty_stmt
+     / expr opt_semi
 
 # Definition-level `~` on `~opt_semi` covers every ASI call site; the
 # missing-else / missing-catch / missing-finally leniency on the other
 # `~`-marked stmts below is absorbed by stmt-level `*^` and
 # `block`'s `^block_close` recovery.
-~opt_semi      =  @punctuation{';'}?
-empty_stmt     =  @punctuation{';'}
+~opt_semi = @punctuation{';'}?
+empty_stmt = @punctuation{';'}
 
 # --- Imports / exports ------------------------------------------------
 
-import_decl    =  kw_import import_body opt_semi
-import_body    =  import_clause kw_from string_lit
-                / string_lit
-import_clause  =  import_default @punctuation{','} import_ns_or_named
-                / import_default
-                / import_ns_or_named
-import_default =  @variable{ident}
-import_ns_or_named =  import_namespace / import_named
-import_namespace =  @operator{'*'} kw_as @variable{ident}
-import_named   =  @punctuation{'{'} import_specifier_list? @punctuation{'}'}
-import_specifier_list =  import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
-import_specifier =  @variable{ident_name} kw_as @variable{ident}
-                  / @variable{ident}
+import_decl = kw_import import_body opt_semi
+import_body = import_clause kw_from string_lit
+            / string_lit
+import_clause = import_default @punctuation{','} import_ns_or_named
+              / import_default
+              / import_ns_or_named
+import_default = @variable{ident}
+import_ns_or_named = import_namespace / import_named
+import_namespace = @operator{'*'} kw_as @variable{ident}
+import_named = @punctuation{'{'} import_specifier_list? @punctuation{'}'}
+import_specifier_list = import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
+import_specifier = @variable{ident_name} kw_as @variable{ident}
+                 / @variable{ident}
 
-export_decl    =  kw_export kw_default export_default_body
-                / kw_export @operator{'*'} (kw_as @variable{ident_name})? kw_from string_lit opt_semi
-                / kw_export export_named
-                / kw_export fn_decl
-                / kw_export class_decl
-                / kw_export var_decl opt_semi
-export_default_body =  fn_decl
-                     / class_decl
-                     / expr opt_semi
+export_decl = kw_export kw_default export_default_body
+            / kw_export @operator{'*'} (kw_as @variable{ident_name})? kw_from string_lit opt_semi
+            / kw_export export_named
+            / kw_export fn_decl
+            / kw_export class_decl
+            / kw_export var_decl opt_semi
+export_default_body = fn_decl
+                    / class_decl
+                    / expr opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named  =  @punctuation{'{'} export_specifier_list? @punctuation{'}'} (kw_from string_lit)? opt_semi
-export_specifier_list =  export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
-export_specifier =  @variable{ident_name} kw_as @variable{ident_name}
-                  / @variable{ident}
+~export_named = @punctuation{'{'} export_specifier_list? @punctuation{'}'} (kw_from string_lit)? opt_semi
+export_specifier_list = export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
+export_specifier = @variable{ident_name} kw_as @variable{ident_name}
+                 / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
 
-fn_decl        =  kw_async fn_decl_core
-                / fn_decl_core
-fn_decl_core   =  kw_function @operator{'*'}? @function{ident} fn_params block
+fn_decl = kw_async fn_decl_core
+        / fn_decl_core
+fn_decl_core = kw_function @operator{'*'}? @function{ident} fn_params block
 
-class_decl     =  kw_class @type{ident} class_heritage? class_body
-class_heritage =  kw_extends expr_lhs
-class_body     =  @punctuation{'{'} class_member* @punctuation{'}'}
-class_member   =  @punctuation{';'}
-                / class_method_or_field
-class_method_or_field =  kw_static? (class_method / class_field)
-class_method   =  kw_async? @operator{'*'}? method_head fn_params block
-                / (kw_get / kw_set) method_head fn_params block
-method_head    =  computed_prop
-                / @function{ident_name}
-                / string_lit
-                / number_lit
-class_field    =  (computed_prop / @property{ident_name}) (@operator{'='} expr_no_comma)? opt_semi
+class_decl = kw_class @type{ident} class_heritage? class_body
+class_heritage = kw_extends expr_lhs
+class_body = @punctuation{'{'} class_member* @punctuation{'}'}
+class_member = @punctuation{';'}
+             / class_method_or_field
+class_method_or_field = kw_static? (class_method / class_field)
+class_method = kw_async? @operator{'*'}? method_head fn_params block
+             / (kw_get / kw_set) method_head fn_params block
+method_head = computed_prop
+            / @function{ident_name}
+            / string_lit
+            / number_lit
+class_field = (computed_prop / @property{ident_name}) (@operator{'='} expr_no_comma)? opt_semi
 
 # --- Variable declarations -------------------------------------------
 
-var_decl       =  (kw_var / kw_let / kw_const) var_declarator_list
-var_declarator_list =  var_declarator (@punctuation{','} var_declarator)*
+var_decl = (kw_var / kw_let / kw_const) var_declarator_list
+var_declarator_list = var_declarator (@punctuation{','} var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
-~var_declarator =  pattern (@operator{'='} expr_no_comma)?
+~var_declarator = pattern (@operator{'='} expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt       =  kw_if @punctuation{'('} expr @punctuation{')'} stmt
-                  (kw_else stmt)?
-for_stmt       =  kw_for kw_await? @punctuation{'('} for_head @punctuation{')'} stmt
-for_head       =  for_c_style
-                / for_in_of
-for_c_style    =  for_init? @punctuation{';'} expr? @punctuation{';'} expr?
-for_in_of      =  for_binding (kw_in / kw_of) expr
-for_init       =  var_decl
-                / expr
-for_binding    =  (kw_var / kw_let / kw_const) pattern
-                / pattern
+~if_stmt = kw_if @punctuation{'('} expr @punctuation{')'} stmt
+           (kw_else stmt)?
+for_stmt = kw_for kw_await? @punctuation{'('} for_head @punctuation{')'} stmt
+for_head = for_c_style
+         / for_in_of
+for_c_style = for_init? @punctuation{';'} expr? @punctuation{';'} expr?
+for_in_of = for_binding (kw_in / kw_of) expr
+for_init = var_decl
+         / expr
+for_binding = (kw_var / kw_let / kw_const) pattern
+            / pattern
 
-while_stmt     =  kw_while @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt  =  kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} opt_semi
-switch_stmt    =  kw_switch @punctuation{'('} expr @punctuation{')'}
-                  @punctuation{'{'} switch_case* @punctuation{'}'}
-switch_case    =  kw_case expr @punctuation{':'} (!switch_case_term stmt)*
-                / kw_default @punctuation{':'} (!switch_case_term stmt)*
-switch_case_term =  kw_case / kw_default / @punctuation{'}'}
+while_stmt = kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt = kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} opt_semi
+switch_stmt = kw_switch @punctuation{'('} expr @punctuation{')'}
+              @punctuation{'{'} switch_case* @punctuation{'}'}
+switch_case = kw_case expr @punctuation{':'} (!switch_case_term stmt)*
+            / kw_default @punctuation{':'} (!switch_case_term stmt)*
+switch_case_term = kw_case / kw_default / @punctuation{'}'}
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt      =  kw_try block catch_clause? finally_clause?
-catch_clause   =  kw_catch (@punctuation{'('} pattern @punctuation{')'})? block
-finally_clause =  kw_finally block
-throw_stmt     =  kw_throw expr opt_semi
+~try_stmt = kw_try block catch_clause? finally_clause?
+catch_clause = kw_catch (@punctuation{'('} pattern @punctuation{')'})? block
+finally_clause = kw_finally block
+throw_stmt = kw_throw expr opt_semi
 # Trailing `expr?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt   =  kw_return expr? opt_semi
-~break_stmt    =  kw_break (@variable{ident})? opt_semi
-~continue_stmt =  kw_continue (@variable{ident})? opt_semi
-debugger_stmt  =  kw_debugger opt_semi
-labeled_stmt   =  @variable{ident} @punctuation{':'} stmt
-block          =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+~return_stmt = kw_return expr? opt_semi
+~break_stmt = kw_break (@variable{ident})? opt_semi
+~continue_stmt = kw_continue (@variable{ident})? opt_semi
+debugger_stmt = kw_debugger opt_semi
+labeled_stmt = @variable{ident} @punctuation{':'} stmt
+block = @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------
 
-fn_params      =  @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list  =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param       =  @operator{'...'} pattern
-                / pattern (@operator{'='} expr_no_comma)?
+fn_params = @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list = fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param = @operator{'...'} pattern
+         / pattern (@operator{'='} expr_no_comma)?
 
 # --- Destructuring patterns ------------------------------------------
 
-pattern        =  array_pattern / object_pattern / @variable{ident}
-array_pattern  =  @punctuation{'['} array_pattern_list? @punctuation{']'}
-array_pattern_list =  array_pattern_el (@punctuation{','} array_pattern_el)* (@punctuation{','})?
-array_pattern_el =  @operator{'...'} pattern
-                  / pattern (@operator{'='} expr_no_comma)?
-                  / ''
-object_pattern =  @punctuation{'{'} object_pattern_list? @punctuation{'}'}
-object_pattern_list =  object_pattern_prop (@punctuation{','} object_pattern_prop)* (@punctuation{','})?
-object_pattern_prop =  @operator{'...'} pattern
-                     / (computed_prop / @property{ident_name}) @punctuation{':'} pattern (@operator{'='} expr_no_comma)?
-                     / @property{ident} (@operator{'='} expr_no_comma)?
+pattern = array_pattern / object_pattern / @variable{ident}
+array_pattern = @punctuation{'['} array_pattern_list? @punctuation{']'}
+array_pattern_list = array_pattern_el (@punctuation{','} array_pattern_el)* (@punctuation{','})?
+array_pattern_el = @operator{'...'} pattern
+                 / pattern (@operator{'='} expr_no_comma)?
+                 / ''
+object_pattern = @punctuation{'{'} object_pattern_list? @punctuation{'}'}
+object_pattern_list = object_pattern_prop (@punctuation{','} object_pattern_prop)* (@punctuation{','})?
+object_pattern_prop = @operator{'...'} pattern
+                    / (computed_prop / @property{ident_name}) @punctuation{':'} pattern (@operator{'='} expr_no_comma)?
+                    / @property{ident} (@operator{'='} expr_no_comma)?
 
-computed_prop  =  @punctuation{'['} expr @punctuation{']'}
+computed_prop = @punctuation{'['} expr @punctuation{']'}
 
 # --- Expressions ------------------------------------------------------
 
-expr           =  expr_no_comma (@punctuation{','} expr_no_comma)*
-expr_no_comma  =  expr_assign
-expr_assign    =  expr_arrow
-                / expr_yield
-                / expr_conditional (assign_op expr_assign)?
+expr = expr_no_comma (@punctuation{','} expr_no_comma)*
+expr_no_comma = expr_assign
+expr_assign = expr_arrow
+            / expr_yield
+            / expr_conditional (assign_op expr_assign)?
 
-assign_op      =  @operator{'**='}
-                / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
-                / @operator{'||='} / @operator{'&&='} / @operator{'??='}
-                / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
-                / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
-                / @operator{'='} !'='
+assign_op = @operator{'**='}
+          / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
+          / @operator{'||='} / @operator{'&&='} / @operator{'??='}
+          / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
+          / @operator{'%='} / @operator{'&='} / @operator{'|='} / @operator{'^='}
+          / @operator{'='} !'='
 
 # Arrow functions tried first. `async x => ...`, `x => ...`,
 # `(a, b) => ...`, `() => ...`.
-expr_arrow     =  arrow_head @operator{'=>'} arrow_body
-arrow_head     =  kw_async arrow_params
-                / arrow_params
-arrow_params   =  @variable{ident}
-                / arrow_paren_params
-arrow_paren_params =  @punctuation{'('} fn_param_list? @punctuation{')'}
-arrow_body     =  block
-                / expr_no_comma
+expr_arrow = arrow_head @operator{'=>'} arrow_body
+arrow_head = kw_async arrow_params
+           / arrow_params
+arrow_params = @variable{ident}
+             / arrow_paren_params
+arrow_paren_params = @punctuation{'('} fn_param_list? @punctuation{')'}
+arrow_body = block
+           / expr_no_comma
 
 # Trailing `(*)? (expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield    =  kw_yield @operator{'*'}? expr_assign?
+~expr_yield = kw_yield @operator{'*'}? expr_assign?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n =  level_n OP level_{n+1} / level_{n+1}` per
@@ -273,129 +273,129 @@ arrow_body     =  block
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
 # Trailing ternary leniency absorbed by stmt-level recovery.
-~expr_conditional =  expr_nullish (@operator{'?'} expr_no_comma @punctuation{':'} expr_no_comma)?
+~expr_conditional = expr_nullish (@operator{'?'} expr_no_comma @punctuation{':'} expr_no_comma)?
 
-expr_nullish   =  expr_nullish @operator{'??'} !'=' expr_lor / expr_lor
-expr_lor       =  expr_lor @operator{'||'} !'=' expr_land / expr_land
-expr_land      =  expr_land @operator{'&&'} !'=' expr_bor / expr_bor
-expr_bor       =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor      =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band      =  expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
-expr_eq        =  expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
-expr_rel       =  expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / kw_instanceof / kw_in) expr_shift / expr_shift
-expr_shift     =  expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add       =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul       =  expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
+expr_nullish = expr_nullish @operator{'??'} !'=' expr_lor / expr_lor
+expr_lor = expr_lor @operator{'||'} !'=' expr_land / expr_land
+expr_land = expr_land @operator{'&&'} !'=' expr_bor / expr_bor
+expr_bor = expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor = expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band = expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq = expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel = expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / kw_instanceof / kw_in) expr_shift / expr_shift
+expr_shift = expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add = expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul = expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
 
 # Right-associative: stays right-recursive, not LR.
-expr_pow       =  expr_unary @operator{'**'} !'=' expr_pow / expr_unary
+expr_pow = expr_unary @operator{'**'} !'=' expr_pow / expr_unary
 
-expr_unary     =  unary_op* expr_postfix
-unary_op       =  kw_typeof
-                / kw_void
-                / kw_delete
-                / kw_await
-                / @operator{'++'} / @operator{'--'}
-                / @operator{'+'} / @operator{'-'}
-                / @operator{'!'} / @operator{'~'}
+expr_unary = unary_op* expr_postfix
+unary_op = kw_typeof
+         / kw_void
+         / kw_delete
+         / kw_await
+         / @operator{'++'} / @operator{'--'}
+         / @operator{'+'} / @operator{'-'}
+         / @operator{'!'} / @operator{'~'}
 
 # Postfix: calls, member, optional chain, index, `++`/`--`.
-expr_postfix   =  expr_lhs postfix_op*
-postfix_op     =  @operator{'++'}
-                / @operator{'--'}
-                / @operator{'?.'} postfix_after_optional
-                / @punctuation{'.'} member_target
-                / @punctuation{'['} expr @punctuation{']'}
-                / call_args
-                / template_lit
-postfix_after_optional =  call_args
-                        / @punctuation{'['} expr @punctuation{']'}
-                        / member_target
-member_target  =  @function{ident_name} &(@punctuation{'('})
-                / @property{ident_name}
-call_args      =  @punctuation{'('} arg_list? @punctuation{')'}
-arg_list       =  arg (@punctuation{','} arg)* (@punctuation{','})?
-arg            =  @operator{'...'} expr_no_comma
-                / expr_no_comma
+expr_postfix = expr_lhs postfix_op*
+postfix_op = @operator{'++'}
+           / @operator{'--'}
+           / @operator{'?.'} postfix_after_optional
+           / @punctuation{'.'} member_target
+           / @punctuation{'['} expr @punctuation{']'}
+           / call_args
+           / template_lit
+postfix_after_optional = call_args
+                       / @punctuation{'['} expr @punctuation{']'}
+                       / member_target
+member_target = @function{ident_name} &(@punctuation{'('})
+              / @property{ident_name}
+call_args = @punctuation{'('} arg_list? @punctuation{')'}
+arg_list = arg (@punctuation{','} arg)* (@punctuation{','})?
+arg = @operator{'...'} expr_no_comma
+    / expr_no_comma
 
-expr_lhs       =  expr_new / expr_primary
-expr_new       =  kw_new expr_new_target
-expr_new_target =  @type{upper_ident} new_tail?
-                 / @variable{lower_ident} new_tail?
-                 / expr_primary new_tail?
-new_tail       =  postfix_op+
+expr_lhs = expr_new / expr_primary
+expr_new = kw_new expr_new_target
+expr_new_target = @type{upper_ident} new_tail?
+                / @variable{lower_ident} new_tail?
+                / expr_primary new_tail?
+new_tail = postfix_op+
 
-expr_primary   =  literal
-                / expr_this
-                / expr_super
-                / expr_fn
-                / expr_class
-                / expr_array
-                / expr_object
-                / expr_paren
-                / call_ident
-                / @type{upper_ident}
-                / @variable{lower_ident}
+expr_primary = literal
+             / expr_this
+             / expr_super
+             / expr_fn
+             / expr_class
+             / expr_array
+             / expr_object
+             / expr_paren
+             / call_ident
+             / @type{upper_ident}
+             / @variable{lower_ident}
 
-call_ident     =  @function{ident} &(@punctuation{'('})
+call_ident = @function{ident} &(@punctuation{'('})
 
-expr_this      =  kw_this
-expr_super     =  kw_super
-expr_fn        =  kw_async? kw_function @operator{'*'}? @function{ident}? fn_params block
-expr_class     =  kw_class @type{ident}? class_heritage? class_body
-expr_array     =  @punctuation{'['} array_elem_list? @punctuation{']'}
-array_elem_list =  array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
-array_elem     =  @operator{'...'} expr_no_comma
-                / expr_no_comma
-                / ''
-expr_object    =  @punctuation{'{'} object_props? @punctuation{'}'}
-object_props   =  object_prop (@punctuation{','} object_prop)* (@punctuation{','})?
-object_prop    =  @operator{'...'} expr_no_comma
-                / object_method
-                / (computed_prop / string_lit / number_lit / @property{ident_name}) @punctuation{':'} expr_no_comma
-                / @property{ident}
-object_method  =  kw_async? @operator{'*'}? method_head fn_params block
-                / (kw_get / kw_set) method_head fn_params block
-expr_paren     =  @punctuation{'('} expr @punctuation{')'}
+expr_this = kw_this
+expr_super = kw_super
+expr_fn = kw_async? kw_function @operator{'*'}? @function{ident}? fn_params block
+expr_class = kw_class @type{ident}? class_heritage? class_body
+expr_array = @punctuation{'['} array_elem_list? @punctuation{']'}
+array_elem_list = array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
+array_elem = @operator{'...'} expr_no_comma
+           / expr_no_comma
+           / ''
+expr_object = @punctuation{'{'} object_props? @punctuation{'}'}
+object_props = object_prop (@punctuation{','} object_prop)* (@punctuation{','})?
+object_prop = @operator{'...'} expr_no_comma
+            / object_method
+            / (computed_prop / string_lit / number_lit / @property{ident_name}) @punctuation{':'} expr_no_comma
+            / @property{ident}
+object_method = kw_async? @operator{'*'}? method_head fn_params block
+              / (kw_get / kw_set) method_head fn_params block
+expr_paren = @punctuation{'('} expr @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 
-literal        =  template_lit
-                / string_lit
-                / number_lit
-                / lit_const
-                / lit_undefined
+literal = template_lit
+        / string_lit
+        / number_lit
+        / lit_const
+        / lit_undefined
 
 # Boolean / null / undefined constants; the `wb` boundary keeps
 # `trueish` / `nullish` from matching the prefix.
-%lit_const     =  @constant{'true'} / @constant{'false'} / @constant{'null'}
-%?lit_undefined =  @constant{'undefined'}
+%lit_const = @constant{'true'} / @constant{'false'} / @constant{'null'}
+%?lit_undefined = @constant{'undefined'}
 
-string_lit     =  @string{sq_string / dq_string}
-*sq_string     =  "'" ('\\' . / !"'" !'\n' .)* "'"
-*dq_string     =  '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit = @string{sq_string / dq_string}
+*sq_string = "'" ('\\' . / !"'" !'\n' .)* "'"
+*dq_string = '"' ('\\' . / !'"' !'\n' .)* '"'
 
 # Template literals with ${...} interpolation. Chunks outside the
 # interpolations get @string; the interpolation braces stay
 # @punctuation and the inner expression is parsed as normal.
-*template_lit  =  @string{'`'} template_body @string{'`'}
-*template_body =  (template_chunk / template_interp)*
-*template_chunk =  @string{('\\' . / !'`' !'${' .)+}
-template_interp =  @punctuation{'${'} expr @punctuation{'}'}
+*template_lit = @string{'`'} template_body @string{'`'}
+*template_body = (template_chunk / template_interp)*
+*template_chunk = @string{('\\' . / !'`' !'${' .)+}
+template_interp = @punctuation{'${'} expr @punctuation{'}'}
 
-number_lit     =  @number{num_body}
-*num_body      =  '0x' hex_digits 'n'?
-                / '0o' oct_digits 'n'?
-                / '0b' bin_digits 'n'?
-                / decimal_num 'n'?
-*decimal_num   =  digit_seq '.' digit_seq? exp_part?
-                / '.' digit_seq exp_part?
-                / digit_seq exp_part?
-*digit_seq     =  \d ([\d_])*
-*hex_digits    =  [\da-fA-F] [\da-fA-F_]*
-*oct_digits    =  [0-7] [0-7_]*
-*bin_digits    =  [01] [01_]*
-*exp_part      =  [eE] [+\-]? \d+
+number_lit = @number{num_body}
+*num_body = '0x' hex_digits 'n'?
+          / '0o' oct_digits 'n'?
+          / '0b' bin_digits 'n'?
+          / decimal_num 'n'?
+*decimal_num = digit_seq '.' digit_seq? exp_part?
+             / '.' digit_seq exp_part?
+             / digit_seq exp_part?
+*digit_seq = \d ([\d_])*
+*hex_digits = [\da-fA-F] [\da-fA-F_]*
+*oct_digits = [0-7] [0-7_]*
+*bin_digits = [01] [01_]*
+*exp_part = [eE] [+\-]? \d+
 
 # --- Identifiers / reserved words ------------------------------------
 
@@ -405,26 +405,26 @@ number_lit     =  @number{num_body}
 # Unicode's identifier properties); same for the ZWNJ/ZWJ continuation
 # extras. Escape forms `\uHHHH` and `\u{H..}` are admitted in both
 # positions.
-*ident         =  !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+*ident = !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
 # `!reserved` guard is dropped so reserved words are accepted. Use at
 # positions where ES allows IdentifierName but not BindingIdentifier
 # (member access after `.` / `?.`, property keys, imported/exported
 # names that aren't local bindings).
-*ident_name    =  ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+*ident_name = ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # Per §12.7.1 UnicodeEscapeSequence: 4 fixed hex digits or `{H..}` for
 # 1-6 hex digits inside braces. Atomic so the prefix-then-fail shape
 # stays internal.
-*js_uesc       =  '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
+*js_uesc = '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
 # `upper_ident` / `lower_ident` keep their ASCII-only start so the
 # case-based shape gate (PascalCase → @type, etc.) doesn't dissolve
 # into "any ID_Start letter". Future refinement via `\p{Lu}` /
 # `\p{Ll}` if a non-ASCII-aware variant is needed.
-*upper_ident   =  !reserved [A-Z] ident_body_part*
-*lower_ident   =  !reserved [a-z_$] ident_body_part*
-ident_body_part =  ident_body / js_uesc
-ident_body     =  [\p{ID_Continue}$\u{200C}\u{200D}]
+*upper_ident = !reserved [A-Z] ident_body_part*
+*lower_ident = !reserved [a-z_$] ident_body_part*
+ident_body_part = ident_body / js_uesc
+ident_body = [\p{ID_Continue}$\u{200C}\u{200D}]
 
 # --- Whitespace / comments --------------------------------------------
 
-*comment       =  @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment = @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -29,13 +29,13 @@
 # function/control-flow bodies resync at the closing `}` instead of
 # failing the enclosing statement.
 
-root           <- (stmt)*^
+root           =  (stmt)*^
 
-trivia         <- (comment / \s)*
+trivia         =  (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (ECMAScript IdentifierPartChar).
-wb             <- !ident_body
+wb             =  !ident_body
 
 # --- Keyword tokens ---------------------------------------------------
 #
@@ -45,47 +45,47 @@ wb             <- !ident_body
 # `from`, `get`, `set`, `static`, `yield`) deliberately kept out of
 # `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
 # must stay one method name.
-%kw_import     <- @keyword{'import'}
-%?kw_from      <- @keyword{'from'}
-%?kw_as        <- @keyword{'as'}
-%kw_export     <- @keyword{'export'}
-%kw_default    <- @keyword{'default'}
-%?kw_async     <- @keyword{'async'}
-%kw_function   <- @keyword{'function'}
-%kw_class      <- @keyword{'class'}
-%kw_extends    <- @keyword{'extends'}
-%?kw_static    <- @keyword{'static'}
-%?kw_get       <- @keyword{'get'}
-%?kw_set       <- @keyword{'set'}
-%kw_var        <- @keyword{'var'}
-%?kw_let       <- @keyword{'let'}
-%kw_const      <- @keyword{'const'}
-%kw_if         <- @keyword{'if'}
-%kw_else       <- @keyword{'else'}
-%kw_for        <- @keyword{'for'}
-%?kw_await     <- @keyword{'await'}
-%kw_in         <- @keyword{'in'}
-%?kw_of        <- @keyword{'of'}
-%kw_while      <- @keyword{'while'}
-%kw_do         <- @keyword{'do'}
-%kw_switch     <- @keyword{'switch'}
-%kw_case       <- @keyword{'case'}
-%kw_try        <- @keyword{'try'}
-%kw_catch      <- @keyword{'catch'}
-%kw_finally    <- @keyword{'finally'}
-%kw_throw      <- @keyword{'throw'}
-%kw_return     <- @keyword{'return'}
-%kw_break      <- @keyword{'break'}
-%kw_continue   <- @keyword{'continue'}
-%kw_debugger   <- @keyword{'debugger'}
-%kw_yield      <- @keyword{'yield'}
-%kw_instanceof <- @keyword{'instanceof'}
-%kw_typeof     <- @keyword{'typeof'}
-%kw_void       <- @keyword{'void'}
-%kw_delete     <- @keyword{'delete'}
-%kw_new        <- @keyword{'new'}
-%kw_this       <- @keyword{'this'}
-%kw_super      <- @keyword{'super'}
+%kw_import     =  @keyword{'import'}
+%?kw_from      =  @keyword{'from'}
+%?kw_as        =  @keyword{'as'}
+%kw_export     =  @keyword{'export'}
+%kw_default    =  @keyword{'default'}
+%?kw_async     =  @keyword{'async'}
+%kw_function   =  @keyword{'function'}
+%kw_class      =  @keyword{'class'}
+%kw_extends    =  @keyword{'extends'}
+%?kw_static    =  @keyword{'static'}
+%?kw_get       =  @keyword{'get'}
+%?kw_set       =  @keyword{'set'}
+%kw_var        =  @keyword{'var'}
+%?kw_let       =  @keyword{'let'}
+%kw_const      =  @keyword{'const'}
+%kw_if         =  @keyword{'if'}
+%kw_else       =  @keyword{'else'}
+%kw_for        =  @keyword{'for'}
+%?kw_await     =  @keyword{'await'}
+%kw_in         =  @keyword{'in'}
+%?kw_of        =  @keyword{'of'}
+%kw_while      =  @keyword{'while'}
+%kw_do         =  @keyword{'do'}
+%kw_switch     =  @keyword{'switch'}
+%kw_case       =  @keyword{'case'}
+%kw_try        =  @keyword{'try'}
+%kw_catch      =  @keyword{'catch'}
+%kw_finally    =  @keyword{'finally'}
+%kw_throw      =  @keyword{'throw'}
+%kw_return     =  @keyword{'return'}
+%kw_break      =  @keyword{'break'}
+%kw_continue   =  @keyword{'continue'}
+%kw_debugger   =  @keyword{'debugger'}
+%kw_yield      =  @keyword{'yield'}
+%kw_instanceof =  @keyword{'instanceof'}
+%kw_typeof     =  @keyword{'typeof'}
+%kw_void       =  @keyword{'void'}
+%kw_delete     =  @keyword{'delete'}
+%kw_new        =  @keyword{'new'}
+%kw_this       =  @keyword{'this'}
+%kw_super      =  @keyword{'super'}
 
 # --- Statements -------------------------------------------------------
 #
@@ -93,7 +93,7 @@ wb             <- !ident_body
 # expression-statements so their leading keywords aren't misparsed as
 # identifiers.
 
-stmt           <- import_decl
+stmt           =  import_decl
                 / export_decl
                 / fn_decl
                 / class_decl
@@ -118,134 +118,134 @@ stmt           <- import_decl
 # missing-else / missing-catch / missing-finally leniency on the other
 # `~`-marked stmts below is absorbed by stmt-level `*^` and
 # `block`'s `^block_close` recovery.
-~opt_semi      <- @punctuation{';'}?
-empty_stmt     <- @punctuation{';'}
+~opt_semi      =  @punctuation{';'}?
+empty_stmt     =  @punctuation{';'}
 
 # --- Imports / exports ------------------------------------------------
 
-import_decl    <- kw_import import_body opt_semi
-import_body    <- import_clause kw_from string_lit
+import_decl    =  kw_import import_body opt_semi
+import_body    =  import_clause kw_from string_lit
                 / string_lit
-import_clause  <- import_default @punctuation{','} import_ns_or_named
+import_clause  =  import_default @punctuation{','} import_ns_or_named
                 / import_default
                 / import_ns_or_named
-import_default <- @variable{ident}
-import_ns_or_named <- import_namespace / import_named
-import_namespace <- @operator{'*'} kw_as @variable{ident}
-import_named   <- @punctuation{'{'} import_specifier_list? @punctuation{'}'}
-import_specifier_list <- import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
-import_specifier <- @variable{ident_name} kw_as @variable{ident}
+import_default =  @variable{ident}
+import_ns_or_named =  import_namespace / import_named
+import_namespace =  @operator{'*'} kw_as @variable{ident}
+import_named   =  @punctuation{'{'} import_specifier_list? @punctuation{'}'}
+import_specifier_list =  import_specifier (@punctuation{','} import_specifier)* (@punctuation{','})?
+import_specifier =  @variable{ident_name} kw_as @variable{ident}
                   / @variable{ident}
 
-export_decl    <- kw_export kw_default export_default_body
+export_decl    =  kw_export kw_default export_default_body
                 / kw_export @operator{'*'} (kw_as @variable{ident_name})? kw_from string_lit opt_semi
                 / kw_export export_named
                 / kw_export fn_decl
                 / kw_export class_decl
                 / kw_export var_decl opt_semi
-export_default_body <- fn_decl
+export_default_body =  fn_decl
                      / class_decl
                      / expr opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named  <- @punctuation{'{'} export_specifier_list? @punctuation{'}'} (kw_from string_lit)? opt_semi
-export_specifier_list <- export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
-export_specifier <- @variable{ident_name} kw_as @variable{ident_name}
+~export_named  =  @punctuation{'{'} export_specifier_list? @punctuation{'}'} (kw_from string_lit)? opt_semi
+export_specifier_list =  export_specifier (@punctuation{','} export_specifier)* (@punctuation{','})?
+export_specifier =  @variable{ident_name} kw_as @variable{ident_name}
                   / @variable{ident}
 
 # --- Function / class declarations ------------------------------------
 
-fn_decl        <- kw_async fn_decl_core
+fn_decl        =  kw_async fn_decl_core
                 / fn_decl_core
-fn_decl_core   <- kw_function @operator{'*'}? @function{ident} fn_params block
+fn_decl_core   =  kw_function @operator{'*'}? @function{ident} fn_params block
 
-class_decl     <- kw_class @type{ident} class_heritage? class_body
-class_heritage <- kw_extends expr_lhs
-class_body     <- @punctuation{'{'} class_member* @punctuation{'}'}
-class_member   <- @punctuation{';'}
+class_decl     =  kw_class @type{ident} class_heritage? class_body
+class_heritage =  kw_extends expr_lhs
+class_body     =  @punctuation{'{'} class_member* @punctuation{'}'}
+class_member   =  @punctuation{';'}
                 / class_method_or_field
-class_method_or_field <- kw_static? (class_method / class_field)
-class_method   <- kw_async? @operator{'*'}? method_head fn_params block
+class_method_or_field =  kw_static? (class_method / class_field)
+class_method   =  kw_async? @operator{'*'}? method_head fn_params block
                 / (kw_get / kw_set) method_head fn_params block
-method_head    <- computed_prop
+method_head    =  computed_prop
                 / @function{ident_name}
                 / string_lit
                 / number_lit
-class_field    <- (computed_prop / @property{ident_name}) (@operator{'='} expr_no_comma)? opt_semi
+class_field    =  (computed_prop / @property{ident_name}) (@operator{'='} expr_no_comma)? opt_semi
 
 # --- Variable declarations -------------------------------------------
 
-var_decl       <- (kw_var / kw_let / kw_const) var_declarator_list
-var_declarator_list <- var_declarator (@punctuation{','} var_declarator)*
+var_decl       =  (kw_var / kw_let / kw_const) var_declarator_list
+var_declarator_list =  var_declarator (@punctuation{','} var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
-~var_declarator <- pattern (@operator{'='} expr_no_comma)?
+~var_declarator =  pattern (@operator{'='} expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt       <- kw_if @punctuation{'('} expr @punctuation{')'} stmt
+~if_stmt       =  kw_if @punctuation{'('} expr @punctuation{')'} stmt
                   (kw_else stmt)?
-for_stmt       <- kw_for kw_await? @punctuation{'('} for_head @punctuation{')'} stmt
-for_head       <- for_c_style
+for_stmt       =  kw_for kw_await? @punctuation{'('} for_head @punctuation{')'} stmt
+for_head       =  for_c_style
                 / for_in_of
-for_c_style    <- for_init? @punctuation{';'} expr? @punctuation{';'} expr?
-for_in_of      <- for_binding (kw_in / kw_of) expr
-for_init       <- var_decl
+for_c_style    =  for_init? @punctuation{';'} expr? @punctuation{';'} expr?
+for_in_of      =  for_binding (kw_in / kw_of) expr
+for_init       =  var_decl
                 / expr
-for_binding    <- (kw_var / kw_let / kw_const) pattern
+for_binding    =  (kw_var / kw_let / kw_const) pattern
                 / pattern
 
-while_stmt     <- kw_while @punctuation{'('} expr @punctuation{')'} stmt
-do_while_stmt  <- kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} opt_semi
-switch_stmt    <- kw_switch @punctuation{'('} expr @punctuation{')'}
+while_stmt     =  kw_while @punctuation{'('} expr @punctuation{')'} stmt
+do_while_stmt  =  kw_do stmt kw_while @punctuation{'('} expr @punctuation{')'} opt_semi
+switch_stmt    =  kw_switch @punctuation{'('} expr @punctuation{')'}
                   @punctuation{'{'} switch_case* @punctuation{'}'}
-switch_case    <- kw_case expr @punctuation{':'} (!switch_case_term stmt)*
+switch_case    =  kw_case expr @punctuation{':'} (!switch_case_term stmt)*
                 / kw_default @punctuation{':'} (!switch_case_term stmt)*
-switch_case_term <- kw_case / kw_default / @punctuation{'}'}
+switch_case_term =  kw_case / kw_default / @punctuation{'}'}
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt      <- kw_try block catch_clause? finally_clause?
-catch_clause   <- kw_catch (@punctuation{'('} pattern @punctuation{')'})? block
-finally_clause <- kw_finally block
-throw_stmt     <- kw_throw expr opt_semi
+~try_stmt      =  kw_try block catch_clause? finally_clause?
+catch_clause   =  kw_catch (@punctuation{'('} pattern @punctuation{')'})? block
+finally_clause =  kw_finally block
+throw_stmt     =  kw_throw expr opt_semi
 # Trailing `expr?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt   <- kw_return expr? opt_semi
-~break_stmt    <- kw_break (@variable{ident})? opt_semi
-~continue_stmt <- kw_continue (@variable{ident})? opt_semi
-debugger_stmt  <- kw_debugger opt_semi
-labeled_stmt   <- @variable{ident} @punctuation{':'} stmt
-block          <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+~return_stmt   =  kw_return expr? opt_semi
+~break_stmt    =  kw_break (@variable{ident})? opt_semi
+~continue_stmt =  kw_continue (@variable{ident})? opt_semi
+debugger_stmt  =  kw_debugger opt_semi
+labeled_stmt   =  @variable{ident} @punctuation{':'} stmt
+block          =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
 # --- Function params and patterns -------------------------------------
 
-fn_params      <- @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list  <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param       <- @operator{'...'} pattern
+fn_params      =  @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list  =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param       =  @operator{'...'} pattern
                 / pattern (@operator{'='} expr_no_comma)?
 
 # --- Destructuring patterns ------------------------------------------
 
-pattern        <- array_pattern / object_pattern / @variable{ident}
-array_pattern  <- @punctuation{'['} array_pattern_list? @punctuation{']'}
-array_pattern_list <- array_pattern_el (@punctuation{','} array_pattern_el)* (@punctuation{','})?
-array_pattern_el <- @operator{'...'} pattern
+pattern        =  array_pattern / object_pattern / @variable{ident}
+array_pattern  =  @punctuation{'['} array_pattern_list? @punctuation{']'}
+array_pattern_list =  array_pattern_el (@punctuation{','} array_pattern_el)* (@punctuation{','})?
+array_pattern_el =  @operator{'...'} pattern
                   / pattern (@operator{'='} expr_no_comma)?
                   / ''
-object_pattern <- @punctuation{'{'} object_pattern_list? @punctuation{'}'}
-object_pattern_list <- object_pattern_prop (@punctuation{','} object_pattern_prop)* (@punctuation{','})?
-object_pattern_prop <- @operator{'...'} pattern
+object_pattern =  @punctuation{'{'} object_pattern_list? @punctuation{'}'}
+object_pattern_list =  object_pattern_prop (@punctuation{','} object_pattern_prop)* (@punctuation{','})?
+object_pattern_prop =  @operator{'...'} pattern
                      / (computed_prop / @property{ident_name}) @punctuation{':'} pattern (@operator{'='} expr_no_comma)?
                      / @property{ident} (@operator{'='} expr_no_comma)?
 
-computed_prop  <- @punctuation{'['} expr @punctuation{']'}
+computed_prop  =  @punctuation{'['} expr @punctuation{']'}
 
 # --- Expressions ------------------------------------------------------
 
-expr           <- expr_no_comma (@punctuation{','} expr_no_comma)*
-expr_no_comma  <- expr_assign
-expr_assign    <- expr_arrow
+expr           =  expr_no_comma (@punctuation{','} expr_no_comma)*
+expr_no_comma  =  expr_assign
+expr_assign    =  expr_arrow
                 / expr_yield
                 / expr_conditional (assign_op expr_assign)?
 
-assign_op      <- @operator{'**='}
+assign_op      =  @operator{'**='}
                 / @operator{'<<='} / @operator{'>>>='} / @operator{'>>='}
                 / @operator{'||='} / @operator{'&&='} / @operator{'??='}
                 / @operator{'+='} / @operator{'-='} / @operator{'*='} / @operator{'/='}
@@ -254,44 +254,44 @@ assign_op      <- @operator{'**='}
 
 # Arrow functions tried first. `async x => ...`, `x => ...`,
 # `(a, b) => ...`, `() => ...`.
-expr_arrow     <- arrow_head @operator{'=>'} arrow_body
-arrow_head     <- kw_async arrow_params
+expr_arrow     =  arrow_head @operator{'=>'} arrow_body
+arrow_head     =  kw_async arrow_params
                 / arrow_params
-arrow_params   <- @variable{ident}
+arrow_params   =  @variable{ident}
                 / arrow_paren_params
-arrow_paren_params <- @punctuation{'('} fn_param_list? @punctuation{')'}
-arrow_body     <- block
+arrow_paren_params =  @punctuation{'('} fn_param_list? @punctuation{')'}
+arrow_body     =  block
                 / expr_no_comma
 
 # Trailing `(*)? (expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield    <- kw_yield @operator{'*'}? expr_assign?
+~expr_yield    =  kw_yield @operator{'*'}? expr_assign?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
-# recursion — `level_n <- level_n OP level_{n+1} / level_{n+1}` per
+# recursion — `level_n =  level_n OP level_{n+1} / level_{n+1}` per
 # level — except `expr_pow` (`**`) which stays right-recursive to
 # preserve right-associativity. Each level inlines its operator
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
 # Trailing ternary leniency absorbed by stmt-level recovery.
-~expr_conditional <- expr_nullish (@operator{'?'} expr_no_comma @punctuation{':'} expr_no_comma)?
+~expr_conditional =  expr_nullish (@operator{'?'} expr_no_comma @punctuation{':'} expr_no_comma)?
 
-expr_nullish   <- expr_nullish @operator{'??'} !'=' expr_lor / expr_lor
-expr_lor       <- expr_lor @operator{'||'} !'=' expr_land / expr_land
-expr_land      <- expr_land @operator{'&&'} !'=' expr_bor / expr_bor
-expr_bor       <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor      <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band      <- expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
-expr_eq        <- expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
-expr_rel       <- expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / kw_instanceof / kw_in) expr_shift / expr_shift
-expr_shift     <- expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add       <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul       <- expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
+expr_nullish   =  expr_nullish @operator{'??'} !'=' expr_lor / expr_lor
+expr_lor       =  expr_lor @operator{'||'} !'=' expr_land / expr_land
+expr_land      =  expr_land @operator{'&&'} !'=' expr_bor / expr_bor
+expr_bor       =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor      =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band      =  expr_band @operator{'&'} !'&' !'=' expr_eq / expr_eq
+expr_eq        =  expr_eq (@operator{'==='} / @operator{'!=='} / @operator{'=='} / @operator{'!='}) expr_rel / expr_rel
+expr_rel       =  expr_rel (@operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>' / kw_instanceof / kw_in) expr_shift / expr_shift
+expr_shift     =  expr_shift (@operator{'>>>'} !'=' / @operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add       =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul       =  expr_mul (@operator{'*'} !'=' !'*' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_pow / expr_pow
 
 # Right-associative: stays right-recursive, not LR.
-expr_pow       <- expr_unary @operator{'**'} !'=' expr_pow / expr_unary
+expr_pow       =  expr_unary @operator{'**'} !'=' expr_pow / expr_unary
 
-expr_unary     <- unary_op* expr_postfix
-unary_op       <- kw_typeof
+expr_unary     =  unary_op* expr_postfix
+unary_op       =  kw_typeof
                 / kw_void
                 / kw_delete
                 / kw_await
@@ -300,32 +300,32 @@ unary_op       <- kw_typeof
                 / @operator{'!'} / @operator{'~'}
 
 # Postfix: calls, member, optional chain, index, `++`/`--`.
-expr_postfix   <- expr_lhs postfix_op*
-postfix_op     <- @operator{'++'}
+expr_postfix   =  expr_lhs postfix_op*
+postfix_op     =  @operator{'++'}
                 / @operator{'--'}
                 / @operator{'?.'} postfix_after_optional
                 / @punctuation{'.'} member_target
                 / @punctuation{'['} expr @punctuation{']'}
                 / call_args
                 / template_lit
-postfix_after_optional <- call_args
+postfix_after_optional =  call_args
                         / @punctuation{'['} expr @punctuation{']'}
                         / member_target
-member_target  <- @function{ident_name} &(@punctuation{'('})
+member_target  =  @function{ident_name} &(@punctuation{'('})
                 / @property{ident_name}
-call_args      <- @punctuation{'('} arg_list? @punctuation{')'}
-arg_list       <- arg (@punctuation{','} arg)* (@punctuation{','})?
-arg            <- @operator{'...'} expr_no_comma
+call_args      =  @punctuation{'('} arg_list? @punctuation{')'}
+arg_list       =  arg (@punctuation{','} arg)* (@punctuation{','})?
+arg            =  @operator{'...'} expr_no_comma
                 / expr_no_comma
 
-expr_lhs       <- expr_new / expr_primary
-expr_new       <- kw_new expr_new_target
-expr_new_target <- @type{upper_ident} new_tail?
+expr_lhs       =  expr_new / expr_primary
+expr_new       =  kw_new expr_new_target
+expr_new_target =  @type{upper_ident} new_tail?
                  / @variable{lower_ident} new_tail?
                  / expr_primary new_tail?
-new_tail       <- postfix_op+
+new_tail       =  postfix_op+
 
-expr_primary   <- literal
+expr_primary   =  literal
                 / expr_this
                 / expr_super
                 / expr_fn
@@ -337,30 +337,30 @@ expr_primary   <- literal
                 / @type{upper_ident}
                 / @variable{lower_ident}
 
-call_ident     <- @function{ident} &(@punctuation{'('})
+call_ident     =  @function{ident} &(@punctuation{'('})
 
-expr_this      <- kw_this
-expr_super     <- kw_super
-expr_fn        <- kw_async? kw_function @operator{'*'}? @function{ident}? fn_params block
-expr_class     <- kw_class @type{ident}? class_heritage? class_body
-expr_array     <- @punctuation{'['} array_elem_list? @punctuation{']'}
-array_elem_list <- array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
-array_elem     <- @operator{'...'} expr_no_comma
+expr_this      =  kw_this
+expr_super     =  kw_super
+expr_fn        =  kw_async? kw_function @operator{'*'}? @function{ident}? fn_params block
+expr_class     =  kw_class @type{ident}? class_heritage? class_body
+expr_array     =  @punctuation{'['} array_elem_list? @punctuation{']'}
+array_elem_list =  array_elem (@punctuation{','} array_elem)* (@punctuation{','})?
+array_elem     =  @operator{'...'} expr_no_comma
                 / expr_no_comma
                 / ''
-expr_object    <- @punctuation{'{'} object_props? @punctuation{'}'}
-object_props   <- object_prop (@punctuation{','} object_prop)* (@punctuation{','})?
-object_prop    <- @operator{'...'} expr_no_comma
+expr_object    =  @punctuation{'{'} object_props? @punctuation{'}'}
+object_props   =  object_prop (@punctuation{','} object_prop)* (@punctuation{','})?
+object_prop    =  @operator{'...'} expr_no_comma
                 / object_method
                 / (computed_prop / string_lit / number_lit / @property{ident_name}) @punctuation{':'} expr_no_comma
                 / @property{ident}
-object_method  <- kw_async? @operator{'*'}? method_head fn_params block
+object_method  =  kw_async? @operator{'*'}? method_head fn_params block
                 / (kw_get / kw_set) method_head fn_params block
-expr_paren     <- @punctuation{'('} expr @punctuation{')'}
+expr_paren     =  @punctuation{'('} expr @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 
-literal        <- template_lit
+literal        =  template_lit
                 / string_lit
                 / number_lit
                 / lit_const
@@ -368,34 +368,34 @@ literal        <- template_lit
 
 # Boolean / null / undefined constants; the `wb` boundary keeps
 # `trueish` / `nullish` from matching the prefix.
-%lit_const     <- @constant{'true'} / @constant{'false'} / @constant{'null'}
-%?lit_undefined <- @constant{'undefined'}
+%lit_const     =  @constant{'true'} / @constant{'false'} / @constant{'null'}
+%?lit_undefined =  @constant{'undefined'}
 
-string_lit     <- @string{sq_string / dq_string}
-*sq_string     <- "'" ('\\' . / !"'" !'\n' .)* "'"
-*dq_string     <- '"' ('\\' . / !'"' !'\n' .)* '"'
+string_lit     =  @string{sq_string / dq_string}
+*sq_string     =  "'" ('\\' . / !"'" !'\n' .)* "'"
+*dq_string     =  '"' ('\\' . / !'"' !'\n' .)* '"'
 
 # Template literals with ${...} interpolation. Chunks outside the
 # interpolations get @string; the interpolation braces stay
 # @punctuation and the inner expression is parsed as normal.
-*template_lit  <- @string{'`'} template_body @string{'`'}
-*template_body <- (template_chunk / template_interp)*
-*template_chunk <- @string{('\\' . / !'`' !'${' .)+}
-template_interp <- @punctuation{'${'} expr @punctuation{'}'}
+*template_lit  =  @string{'`'} template_body @string{'`'}
+*template_body =  (template_chunk / template_interp)*
+*template_chunk =  @string{('\\' . / !'`' !'${' .)+}
+template_interp =  @punctuation{'${'} expr @punctuation{'}'}
 
-number_lit     <- @number{num_body}
-*num_body      <- '0x' hex_digits 'n'?
+number_lit     =  @number{num_body}
+*num_body      =  '0x' hex_digits 'n'?
                 / '0o' oct_digits 'n'?
                 / '0b' bin_digits 'n'?
                 / decimal_num 'n'?
-*decimal_num   <- digit_seq '.' digit_seq? exp_part?
+*decimal_num   =  digit_seq '.' digit_seq? exp_part?
                 / '.' digit_seq exp_part?
                 / digit_seq exp_part?
-*digit_seq     <- \d ([\d_])*
-*hex_digits    <- [\da-fA-F] [\da-fA-F_]*
-*oct_digits    <- [0-7] [0-7_]*
-*bin_digits    <- [01] [01_]*
-*exp_part      <- [eE] [+\-]? \d+
+*digit_seq     =  \d ([\d_])*
+*hex_digits    =  [\da-fA-F] [\da-fA-F_]*
+*oct_digits    =  [0-7] [0-7_]*
+*bin_digits    =  [01] [01_]*
+*exp_part      =  [eE] [+\-]? \d+
 
 # --- Identifiers / reserved words ------------------------------------
 
@@ -405,26 +405,26 @@ number_lit     <- @number{num_body}
 # Unicode's identifier properties); same for the ZWNJ/ZWJ continuation
 # extras. Escape forms `\uHHHH` and `\u{H..}` are admitted in both
 # positions.
-*ident         <- !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+*ident         =  !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
 # `!reserved` guard is dropped so reserved words are accepted. Use at
 # positions where ES allows IdentifierName but not BindingIdentifier
 # (member access after `.` / `?.`, property keys, imported/exported
 # names that aren't local bindings).
-*ident_name    <- ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+*ident_name    =  ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # Per §12.7.1 UnicodeEscapeSequence: 4 fixed hex digits or `{H..}` for
 # 1-6 hex digits inside braces. Atomic so the prefix-then-fail shape
 # stays internal.
-*js_uesc       <- '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
+*js_uesc       =  '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
 # `upper_ident` / `lower_ident` keep their ASCII-only start so the
 # case-based shape gate (PascalCase → @type, etc.) doesn't dissolve
 # into "any ID_Start letter". Future refinement via `\p{Lu}` /
 # `\p{Ll}` if a non-ASCII-aware variant is needed.
-*upper_ident   <- !reserved [A-Z] ident_body_part*
-*lower_ident   <- !reserved [a-z_$] ident_body_part*
-ident_body_part <- ident_body / js_uesc
-ident_body     <- [\p{ID_Continue}$\u{200C}\u{200D}]
+*upper_ident   =  !reserved [A-Z] ident_body_part*
+*lower_ident   =  !reserved [a-z_$] ident_body_part*
+ident_body_part =  ident_body / js_uesc
+ident_body     =  [\p{ID_Continue}$\u{200C}\u{200D}]
 
 # --- Whitespace / comments --------------------------------------------
 
-*comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment       =  @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,10 +1,10 @@
 # JSON grammar with highlight annotations.
 
-root        <- value
+root        =  value
 
-trivia      <- \s*
+trivia      =  \s*
 
-value       <- @string{string}
+value       =  @string{string}
              / @number{number}
              / object
              / array
@@ -12,22 +12,22 @@ value       <- @string{string}
              / @constant{'false'}
              / @constant{'null'}
 
-object      <- @punctuation{'{'}
+object      =  @punctuation{'{'}
                (pair (@punctuation{','} pair)*)?
                @punctuation{'}'}
 
-pair        <- @property{string} @punctuation{':'} value
+pair        =  @property{string} @punctuation{':'} value
 
-array       <- @punctuation{'['}
+array       =  @punctuation{'['}
                (value (@punctuation{','} value)*)?
                @punctuation{']'}
 
-*string      <- '"' string_char* '"'
-*string_char <- '\\' ["\\/bfnrt]
+*string      =  '"' string_char* '"'
+*string_char =  '\\' ["\\/bfnrt]
               / '\\' 'u' [\da-fA-F]{4}
               / [^"\\]
 
-*number      <- '-'? int frac? exp?
-*int         <- '0' / [1-9] \d*
-*frac        <- '.' \d+
-*exp         <- [eE] [+\-]? \d+
+*number      =  '-'? int frac? exp?
+*int         =  '0' / [1-9] \d*
+*frac        =  '.' \d+
+*exp         =  [eE] [+\-]? \d+

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -1,33 +1,33 @@
 # JSON grammar with highlight annotations.
 
-root        =  value
+root = value
 
-trivia      =  \s*
+trivia = \s*
 
-value       =  @string{string}
-             / @number{number}
-             / object
-             / array
-             / @constant{'true'}
-             / @constant{'false'}
-             / @constant{'null'}
+value = @string{string}
+      / @number{number}
+      / object
+      / array
+      / @constant{'true'}
+      / @constant{'false'}
+      / @constant{'null'}
 
-object      =  @punctuation{'{'}
-               (pair (@punctuation{','} pair)*)?
-               @punctuation{'}'}
+object = @punctuation{'{'}
+         (pair (@punctuation{','} pair)*)?
+         @punctuation{'}'}
 
-pair        =  @property{string} @punctuation{':'} value
+pair = @property{string} @punctuation{':'} value
 
-array       =  @punctuation{'['}
-               (value (@punctuation{','} value)*)?
-               @punctuation{']'}
+array = @punctuation{'['}
+        (value (@punctuation{','} value)*)?
+        @punctuation{']'}
 
-*string      =  '"' string_char* '"'
-*string_char =  '\\' ["\\/bfnrt]
-              / '\\' 'u' [\da-fA-F]{4}
-              / [^"\\]
+*string = '"' string_char* '"'
+*string_char = '\\' ["\\/bfnrt]
+             / '\\' 'u' [\da-fA-F]{4}
+             / [^"\\]
 
-*number      =  '-'? int frac? exp?
-*int         =  '0' / [1-9] \d*
-*frac        =  '.' \d+
-*exp         =  [eE] [+\-]? \d+
+*number = '-'? int frac? exp?
+*int = '0' / [1-9] \d*
+*frac = '.' \d+
+*exp = [eE] [+\-]? \d+

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -24,254 +24,254 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-root          =  (item)*^
+root = (item)*^
 
-trivia        =  (comment / \s)*
+trivia = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Rust Reference XID_Continue).
-wb            =  !ident_body
+wb = !ident_body
 
 # --- Keyword tokens ----------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`fnfoo`).
-%kw_use       =  @keyword{'use'}
-%kw_as        =  @keyword{'as'}
-%kw_self      =  @keyword{'self'}
-%kw_self_ty   =  @keyword{'Self'}
-%kw_super     =  @keyword{'super'}
-%kw_crate     =  @keyword{'crate'}
-%kw_fn        =  @keyword{'fn'}
-%kw_const     =  @keyword{'const'}
-%kw_static    =  @keyword{'static'}
-%kw_type      =  @keyword{'type'}
-%kw_async     =  @keyword{'async'}
-%kw_unsafe    =  @keyword{'unsafe'}
-%kw_extern    =  @keyword{'extern'}
-%kw_mut       =  @keyword{'mut'}
-%kw_struct    =  @keyword{'struct'}
-%kw_enum      =  @keyword{'enum'}
-%kw_impl      =  @keyword{'impl'}
-%kw_for       =  @keyword{'for'}
-%kw_trait     =  @keyword{'trait'}
-%kw_mod       =  @keyword{'mod'}
-%kw_pub       =  @keyword{'pub'}
-%kw_in        =  @keyword{'in'}
-%kw_where     =  @keyword{'where'}
-%kw_dyn       =  @keyword{'dyn'}
-%kw_box       =  @keyword{'box'}
-%kw_ref       =  @keyword{'ref'}
-%kw_if        =  @keyword{'if'}
-%kw_let       =  @keyword{'let'}
-%kw_else      =  @keyword{'else'}
-%kw_match     =  @keyword{'match'}
-%kw_while     =  @keyword{'while'}
-%kw_loop      =  @keyword{'loop'}
-%kw_return    =  @keyword{'return'}
-%kw_break     =  @keyword{'break'}
-%kw_continue  =  @keyword{'continue'}
-%kw_move      =  @keyword{'move'}
-%kw_await     =  @keyword{'await'}
+%kw_use = @keyword{'use'}
+%kw_as = @keyword{'as'}
+%kw_self = @keyword{'self'}
+%kw_self_ty = @keyword{'Self'}
+%kw_super = @keyword{'super'}
+%kw_crate = @keyword{'crate'}
+%kw_fn = @keyword{'fn'}
+%kw_const = @keyword{'const'}
+%kw_static = @keyword{'static'}
+%kw_type = @keyword{'type'}
+%kw_async = @keyword{'async'}
+%kw_unsafe = @keyword{'unsafe'}
+%kw_extern = @keyword{'extern'}
+%kw_mut = @keyword{'mut'}
+%kw_struct = @keyword{'struct'}
+%kw_enum = @keyword{'enum'}
+%kw_impl = @keyword{'impl'}
+%kw_for = @keyword{'for'}
+%kw_trait = @keyword{'trait'}
+%kw_mod = @keyword{'mod'}
+%kw_pub = @keyword{'pub'}
+%kw_in = @keyword{'in'}
+%kw_where = @keyword{'where'}
+%kw_dyn = @keyword{'dyn'}
+%kw_box = @keyword{'box'}
+%kw_ref = @keyword{'ref'}
+%kw_if = @keyword{'if'}
+%kw_let = @keyword{'let'}
+%kw_else = @keyword{'else'}
+%kw_match = @keyword{'match'}
+%kw_while = @keyword{'while'}
+%kw_loop = @keyword{'loop'}
+%kw_return = @keyword{'return'}
+%kw_break = @keyword{'break'}
+%kw_continue = @keyword{'continue'}
+%kw_move = @keyword{'move'}
+%kw_await = @keyword{'await'}
 
 # --- Items -------------------------------------------------------------
 #
 # Order matters (PEG first-match). Attributes / inner-attributes must
 # precede regular items so `#[...]` and `#![...]` are not misparsed
 # as expression-statements starting with `#`.
-item          =  attr_outer
-               / attr_inner
-               / use_item
-               / fn_item
-               / struct_item
-               / enum_item
-               / impl_item
-               / trait_item
-               / mod_item
-               / extern_item
-               / const_item
-               / static_item
-               / type_alias_item
-               / macro_rules_item
-               / macro_invocation_stmt
-               / stmt
+item = attr_outer
+     / attr_inner
+     / use_item
+     / fn_item
+     / struct_item
+     / enum_item
+     / impl_item
+     / trait_item
+     / mod_item
+     / extern_item
+     / const_item
+     / static_item
+     / type_alias_item
+     / macro_rules_item
+     / macro_invocation_stmt
+     / stmt
 
 # Attributes and doc-comments at item position.
-*attr_outer   =  @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'}
-*attr_inner   =  @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'}
-*attr_body    =  .. ']'
+*attr_outer = @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_inner = @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_body = .. ']'
 
 # `use foo::bar::{baz, qux as q};`
-use_item      =  kw_use use_tree @punctuation{';'}
-use_tree      =  use_path use_tail?
-use_tail      =  kw_as ident_any
-               / @punctuation{'::'} @punctuation{'*'}
-               / @punctuation{'::'} @punctuation{'{'} use_tree_list? @punctuation{'}'}
-use_tree_list =  use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
-use_path      =  use_seg (@punctuation{'::'} use_seg)*
-use_seg       =  kw_self
-               / kw_super
-               / kw_crate
-               / @type{upper_ident}
-               / @variable{lower_ident}
+use_item = kw_use use_tree @punctuation{';'}
+use_tree = use_path use_tail?
+use_tail = kw_as ident_any
+         / @punctuation{'::'} @punctuation{'*'}
+         / @punctuation{'::'} @punctuation{'{'} use_tree_list? @punctuation{'}'}
+use_tree_list = use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
+use_path = use_seg (@punctuation{'::'} use_seg)*
+use_seg = kw_self
+        / kw_super
+        / kw_crate
+        / @type{upper_ident}
+        / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       =  vis? fn_qualifier* kw_fn @function{ident} generic_params?
-                 fn_params fn_return? where_clause? (block / @punctuation{';'})
-fn_qualifier  =  kw_const
-               / kw_async
-               / kw_unsafe
-               / kw_extern string_lit?
-fn_params     =  @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param      =  attr_outer? self_param
-               / attr_outer? fn_param_named
-fn_param_named =  pattern_no_or @punctuation{':'} type_expr
-self_param    =  ref_marker? kw_mut? kw_self
-               / kw_mut kw_self
-               / kw_self @punctuation{':'} type_expr
-ref_marker    =  @punctuation{'&'} lifetime?
-fn_return     =  @punctuation{'->'} type_expr
+fn_item = vis? fn_qualifier* kw_fn @function{ident} generic_params?
+          fn_params fn_return? where_clause? (block / @punctuation{';'})
+fn_qualifier = kw_const
+             / kw_async
+             / kw_unsafe
+             / kw_extern string_lit?
+fn_params = @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list = fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param = attr_outer? self_param
+         / attr_outer? fn_param_named
+fn_param_named = pattern_no_or @punctuation{':'} type_expr
+self_param = ref_marker? kw_mut? kw_self
+           / kw_mut kw_self
+           / kw_self @punctuation{':'} type_expr
+ref_marker = @punctuation{'&'} lifetime?
+fn_return = @punctuation{'->'} type_expr
 
 # `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
-struct_item   =  vis? kw_struct @type{ident} generic_params?
-                 (struct_body_named / struct_body_tuple / @punctuation{';'})
-struct_body_named =  where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
-struct_body_tuple =  @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
-struct_fields =  struct_field (@punctuation{','} struct_field)* (@punctuation{','})?
-struct_field  =  attr_outer* vis? @property{ident} @punctuation{':'} type_expr
-tuple_fields  =  tuple_field (@punctuation{','} tuple_field)* (@punctuation{','})?
-tuple_field   =  attr_outer* vis? type_expr
+struct_item = vis? kw_struct @type{ident} generic_params?
+              (struct_body_named / struct_body_tuple / @punctuation{';'})
+struct_body_named = where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
+struct_body_tuple = @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
+struct_fields = struct_field (@punctuation{','} struct_field)* (@punctuation{','})?
+struct_field = attr_outer* vis? @property{ident} @punctuation{':'} type_expr
+tuple_fields = tuple_field (@punctuation{','} tuple_field)* (@punctuation{','})?
+tuple_field = attr_outer* vis? type_expr
 
 # `enum E { A, B(T), C { x: T } }`
-enum_item     =  vis? kw_enum @type{ident} generic_params? where_clause?
-                 @punctuation{'{'} enum_variants? @punctuation{'}'}
-enum_variants =  enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
-enum_variant  =  attr_outer* @type{ident} enum_variant_body?
-enum_variant_body =  @punctuation{'('} tuple_fields? @punctuation{')'}
-                   / @punctuation{'{'} struct_fields? @punctuation{'}'}
-                   / @punctuation{'='} expr
+enum_item = vis? kw_enum @type{ident} generic_params? where_clause?
+            @punctuation{'{'} enum_variants? @punctuation{'}'}
+enum_variants = enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
+enum_variant = attr_outer* @type{ident} enum_variant_body?
+enum_variant_body = @punctuation{'('} tuple_fields? @punctuation{')'}
+                  / @punctuation{'{'} struct_fields? @punctuation{'}'}
+                  / @punctuation{'='} expr
 
 # `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
-impl_item     =  kw_impl generic_params? impl_head where_clause?
-                 @punctuation{'{'} impl_body @punctuation{'}'}
-impl_head     =  type_expr (kw_for type_expr)?
-impl_body     =  item*
+impl_item = kw_impl generic_params? impl_head where_clause?
+            @punctuation{'{'} impl_body @punctuation{'}'}
+impl_head = type_expr (kw_for type_expr)?
+impl_body = item*
 
 # `trait T<U>: Bound { ... }`
-trait_item    =  vis? kw_unsafe? kw_trait @type{ident}
-                 generic_params? trait_bounds? where_clause?
-                 @punctuation{'{'} impl_body @punctuation{'}'}
-trait_bounds  =  @punctuation{':'} bound_list
+trait_item = vis? kw_unsafe? kw_trait @type{ident}
+             generic_params? trait_bounds? where_clause?
+             @punctuation{'{'} impl_body @punctuation{'}'}
+trait_bounds = @punctuation{':'} bound_list
 
 # `mod name;` / `mod name { ... }`
-mod_item      =  vis? kw_mod @variable{ident}
-                 (@punctuation{';'} / @punctuation{'{'} item* @punctuation{'}'})
+mod_item = vis? kw_mod @variable{ident}
+           (@punctuation{';'} / @punctuation{'{'} item* @punctuation{'}'})
 
 # `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
-extern_item   =  kw_extern string_lit? @punctuation{'{'} item* @punctuation{'}'}
+extern_item = kw_extern string_lit? @punctuation{'{'} item* @punctuation{'}'}
 
-const_item    =  vis? kw_const @constant{ident} @punctuation{':'} type_expr
-                 @punctuation{'='} expr @punctuation{';'}
-static_item   =  vis? kw_static kw_mut? @constant{ident} @punctuation{':'} type_expr
-                 @punctuation{'='} expr @punctuation{';'}
-type_alias_item =  vis? kw_type @type{ident} generic_params? where_clause?
-                   @punctuation{'='} type_expr @punctuation{';'}
+const_item = vis? kw_const @constant{ident} @punctuation{':'} type_expr
+             @punctuation{'='} expr @punctuation{';'}
+static_item = vis? kw_static kw_mut? @constant{ident} @punctuation{':'} type_expr
+              @punctuation{'='} expr @punctuation{';'}
+type_alias_item = vis? kw_type @type{ident} generic_params? where_clause?
+                  @punctuation{'='} type_expr @punctuation{';'}
 
 # `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
 # soup; balance braces.
-macro_rules_item =  @function{'macro_rules'} @punctuation{'!'} @function{ident} brace_block
+macro_rules_item = @function{'macro_rules'} @punctuation{'!'} @function{ident} brace_block
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
 # Trailing `;?` absorbed by `root`'s `*^`.
-~macro_invocation_stmt =  @function{ident} @punctuation{'!'} macro_args (@punctuation{';'})?
-macro_args    =  paren_group
-               / brace_block
-               / bracket_group
+~macro_invocation_stmt = @function{ident} @punctuation{'!'} macro_args (@punctuation{';'})?
+macro_args = paren_group
+           / brace_block
+           / bracket_group
 
 # Visibility modifier.
-vis           =  kw_pub (@punctuation{'('} vis_scope @punctuation{')'})?
-vis_scope     =  kw_crate / kw_self / kw_super
-               / kw_in use_path
+vis = kw_pub (@punctuation{'('} vis_scope @punctuation{')'})?
+vis_scope = kw_crate / kw_self / kw_super
+          / kw_in use_path
 
 # --- Generic parameters and where-clauses ----------------------------
 
-generic_params =  @punctuation{'<'} generic_param_list? @punctuation{'>'}
-generic_param_list =  generic_param (@punctuation{','} generic_param)* (@punctuation{','})?
-generic_param =  lifetime_param
-               / type_param
-               / const_param
-lifetime_param =  lifetime (@punctuation{':'} lifetime_bounds)?
-lifetime_bounds =  lifetime (@punctuation{'+'} lifetime)*
-type_param    =  @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
-const_param   =  kw_const @constant{ident} @punctuation{':'} type_expr
+generic_params = @punctuation{'<'} generic_param_list? @punctuation{'>'}
+generic_param_list = generic_param (@punctuation{','} generic_param)* (@punctuation{','})?
+generic_param = lifetime_param
+              / type_param
+              / const_param
+lifetime_param = lifetime (@punctuation{':'} lifetime_bounds)?
+lifetime_bounds = lifetime (@punctuation{'+'} lifetime)*
+type_param = @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
+const_param = kw_const @constant{ident} @punctuation{':'} type_expr
 
-where_clause  =  kw_where where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
-where_pred    =  lifetime @punctuation{':'} lifetime_bounds
-               / type_expr @punctuation{':'} bound_list
+where_clause = kw_where where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
+where_pred = lifetime @punctuation{':'} lifetime_bounds
+           / type_expr @punctuation{':'} bound_list
 
-bound_list    =  bound (@punctuation{'+'} bound)*
-bound         =  lifetime
-               / (@punctuation{'?'})? type_path
+bound_list = bound (@punctuation{'+'} bound)*
+bound = lifetime
+      / (@punctuation{'?'})? type_path
 
 # --- Types -------------------------------------------------------------
 #
 # `&'a mut T`, `[T; N]`, `(T, U)`, `Foo<T>`, `dyn Trait`, `impl Trait`,
 # `fn(T) -> U`, `!`, etc.
 
-type_expr     =  type_fn
-               / type_impl
-               / type_dyn
-               / type_ref
-               / type_ptr
-               / type_array_or_slice
-               / type_tuple_or_group
-               / type_never
-               / type_path
+type_expr = type_fn
+          / type_impl
+          / type_dyn
+          / type_ref
+          / type_ptr
+          / type_array_or_slice
+          / type_tuple_or_group
+          / type_never
+          / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn      =  type_fn_qualifier* kw_fn @punctuation{'('} type_list? @punctuation{')'}
-                 (@punctuation{'->'} type_expr)?
-type_fn_qualifier =  kw_unsafe
-                   / kw_extern string_lit?
-type_list     =  type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
+~type_fn = type_fn_qualifier* kw_fn @punctuation{'('} type_list? @punctuation{')'}
+           (@punctuation{'->'} type_expr)?
+type_fn_qualifier = kw_unsafe
+                  / kw_extern string_lit?
+type_list = type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
-type_impl     =  kw_impl bound_list
-type_dyn      =  kw_dyn bound_list
+type_impl = kw_impl bound_list
+type_dyn = kw_dyn bound_list
 
-type_ref      =  @punctuation{'&'} lifetime? kw_mut? type_expr
-type_ptr      =  @punctuation{'*'} (kw_mut / kw_const) type_expr
+type_ref = @punctuation{'&'} lifetime? kw_mut? type_expr
+type_ptr = @punctuation{'*'} (kw_mut / kw_const) type_expr
 
-type_array_or_slice =  @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
-type_tuple_or_group =  @punctuation{'('} type_list? @punctuation{')'}
+type_array_or_slice = @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
+type_tuple_or_group = @punctuation{'('} type_list? @punctuation{')'}
 
-type_never    =  @punctuation{'!'}
+type_never = @punctuation{'!'}
 
-type_path     =  type_path_seg (@punctuation{'::'} type_path_seg)*
-type_path_seg =  @type{upper_ident} path_tail?
-               / @variable{lower_ident} path_tail?
-               / kw_self
-               / kw_self_ty
-               / kw_super
-               / kw_crate
+type_path = type_path_seg (@punctuation{'::'} type_path_seg)*
+type_path_seg = @type{upper_ident} path_tail?
+              / @variable{lower_ident} path_tail?
+              / kw_self
+              / kw_self_ty
+              / kw_super
+              / kw_crate
 
 # Either angle-bracket generics (`Foo<T>`) or paren-sugar for Fn-traits
 # (`Fn(T) -> U`); Rust's reference grammar splits these as
 # `GenericArgs` vs `ParenthesizedGenericArgs`.
-path_tail     =  generic_args
-               / paren_generic_args
+path_tail = generic_args
+          / paren_generic_args
 
-generic_args  =  @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'}
-               / @punctuation{'<'} generic_arg_list? @punctuation{'>'}
+generic_args = @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'}
+             / @punctuation{'<'} generic_arg_list? @punctuation{'>'}
 # Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
-~paren_generic_args =  @punctuation{'('} type_list? @punctuation{')'} (@punctuation{'->'} type_expr)?
-generic_arg_list =  generic_arg (@punctuation{','} generic_arg)* (@punctuation{','})?
-generic_arg   =  lifetime
-               / type_expr
-               / @constant{ident} @punctuation{'='} type_expr
-               / expr_block
-               / literal
+~paren_generic_args = @punctuation{'('} type_list? @punctuation{')'} (@punctuation{'->'} type_expr)?
+generic_arg_list = generic_arg (@punctuation{','} generic_arg)* (@punctuation{','})?
+generic_arg = lifetime
+            / type_expr
+            / @constant{ident} @punctuation{'='} type_expr
+            / expr_block
+            / literal
 
 # --- Patterns ----------------------------------------------------------
 #
@@ -280,39 +280,39 @@ generic_arg   =  lifetime
 # fn params), use `pattern_no_or` so the closing `|` isn't eaten by
 # `pattern_or`'s greedy `*`. Mirrors Rust's reference `PatternNoTopAlt`.
 
-pattern       =  pattern_or
-pattern_no_or =  pattern_atom
-pattern_or    =  pattern_atom (@punctuation{'|'} pattern_atom)*
-pattern_atom  =  pattern_ref
-               / pattern_box
-               / pattern_tuple
-               / pattern_struct_or_enum
-               / pattern_slice
-               / pattern_range
-               / pattern_literal
-               / pattern_wild
-               / pattern_rest
-               / pattern_binding
-pattern_ref   =  @punctuation{'&'} kw_mut? pattern_atom
-pattern_box   =  kw_box pattern_atom
-pattern_tuple =  @punctuation{'('} pattern_list? @punctuation{')'}
-pattern_list  =  pattern (@punctuation{','} pattern)* (@punctuation{','})?
+pattern = pattern_or
+pattern_no_or = pattern_atom
+pattern_or = pattern_atom (@punctuation{'|'} pattern_atom)*
+pattern_atom = pattern_ref
+             / pattern_box
+             / pattern_tuple
+             / pattern_struct_or_enum
+             / pattern_slice
+             / pattern_range
+             / pattern_literal
+             / pattern_wild
+             / pattern_rest
+             / pattern_binding
+pattern_ref = @punctuation{'&'} kw_mut? pattern_atom
+pattern_box = kw_box pattern_atom
+pattern_tuple = @punctuation{'('} pattern_list? @punctuation{')'}
+pattern_list = pattern (@punctuation{','} pattern)* (@punctuation{','})?
 # Trailing `::` chain leniency absorbed by outer recovery.
-~pattern_struct_or_enum =  @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
-                          (pattern_struct_body / pattern_tuple)?
-pattern_struct_body =  @punctuation{'{'} pattern_struct_fields? @punctuation{'}'}
-pattern_struct_fields =  pattern_struct_field (@punctuation{','} pattern_struct_field)* (@punctuation{','})?
-pattern_struct_field  =  @property{ident} @punctuation{':'} pattern
-                       / @property{ident}
-                       / @punctuation{'..'}
-pattern_slice =  @punctuation{'['} pattern_list? @punctuation{']'}
-pattern_range =  pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
-pattern_literal =  string_lit / char_lit / number_lit / lit_const
-pattern_wild  =  @punctuation{'_'}
-pattern_rest  =  @punctuation{'..'}
+~pattern_struct_or_enum = @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
+                         (pattern_struct_body / pattern_tuple)?
+pattern_struct_body = @punctuation{'{'} pattern_struct_fields? @punctuation{'}'}
+pattern_struct_fields = pattern_struct_field (@punctuation{','} pattern_struct_field)* (@punctuation{','})?
+pattern_struct_field = @property{ident} @punctuation{':'} pattern
+                     / @property{ident}
+                     / @punctuation{'..'}
+pattern_slice = @punctuation{'['} pattern_list? @punctuation{']'}
+pattern_range = pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
+pattern_literal = string_lit / char_lit / number_lit / lit_const
+pattern_wild = @punctuation{'_'}
+pattern_rest = @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding =  kw_ref? kw_mut? @variable{ident}
-                   (@punctuation{'@'} pattern_atom)?
+~pattern_binding = kw_ref? kw_mut? @variable{ident}
+                  (@punctuation{'@'} pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
 #
@@ -325,128 +325,128 @@ pattern_rest  =  @punctuation{'..'}
 # matching binary, `&` vs `&&`, `|` vs `||`) need explicit
 # `!`-lookaheads inside each level's operator alternation.
 
-expr          =  expr_assign
+expr = expr_assign
 
 # Right-associative: `a = b = c` parses as `a = (b = c)`.
-expr_assign   =  expr_range assign_op expr_assign / expr_range
+expr_assign = expr_range assign_op expr_assign / expr_range
 
-assign_op     =  @operator{'<<='} / @operator{'>>='}
-               / @operator{'+='}  / @operator{'-='}
-               / @operator{'*='}  / @operator{'/='}
-               / @operator{'%='}  / @operator{'&='}
-               / @operator{'|='}  / @operator{'^='}
-               / @operator{'='} !'='
+assign_op = @operator{'<<='} / @operator{'>>='}
+          / @operator{'+='}  / @operator{'-='}
+          / @operator{'*='}  / @operator{'/='}
+          / @operator{'%='}  / @operator{'&='}
+          / @operator{'|='}  / @operator{'^='}
+          / @operator{'='} !'='
 
 # Range: `a..b`, `a..=b`, `..b`, `a..`, `..`. Non-associative.
-expr_range    =  expr_lor ((@punctuation{'..='} / @punctuation{'..'}) expr_lor?)?
-               / (@punctuation{'..='} / @punctuation{'..'}) expr_lor?
+expr_range = expr_lor ((@punctuation{'..='} / @punctuation{'..'}) expr_lor?)?
+           / (@punctuation{'..='} / @punctuation{'..'}) expr_lor?
 
-expr_lor      =  expr_lor @operator{'||'} expr_land / expr_land
-expr_land     =  expr_land @operator{'&&'} expr_cmp / expr_cmp
-expr_cmp      =  expr_cmp (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_bor / expr_bor
-expr_bor      =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor     =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band     =  expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
-expr_shift    =  expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add      =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul      =  expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
-expr_as       =  expr_as kw_as type_expr_suffix_marker / expr_unary
+expr_lor = expr_lor @operator{'||'} expr_land / expr_land
+expr_land = expr_land @operator{'&&'} expr_cmp / expr_cmp
+expr_cmp = expr_cmp (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_bor / expr_bor
+expr_bor = expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor = expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band = expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
+expr_shift = expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add = expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul = expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
+expr_as = expr_as kw_as type_expr_suffix_marker / expr_unary
 
 # A marker rule: when `as` matches, consume the following type. Split
 # from the cascade so the type_expr stays attached.
-type_expr_suffix_marker =  type_expr
+type_expr_suffix_marker = type_expr
 
-expr_unary    =  unary_op* expr_postfix
-unary_op      =  @operator{'&'} lifetime? kw_mut?
-               / @operator{'*'}
-               / @operator{'-'}
-               / @operator{'!'}
+expr_unary = unary_op* expr_postfix
+unary_op = @operator{'&'} lifetime? kw_mut?
+         / @operator{'*'}
+         / @operator{'-'}
+         / @operator{'!'}
 
 # Postfix chain: calls, indexing, field access, try `?`.
-expr_postfix  =  expr_primary postfix_op*
-postfix_op    =  @punctuation{'?'}
-               / @punctuation{'.'} kw_await
-               / @punctuation{'.'} postfix_member
-               / @punctuation{'('} expr_list? @punctuation{')'}
-               / @punctuation{'['} expr @punctuation{']'}
-postfix_member =  turbofish_method
-                / @function{ident} (@punctuation{'('} expr_list? @punctuation{')'})?
-                / @number{digit_seq}
+expr_postfix = expr_primary postfix_op*
+postfix_op = @punctuation{'?'}
+           / @punctuation{'.'} kw_await
+           / @punctuation{'.'} postfix_member
+           / @punctuation{'('} expr_list? @punctuation{')'}
+           / @punctuation{'['} expr @punctuation{']'}
+postfix_member = turbofish_method
+               / @function{ident} (@punctuation{'('} expr_list? @punctuation{')'})?
+               / @number{digit_seq}
 # Trailing `(args)?` absorbed by outer recovery.
-~turbofish_method =  @function{ident} @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'} (@punctuation{'('} expr_list? @punctuation{')'})?
+~turbofish_method = @function{ident} @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'} (@punctuation{'('} expr_list? @punctuation{')'})?
 
-expr_primary  =  literal
-               / expr_if
-               / expr_match
-               / expr_while
-               / expr_loop
-               / expr_for
-               / expr_return
-               / expr_break
-               / expr_continue
-               / expr_unsafe
-               / expr_closure
-               / expr_block
-               / expr_async_block
-               / expr_tuple_or_paren
-               / expr_array
-               / expr_macro_or_path
-               / expr_keyword
+expr_primary = literal
+             / expr_if
+             / expr_match
+             / expr_while
+             / expr_loop
+             / expr_for
+             / expr_return
+             / expr_break
+             / expr_continue
+             / expr_unsafe
+             / expr_closure
+             / expr_block
+             / expr_async_block
+             / expr_tuple_or_paren
+             / expr_array
+             / expr_macro_or_path
+             / expr_keyword
 
 # Trailing `(else (if | block))?` leniency absorbed by `root`'s `*^` and `block`'s `^block_close`.
-~expr_if      =  kw_if (kw_let pattern @operator{'='})? expr block
-                 (kw_else (expr_if / block))?
-expr_match    =  kw_match expr @punctuation{'{'} match_arms? @punctuation{'}'}
-match_arms    =  match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
-match_arm     =  attr_outer* pattern (kw_if expr)? @punctuation{'=>'} expr
-expr_while    =  kw_while (kw_let pattern @operator{'='})? expr block
-expr_loop     =  loop_label? kw_loop block
-expr_for      =  kw_for pattern kw_in expr block
+~expr_if = kw_if (kw_let pattern @operator{'='})? expr block
+           (kw_else (expr_if / block))?
+expr_match = kw_match expr @punctuation{'{'} match_arms? @punctuation{'}'}
+match_arms = match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
+match_arm = attr_outer* pattern (kw_if expr)? @punctuation{'=>'} expr
+expr_while = kw_while (kw_let pattern @operator{'='})? expr block
+expr_loop = loop_label? kw_loop block
+expr_for = kw_for pattern kw_in expr block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return  =  kw_return expr?
-~expr_break   =  kw_break loop_label? expr?
-~expr_continue =  kw_continue loop_label?
-expr_unsafe   =  kw_unsafe block
-expr_closure  =  kw_move? @punctuation{'|'} closure_params? @punctuation{'|'}
-                 (@punctuation{'->'} type_expr)? expr
-closure_params =  closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
-closure_param =  pattern_no_or (@punctuation{':'} type_expr)?
-expr_block    =  block
-expr_async_block =  kw_async kw_move? block
-expr_tuple_or_paren =  @punctuation{'('} expr_list? @punctuation{')'}
-expr_array    =  @punctuation{'['} expr_array_body? @punctuation{']'}
-expr_array_body =  expr @punctuation{';'} expr
-                 / expr (@punctuation{','} expr)* (@punctuation{','})?
-expr_list     =  expr (@punctuation{','} expr)* (@punctuation{','})?
-expr_keyword  =  kw_self / kw_self_ty / kw_super / kw_crate
+~expr_return = kw_return expr?
+~expr_break = kw_break loop_label? expr?
+~expr_continue = kw_continue loop_label?
+expr_unsafe = kw_unsafe block
+expr_closure = kw_move? @punctuation{'|'} closure_params? @punctuation{'|'}
+               (@punctuation{'->'} type_expr)? expr
+closure_params = closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
+closure_param = pattern_no_or (@punctuation{':'} type_expr)?
+expr_block = block
+expr_async_block = kw_async kw_move? block
+expr_tuple_or_paren = @punctuation{'('} expr_list? @punctuation{')'}
+expr_array = @punctuation{'['} expr_array_body? @punctuation{']'}
+expr_array_body = expr @punctuation{';'} expr
+                / expr (@punctuation{','} expr)* (@punctuation{','})?
+expr_list = expr (@punctuation{','} expr)* (@punctuation{','})?
+expr_keyword = kw_self / kw_self_ty / kw_super / kw_crate
 
-*loop_label   =  @punctuation{'\''} @variable{ident} @punctuation{':'}
+*loop_label = @punctuation{'\''} @variable{ident} @punctuation{':'}
 
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
 # Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
-~expr_macro_or_path =  path_expr (struct_init / @punctuation{'!'} macro_args)?
-path_expr     =  path_seg (@punctuation{'::'} path_seg)*
-path_seg      =  @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
-               / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
+~expr_macro_or_path = path_expr (struct_init / @punctuation{'!'} macro_args)?
+path_expr = path_seg (@punctuation{'::'} path_seg)*
+path_seg = @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
+         / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
 
-struct_init   =  @punctuation{'{'} struct_init_fields? @punctuation{'}'}
-struct_init_fields =  struct_init_field (@punctuation{','} struct_init_field)* (@punctuation{','} struct_init_base?)?
-struct_init_field  =  @punctuation{'..'} expr
-                    / @property{ident} @punctuation{':'} expr
-                    / @property{ident}
-struct_init_base   =  @punctuation{'..'} expr
+struct_init = @punctuation{'{'} struct_init_fields? @punctuation{'}'}
+struct_init_fields = struct_init_field (@punctuation{','} struct_init_field)* (@punctuation{','} struct_init_base?)?
+struct_init_field = @punctuation{'..'} expr
+                  / @property{ident} @punctuation{':'} expr
+                  / @property{ident}
+struct_init_base = @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block = @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          =  let_stmt
-               / expr @punctuation{';'}
-               / expr                                    # trailing expression (block-valued)
+stmt = let_stmt
+     / expr @punctuation{';'}
+     / expr                                    # trailing expression (block-valued)
 
-let_stmt      =  kw_let pattern (@punctuation{':'} type_expr)?
-                 (@punctuation{'='} expr)? (kw_else block)? @punctuation{';'}
+let_stmt = kw_let pattern (@punctuation{':'} type_expr)?
+           (@punctuation{'='} expr)? (kw_else block)? @punctuation{';'}
 
 # --- Balanced-bracket helpers (used for macro bodies) -----------------
 #
@@ -458,62 +458,62 @@ let_stmt      =  kw_let pattern (@punctuation{':'} type_expr)?
 # the brackets — necessary for multi-line macro argument lists like
 # `vec![\n  1,\n]`.
 
-brace_block   =  @punctuation{'{'} balanced_body @punctuation{'}'}
-paren_group   =  @punctuation{'('} balanced_body @punctuation{')'}
-bracket_group =  @punctuation{'['} balanced_body @punctuation{']'}
-balanced_body =  balanced_atom*
-balanced_atom =  brace_block
-               / paren_group
-               / bracket_group
-               / string_lit
-               / char_lit
-               / comment
-               / !([{}()\[\]]) .
+brace_block = @punctuation{'{'} balanced_body @punctuation{'}'}
+paren_group = @punctuation{'('} balanced_body @punctuation{')'}
+bracket_group = @punctuation{'['} balanced_body @punctuation{']'}
+balanced_body = balanced_atom*
+balanced_atom = brace_block
+              / paren_group
+              / bracket_group
+              / string_lit
+              / char_lit
+              / comment
+              / !([{}()\[\]]) .
 
 # --- Literals ----------------------------------------------------------
 
-literal       =  string_lit / char_lit / number_lit / lit_const
+literal = string_lit / char_lit / number_lit / lit_const
 
 # Boolean constants as a `%` reserved-word alternation so the `wb`
 # boundary keeps `trueish` from matching the `true` prefix.
-%lit_const    =  @constant{'true'} / @constant{'false'}
+%lit_const = @constant{'true'} / @constant{'false'}
 
 # Raw strings first (longer prefix), then regular.
-string_lit    =  @string{raw_string / byte_string / regular_string}
-*regular_string =  '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*byte_string  =  'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*raw_string   =  'r' raw_hashes '"' (.. '"') '"' raw_hashes
-               / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
+string_lit = @string{raw_string / byte_string / regular_string}
+*regular_string = '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*byte_string = 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*raw_string = 'r' raw_hashes '"' (.. '"') '"' raw_hashes
+            / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
 # Consume matching hash fences; the body is "up to the closing delim".
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
-*raw_hashes   =  '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
+*raw_hashes = '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
 
-*char_lit     =  @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
+*char_lit = @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
 
-number_lit    =  @number{num_body}
-*num_body     =  float_num / int_num
-*float_num    =  digit_seq '.' digit_seq (exp_part)? num_suffix?
-               / digit_seq exp_part num_suffix?
-*int_num      =  '0x' hex_digits num_suffix?
-               / '0o' oct_digits num_suffix?
-               / '0b' bin_digits num_suffix?
-               / digit_seq num_suffix?
-*digit_seq    =  \d ([\d_])*
-*hex_digits   =  [\da-fA-F] [\da-fA-F_]*
-*oct_digits   =  [0-7] [0-7_]*
-*bin_digits   =  [01] [01_]*
-*exp_part     =  [eE] [+\-]? digit_seq
-*num_suffix   =  [a-zA-Z_] [a-zA-Z\d_]*
+number_lit = @number{num_body}
+*num_body = float_num / int_num
+*float_num = digit_seq '.' digit_seq (exp_part)? num_suffix?
+           / digit_seq exp_part num_suffix?
+*int_num = '0x' hex_digits num_suffix?
+         / '0o' oct_digits num_suffix?
+         / '0b' bin_digits num_suffix?
+         / digit_seq num_suffix?
+*digit_seq = \d ([\d_])*
+*hex_digits = [\da-fA-F] [\da-fA-F_]*
+*oct_digits = [0-7] [0-7_]*
+*bin_digits = [01] [01_]*
+*exp_part = [eE] [+\-]? digit_seq
+*num_suffix = [a-zA-Z_] [a-zA-Z\d_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
-*lifetime     =  @type{"'" ident_body+}
+*lifetime = @type{"'" ident_body+}
 
 # `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
 # of special meaning for highlighting.
-ident_any     =  @type{upper_ident}
-               / @variable{lower_ident}
+ident_any = @type{upper_ident}
+          / @variable{lower_ident}
 # Per Rust Reference "Identifiers": XID_Start (or `_`) followed by
 # XID_Continue per UAX #31. `r#` raw-identifier prefix admits keywords
 # as identifiers. `_` is XID_Continue but not XID_Start, so the start
@@ -525,13 +525,13 @@ ident_any     =  @type{upper_ident}
 # non-ASCII letters into both ranges would collapse that distinction.
 # Stage 2 widens the body but leaves the shape gate ASCII; future work
 # can refine the upper/lower split using `\p{Lu}` / `\p{Ll}` if needed.
-*upper_ident  =  'r#'? [A-Z] ident_body*
-*lower_ident  =  'r#'? [a-z_] ident_body*
-*ident        =  'r#'? [\p{XID_Start}_] ident_body*
-ident_body    =  [\p{XID_Continue}]
+*upper_ident = 'r#'? [A-Z] ident_body*
+*lower_ident = 'r#'? [a-z_] ident_body*
+*ident = 'r#'? [\p{XID_Start}_] ident_body*
+ident_body = [\p{XID_Continue}]
 
 # --- Whitespace and comments ------------------------------------------
 
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment = @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -24,63 +24,63 @@
 # malformed bodies (fn, match arm, etc.) resync at the closing `}`
 # instead of failing the enclosing item.
 
-root          <- (item)*^
+root          =  (item)*^
 
-trivia        <- (comment / \s)*
+trivia        =  (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Rust Reference XID_Continue).
-wb            <- !ident_body
+wb            =  !ident_body
 
 # --- Keyword tokens ----------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`fnfoo`).
-%kw_use       <- @keyword{'use'}
-%kw_as        <- @keyword{'as'}
-%kw_self      <- @keyword{'self'}
-%kw_self_ty   <- @keyword{'Self'}
-%kw_super     <- @keyword{'super'}
-%kw_crate     <- @keyword{'crate'}
-%kw_fn        <- @keyword{'fn'}
-%kw_const     <- @keyword{'const'}
-%kw_static    <- @keyword{'static'}
-%kw_type      <- @keyword{'type'}
-%kw_async     <- @keyword{'async'}
-%kw_unsafe    <- @keyword{'unsafe'}
-%kw_extern    <- @keyword{'extern'}
-%kw_mut       <- @keyword{'mut'}
-%kw_struct    <- @keyword{'struct'}
-%kw_enum      <- @keyword{'enum'}
-%kw_impl      <- @keyword{'impl'}
-%kw_for       <- @keyword{'for'}
-%kw_trait     <- @keyword{'trait'}
-%kw_mod       <- @keyword{'mod'}
-%kw_pub       <- @keyword{'pub'}
-%kw_in        <- @keyword{'in'}
-%kw_where     <- @keyword{'where'}
-%kw_dyn       <- @keyword{'dyn'}
-%kw_box       <- @keyword{'box'}
-%kw_ref       <- @keyword{'ref'}
-%kw_if        <- @keyword{'if'}
-%kw_let       <- @keyword{'let'}
-%kw_else      <- @keyword{'else'}
-%kw_match     <- @keyword{'match'}
-%kw_while     <- @keyword{'while'}
-%kw_loop      <- @keyword{'loop'}
-%kw_return    <- @keyword{'return'}
-%kw_break     <- @keyword{'break'}
-%kw_continue  <- @keyword{'continue'}
-%kw_move      <- @keyword{'move'}
-%kw_await     <- @keyword{'await'}
+%kw_use       =  @keyword{'use'}
+%kw_as        =  @keyword{'as'}
+%kw_self      =  @keyword{'self'}
+%kw_self_ty   =  @keyword{'Self'}
+%kw_super     =  @keyword{'super'}
+%kw_crate     =  @keyword{'crate'}
+%kw_fn        =  @keyword{'fn'}
+%kw_const     =  @keyword{'const'}
+%kw_static    =  @keyword{'static'}
+%kw_type      =  @keyword{'type'}
+%kw_async     =  @keyword{'async'}
+%kw_unsafe    =  @keyword{'unsafe'}
+%kw_extern    =  @keyword{'extern'}
+%kw_mut       =  @keyword{'mut'}
+%kw_struct    =  @keyword{'struct'}
+%kw_enum      =  @keyword{'enum'}
+%kw_impl      =  @keyword{'impl'}
+%kw_for       =  @keyword{'for'}
+%kw_trait     =  @keyword{'trait'}
+%kw_mod       =  @keyword{'mod'}
+%kw_pub       =  @keyword{'pub'}
+%kw_in        =  @keyword{'in'}
+%kw_where     =  @keyword{'where'}
+%kw_dyn       =  @keyword{'dyn'}
+%kw_box       =  @keyword{'box'}
+%kw_ref       =  @keyword{'ref'}
+%kw_if        =  @keyword{'if'}
+%kw_let       =  @keyword{'let'}
+%kw_else      =  @keyword{'else'}
+%kw_match     =  @keyword{'match'}
+%kw_while     =  @keyword{'while'}
+%kw_loop      =  @keyword{'loop'}
+%kw_return    =  @keyword{'return'}
+%kw_break     =  @keyword{'break'}
+%kw_continue  =  @keyword{'continue'}
+%kw_move      =  @keyword{'move'}
+%kw_await     =  @keyword{'await'}
 
 # --- Items -------------------------------------------------------------
 #
 # Order matters (PEG first-match). Attributes / inner-attributes must
 # precede regular items so `#[...]` and `#![...]` are not misparsed
 # as expression-statements starting with `#`.
-item          <- attr_outer
+item          =  attr_outer
                / attr_inner
                / use_item
                / fn_item
@@ -98,121 +98,121 @@ item          <- attr_outer
                / stmt
 
 # Attributes and doc-comments at item position.
-*attr_outer   <- @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'}
-*attr_inner   <- @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'}
-*attr_body    <- .. ']'
+*attr_outer   =  @punctuation{'#'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_inner   =  @punctuation{'#'} @punctuation{'!'} @punctuation{'['} attr_body @punctuation{']'}
+*attr_body    =  .. ']'
 
 # `use foo::bar::{baz, qux as q};`
-use_item      <- kw_use use_tree @punctuation{';'}
-use_tree      <- use_path use_tail?
-use_tail      <- kw_as ident_any
+use_item      =  kw_use use_tree @punctuation{';'}
+use_tree      =  use_path use_tail?
+use_tail      =  kw_as ident_any
                / @punctuation{'::'} @punctuation{'*'}
                / @punctuation{'::'} @punctuation{'{'} use_tree_list? @punctuation{'}'}
-use_tree_list <- use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
-use_path      <- use_seg (@punctuation{'::'} use_seg)*
-use_seg       <- kw_self
+use_tree_list =  use_tree (@punctuation{','} use_tree)* (@punctuation{','})?
+use_path      =  use_seg (@punctuation{'::'} use_seg)*
+use_seg       =  kw_self
                / kw_super
                / kw_crate
                / @type{upper_ident}
                / @variable{lower_ident}
 
 # `fn name<T>(a: T) -> T where T: Bound { ... }`
-fn_item       <- vis? fn_qualifier* kw_fn @function{ident} generic_params?
+fn_item       =  vis? fn_qualifier* kw_fn @function{ident} generic_params?
                  fn_params fn_return? where_clause? (block / @punctuation{';'})
-fn_qualifier  <- kw_const
+fn_qualifier  =  kw_const
                / kw_async
                / kw_unsafe
                / kw_extern string_lit?
-fn_params     <- @punctuation{'('} fn_param_list? @punctuation{')'}
-fn_param_list <- fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
-fn_param      <- attr_outer? self_param
+fn_params     =  @punctuation{'('} fn_param_list? @punctuation{')'}
+fn_param_list =  fn_param (@punctuation{','} fn_param)* (@punctuation{','})?
+fn_param      =  attr_outer? self_param
                / attr_outer? fn_param_named
-fn_param_named <- pattern_no_or @punctuation{':'} type_expr
-self_param    <- ref_marker? kw_mut? kw_self
+fn_param_named =  pattern_no_or @punctuation{':'} type_expr
+self_param    =  ref_marker? kw_mut? kw_self
                / kw_mut kw_self
                / kw_self @punctuation{':'} type_expr
-ref_marker    <- @punctuation{'&'} lifetime?
-fn_return     <- @punctuation{'->'} type_expr
+ref_marker    =  @punctuation{'&'} lifetime?
+fn_return     =  @punctuation{'->'} type_expr
 
 # `struct Foo { a: T, b: U }` / `struct Foo(T, U);` / `struct Foo;`
-struct_item   <- vis? kw_struct @type{ident} generic_params?
+struct_item   =  vis? kw_struct @type{ident} generic_params?
                  (struct_body_named / struct_body_tuple / @punctuation{';'})
-struct_body_named <- where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
-struct_body_tuple <- @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
-struct_fields <- struct_field (@punctuation{','} struct_field)* (@punctuation{','})?
-struct_field  <- attr_outer* vis? @property{ident} @punctuation{':'} type_expr
-tuple_fields  <- tuple_field (@punctuation{','} tuple_field)* (@punctuation{','})?
-tuple_field   <- attr_outer* vis? type_expr
+struct_body_named =  where_clause? @punctuation{'{'} struct_fields? @punctuation{'}'}
+struct_body_tuple =  @punctuation{'('} tuple_fields? @punctuation{')'} where_clause? @punctuation{';'}
+struct_fields =  struct_field (@punctuation{','} struct_field)* (@punctuation{','})?
+struct_field  =  attr_outer* vis? @property{ident} @punctuation{':'} type_expr
+tuple_fields  =  tuple_field (@punctuation{','} tuple_field)* (@punctuation{','})?
+tuple_field   =  attr_outer* vis? type_expr
 
 # `enum E { A, B(T), C { x: T } }`
-enum_item     <- vis? kw_enum @type{ident} generic_params? where_clause?
+enum_item     =  vis? kw_enum @type{ident} generic_params? where_clause?
                  @punctuation{'{'} enum_variants? @punctuation{'}'}
-enum_variants <- enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
-enum_variant  <- attr_outer* @type{ident} enum_variant_body?
-enum_variant_body <- @punctuation{'('} tuple_fields? @punctuation{')'}
+enum_variants =  enum_variant (@punctuation{','} enum_variant)* (@punctuation{','})?
+enum_variant  =  attr_outer* @type{ident} enum_variant_body?
+enum_variant_body =  @punctuation{'('} tuple_fields? @punctuation{')'}
                    / @punctuation{'{'} struct_fields? @punctuation{'}'}
                    / @punctuation{'='} expr
 
 # `impl<T> Trait<T> for Foo<T> where T: Bound { ... }`
-impl_item     <- kw_impl generic_params? impl_head where_clause?
+impl_item     =  kw_impl generic_params? impl_head where_clause?
                  @punctuation{'{'} impl_body @punctuation{'}'}
-impl_head     <- type_expr (kw_for type_expr)?
-impl_body     <- item*
+impl_head     =  type_expr (kw_for type_expr)?
+impl_body     =  item*
 
 # `trait T<U>: Bound { ... }`
-trait_item    <- vis? kw_unsafe? kw_trait @type{ident}
+trait_item    =  vis? kw_unsafe? kw_trait @type{ident}
                  generic_params? trait_bounds? where_clause?
                  @punctuation{'{'} impl_body @punctuation{'}'}
-trait_bounds  <- @punctuation{':'} bound_list
+trait_bounds  =  @punctuation{':'} bound_list
 
 # `mod name;` / `mod name { ... }`
-mod_item      <- vis? kw_mod @variable{ident}
+mod_item      =  vis? kw_mod @variable{ident}
                  (@punctuation{';'} / @punctuation{'{'} item* @punctuation{'}'})
 
 # `extern "C" { ... }` — extern as an *item* (not as an fn qualifier).
-extern_item   <- kw_extern string_lit? @punctuation{'{'} item* @punctuation{'}'}
+extern_item   =  kw_extern string_lit? @punctuation{'{'} item* @punctuation{'}'}
 
-const_item    <- vis? kw_const @constant{ident} @punctuation{':'} type_expr
+const_item    =  vis? kw_const @constant{ident} @punctuation{':'} type_expr
                  @punctuation{'='} expr @punctuation{';'}
-static_item   <- vis? kw_static kw_mut? @constant{ident} @punctuation{':'} type_expr
+static_item   =  vis? kw_static kw_mut? @constant{ident} @punctuation{':'} type_expr
                  @punctuation{'='} expr @punctuation{';'}
-type_alias_item <- vis? kw_type @type{ident} generic_params? where_clause?
+type_alias_item =  vis? kw_type @type{ident} generic_params? where_clause?
                    @punctuation{'='} type_expr @punctuation{';'}
 
 # `macro_rules! name { (...) => {...}; ... }` — body is arbitrary token
 # soup; balance braces.
-macro_rules_item <- @function{'macro_rules'} @punctuation{'!'} @function{ident} brace_block
+macro_rules_item =  @function{'macro_rules'} @punctuation{'!'} @function{ident} brace_block
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
 # Trailing `;?` absorbed by `root`'s `*^`.
-~macro_invocation_stmt <- @function{ident} @punctuation{'!'} macro_args (@punctuation{';'})?
-macro_args    <- paren_group
+~macro_invocation_stmt =  @function{ident} @punctuation{'!'} macro_args (@punctuation{';'})?
+macro_args    =  paren_group
                / brace_block
                / bracket_group
 
 # Visibility modifier.
-vis           <- kw_pub (@punctuation{'('} vis_scope @punctuation{')'})?
-vis_scope     <- kw_crate / kw_self / kw_super
+vis           =  kw_pub (@punctuation{'('} vis_scope @punctuation{')'})?
+vis_scope     =  kw_crate / kw_self / kw_super
                / kw_in use_path
 
 # --- Generic parameters and where-clauses ----------------------------
 
-generic_params <- @punctuation{'<'} generic_param_list? @punctuation{'>'}
-generic_param_list <- generic_param (@punctuation{','} generic_param)* (@punctuation{','})?
-generic_param <- lifetime_param
+generic_params =  @punctuation{'<'} generic_param_list? @punctuation{'>'}
+generic_param_list =  generic_param (@punctuation{','} generic_param)* (@punctuation{','})?
+generic_param =  lifetime_param
                / type_param
                / const_param
-lifetime_param <- lifetime (@punctuation{':'} lifetime_bounds)?
-lifetime_bounds <- lifetime (@punctuation{'+'} lifetime)*
-type_param    <- @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
-const_param   <- kw_const @constant{ident} @punctuation{':'} type_expr
+lifetime_param =  lifetime (@punctuation{':'} lifetime_bounds)?
+lifetime_bounds =  lifetime (@punctuation{'+'} lifetime)*
+type_param    =  @type{ident} (@punctuation{':'} bound_list)? (@punctuation{'='} type_expr)?
+const_param   =  kw_const @constant{ident} @punctuation{':'} type_expr
 
-where_clause  <- kw_where where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
-where_pred    <- lifetime @punctuation{':'} lifetime_bounds
+where_clause  =  kw_where where_pred (@punctuation{','} where_pred)* (@punctuation{','})?
+where_pred    =  lifetime @punctuation{':'} lifetime_bounds
                / type_expr @punctuation{':'} bound_list
 
-bound_list    <- bound (@punctuation{'+'} bound)*
-bound         <- lifetime
+bound_list    =  bound (@punctuation{'+'} bound)*
+bound         =  lifetime
                / (@punctuation{'?'})? type_path
 
 # --- Types -------------------------------------------------------------
@@ -220,7 +220,7 @@ bound         <- lifetime
 # `&'a mut T`, `[T; N]`, `(T, U)`, `Foo<T>`, `dyn Trait`, `impl Trait`,
 # `fn(T) -> U`, `!`, etc.
 
-type_expr     <- type_fn
+type_expr     =  type_fn
                / type_impl
                / type_dyn
                / type_ref
@@ -231,25 +231,25 @@ type_expr     <- type_fn
                / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn      <- type_fn_qualifier* kw_fn @punctuation{'('} type_list? @punctuation{')'}
+~type_fn      =  type_fn_qualifier* kw_fn @punctuation{'('} type_list? @punctuation{')'}
                  (@punctuation{'->'} type_expr)?
-type_fn_qualifier <- kw_unsafe
+type_fn_qualifier =  kw_unsafe
                    / kw_extern string_lit?
-type_list     <- type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
+type_list     =  type_expr (@punctuation{','} type_expr)* (@punctuation{','})?
 
-type_impl     <- kw_impl bound_list
-type_dyn      <- kw_dyn bound_list
+type_impl     =  kw_impl bound_list
+type_dyn      =  kw_dyn bound_list
 
-type_ref      <- @punctuation{'&'} lifetime? kw_mut? type_expr
-type_ptr      <- @punctuation{'*'} (kw_mut / kw_const) type_expr
+type_ref      =  @punctuation{'&'} lifetime? kw_mut? type_expr
+type_ptr      =  @punctuation{'*'} (kw_mut / kw_const) type_expr
 
-type_array_or_slice <- @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
-type_tuple_or_group <- @punctuation{'('} type_list? @punctuation{')'}
+type_array_or_slice =  @punctuation{'['} type_expr (@punctuation{';'} expr)? @punctuation{']'}
+type_tuple_or_group =  @punctuation{'('} type_list? @punctuation{')'}
 
-type_never    <- @punctuation{'!'}
+type_never    =  @punctuation{'!'}
 
-type_path     <- type_path_seg (@punctuation{'::'} type_path_seg)*
-type_path_seg <- @type{upper_ident} path_tail?
+type_path     =  type_path_seg (@punctuation{'::'} type_path_seg)*
+type_path_seg =  @type{upper_ident} path_tail?
                / @variable{lower_ident} path_tail?
                / kw_self
                / kw_self_ty
@@ -259,15 +259,15 @@ type_path_seg <- @type{upper_ident} path_tail?
 # Either angle-bracket generics (`Foo<T>`) or paren-sugar for Fn-traits
 # (`Fn(T) -> U`); Rust's reference grammar splits these as
 # `GenericArgs` vs `ParenthesizedGenericArgs`.
-path_tail     <- generic_args
+path_tail     =  generic_args
                / paren_generic_args
 
-generic_args  <- @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'}
+generic_args  =  @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'}
                / @punctuation{'<'} generic_arg_list? @punctuation{'>'}
 # Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
-~paren_generic_args <- @punctuation{'('} type_list? @punctuation{')'} (@punctuation{'->'} type_expr)?
-generic_arg_list <- generic_arg (@punctuation{','} generic_arg)* (@punctuation{','})?
-generic_arg   <- lifetime
+~paren_generic_args =  @punctuation{'('} type_list? @punctuation{')'} (@punctuation{'->'} type_expr)?
+generic_arg_list =  generic_arg (@punctuation{','} generic_arg)* (@punctuation{','})?
+generic_arg   =  lifetime
                / type_expr
                / @constant{ident} @punctuation{'='} type_expr
                / expr_block
@@ -280,10 +280,10 @@ generic_arg   <- lifetime
 # fn params), use `pattern_no_or` so the closing `|` isn't eaten by
 # `pattern_or`'s greedy `*`. Mirrors Rust's reference `PatternNoTopAlt`.
 
-pattern       <- pattern_or
-pattern_no_or <- pattern_atom
-pattern_or    <- pattern_atom (@punctuation{'|'} pattern_atom)*
-pattern_atom  <- pattern_ref
+pattern       =  pattern_or
+pattern_no_or =  pattern_atom
+pattern_or    =  pattern_atom (@punctuation{'|'} pattern_atom)*
+pattern_atom  =  pattern_ref
                / pattern_box
                / pattern_tuple
                / pattern_struct_or_enum
@@ -293,31 +293,31 @@ pattern_atom  <- pattern_ref
                / pattern_wild
                / pattern_rest
                / pattern_binding
-pattern_ref   <- @punctuation{'&'} kw_mut? pattern_atom
-pattern_box   <- kw_box pattern_atom
-pattern_tuple <- @punctuation{'('} pattern_list? @punctuation{')'}
-pattern_list  <- pattern (@punctuation{','} pattern)* (@punctuation{','})?
+pattern_ref   =  @punctuation{'&'} kw_mut? pattern_atom
+pattern_box   =  kw_box pattern_atom
+pattern_tuple =  @punctuation{'('} pattern_list? @punctuation{')'}
+pattern_list  =  pattern (@punctuation{','} pattern)* (@punctuation{','})?
 # Trailing `::` chain leniency absorbed by outer recovery.
-~pattern_struct_or_enum <- @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
+~pattern_struct_or_enum =  @type{upper_ident} (@punctuation{'::'} @type{upper_ident})*
                           (pattern_struct_body / pattern_tuple)?
-pattern_struct_body <- @punctuation{'{'} pattern_struct_fields? @punctuation{'}'}
-pattern_struct_fields <- pattern_struct_field (@punctuation{','} pattern_struct_field)* (@punctuation{','})?
-pattern_struct_field  <- @property{ident} @punctuation{':'} pattern
+pattern_struct_body =  @punctuation{'{'} pattern_struct_fields? @punctuation{'}'}
+pattern_struct_fields =  pattern_struct_field (@punctuation{','} pattern_struct_field)* (@punctuation{','})?
+pattern_struct_field  =  @property{ident} @punctuation{':'} pattern
                        / @property{ident}
                        / @punctuation{'..'}
-pattern_slice <- @punctuation{'['} pattern_list? @punctuation{']'}
-pattern_range <- pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
-pattern_literal <- string_lit / char_lit / number_lit / lit_const
-pattern_wild  <- @punctuation{'_'}
-pattern_rest  <- @punctuation{'..'}
+pattern_slice =  @punctuation{'['} pattern_list? @punctuation{']'}
+pattern_range =  pattern_literal (@punctuation{'..='} / @punctuation{'..'}) pattern_literal
+pattern_literal =  string_lit / char_lit / number_lit / lit_const
+pattern_wild  =  @punctuation{'_'}
+pattern_rest  =  @punctuation{'..'}
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding <- kw_ref? kw_mut? @variable{ident}
+~pattern_binding =  kw_ref? kw_mut? @variable{ident}
                    (@punctuation{'@'} pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
 #
 # Precedence is encoded by direct left recursion: each binary level is
-# `expr_LEVEL <- expr_LEVEL OP expr_NEXT / expr_NEXT`, mirroring the
+# `expr_LEVEL =  expr_LEVEL OP expr_NEXT / expr_NEXT`, mirroring the
 # Rust reference precedence table. Assignment is right-associative
 # (single right-recursive rule); range is non-associative with
 # special prefix/suffix forms; everything else is left-associative LR.
@@ -325,12 +325,12 @@ pattern_rest  <- @punctuation{'..'}
 # matching binary, `&` vs `&&`, `|` vs `||`) need explicit
 # `!`-lookaheads inside each level's operator alternation.
 
-expr          <- expr_assign
+expr          =  expr_assign
 
 # Right-associative: `a = b = c` parses as `a = (b = c)`.
-expr_assign   <- expr_range assign_op expr_assign / expr_range
+expr_assign   =  expr_range assign_op expr_assign / expr_range
 
-assign_op     <- @operator{'<<='} / @operator{'>>='}
+assign_op     =  @operator{'<<='} / @operator{'>>='}
                / @operator{'+='}  / @operator{'-='}
                / @operator{'*='}  / @operator{'/='}
                / @operator{'%='}  / @operator{'&='}
@@ -338,44 +338,44 @@ assign_op     <- @operator{'<<='} / @operator{'>>='}
                / @operator{'='} !'='
 
 # Range: `a..b`, `a..=b`, `..b`, `a..`, `..`. Non-associative.
-expr_range    <- expr_lor ((@punctuation{'..='} / @punctuation{'..'}) expr_lor?)?
+expr_range    =  expr_lor ((@punctuation{'..='} / @punctuation{'..'}) expr_lor?)?
                / (@punctuation{'..='} / @punctuation{'..'}) expr_lor?
 
-expr_lor      <- expr_lor @operator{'||'} expr_land / expr_land
-expr_land     <- expr_land @operator{'&&'} expr_cmp / expr_cmp
-expr_cmp      <- expr_cmp (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_bor / expr_bor
-expr_bor      <- expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
-expr_bxor     <- expr_bxor @operator{'^'} !'=' expr_band / expr_band
-expr_band     <- expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
-expr_shift    <- expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
-expr_add      <- expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
-expr_mul      <- expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
-expr_as       <- expr_as kw_as type_expr_suffix_marker / expr_unary
+expr_lor      =  expr_lor @operator{'||'} expr_land / expr_land
+expr_land     =  expr_land @operator{'&&'} expr_cmp / expr_cmp
+expr_cmp      =  expr_cmp (@operator{'=='} / @operator{'!='} / @operator{'<='} / @operator{'>='} / @operator{'<'} !'<' / @operator{'>'} !'>') expr_bor / expr_bor
+expr_bor      =  expr_bor @operator{'|'} !'|' !'=' expr_bxor / expr_bxor
+expr_bxor     =  expr_bxor @operator{'^'} !'=' expr_band / expr_band
+expr_band     =  expr_band @operator{'&'} !'&' !'=' expr_shift / expr_shift
+expr_shift    =  expr_shift (@operator{'<<'} !'=' / @operator{'>>'} !'=') expr_add / expr_add
+expr_add      =  expr_add (@operator{'+'} !'=' / @operator{'-'} !'=') expr_mul / expr_mul
+expr_mul      =  expr_mul (@operator{'*'} !'=' / @operator{'/'} !'=' / @operator{'%'} !'=') expr_as / expr_as
+expr_as       =  expr_as kw_as type_expr_suffix_marker / expr_unary
 
 # A marker rule: when `as` matches, consume the following type. Split
 # from the cascade so the type_expr stays attached.
-type_expr_suffix_marker <- type_expr
+type_expr_suffix_marker =  type_expr
 
-expr_unary    <- unary_op* expr_postfix
-unary_op      <- @operator{'&'} lifetime? kw_mut?
+expr_unary    =  unary_op* expr_postfix
+unary_op      =  @operator{'&'} lifetime? kw_mut?
                / @operator{'*'}
                / @operator{'-'}
                / @operator{'!'}
 
 # Postfix chain: calls, indexing, field access, try `?`.
-expr_postfix  <- expr_primary postfix_op*
-postfix_op    <- @punctuation{'?'}
+expr_postfix  =  expr_primary postfix_op*
+postfix_op    =  @punctuation{'?'}
                / @punctuation{'.'} kw_await
                / @punctuation{'.'} postfix_member
                / @punctuation{'('} expr_list? @punctuation{')'}
                / @punctuation{'['} expr @punctuation{']'}
-postfix_member <- turbofish_method
+postfix_member =  turbofish_method
                 / @function{ident} (@punctuation{'('} expr_list? @punctuation{')'})?
                 / @number{digit_seq}
 # Trailing `(args)?` absorbed by outer recovery.
-~turbofish_method <- @function{ident} @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'} (@punctuation{'('} expr_list? @punctuation{')'})?
+~turbofish_method =  @function{ident} @punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'} (@punctuation{'('} expr_list? @punctuation{')'})?
 
-expr_primary  <- literal
+expr_primary  =  literal
                / expr_if
                / expr_match
                / expr_while
@@ -394,58 +394,58 @@ expr_primary  <- literal
                / expr_keyword
 
 # Trailing `(else (if | block))?` leniency absorbed by `root`'s `*^` and `block`'s `^block_close`.
-~expr_if      <- kw_if (kw_let pattern @operator{'='})? expr block
+~expr_if      =  kw_if (kw_let pattern @operator{'='})? expr block
                  (kw_else (expr_if / block))?
-expr_match    <- kw_match expr @punctuation{'{'} match_arms? @punctuation{'}'}
-match_arms    <- match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
-match_arm     <- attr_outer* pattern (kw_if expr)? @punctuation{'=>'} expr
-expr_while    <- kw_while (kw_let pattern @operator{'='})? expr block
-expr_loop     <- loop_label? kw_loop block
-expr_for      <- kw_for pattern kw_in expr block
+expr_match    =  kw_match expr @punctuation{'{'} match_arms? @punctuation{'}'}
+match_arms    =  match_arm (@punctuation{','} match_arm)* (@punctuation{','})?
+match_arm     =  attr_outer* pattern (kw_if expr)? @punctuation{'=>'} expr
+expr_while    =  kw_while (kw_let pattern @operator{'='})? expr block
+expr_loop     =  loop_label? kw_loop block
+expr_for      =  kw_for pattern kw_in expr block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return  <- kw_return expr?
-~expr_break   <- kw_break loop_label? expr?
-~expr_continue <- kw_continue loop_label?
-expr_unsafe   <- kw_unsafe block
-expr_closure  <- kw_move? @punctuation{'|'} closure_params? @punctuation{'|'}
+~expr_return  =  kw_return expr?
+~expr_break   =  kw_break loop_label? expr?
+~expr_continue =  kw_continue loop_label?
+expr_unsafe   =  kw_unsafe block
+expr_closure  =  kw_move? @punctuation{'|'} closure_params? @punctuation{'|'}
                  (@punctuation{'->'} type_expr)? expr
-closure_params <- closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
-closure_param <- pattern_no_or (@punctuation{':'} type_expr)?
-expr_block    <- block
-expr_async_block <- kw_async kw_move? block
-expr_tuple_or_paren <- @punctuation{'('} expr_list? @punctuation{')'}
-expr_array    <- @punctuation{'['} expr_array_body? @punctuation{']'}
-expr_array_body <- expr @punctuation{';'} expr
+closure_params =  closure_param (@punctuation{','} closure_param)* (@punctuation{','})?
+closure_param =  pattern_no_or (@punctuation{':'} type_expr)?
+expr_block    =  block
+expr_async_block =  kw_async kw_move? block
+expr_tuple_or_paren =  @punctuation{'('} expr_list? @punctuation{')'}
+expr_array    =  @punctuation{'['} expr_array_body? @punctuation{']'}
+expr_array_body =  expr @punctuation{';'} expr
                  / expr (@punctuation{','} expr)* (@punctuation{','})?
-expr_list     <- expr (@punctuation{','} expr)* (@punctuation{','})?
-expr_keyword  <- kw_self / kw_self_ty / kw_super / kw_crate
+expr_list     =  expr (@punctuation{','} expr)* (@punctuation{','})?
+expr_keyword  =  kw_self / kw_self_ty / kw_super / kw_crate
 
-*loop_label   <- @punctuation{'\''} @variable{ident} @punctuation{':'}
+*loop_label   =  @punctuation{'\''} @variable{ident} @punctuation{':'}
 
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
 # Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
-~expr_macro_or_path <- path_expr (struct_init / @punctuation{'!'} macro_args)?
-path_expr     <- path_seg (@punctuation{'::'} path_seg)*
-path_seg      <- @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
+~expr_macro_or_path =  path_expr (struct_init / @punctuation{'!'} macro_args)?
+path_expr     =  path_seg (@punctuation{'::'} path_seg)*
+path_seg      =  @type{upper_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
                / @function{lower_ident} (@punctuation{'::'} @punctuation{'<'} generic_arg_list? @punctuation{'>'})?
 
-struct_init   <- @punctuation{'{'} struct_init_fields? @punctuation{'}'}
-struct_init_fields <- struct_init_field (@punctuation{','} struct_init_field)* (@punctuation{','} struct_init_base?)?
-struct_init_field  <- @punctuation{'..'} expr
+struct_init   =  @punctuation{'{'} struct_init_fields? @punctuation{'}'}
+struct_init_fields =  struct_init_field (@punctuation{','} struct_init_field)* (@punctuation{','} struct_init_base?)?
+struct_init_field  =  @punctuation{'..'} expr
                     / @property{ident} @punctuation{':'} expr
                     / @property{ident}
-struct_init_base   <- @punctuation{'..'} expr
+struct_init_base   =  @punctuation{'..'} expr
 
 # --- Statements & blocks ----------------------------------------------
 
-block         <- @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block         =  @punctuation{'{'} (stmt* @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 
-stmt          <- let_stmt
+stmt          =  let_stmt
                / expr @punctuation{';'}
                / expr                                    # trailing expression (block-valued)
 
-let_stmt      <- kw_let pattern (@punctuation{':'} type_expr)?
+let_stmt      =  kw_let pattern (@punctuation{':'} type_expr)?
                  (@punctuation{'='} expr)? (kw_else block)? @punctuation{';'}
 
 # --- Balanced-bracket helpers (used for macro bodies) -----------------
@@ -458,11 +458,11 @@ let_stmt      <- kw_let pattern (@punctuation{':'} type_expr)?
 # the brackets — necessary for multi-line macro argument lists like
 # `vec![\n  1,\n]`.
 
-brace_block   <- @punctuation{'{'} balanced_body @punctuation{'}'}
-paren_group   <- @punctuation{'('} balanced_body @punctuation{')'}
-bracket_group <- @punctuation{'['} balanced_body @punctuation{']'}
-balanced_body <- balanced_atom*
-balanced_atom <- brace_block
+brace_block   =  @punctuation{'{'} balanced_body @punctuation{'}'}
+paren_group   =  @punctuation{'('} balanced_body @punctuation{')'}
+bracket_group =  @punctuation{'['} balanced_body @punctuation{']'}
+balanced_body =  balanced_atom*
+balanced_atom =  brace_block
                / paren_group
                / bracket_group
                / string_lit
@@ -472,47 +472,47 @@ balanced_atom <- brace_block
 
 # --- Literals ----------------------------------------------------------
 
-literal       <- string_lit / char_lit / number_lit / lit_const
+literal       =  string_lit / char_lit / number_lit / lit_const
 
 # Boolean constants as a `%` reserved-word alternation so the `wb`
 # boundary keeps `trueish` from matching the `true` prefix.
-%lit_const    <- @constant{'true'} / @constant{'false'}
+%lit_const    =  @constant{'true'} / @constant{'false'}
 
 # Raw strings first (longer prefix), then regular.
-string_lit    <- @string{raw_string / byte_string / regular_string}
-*regular_string <- '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*byte_string  <- 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*raw_string   <- 'r' raw_hashes '"' (.. '"') '"' raw_hashes
+string_lit    =  @string{raw_string / byte_string / regular_string}
+*regular_string =  '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*byte_string  =  'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
+*raw_string   =  'r' raw_hashes '"' (.. '"') '"' raw_hashes
                / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
 # Consume matching hash fences; the body is "up to the closing delim".
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
-*raw_hashes   <- '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
+*raw_hashes   =  '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
 
-*char_lit     <- @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
+*char_lit     =  @string{"'" ('\\' (!'\n' .) / !"'" .) "'"}
 
-number_lit    <- @number{num_body}
-*num_body     <- float_num / int_num
-*float_num    <- digit_seq '.' digit_seq (exp_part)? num_suffix?
+number_lit    =  @number{num_body}
+*num_body     =  float_num / int_num
+*float_num    =  digit_seq '.' digit_seq (exp_part)? num_suffix?
                / digit_seq exp_part num_suffix?
-*int_num      <- '0x' hex_digits num_suffix?
+*int_num      =  '0x' hex_digits num_suffix?
                / '0o' oct_digits num_suffix?
                / '0b' bin_digits num_suffix?
                / digit_seq num_suffix?
-*digit_seq    <- \d ([\d_])*
-*hex_digits   <- [\da-fA-F] [\da-fA-F_]*
-*oct_digits   <- [0-7] [0-7_]*
-*bin_digits   <- [01] [01_]*
-*exp_part     <- [eE] [+\-]? digit_seq
-*num_suffix   <- [a-zA-Z_] [a-zA-Z\d_]*
+*digit_seq    =  \d ([\d_])*
+*hex_digits   =  [\da-fA-F] [\da-fA-F_]*
+*oct_digits   =  [0-7] [0-7_]*
+*bin_digits   =  [01] [01_]*
+*exp_part     =  [eE] [+\-]? digit_seq
+*num_suffix   =  [a-zA-Z_] [a-zA-Z\d_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
-*lifetime     <- @type{"'" ident_body+}
+*lifetime     =  @type{"'" ident_body+}
 
 # `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
 # of special meaning for highlighting.
-ident_any     <- @type{upper_ident}
+ident_any     =  @type{upper_ident}
                / @variable{lower_ident}
 # Per Rust Reference "Identifiers": XID_Start (or `_`) followed by
 # XID_Continue per UAX #31. `r#` raw-identifier prefix admits keywords
@@ -525,13 +525,13 @@ ident_any     <- @type{upper_ident}
 # non-ASCII letters into both ranges would collapse that distinction.
 # Stage 2 widens the body but leaves the shape gate ASCII; future work
 # can refine the upper/lower split using `\p{Lu}` / `\p{Ll}` if needed.
-*upper_ident  <- 'r#'? [A-Z] ident_body*
-*lower_ident  <- 'r#'? [a-z_] ident_body*
-*ident        <- 'r#'? [\p{XID_Start}_] ident_body*
-ident_body    <- [\p{XID_Continue}]
+*upper_ident  =  'r#'? [A-Z] ident_body*
+*lower_ident  =  'r#'? [a-z_] ident_body*
+*ident        =  'r#'? [\p{XID_Start}_] ident_body*
+ident_body    =  [\p{XID_Continue}]
 
 # --- Whitespace and comments ------------------------------------------
 
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-*comment      <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+*comment      =  @comment{'//' .. '\n' / '/*' ..= '*/'}

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -53,16 +53,16 @@
 
 # --- Top level --------------------------------------------------------
 
-root       <- (statement stmt_sep?)*^[;]
+root       =  (statement stmt_sep?)*^[;]
 
-trivia    <- (comment / \s)*
+trivia    =  (comment / \s)*
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Matches the full identifier-continue
 # class (`ident_cont`, Unicode included).
-wb        <- !ident_cont
-stmt_sep   <- @punctuation{';'}
-statement       <- explain_stmt / statement_body
-statement_body  <- select_stmt
+wb        =  !ident_cont
+stmt_sep   =  @punctuation{';'}
+statement       =  explain_stmt / statement_body
+statement_body  =  select_stmt
                  / insert_stmt
                  / update_stmt
                  / delete_stmt
@@ -91,60 +91,60 @@ statement_body  <- select_stmt
 # --- SELECT statement -------------------------------------------------
 
 # Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
-~select_stmt   <- with_clause? select_core compound_tail* order_clause? limit_clause?
+~select_stmt   =  with_clause? select_core compound_tail* order_clause? limit_clause?
 
-with_clause    <- kw_with (kw_recursive)? cte_defn (@punctuation{','} cte_defn)*
-cte_defn       <- @type{bare_ident}
+with_clause    =  kw_with (kw_recursive)? cte_defn (@punctuation{','} cte_defn)*
+cte_defn       =  @type{bare_ident}
                   (@punctuation{'('} ident_list @punctuation{')'})?
                   kw_as @punctuation{'('} select_stmt @punctuation{')'}
 
 # Trailing `(window_clause)?` absorbed by `*^[;]`.
-~select_core   <- kw_select ((kw_distinct / kw_all))? result_list
+~select_core   =  kw_select ((kw_distinct / kw_all))? result_list
                   (from_clause)? (where_clause)? (group_clause)? (having_clause)?
                   (window_clause)?
 
-result_list    <- result_column (@punctuation{','} result_column)*
+result_list    =  result_column (@punctuation{','} result_column)*
 # A column expression that didn't reach a known boundary is treated
 # as malformed. The `^^bad_column (result_column_boundary)`
 # operator anchors the inner branch on the boundary (so e.g.
 # `blob.rid IN leaf` fails because `IN` isn't in the boundary set)
 # and synthesizes the recovery body `(!(result_column_boundary) .)*`
 # from the same argument.
-result_column  <- (table_star / @operator{'*'} / aliased_expr)
+result_column  =  (table_star / @operator{'*'} / aliased_expr)
                   ^^bad_column (result_column_boundary)
-result_column_boundary <- @punctuation{','} / @punctuation{')'} / @punctuation{';'}
+result_column_boundary =  @punctuation{','} / @punctuation{')'} / @punctuation{';'}
                         / kw_from / kw_where / kw_group / kw_having
                         / kw_order / kw_limit / kw_offset / kw_window
                         / kw_union / kw_intersect / kw_except
                         / !.
-table_star     <- @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
-aliased_expr   <- expr (kw_as @variable{bare_ident_nonkw}
+table_star     =  @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
+aliased_expr   =  expr (kw_as @variable{bare_ident_nonkw}
                       / @variable{bare_ident_nonkw})?
 
-compound_tail  <- (kw_union (kw_all)? / kw_intersect / kw_except) select_core
+compound_tail  =  (kw_union (kw_all)? / kw_intersect / kw_except) select_core
 
-from_clause    <- kw_from table_or_subquery (join_clause)*
-table_or_subquery <- @punctuation{'('} select_stmt @punctuation{')'} (table_alias)?
+from_clause    =  kw_from table_or_subquery (join_clause)*
+table_or_subquery =  @punctuation{'('} select_stmt @punctuation{')'} (table_alias)?
                    / qualified_table_name (table_alias)?
 # Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
-~qualified_table_name <- @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
-table_alias    <- kw_as @variable{bare_ident_nonkw}
+~qualified_table_name =  @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
+table_alias    =  kw_as @variable{bare_ident_nonkw}
                 / @variable{bare_ident_nonkw}
 
 # Trailing `(join_constraint)?` absorbed by `*^[;]`.
-~join_clause   <- join_op table_or_subquery (join_constraint)?
-join_op        <- @punctuation{','}
+~join_clause   =  join_op table_or_subquery (join_constraint)?
+join_op        =  @punctuation{','}
                 / kw_natural (join_type)? kw_join
                 / join_type kw_join
                 / kw_join
-join_type      <- kw_left (kw_outer)?
+join_type      =  kw_left (kw_outer)?
                 / kw_right (kw_outer)?
                 / kw_full (kw_outer)?
                 / kw_inner
                 / kw_cross
-join_constraint<- kw_on expr
+join_constraint=  kw_on expr
                 / kw_using @punctuation{'('} ident_list @punctuation{')'}
-ident_list     <- @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_ident_nonkw})*
+ident_list     =  @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_ident_nonkw})*
 
 # Like `result_column`, `where_clause` uses `^^bad_where` to turn
 # partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY …`
@@ -152,21 +152,21 @@ ident_list     <- @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_
 # The operator sits *inside* the `kw_where` match so a missing WHERE
 # keyword still fails the rule cleanly (no spurious empty recovery
 # captures on clean SELECTs).
-where_clause   <- kw_where (expr ^^bad_where (where_clause_boundary))
-where_clause_boundary <- @punctuation{')'} / @punctuation{';'}
+where_clause   =  kw_where (expr ^^bad_where (where_clause_boundary))
+where_clause_boundary =  @punctuation{')'} / @punctuation{';'}
                        / kw_group / kw_having / kw_order / kw_limit
                        / kw_offset / kw_window / kw_returning
                        / kw_union / kw_intersect / kw_except
                        / !.
-group_clause   <- kw_group kw_by expr (@punctuation{','} expr)*
-having_clause  <- kw_having expr
+group_clause   =  kw_group kw_by expr (@punctuation{','} expr)*
+having_clause  =  kw_having expr
 
-order_clause   <- kw_order kw_by order_item (@punctuation{','} order_item)*
+order_clause   =  kw_order kw_by order_item (@punctuation{','} order_item)*
 # Trailing `(asc/desc)?` absorbed by `*^[;]`.
-~order_item    <- expr ((kw_asc / kw_desc))?
+~order_item    =  expr ((kw_asc / kw_desc))?
 
 # Trailing `(offset)?` absorbed by `*^[;]`.
-~limit_clause  <- kw_limit expr (kw_offset expr
+~limit_clause  =  kw_limit expr (kw_offset expr
                                       / @punctuation{','} expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
@@ -176,12 +176,12 @@ order_clause   <- kw_order kw_by order_item (@punctuation{','} order_item)*
 # are matched positionally here, so existing SELECTs that use any of
 # those as identifiers keep working.
 
-window_clause  <- kw_window named_window (@punctuation{','} named_window)*
-named_window   <- @variable{bare_ident_nonkw} kw_as window_defn
+window_clause  =  kw_window named_window (@punctuation{','} named_window)*
+named_window   =  @variable{bare_ident_nonkw} kw_as window_defn
 
-filter_clause  <- kw_filter @punctuation{'('} kw_where expr @punctuation{')'}
+filter_clause  =  kw_filter @punctuation{'('} kw_where expr @punctuation{')'}
 
-window_defn    <- @punctuation{'('}
+window_defn    =  @punctuation{'('}
                       (!window_section_keyword @variable{bare_ident_nonkw})?
                       (kw_partition kw_by expr (@punctuation{','} expr)*)?
                       (window_order_body)?
@@ -190,18 +190,18 @@ window_defn    <- @punctuation{'('}
 # that actually starts the next positional section (PARTITION / ORDER /
 # RANGE / ROWS / GROUPS). Without the lookahead, PEG would eat
 # `PARTITION` as a bare identifier and then fail on the partition clause.
-window_section_keyword <- kw_partition / kw_order / kw_range / kw_rows / kw_groups
-window_order_body <- kw_order kw_by order_item (@punctuation{','} order_item)*
-window_ref     <- window_defn / @variable{bare_ident_nonkw}
+window_section_keyword =  kw_partition / kw_order / kw_range / kw_rows / kw_groups
+window_order_body =  kw_order kw_by order_item (@punctuation{','} order_item)*
+window_ref     =  window_defn / @variable{bare_ident_nonkw}
 
-frame_spec     <- (kw_range / kw_rows / kw_groups)
+frame_spec     =  (kw_range / kw_rows / kw_groups)
                   (kw_between frame_bound kw_and frame_bound
                    / frame_bound)
                   (kw_exclude frame_exclude)?
-frame_bound    <- kw_unbounded (kw_preceding / kw_following)
+frame_bound    =  kw_unbounded (kw_preceding / kw_following)
                 / kw_current kw_row
                 / expr (kw_preceding / kw_following)
-frame_exclude  <- kw_no kw_others
+frame_exclude  =  kw_no kw_others
                 / kw_current kw_row
                 / kw_group
                 / kw_ties
@@ -211,42 +211,42 @@ frame_exclude  <- kw_no kw_others
 # `update_set_list`, which is defined here.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~insert_stmt   <- with_clause? insert_prefix kw_into qualified_table_name
+~insert_stmt   =  with_clause? insert_prefix kw_into qualified_table_name
                   (kw_as @variable{bare_ident_nonkw})?
                   (@punctuation{'('} ident_list @punctuation{')'})?
                   insert_source
                   (upsert_clause)*
                   (returning_clause)?
 
-insert_prefix  <- kw_insert (kw_or conflict_action)?
+insert_prefix  =  kw_insert (kw_or conflict_action)?
                 / kw_replace
 
-insert_source  <- kw_default kw_values
+insert_source  =  kw_default kw_values
                 / kw_values values_row (@punctuation{','} values_row)*
                 / select_stmt
-values_row     <- @punctuation{'('} expr (@punctuation{','} expr)* @punctuation{')'}
+values_row     =  @punctuation{'('} expr (@punctuation{','} expr)* @punctuation{')'}
 
-conflict_action <- kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
+conflict_action =  kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
 
-upsert_clause  <- kw_on kw_conflict
+upsert_clause  =  kw_on kw_conflict
                   (@punctuation{'('} indexed_col_list @punctuation{')'} (where_clause)?)?
                   kw_do (kw_nothing
                              / kw_update kw_set update_set_list (where_clause)?)
 
-indexed_col_list <- indexed_col (@punctuation{','} indexed_col)*
-indexed_col      <- expr (kw_collate @type{bare_ident})? ((kw_asc / kw_desc))?
+indexed_col_list =  indexed_col (@punctuation{','} indexed_col)*
+indexed_col      =  expr (kw_collate @type{bare_ident})? ((kw_asc / kw_desc))?
 
-update_set_list <- update_set_item (@punctuation{','} update_set_item)*
-update_set_item <- @variable{bare_ident_nonkw} @operator{'='} expr
+update_set_list =  update_set_item (@punctuation{','} update_set_item)*
+update_set_item =  @variable{bare_ident_nonkw} @operator{'='} expr
                  / @punctuation{'('} ident_list @punctuation{')'} @operator{'='} row_value
 # RHS of a column-tuple assignment: parens-wrapped row-value (literal
 # list or sub-select) or a single expression that yields a row.
-row_value        <- @punctuation{'('}
+row_value        =  @punctuation{'('}
                     (select_stmt / expr (@punctuation{','} expr)*)
                     @punctuation{')'}
                   / expr
 
-returning_clause <- kw_returning result_list
+returning_clause =  kw_returning result_list
 
 # --- DML: UPDATE, DELETE ---------------------------------------------
 # UPDATE FROM and DELETE reuse `from_clause` and `where_clause` from
@@ -255,7 +255,7 @@ returning_clause <- kw_returning result_list
 # should not pretend the syntax doesn't exist.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~update_stmt <- with_clause? kw_update (kw_or conflict_action)?
+~update_stmt =  with_clause? kw_update (kw_or conflict_action)?
                qualified_table_name (table_alias)?
                kw_set update_set_list
                (from_clause)?
@@ -264,7 +264,7 @@ returning_clause <- kw_returning result_list
                limit_clause?
                (returning_clause)?
 
-~delete_stmt <- with_clause? kw_delete kw_from qualified_table_name (table_alias)?
+~delete_stmt =  with_clause? kw_delete kw_from qualified_table_name (table_alias)?
                (where_clause)?
                order_clause?
                limit_clause?
@@ -277,7 +277,7 @@ returning_clause <- kw_returning result_list
 # requires a non-keyword leading identifier, while table_constraint
 # starts with CONSTRAINT, PRIMARY, UNIQUE, CHECK, or FOREIGN.
 
-create_table_stmt <- kw_create ((kw_temporary / kw_temp))? kw_table
+create_table_stmt =  kw_create ((kw_temporary / kw_temp))? kw_table
                      (kw_if kw_not kw_exists)?
                      qualified_table_name
                      (@punctuation{'('}
@@ -288,21 +288,21 @@ create_table_stmt <- kw_create ((kw_temporary / kw_temp))? kw_table
                        / kw_as select_stmt)
 
 # Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
-~column_def    <- @variable{bare_ident_nonkw}
+~column_def    =  @variable{bare_ident_nonkw}
                   (type_name)?
                   (column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
 # Trailing `(...)?` leniency absorbed by `*^[;]`.
-~type_name     <- @type{bare_ident_nonkw} (@type{bare_ident_nonkw})*
+~type_name     =  @type{bare_ident_nonkw} (@type{bare_ident_nonkw})*
                   (@punctuation{'('} signed_number
                        (@punctuation{','} signed_number)? @punctuation{')'})?
 
-signed_number  <- (@operator{'-'} / @operator{'+'})? @number{number_body}
+signed_number  =  (@operator{'-'} / @operator{'+'})? @number{number_body}
 
-column_constraint      <- (kw_constraint @variable{bare_ident_nonkw})? column_constraint_body
-column_constraint_body <-
+column_constraint      =  (kw_constraint @variable{bare_ident_nonkw})? column_constraint_body
+column_constraint_body =
       kw_primary kw_key ((kw_asc / kw_desc))? (conflict_clause)? (kw_autoincrement)?
     / (kw_not)? kw_null (conflict_clause)?
     / kw_unique (conflict_clause)?
@@ -313,8 +313,8 @@ column_constraint_body <-
     / (kw_generated kw_always)? kw_as @punctuation{'('} expr @punctuation{')'}
       ((kw_stored / kw_virtual))?
 
-table_constraint      <- (kw_constraint @variable{bare_ident_nonkw})? table_constraint_body
-table_constraint_body <-
+table_constraint      =  (kw_constraint @variable{bare_ident_nonkw})? table_constraint_body
+table_constraint_body =
       (kw_primary kw_key / kw_unique)
           @punctuation{'('} indexed_col_list @punctuation{')'}
           (conflict_clause)?
@@ -323,26 +323,26 @@ table_constraint_body <-
           foreign_key_clause
 
 # Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
-~foreign_key_clause <- kw_references @type{bare_ident_nonkw}
+~foreign_key_clause =  kw_references @type{bare_ident_nonkw}
                       (@punctuation{'('} ident_list @punctuation{')'})?
                       (fk_action)*
                       (fk_deferrable)?
-fk_action      <- kw_on (kw_delete / kw_update) fk_action_body
+fk_action      =  kw_on (kw_delete / kw_update) fk_action_body
                 / kw_match @variable{bare_ident_nonkw}
-fk_action_body <- kw_set (kw_null / kw_default)
+fk_action_body =  kw_set (kw_null / kw_default)
                 / kw_cascade
                 / kw_restrict
                 / kw_no kw_action
 # Trailing `(initially)?` absorbed by `*^[;]`.
-~fk_deferrable <- (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
+~fk_deferrable =  (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
 
-conflict_clause <- kw_on kw_conflict conflict_action
+conflict_clause =  kw_on kw_conflict conflict_action
 
-table_option   <- kw_without kw_rowid / kw_strict
+table_option   =  kw_without kw_rowid / kw_strict
 
-drop_table_stmt <- kw_drop kw_table (kw_if kw_exists)? qualified_table_name
+drop_table_stmt =  kw_drop kw_table (kw_if kw_exists)? qualified_table_name
 
-alter_table_stmt <- kw_alter kw_table qualified_table_name (
+alter_table_stmt =  kw_alter kw_table qualified_table_name (
       kw_rename kw_to @type{bare_ident_nonkw}
     / kw_rename (kw_column)? @variable{bare_ident_nonkw}
         kw_to @variable{bare_ident_nonkw}
@@ -353,29 +353,29 @@ alter_table_stmt <- kw_alter kw_table qualified_table_name (
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
 # Trailing `(where_clause)?` absorbed by `*^[;]`.
-~create_index_stmt <- kw_create (kw_unique)? kw_index
+~create_index_stmt =  kw_create (kw_unique)? kw_index
                      (kw_if kw_not kw_exists)?
                      qualified_table_name
                      kw_on @type{bare_ident_nonkw}
                      @punctuation{'('} indexed_col_list @punctuation{')'}
                      (where_clause)?
 
-drop_index_stmt   <- kw_drop kw_index (kw_if kw_exists)? qualified_table_name
+drop_index_stmt   =  kw_drop kw_index (kw_if kw_exists)? qualified_table_name
 
-create_view_stmt  <- kw_create ((kw_temporary / kw_temp))? kw_view
+create_view_stmt  =  kw_create ((kw_temporary / kw_temp))? kw_view
                      (kw_if kw_not kw_exists)?
                      qualified_table_name
                      (@punctuation{'('} ident_list @punctuation{')'})?
                      kw_as select_stmt
 
-drop_view_stmt    <- kw_drop kw_view (kw_if kw_exists)? qualified_table_name
+drop_view_stmt    =  kw_drop kw_view (kw_if kw_exists)? qualified_table_name
 
 # --- DDL: CREATE / DROP TRIGGER --------------------------------------
 # Trigger bodies are `;`-separated sequences of DML/SELECT wrapped in
 # BEGIN...END. The inner `;` is mandatory after each body statement,
 # which keeps the nesting disjoint from sql_file's top-level stmt_sep.
 
-create_trigger_stmt <- kw_create ((kw_temporary / kw_temp))? kw_trigger
+create_trigger_stmt =  kw_create ((kw_temporary / kw_temp))? kw_trigger
                        (kw_if kw_not kw_exists)?
                        qualified_table_name
                        ((kw_before / kw_after / kw_instead kw_of))?
@@ -386,24 +386,24 @@ create_trigger_stmt <- kw_create ((kw_temporary / kw_temp))? kw_trigger
                        kw_begin
                        (trigger_body_stmt @punctuation{';'})+
                        kw_end
-trigger_event     <- kw_delete
+trigger_event     =  kw_delete
                    / kw_insert
                    / kw_update (kw_of ident_list)?
-trigger_body_stmt <- insert_stmt / update_stmt / delete_stmt / select_stmt
+trigger_body_stmt =  insert_stmt / update_stmt / delete_stmt / select_stmt
 
-drop_trigger_stmt <- kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
+drop_trigger_stmt =  kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
 
 # --- Transactions & savepoints ---------------------------------------
 
 # Trailing `(transaction-mode)?` absorbed by `*^[;]`.
-~begin_stmt    <- kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
+~begin_stmt    =  kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
                   (kw_transaction)?
 # Trailing `(transaction)?` absorbed by `*^[;]`.
-~commit_stmt   <- (kw_commit / kw_end) (kw_transaction)?
-~rollback_stmt <- kw_rollback (kw_transaction)?
+~commit_stmt   =  (kw_commit / kw_end) (kw_transaction)?
+~rollback_stmt =  kw_rollback (kw_transaction)?
                   (kw_to (kw_savepoint)? @variable{bare_ident_nonkw})?
-savepoint_stmt <- kw_savepoint @variable{bare_ident_nonkw}
-release_stmt   <- kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
+savepoint_stmt =  kw_savepoint @variable{bare_ident_nonkw}
+release_stmt   =  kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
 
 # --- PRAGMA, admin statements, EXPLAIN, CREATE VIRTUAL TABLE ---------
 # EXPLAIN wraps statement_body rather than statement, so
@@ -413,47 +413,47 @@ release_stmt   <- kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
 # the module is invoked, not merely referenced.
 
 # Trailing `(value)?` absorbed by `*^[;]`.
-~pragma_stmt    <- kw_pragma qualified_table_name
+~pragma_stmt    =  kw_pragma qualified_table_name
                    (@operator{'='} pragma_value
                     / @punctuation{'('} pragma_value @punctuation{')'})?
-pragma_value    <- signed_number / string_lit / @variable{bare_ident}
+pragma_value    =  signed_number / string_lit / @variable{bare_ident}
 
 # Trailing `(into)?` absorbed by `*^[;]`.
-~vacuum_stmt    <- kw_vacuum (@type{bare_ident_nonkw})? (kw_into string_lit)?
+~vacuum_stmt    =  kw_vacuum (@type{bare_ident_nonkw})? (kw_into string_lit)?
 
-attach_stmt     <- kw_attach (kw_database)? expr kw_as
+attach_stmt     =  kw_attach (kw_database)? expr kw_as
                    @type{bare_ident_nonkw}
-detach_stmt     <- kw_detach (kw_database)? @type{bare_ident_nonkw}
+detach_stmt     =  kw_detach (kw_database)? @type{bare_ident_nonkw}
 
 # Trailing `(target)?` absorbed by `*^[;]`.
-~reindex_stmt   <- kw_reindex (qualified_table_name)?
-~analyze_stmt   <- kw_analyze (qualified_table_name)?
+~reindex_stmt   =  kw_reindex (qualified_table_name)?
+~analyze_stmt   =  kw_analyze (qualified_table_name)?
 
-explain_stmt    <- kw_explain (kw_query kw_plan)? statement_body
+explain_stmt    =  kw_explain (kw_query kw_plan)? statement_body
 
 # Trailing `(args)?` absorbed by `*^[;]`.
-~create_virtual_table_stmt <-
+~create_virtual_table_stmt =
     kw_create kw_virtual kw_table
     (kw_if kw_not kw_exists)?
     qualified_table_name
     kw_using @function{bare_ident_nonkw}
     (@punctuation{'('} vtab_args? @punctuation{')'})?
-vtab_args       <- vtab_arg (@punctuation{','} vtab_arg)*
+vtab_args       =  vtab_arg (@punctuation{','} vtab_arg)*
 # Module args are deliberately permissive — fts5/rtree/etc have
 # module-specific mini-grammars that are not worth modelling.
-vtab_arg        <- (!@punctuation{','} !@punctuation{')'} .)+
+vtab_arg        =  (!@punctuation{','} !@punctuation{')'} .)+
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
 # matches the next-higher level or chains several of them with an
 # operator. No shared-prefix issues between levels.
 
-expr        <- or_expr
-or_expr     <- and_expr (kw_or and_expr)*
-and_expr    <- not_expr (kw_and not_expr)*
-not_expr    <- kw_not not_expr / cmp_expr
-cmp_expr    <- bit_expr cmp_tail*
-cmp_tail    <- kw_is (kw_not)? bit_expr
+expr        =  or_expr
+or_expr     =  and_expr (kw_or and_expr)*
+and_expr    =  not_expr (kw_and not_expr)*
+not_expr    =  kw_not not_expr / cmp_expr
+cmp_expr    =  bit_expr cmp_tail*
+cmp_tail    =  kw_is (kw_not)? bit_expr
              / (kw_not)? kw_between bit_expr kw_and bit_expr
              / (kw_not)? kw_in @punctuation{'('} in_args? @punctuation{')'}
              / (kw_not)? kw_like bit_expr (kw_escape bit_expr)?
@@ -461,24 +461,24 @@ cmp_tail    <- kw_is (kw_not)? bit_expr
              / (kw_not)? kw_match bit_expr
              / (kw_not)? kw_regexp bit_expr
              / cmp_op bit_expr
-in_args     <- select_stmt / expr (@punctuation{','} expr)*
-cmp_op      <- @operator{'=='} / @operator{'<='} / @operator{'>='}
+in_args     =  select_stmt / expr (@punctuation{','} expr)*
+cmp_op      =  @operator{'=='} / @operator{'<='} / @operator{'>='}
              / @operator{'!='} / @operator{'<>'} / @operator{'='}
              / @operator{'<'} / @operator{'>'}
-bit_expr    <- add_expr (bit_op add_expr)*
-bit_op      <- @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
-add_expr    <- mul_expr (add_op mul_expr)*
-add_op      <- @operator{'+'} / @operator{'-'}
-mul_expr    <- concat_expr (mul_op concat_expr)*
-mul_op      <- @operator{'*'} / @operator{'/'} / @operator{'%'}
-concat_expr <- unary_expr (@operator{'||'} unary_expr)*
-unary_expr  <- (@operator{'-'} / @operator{'+'} / @operator{'~'}) unary_expr
+bit_expr    =  add_expr (bit_op add_expr)*
+bit_op      =  @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
+add_expr    =  mul_expr (add_op mul_expr)*
+add_op      =  @operator{'+'} / @operator{'-'}
+mul_expr    =  concat_expr (mul_op concat_expr)*
+mul_op      =  @operator{'*'} / @operator{'/'} / @operator{'%'}
+concat_expr =  unary_expr (@operator{'||'} unary_expr)*
+unary_expr  =  (@operator{'-'} / @operator{'+'} / @operator{'~'}) unary_expr
              / primary
 
 # Shared-prefix hotspots: function_call / qualified_column_ref /
 # column_ref_bare all start with an identifier — the classic packrat
 # motivator.
-primary     <- literal
+primary     =  literal
              / case_expr
              / cast_expr
              / exists_expr
@@ -488,55 +488,55 @@ primary     <- literal
              / column_ref_bare
              / bind_param
 
-paren_primary <- @punctuation{'('} (select_stmt / expr) @punctuation{')'}
+paren_primary =  @punctuation{'('} (select_stmt / expr) @punctuation{')'}
 
 # Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
-~function_call <- @function{bare_ident_nonkw} @punctuation{'('} func_args? @punctuation{')'}
+~function_call =  @function{bare_ident_nonkw} @punctuation{'('} func_args? @punctuation{')'}
                  (filter_clause)?
                  (kw_over window_ref)?
-func_args   <- @operator{'*'}
+func_args   =  @operator{'*'}
              / (kw_distinct)? expr (@punctuation{','} expr)*
 
-qualified_column_ref <- @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
-column_ref_bare      <- @variable{bare_ident_nonkw}
+qualified_column_ref =  @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
+column_ref_bare      =  @variable{bare_ident_nonkw}
 
-case_expr   <- kw_case (expr)? (when_clause)+ (kw_else expr)? kw_end
-when_clause <- kw_when expr kw_then expr
+case_expr   =  kw_case (expr)? (when_clause)+ (kw_else expr)? kw_end
+when_clause =  kw_when expr kw_then expr
 
-cast_expr   <- kw_cast @punctuation{'('} expr kw_as @type{bare_ident} @punctuation{')'}
+cast_expr   =  kw_cast @punctuation{'('} expr kw_as @type{bare_ident} @punctuation{')'}
 
-exists_expr <- kw_exists @punctuation{'('} select_stmt @punctuation{')'}
+exists_expr =  kw_exists @punctuation{'('} select_stmt @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 # Order matters: blob before string (X' prefix consumed first); number
 # tries hex / float / int in that order inside number_body.
 
-literal     <- blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
+literal     =  blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
 
-%null_lit    <- @constant{null_body}
-%bool_lit    <- @constant{bool_body}
-*null_body   <- i"null"
-*bool_body   <- i"true" / i"false"
+%null_lit    =  @constant{null_body}
+%bool_lit    =  @constant{bool_body}
+*null_body   =  i"null"
+*bool_body   =  i"true" / i"false"
 
-*blob_lit    <- @string{blob_body}
-*blob_body   <- [xX] "'" [\da-fA-F]* "'"
-*string_lit  <- @string{string_body}
-*string_body <- "'" ("''" / !"'" .)* "'"
+*blob_lit    =  @string{blob_body}
+*blob_body   =  [xX] "'" [\da-fA-F]* "'"
+*string_lit  =  @string{string_body}
+*string_body =  "'" ("''" / !"'" .)* "'"
 
 # Hex is a `%` rule so the compiler appends the `wb` boundary: hex
 # digits include a-f, so a hex run can butt against identifier chars
 # (`0x1Fg` must fall back to `0` + `x1Fg`, not lex `0x1F`). float/int
 # use `\d`, which can't, so they carry no boundary.
-number_body <- hex_body / float_body / int_body
-%hex_body   <- '0x' [\da-fA-F]+
-*float_body <- \d+ '.' \d+ ([eE] [+\-]? \d+)?
+number_body =  hex_body / float_body / int_body
+%hex_body   =  '0x' [\da-fA-F]+
+*float_body =  \d+ '.' \d+ ([eE] [+\-]? \d+)?
             / \d+ [eE] [+\-]? \d+
-*int_body   <- \d+
+*int_body   =  \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.
-*bind_param  <- @variable{bind_body}
-*bind_body   <- '?' \d*
+*bind_param  =  @variable{bind_body}
+*bind_body   =  '?' \d*
              / [:@$] ident_start ident_cont*
 
 # --- Identifiers ------------------------------------------------------
@@ -547,20 +547,20 @@ number_body <- hex_body / float_body / int_body
 # names and CTE heads where a keyword like INTEGER is actually the
 # content we want to capture as @type).
 
-*bare_ident_nonkw  <- quoted_ident / !reserved bare_raw
-*bare_ident        <- quoted_ident / bare_raw
-*quoted_ident      <- double_quoted_id / backtick_id / bracket_id
+*bare_ident_nonkw  =  quoted_ident / !reserved bare_raw
+*bare_ident        =  quoted_ident / bare_raw
+*quoted_ident      =  double_quoted_id / backtick_id / bracket_id
 
-*bare_raw          <- ident_start ident_cont*
+*bare_raw          =  ident_start ident_cont*
 # Per sqlite.org/draft/tokenreq.html ALPHABETIC + ALPHANUMERIC: the
 # ASCII letter/underscore range, the ASCII digits (continuation only),
 # `$` (continuation only), plus any code point above U+007F.
-*ident_start       <- [a-zA-Z_\u{80}-\u{10FFFF}]
-*ident_cont        <- [a-zA-Z\d_$\u{80}-\u{10FFFF}]
+*ident_start       =  [a-zA-Z_\u{80}-\u{10FFFF}]
+*ident_cont        =  [a-zA-Z\d_$\u{80}-\u{10FFFF}]
 
-*double_quoted_id  <- '"' ('""' / !'"' !\R .)* '"'
-*backtick_id       <- '`' ('``' / !'`' !\R .)* '`'
-*bracket_id        <- '[' .. (']' / \R) ']'
+*double_quoted_id  =  '"' ('""' / !'"' !\R .)* '"'
+*backtick_id       =  '`' ('``' / !'`' !\R .)* '`'
+*bracket_id        =  '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Each kw_* is a `%` reserved-word rule: the compiler appends a `wb`
@@ -568,155 +568,155 @@ number_body <- hex_body / float_body / int_body
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.
 
-%kw_select    <- @keyword{i"select"}
-%kw_from      <- @keyword{i"from"}
-%kw_where     <- @keyword{i"where"}
-%kw_group     <- @keyword{i"group"}
-%kw_by        <- @keyword{i"by"}
-%kw_having    <- @keyword{i"having"}
-%kw_order     <- @keyword{i"order"}
-%kw_asc       <- @keyword{i"asc"}
-%kw_desc      <- @keyword{i"desc"}
-%kw_limit     <- @keyword{i"limit"}
-%kw_offset    <- @keyword{i"offset"}
-%kw_join      <- @keyword{i"join"}
-%kw_inner     <- @keyword{i"inner"}
-%kw_left      <- @keyword{i"left"}
-%kw_right     <- @keyword{i"right"}
-%kw_full      <- @keyword{i"full"}
-%kw_outer     <- @keyword{i"outer"}
-%kw_cross     <- @keyword{i"cross"}
-%kw_natural   <- @keyword{i"natural"}
-%kw_on        <- @keyword{i"on"}
-%kw_using     <- @keyword{i"using"}
-%kw_as        <- @keyword{i"as"}
-%kw_distinct  <- @keyword{i"distinct"}
-%kw_all       <- @keyword{i"all"}
-%kw_union     <- @keyword{i"union"}
-%kw_intersect <- @keyword{i"intersect"}
-%kw_except    <- @keyword{i"except"}
-%kw_with      <- @keyword{i"with"}
-%kw_and       <- @keyword{i"and"}
-%kw_or        <- @keyword{i"or"}
-%kw_not       <- @keyword{i"not"}
-%kw_is        <- @keyword{i"is"}
-%kw_in        <- @keyword{i"in"}
-%kw_like      <- @keyword{i"like"}
-%kw_glob      <- @keyword{i"glob"}
-%kw_match     <- @keyword{i"match"}
-%kw_regexp    <- @keyword{i"regexp"}
-%kw_between   <- @keyword{i"between"}
-%kw_escape    <- @keyword{i"escape"}
-%kw_case      <- @keyword{i"case"}
-%kw_when      <- @keyword{i"when"}
-%kw_then      <- @keyword{i"then"}
-%kw_else      <- @keyword{i"else"}
-%kw_end       <- @keyword{i"end"}
-%kw_cast      <- @keyword{i"cast"}
-%kw_exists    <- @keyword{i"exists"}
-%kw_collate   <- @keyword{i"collate"}
+%kw_select    =  @keyword{i"select"}
+%kw_from      =  @keyword{i"from"}
+%kw_where     =  @keyword{i"where"}
+%kw_group     =  @keyword{i"group"}
+%kw_by        =  @keyword{i"by"}
+%kw_having    =  @keyword{i"having"}
+%kw_order     =  @keyword{i"order"}
+%kw_asc       =  @keyword{i"asc"}
+%kw_desc      =  @keyword{i"desc"}
+%kw_limit     =  @keyword{i"limit"}
+%kw_offset    =  @keyword{i"offset"}
+%kw_join      =  @keyword{i"join"}
+%kw_inner     =  @keyword{i"inner"}
+%kw_left      =  @keyword{i"left"}
+%kw_right     =  @keyword{i"right"}
+%kw_full      =  @keyword{i"full"}
+%kw_outer     =  @keyword{i"outer"}
+%kw_cross     =  @keyword{i"cross"}
+%kw_natural   =  @keyword{i"natural"}
+%kw_on        =  @keyword{i"on"}
+%kw_using     =  @keyword{i"using"}
+%kw_as        =  @keyword{i"as"}
+%kw_distinct  =  @keyword{i"distinct"}
+%kw_all       =  @keyword{i"all"}
+%kw_union     =  @keyword{i"union"}
+%kw_intersect =  @keyword{i"intersect"}
+%kw_except    =  @keyword{i"except"}
+%kw_with      =  @keyword{i"with"}
+%kw_and       =  @keyword{i"and"}
+%kw_or        =  @keyword{i"or"}
+%kw_not       =  @keyword{i"not"}
+%kw_is        =  @keyword{i"is"}
+%kw_in        =  @keyword{i"in"}
+%kw_like      =  @keyword{i"like"}
+%kw_glob      =  @keyword{i"glob"}
+%kw_match     =  @keyword{i"match"}
+%kw_regexp    =  @keyword{i"regexp"}
+%kw_between   =  @keyword{i"between"}
+%kw_escape    =  @keyword{i"escape"}
+%kw_case      =  @keyword{i"case"}
+%kw_when      =  @keyword{i"when"}
+%kw_then      =  @keyword{i"then"}
+%kw_else      =  @keyword{i"else"}
+%kw_end       =  @keyword{i"end"}
+%kw_cast      =  @keyword{i"cast"}
+%kw_exists    =  @keyword{i"exists"}
+%kw_collate   =  @keyword{i"collate"}
 
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-%?kw_recursive<- @keyword{i"recursive"}
-%kw_window    <- @keyword{i"window"}
-%kw_over      <- @keyword{i"over"}
-%?kw_filter   <- @keyword{i"filter"}
-%?kw_partition<- @keyword{i"partition"}
-%?kw_range    <- @keyword{i"range"}
-%?kw_rows     <- @keyword{i"rows"}
-%?kw_groups   <- @keyword{i"groups"}
-%?kw_unbounded<- @keyword{i"unbounded"}
-%?kw_preceding<- @keyword{i"preceding"}
-%?kw_following<- @keyword{i"following"}
-%?kw_current  <- @keyword{i"current"}
-%?kw_row      <- @keyword{i"row"}
-%?kw_exclude  <- @keyword{i"exclude"}
-%?kw_ties     <- @keyword{i"ties"}
-%?kw_others   <- @keyword{i"others"}
-%kw_no        <- @keyword{i"no"}
+%?kw_recursive=  @keyword{i"recursive"}
+%kw_window    =  @keyword{i"window"}
+%kw_over      =  @keyword{i"over"}
+%?kw_filter   =  @keyword{i"filter"}
+%?kw_partition=  @keyword{i"partition"}
+%?kw_range    =  @keyword{i"range"}
+%?kw_rows     =  @keyword{i"rows"}
+%?kw_groups   =  @keyword{i"groups"}
+%?kw_unbounded=  @keyword{i"unbounded"}
+%?kw_preceding=  @keyword{i"preceding"}
+%?kw_following=  @keyword{i"following"}
+%?kw_current  =  @keyword{i"current"}
+%?kw_row      =  @keyword{i"row"}
+%?kw_exclude  =  @keyword{i"exclude"}
+%?kw_ties     =  @keyword{i"ties"}
+%?kw_others   =  @keyword{i"others"}
+%kw_no        =  @keyword{i"no"}
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
 # rule goes here so UPSERT's DO UPDATE path can use it now.
-%kw_insert    <- @keyword{i"insert"}
-%kw_replace   <- @keyword{i"replace"}
-%kw_into      <- @keyword{i"into"}
-%kw_values    <- @keyword{i"values"}
-%kw_default   <- @keyword{i"default"}
-%kw_conflict  <- @keyword{i"conflict"}
-%?kw_do       <- @keyword{i"do"}
-%kw_nothing   <- @keyword{i"nothing"}
-%kw_rollback  <- @keyword{i"rollback"}
-%kw_abort     <- @keyword{i"abort"}
-%kw_fail      <- @keyword{i"fail"}
-%kw_ignore    <- @keyword{i"ignore"}
-%kw_set       <- @keyword{i"set"}
-%kw_returning <- @keyword{i"returning"}
-%kw_update    <- @keyword{i"update"}
-%kw_delete    <- @keyword{i"delete"}
+%kw_insert    =  @keyword{i"insert"}
+%kw_replace   =  @keyword{i"replace"}
+%kw_into      =  @keyword{i"into"}
+%kw_values    =  @keyword{i"values"}
+%kw_default   =  @keyword{i"default"}
+%kw_conflict  =  @keyword{i"conflict"}
+%?kw_do       =  @keyword{i"do"}
+%kw_nothing   =  @keyword{i"nothing"}
+%kw_rollback  =  @keyword{i"rollback"}
+%kw_abort     =  @keyword{i"abort"}
+%kw_fail      =  @keyword{i"fail"}
+%kw_ignore    =  @keyword{i"ignore"}
+%kw_set       =  @keyword{i"set"}
+%kw_returning =  @keyword{i"returning"}
+%kw_update    =  @keyword{i"update"}
+%kw_delete    =  @keyword{i"delete"}
 
 # DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
-%kw_create    <- @keyword{i"create"}
-%kw_table     <- @keyword{i"table"}
-%kw_alter     <- @keyword{i"alter"}
-%kw_drop      <- @keyword{i"drop"}
-%kw_rename    <- @keyword{i"rename"}
-%kw_add       <- @keyword{i"add"}
-%kw_column    <- @keyword{i"column"}
-%kw_if        <- @keyword{i"if"}
-%kw_temp      <- @keyword{i"temp"}
-%kw_temporary <- @keyword{i"temporary"}
-%kw_primary   <- @keyword{i"primary"}
-%?kw_key      <- @keyword{i"key"}
-%kw_unique    <- @keyword{i"unique"}
-%kw_check     <- @keyword{i"check"}
-%kw_null      <- @keyword{i"null"}
-%kw_references <- @keyword{i"references"}
-%kw_generated <- @keyword{i"generated"}
-%kw_always    <- @keyword{i"always"}
-%kw_stored    <- @keyword{i"stored"}
-%kw_virtual   <- @keyword{i"virtual"}
-%kw_constraint<- @keyword{i"constraint"}
-%kw_foreign   <- @keyword{i"foreign"}
-%kw_action    <- @keyword{i"action"}
-%kw_cascade   <- @keyword{i"cascade"}
-%kw_restrict  <- @keyword{i"restrict"}
-%kw_deferrable<- @keyword{i"deferrable"}
-%kw_initially <- @keyword{i"initially"}
-%kw_immediate <- @keyword{i"immediate"}
-%kw_deferred  <- @keyword{i"deferred"}
-%kw_autoincrement <- @keyword{i"autoincrement"}
-%kw_rowid     <- @keyword{i"rowid"}
-%kw_strict    <- @keyword{i"strict"}
-%kw_without   <- @keyword{i"without"}
-%kw_to        <- @keyword{i"to"}
-%kw_index     <- @keyword{i"index"}
-%kw_view      <- @keyword{i"view"}
-%kw_trigger   <- @keyword{i"trigger"}
-%kw_before    <- @keyword{i"before"}
-%kw_after     <- @keyword{i"after"}
-%kw_instead   <- @keyword{i"instead"}
-%kw_of        <- @keyword{i"of"}
-%kw_for       <- @keyword{i"for"}
-%kw_each      <- @keyword{i"each"}
-%kw_begin     <- @keyword{i"begin"}
-%kw_commit    <- @keyword{i"commit"}
-%kw_transaction <- @keyword{i"transaction"}
-%kw_savepoint <- @keyword{i"savepoint"}
-%kw_release   <- @keyword{i"release"}
-%kw_exclusive <- @keyword{i"exclusive"}
-%kw_pragma    <- @keyword{i"pragma"}
-%kw_vacuum    <- @keyword{i"vacuum"}
-%kw_attach    <- @keyword{i"attach"}
-%kw_detach    <- @keyword{i"detach"}
-%kw_database  <- @keyword{i"database"}
-%kw_reindex   <- @keyword{i"reindex"}
-%kw_analyze   <- @keyword{i"analyze"}
-%kw_explain   <- @keyword{i"explain"}
-%kw_query     <- @keyword{i"query"}
-%kw_plan      <- @keyword{i"plan"}
+%kw_create    =  @keyword{i"create"}
+%kw_table     =  @keyword{i"table"}
+%kw_alter     =  @keyword{i"alter"}
+%kw_drop      =  @keyword{i"drop"}
+%kw_rename    =  @keyword{i"rename"}
+%kw_add       =  @keyword{i"add"}
+%kw_column    =  @keyword{i"column"}
+%kw_if        =  @keyword{i"if"}
+%kw_temp      =  @keyword{i"temp"}
+%kw_temporary =  @keyword{i"temporary"}
+%kw_primary   =  @keyword{i"primary"}
+%?kw_key      =  @keyword{i"key"}
+%kw_unique    =  @keyword{i"unique"}
+%kw_check     =  @keyword{i"check"}
+%kw_null      =  @keyword{i"null"}
+%kw_references =  @keyword{i"references"}
+%kw_generated =  @keyword{i"generated"}
+%kw_always    =  @keyword{i"always"}
+%kw_stored    =  @keyword{i"stored"}
+%kw_virtual   =  @keyword{i"virtual"}
+%kw_constraint=  @keyword{i"constraint"}
+%kw_foreign   =  @keyword{i"foreign"}
+%kw_action    =  @keyword{i"action"}
+%kw_cascade   =  @keyword{i"cascade"}
+%kw_restrict  =  @keyword{i"restrict"}
+%kw_deferrable=  @keyword{i"deferrable"}
+%kw_initially =  @keyword{i"initially"}
+%kw_immediate =  @keyword{i"immediate"}
+%kw_deferred  =  @keyword{i"deferred"}
+%kw_autoincrement =  @keyword{i"autoincrement"}
+%kw_rowid     =  @keyword{i"rowid"}
+%kw_strict    =  @keyword{i"strict"}
+%kw_without   =  @keyword{i"without"}
+%kw_to        =  @keyword{i"to"}
+%kw_index     =  @keyword{i"index"}
+%kw_view      =  @keyword{i"view"}
+%kw_trigger   =  @keyword{i"trigger"}
+%kw_before    =  @keyword{i"before"}
+%kw_after     =  @keyword{i"after"}
+%kw_instead   =  @keyword{i"instead"}
+%kw_of        =  @keyword{i"of"}
+%kw_for       =  @keyword{i"for"}
+%kw_each      =  @keyword{i"each"}
+%kw_begin     =  @keyword{i"begin"}
+%kw_commit    =  @keyword{i"commit"}
+%kw_transaction =  @keyword{i"transaction"}
+%kw_savepoint =  @keyword{i"savepoint"}
+%kw_release   =  @keyword{i"release"}
+%kw_exclusive =  @keyword{i"exclusive"}
+%kw_pragma    =  @keyword{i"pragma"}
+%kw_vacuum    =  @keyword{i"vacuum"}
+%kw_attach    =  @keyword{i"attach"}
+%kw_detach    =  @keyword{i"detach"}
+%kw_database  =  @keyword{i"database"}
+%kw_reindex   =  @keyword{i"reindex"}
+%kw_analyze   =  @keyword{i"analyze"}
+%kw_explain   =  @keyword{i"explain"}
+%kw_query     =  @keyword{i"query"}
+%kw_plan      =  @keyword{i"plan"}
 
 # --- Whitespace & comments -------------------------------------------
 
-*comment       <- @comment{'--' .. \R / '/*' ..= '*/'}
+*comment       =  @comment{'--' .. \R / '/*' ..= '*/'}

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -53,98 +53,98 @@
 
 # --- Top level --------------------------------------------------------
 
-root       =  (statement stmt_sep?)*^[;]
+root = (statement stmt_sep?)*^[;]
 
-trivia    =  (comment / \s)*
+trivia = (comment / \s)*
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Matches the full identifier-continue
 # class (`ident_cont`, Unicode included).
-wb        =  !ident_cont
-stmt_sep   =  @punctuation{';'}
-statement       =  explain_stmt / statement_body
-statement_body  =  select_stmt
-                 / insert_stmt
-                 / update_stmt
-                 / delete_stmt
-                 / create_virtual_table_stmt
-                 / create_table_stmt
-                 / create_index_stmt
-                 / create_view_stmt
-                 / create_trigger_stmt
-                 / drop_table_stmt
-                 / drop_index_stmt
-                 / drop_view_stmt
-                 / drop_trigger_stmt
-                 / alter_table_stmt
-                 / begin_stmt
-                 / commit_stmt
-                 / rollback_stmt
-                 / savepoint_stmt
-                 / release_stmt
-                 / pragma_stmt
-                 / vacuum_stmt
-                 / attach_stmt
-                 / detach_stmt
-                 / reindex_stmt
-                 / analyze_stmt
+wb = !ident_cont
+stmt_sep = @punctuation{';'}
+statement = explain_stmt / statement_body
+statement_body = select_stmt
+               / insert_stmt
+               / update_stmt
+               / delete_stmt
+               / create_virtual_table_stmt
+               / create_table_stmt
+               / create_index_stmt
+               / create_view_stmt
+               / create_trigger_stmt
+               / drop_table_stmt
+               / drop_index_stmt
+               / drop_view_stmt
+               / drop_trigger_stmt
+               / alter_table_stmt
+               / begin_stmt
+               / commit_stmt
+               / rollback_stmt
+               / savepoint_stmt
+               / release_stmt
+               / pragma_stmt
+               / vacuum_stmt
+               / attach_stmt
+               / detach_stmt
+               / reindex_stmt
+               / analyze_stmt
 
 # --- SELECT statement -------------------------------------------------
 
 # Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
-~select_stmt   =  with_clause? select_core compound_tail* order_clause? limit_clause?
+~select_stmt = with_clause? select_core compound_tail* order_clause? limit_clause?
 
-with_clause    =  kw_with (kw_recursive)? cte_defn (@punctuation{','} cte_defn)*
-cte_defn       =  @type{bare_ident}
-                  (@punctuation{'('} ident_list @punctuation{')'})?
-                  kw_as @punctuation{'('} select_stmt @punctuation{')'}
+with_clause = kw_with (kw_recursive)? cte_defn (@punctuation{','} cte_defn)*
+cte_defn = @type{bare_ident}
+           (@punctuation{'('} ident_list @punctuation{')'})?
+           kw_as @punctuation{'('} select_stmt @punctuation{')'}
 
 # Trailing `(window_clause)?` absorbed by `*^[;]`.
-~select_core   =  kw_select ((kw_distinct / kw_all))? result_list
-                  (from_clause)? (where_clause)? (group_clause)? (having_clause)?
-                  (window_clause)?
+~select_core = kw_select ((kw_distinct / kw_all))? result_list
+               (from_clause)? (where_clause)? (group_clause)? (having_clause)?
+               (window_clause)?
 
-result_list    =  result_column (@punctuation{','} result_column)*
+result_list = result_column (@punctuation{','} result_column)*
 # A column expression that didn't reach a known boundary is treated
 # as malformed. The `^^bad_column (result_column_boundary)`
 # operator anchors the inner branch on the boundary (so e.g.
 # `blob.rid IN leaf` fails because `IN` isn't in the boundary set)
 # and synthesizes the recovery body `(!(result_column_boundary) .)*`
 # from the same argument.
-result_column  =  (table_star / @operator{'*'} / aliased_expr)
-                  ^^bad_column (result_column_boundary)
-result_column_boundary =  @punctuation{','} / @punctuation{')'} / @punctuation{';'}
-                        / kw_from / kw_where / kw_group / kw_having
-                        / kw_order / kw_limit / kw_offset / kw_window
-                        / kw_union / kw_intersect / kw_except
-                        / !.
-table_star     =  @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
-aliased_expr   =  expr (kw_as @variable{bare_ident_nonkw}
-                      / @variable{bare_ident_nonkw})?
+result_column = (table_star / @operator{'*'} / aliased_expr)
+                ^^bad_column (result_column_boundary)
+result_column_boundary = @punctuation{','} / @punctuation{')'} / @punctuation{';'}
+                       / kw_from / kw_where / kw_group / kw_having
+                       / kw_order / kw_limit / kw_offset / kw_window
+                       / kw_union / kw_intersect / kw_except
+                       / !.
+table_star = @type{bare_ident_nonkw} @punctuation{'.'} @operator{'*'}
+aliased_expr = expr (kw_as @variable{bare_ident_nonkw}
+                   / @variable{bare_ident_nonkw})?
 
-compound_tail  =  (kw_union (kw_all)? / kw_intersect / kw_except) select_core
+compound_tail = (kw_union (kw_all)? / kw_intersect / kw_except) select_core
 
-from_clause    =  kw_from table_or_subquery (join_clause)*
-table_or_subquery =  @punctuation{'('} select_stmt @punctuation{')'} (table_alias)?
-                   / qualified_table_name (table_alias)?
+from_clause = kw_from table_or_subquery (join_clause)*
+table_or_subquery = @punctuation{'('} select_stmt @punctuation{')'} (table_alias)?
+                  / qualified_table_name (table_alias)?
 # Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
-~qualified_table_name =  @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
-table_alias    =  kw_as @variable{bare_ident_nonkw}
-                / @variable{bare_ident_nonkw}
+~qualified_table_name = @type{bare_ident_nonkw} (@punctuation{'.'} @type{bare_ident_nonkw})?
+table_alias = kw_as @variable{bare_ident_nonkw}
+            / @variable{bare_ident_nonkw}
 
 # Trailing `(join_constraint)?` absorbed by `*^[;]`.
-~join_clause   =  join_op table_or_subquery (join_constraint)?
-join_op        =  @punctuation{','}
-                / kw_natural (join_type)? kw_join
-                / join_type kw_join
-                / kw_join
-join_type      =  kw_left (kw_outer)?
-                / kw_right (kw_outer)?
-                / kw_full (kw_outer)?
-                / kw_inner
-                / kw_cross
-join_constraint=  kw_on expr
+~join_clause = join_op table_or_subquery (join_constraint)?
+join_op = @punctuation{','}
+        / kw_natural (join_type)? kw_join
+        / join_type kw_join
+        / kw_join
+join_type = kw_left (kw_outer)?
+          / kw_right (kw_outer)?
+          / kw_full (kw_outer)?
+          / kw_inner
+          / kw_cross
+join_constraint = kw_on expr
                 / kw_using @punctuation{'('} ident_list @punctuation{')'}
-ident_list     =  @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_ident_nonkw})*
+ident_list = @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_ident_nonkw})*
 
 # Like `result_column`, `where_clause` uses `^^bad_where` to turn
 # partial-parse leftovers (e.g. `WHERE x NOT IN phantom ORDER BY …`
@@ -152,22 +152,22 @@ ident_list     =  @variable{bare_ident_nonkw} (@punctuation{','} @variable{bare_
 # The operator sits *inside* the `kw_where` match so a missing WHERE
 # keyword still fails the rule cleanly (no spurious empty recovery
 # captures on clean SELECTs).
-where_clause   =  kw_where (expr ^^bad_where (where_clause_boundary))
-where_clause_boundary =  @punctuation{')'} / @punctuation{';'}
-                       / kw_group / kw_having / kw_order / kw_limit
-                       / kw_offset / kw_window / kw_returning
-                       / kw_union / kw_intersect / kw_except
-                       / !.
-group_clause   =  kw_group kw_by expr (@punctuation{','} expr)*
-having_clause  =  kw_having expr
+where_clause = kw_where (expr ^^bad_where (where_clause_boundary))
+where_clause_boundary = @punctuation{')'} / @punctuation{';'}
+                      / kw_group / kw_having / kw_order / kw_limit
+                      / kw_offset / kw_window / kw_returning
+                      / kw_union / kw_intersect / kw_except
+                      / !.
+group_clause = kw_group kw_by expr (@punctuation{','} expr)*
+having_clause = kw_having expr
 
-order_clause   =  kw_order kw_by order_item (@punctuation{','} order_item)*
+order_clause = kw_order kw_by order_item (@punctuation{','} order_item)*
 # Trailing `(asc/desc)?` absorbed by `*^[;]`.
-~order_item    =  expr ((kw_asc / kw_desc))?
+~order_item = expr ((kw_asc / kw_desc))?
 
 # Trailing `(offset)?` absorbed by `*^[;]`.
-~limit_clause  =  kw_limit expr (kw_offset expr
-                                      / @punctuation{','} expr)?
+~limit_clause = kw_limit expr (kw_offset expr
+                                    / @punctuation{','} expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
 # Not counted as reserved keywords in SQLite aside from WINDOW and
@@ -176,77 +176,77 @@ order_clause   =  kw_order kw_by order_item (@punctuation{','} order_item)*
 # are matched positionally here, so existing SELECTs that use any of
 # those as identifiers keep working.
 
-window_clause  =  kw_window named_window (@punctuation{','} named_window)*
-named_window   =  @variable{bare_ident_nonkw} kw_as window_defn
+window_clause = kw_window named_window (@punctuation{','} named_window)*
+named_window = @variable{bare_ident_nonkw} kw_as window_defn
 
-filter_clause  =  kw_filter @punctuation{'('} kw_where expr @punctuation{')'}
+filter_clause = kw_filter @punctuation{'('} kw_where expr @punctuation{')'}
 
-window_defn    =  @punctuation{'('}
-                      (!window_section_keyword @variable{bare_ident_nonkw})?
-                      (kw_partition kw_by expr (@punctuation{','} expr)*)?
-                      (window_order_body)?
-                      (frame_spec)? @punctuation{')'}
+window_defn = @punctuation{'('}
+                  (!window_section_keyword @variable{bare_ident_nonkw})?
+                  (kw_partition kw_by expr (@punctuation{','} expr)*)?
+                  (window_order_body)?
+                  (frame_spec)? @punctuation{')'}
 # Guard the optional base-window-name slot against consuming a keyword
 # that actually starts the next positional section (PARTITION / ORDER /
 # RANGE / ROWS / GROUPS). Without the lookahead, PEG would eat
 # `PARTITION` as a bare identifier and then fail on the partition clause.
-window_section_keyword =  kw_partition / kw_order / kw_range / kw_rows / kw_groups
-window_order_body =  kw_order kw_by order_item (@punctuation{','} order_item)*
-window_ref     =  window_defn / @variable{bare_ident_nonkw}
+window_section_keyword = kw_partition / kw_order / kw_range / kw_rows / kw_groups
+window_order_body = kw_order kw_by order_item (@punctuation{','} order_item)*
+window_ref = window_defn / @variable{bare_ident_nonkw}
 
-frame_spec     =  (kw_range / kw_rows / kw_groups)
-                  (kw_between frame_bound kw_and frame_bound
-                   / frame_bound)
-                  (kw_exclude frame_exclude)?
-frame_bound    =  kw_unbounded (kw_preceding / kw_following)
-                / kw_current kw_row
-                / expr (kw_preceding / kw_following)
-frame_exclude  =  kw_no kw_others
-                / kw_current kw_row
-                / kw_group
-                / kw_ties
+frame_spec = (kw_range / kw_rows / kw_groups)
+             (kw_between frame_bound kw_and frame_bound
+              / frame_bound)
+             (kw_exclude frame_exclude)?
+frame_bound = kw_unbounded (kw_preceding / kw_following)
+            / kw_current kw_row
+            / expr (kw_preceding / kw_following)
+frame_exclude = kw_no kw_others
+              / kw_current kw_row
+              / kw_group
+              / kw_ties
 
 # --- DML: INSERT ------------------------------------------------------
 # UPSERT's DO UPDATE path and UPDATE (added in a later commit) share
 # `update_set_list`, which is defined here.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~insert_stmt   =  with_clause? insert_prefix kw_into qualified_table_name
-                  (kw_as @variable{bare_ident_nonkw})?
-                  (@punctuation{'('} ident_list @punctuation{')'})?
-                  insert_source
-                  (upsert_clause)*
-                  (returning_clause)?
+~insert_stmt = with_clause? insert_prefix kw_into qualified_table_name
+               (kw_as @variable{bare_ident_nonkw})?
+               (@punctuation{'('} ident_list @punctuation{')'})?
+               insert_source
+               (upsert_clause)*
+               (returning_clause)?
 
-insert_prefix  =  kw_insert (kw_or conflict_action)?
-                / kw_replace
+insert_prefix = kw_insert (kw_or conflict_action)?
+              / kw_replace
 
-insert_source  =  kw_default kw_values
-                / kw_values values_row (@punctuation{','} values_row)*
-                / select_stmt
-values_row     =  @punctuation{'('} expr (@punctuation{','} expr)* @punctuation{')'}
+insert_source = kw_default kw_values
+              / kw_values values_row (@punctuation{','} values_row)*
+              / select_stmt
+values_row = @punctuation{'('} expr (@punctuation{','} expr)* @punctuation{')'}
 
-conflict_action =  kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
+conflict_action = kw_rollback / kw_abort / kw_fail / kw_ignore / kw_replace
 
-upsert_clause  =  kw_on kw_conflict
-                  (@punctuation{'('} indexed_col_list @punctuation{')'} (where_clause)?)?
-                  kw_do (kw_nothing
-                             / kw_update kw_set update_set_list (where_clause)?)
+upsert_clause = kw_on kw_conflict
+                (@punctuation{'('} indexed_col_list @punctuation{')'} (where_clause)?)?
+                kw_do (kw_nothing
+                           / kw_update kw_set update_set_list (where_clause)?)
 
-indexed_col_list =  indexed_col (@punctuation{','} indexed_col)*
-indexed_col      =  expr (kw_collate @type{bare_ident})? ((kw_asc / kw_desc))?
+indexed_col_list = indexed_col (@punctuation{','} indexed_col)*
+indexed_col = expr (kw_collate @type{bare_ident})? ((kw_asc / kw_desc))?
 
-update_set_list =  update_set_item (@punctuation{','} update_set_item)*
-update_set_item =  @variable{bare_ident_nonkw} @operator{'='} expr
-                 / @punctuation{'('} ident_list @punctuation{')'} @operator{'='} row_value
+update_set_list = update_set_item (@punctuation{','} update_set_item)*
+update_set_item = @variable{bare_ident_nonkw} @operator{'='} expr
+                / @punctuation{'('} ident_list @punctuation{')'} @operator{'='} row_value
 # RHS of a column-tuple assignment: parens-wrapped row-value (literal
 # list or sub-select) or a single expression that yields a row.
-row_value        =  @punctuation{'('}
-                    (select_stmt / expr (@punctuation{','} expr)*)
-                    @punctuation{')'}
-                  / expr
+row_value = @punctuation{'('}
+            (select_stmt / expr (@punctuation{','} expr)*)
+            @punctuation{')'}
+          / expr
 
-returning_clause =  kw_returning result_list
+returning_clause = kw_returning result_list
 
 # --- DML: UPDATE, DELETE ---------------------------------------------
 # UPDATE FROM and DELETE reuse `from_clause` and `where_clause` from
@@ -255,20 +255,20 @@ returning_clause =  kw_returning result_list
 # should not pretend the syntax doesn't exist.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~update_stmt =  with_clause? kw_update (kw_or conflict_action)?
-               qualified_table_name (table_alias)?
-               kw_set update_set_list
-               (from_clause)?
-               (where_clause)?
-               order_clause?
-               limit_clause?
-               (returning_clause)?
+~update_stmt = with_clause? kw_update (kw_or conflict_action)?
+              qualified_table_name (table_alias)?
+              kw_set update_set_list
+              (from_clause)?
+              (where_clause)?
+              order_clause?
+              limit_clause?
+              (returning_clause)?
 
-~delete_stmt =  with_clause? kw_delete kw_from qualified_table_name (table_alias)?
-               (where_clause)?
-               order_clause?
-               limit_clause?
-               (returning_clause)?
+~delete_stmt = with_clause? kw_delete kw_from qualified_table_name (table_alias)?
+              (where_clause)?
+              order_clause?
+              limit_clause?
+              (returning_clause)?
 
 # --- DDL: CREATE / DROP / ALTER TABLE --------------------------------
 # Interleaves column_def with table_constraint because SQLite does
@@ -277,31 +277,31 @@ returning_clause =  kw_returning result_list
 # requires a non-keyword leading identifier, while table_constraint
 # starts with CONSTRAINT, PRIMARY, UNIQUE, CHECK, or FOREIGN.
 
-create_table_stmt =  kw_create ((kw_temporary / kw_temp))? kw_table
-                     (kw_if kw_not kw_exists)?
-                     qualified_table_name
-                     (@punctuation{'('}
-                             (column_def / table_constraint)
-                             (@punctuation{','} (column_def / table_constraint))*
-                         @punctuation{')'}
-                         (table_option (@punctuation{','} table_option)*)?
-                       / kw_as select_stmt)
+create_table_stmt = kw_create ((kw_temporary / kw_temp))? kw_table
+                    (kw_if kw_not kw_exists)?
+                    qualified_table_name
+                    (@punctuation{'('}
+                            (column_def / table_constraint)
+                            (@punctuation{','} (column_def / table_constraint))*
+                        @punctuation{')'}
+                        (table_option (@punctuation{','} table_option)*)?
+                      / kw_as select_stmt)
 
 # Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
-~column_def    =  @variable{bare_ident_nonkw}
-                  (type_name)?
-                  (column_constraint)*
+~column_def = @variable{bare_ident_nonkw}
+              (type_name)?
+              (column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
 # Trailing `(...)?` leniency absorbed by `*^[;]`.
-~type_name     =  @type{bare_ident_nonkw} (@type{bare_ident_nonkw})*
-                  (@punctuation{'('} signed_number
-                       (@punctuation{','} signed_number)? @punctuation{')'})?
+~type_name = @type{bare_ident_nonkw} (@type{bare_ident_nonkw})*
+             (@punctuation{'('} signed_number
+                  (@punctuation{','} signed_number)? @punctuation{')'})?
 
-signed_number  =  (@operator{'-'} / @operator{'+'})? @number{number_body}
+signed_number = (@operator{'-'} / @operator{'+'})? @number{number_body}
 
-column_constraint      =  (kw_constraint @variable{bare_ident_nonkw})? column_constraint_body
+column_constraint = (kw_constraint @variable{bare_ident_nonkw})? column_constraint_body
 column_constraint_body =
       kw_primary kw_key ((kw_asc / kw_desc))? (conflict_clause)? (kw_autoincrement)?
     / (kw_not)? kw_null (conflict_clause)?
@@ -313,7 +313,7 @@ column_constraint_body =
     / (kw_generated kw_always)? kw_as @punctuation{'('} expr @punctuation{')'}
       ((kw_stored / kw_virtual))?
 
-table_constraint      =  (kw_constraint @variable{bare_ident_nonkw})? table_constraint_body
+table_constraint = (kw_constraint @variable{bare_ident_nonkw})? table_constraint_body
 table_constraint_body =
       (kw_primary kw_key / kw_unique)
           @punctuation{'('} indexed_col_list @punctuation{')'}
@@ -323,87 +323,87 @@ table_constraint_body =
           foreign_key_clause
 
 # Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
-~foreign_key_clause =  kw_references @type{bare_ident_nonkw}
-                      (@punctuation{'('} ident_list @punctuation{')'})?
-                      (fk_action)*
-                      (fk_deferrable)?
-fk_action      =  kw_on (kw_delete / kw_update) fk_action_body
-                / kw_match @variable{bare_ident_nonkw}
-fk_action_body =  kw_set (kw_null / kw_default)
-                / kw_cascade
-                / kw_restrict
-                / kw_no kw_action
+~foreign_key_clause = kw_references @type{bare_ident_nonkw}
+                     (@punctuation{'('} ident_list @punctuation{')'})?
+                     (fk_action)*
+                     (fk_deferrable)?
+fk_action = kw_on (kw_delete / kw_update) fk_action_body
+          / kw_match @variable{bare_ident_nonkw}
+fk_action_body = kw_set (kw_null / kw_default)
+               / kw_cascade
+               / kw_restrict
+               / kw_no kw_action
 # Trailing `(initially)?` absorbed by `*^[;]`.
-~fk_deferrable =  (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
+~fk_deferrable = (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
 
-conflict_clause =  kw_on kw_conflict conflict_action
+conflict_clause = kw_on kw_conflict conflict_action
 
-table_option   =  kw_without kw_rowid / kw_strict
+table_option = kw_without kw_rowid / kw_strict
 
-drop_table_stmt =  kw_drop kw_table (kw_if kw_exists)? qualified_table_name
+drop_table_stmt = kw_drop kw_table (kw_if kw_exists)? qualified_table_name
 
-alter_table_stmt =  kw_alter kw_table qualified_table_name (
-      kw_rename kw_to @type{bare_ident_nonkw}
-    / kw_rename (kw_column)? @variable{bare_ident_nonkw}
-        kw_to @variable{bare_ident_nonkw}
-    / kw_add (kw_column)? column_def
-    / kw_drop (kw_column)? @variable{bare_ident_nonkw}
-  )
+alter_table_stmt = kw_alter kw_table qualified_table_name (
+     kw_rename kw_to @type{bare_ident_nonkw}
+   / kw_rename (kw_column)? @variable{bare_ident_nonkw}
+       kw_to @variable{bare_ident_nonkw}
+   / kw_add (kw_column)? column_def
+   / kw_drop (kw_column)? @variable{bare_ident_nonkw}
+ )
 
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
 # Trailing `(where_clause)?` absorbed by `*^[;]`.
-~create_index_stmt =  kw_create (kw_unique)? kw_index
-                     (kw_if kw_not kw_exists)?
-                     qualified_table_name
-                     kw_on @type{bare_ident_nonkw}
-                     @punctuation{'('} indexed_col_list @punctuation{')'}
-                     (where_clause)?
+~create_index_stmt = kw_create (kw_unique)? kw_index
+                    (kw_if kw_not kw_exists)?
+                    qualified_table_name
+                    kw_on @type{bare_ident_nonkw}
+                    @punctuation{'('} indexed_col_list @punctuation{')'}
+                    (where_clause)?
 
-drop_index_stmt   =  kw_drop kw_index (kw_if kw_exists)? qualified_table_name
+drop_index_stmt = kw_drop kw_index (kw_if kw_exists)? qualified_table_name
 
-create_view_stmt  =  kw_create ((kw_temporary / kw_temp))? kw_view
-                     (kw_if kw_not kw_exists)?
-                     qualified_table_name
-                     (@punctuation{'('} ident_list @punctuation{')'})?
-                     kw_as select_stmt
+create_view_stmt = kw_create ((kw_temporary / kw_temp))? kw_view
+                   (kw_if kw_not kw_exists)?
+                   qualified_table_name
+                   (@punctuation{'('} ident_list @punctuation{')'})?
+                   kw_as select_stmt
 
-drop_view_stmt    =  kw_drop kw_view (kw_if kw_exists)? qualified_table_name
+drop_view_stmt = kw_drop kw_view (kw_if kw_exists)? qualified_table_name
 
 # --- DDL: CREATE / DROP TRIGGER --------------------------------------
 # Trigger bodies are `;`-separated sequences of DML/SELECT wrapped in
 # BEGIN...END. The inner `;` is mandatory after each body statement,
 # which keeps the nesting disjoint from sql_file's top-level stmt_sep.
 
-create_trigger_stmt =  kw_create ((kw_temporary / kw_temp))? kw_trigger
-                       (kw_if kw_not kw_exists)?
-                       qualified_table_name
-                       ((kw_before / kw_after / kw_instead kw_of))?
-                       trigger_event
-                       kw_on @type{bare_ident_nonkw}
-                       (kw_for kw_each kw_row)?
-                       (kw_when expr)?
-                       kw_begin
-                       (trigger_body_stmt @punctuation{';'})+
-                       kw_end
-trigger_event     =  kw_delete
-                   / kw_insert
-                   / kw_update (kw_of ident_list)?
-trigger_body_stmt =  insert_stmt / update_stmt / delete_stmt / select_stmt
+create_trigger_stmt = kw_create ((kw_temporary / kw_temp))? kw_trigger
+                      (kw_if kw_not kw_exists)?
+                      qualified_table_name
+                      ((kw_before / kw_after / kw_instead kw_of))?
+                      trigger_event
+                      kw_on @type{bare_ident_nonkw}
+                      (kw_for kw_each kw_row)?
+                      (kw_when expr)?
+                      kw_begin
+                      (trigger_body_stmt @punctuation{';'})+
+                      kw_end
+trigger_event = kw_delete
+              / kw_insert
+              / kw_update (kw_of ident_list)?
+trigger_body_stmt = insert_stmt / update_stmt / delete_stmt / select_stmt
 
-drop_trigger_stmt =  kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
+drop_trigger_stmt = kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
 
 # --- Transactions & savepoints ---------------------------------------
 
 # Trailing `(transaction-mode)?` absorbed by `*^[;]`.
-~begin_stmt    =  kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
-                  (kw_transaction)?
+~begin_stmt = kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
+              (kw_transaction)?
 # Trailing `(transaction)?` absorbed by `*^[;]`.
-~commit_stmt   =  (kw_commit / kw_end) (kw_transaction)?
-~rollback_stmt =  kw_rollback (kw_transaction)?
-                  (kw_to (kw_savepoint)? @variable{bare_ident_nonkw})?
-savepoint_stmt =  kw_savepoint @variable{bare_ident_nonkw}
-release_stmt   =  kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
+~commit_stmt = (kw_commit / kw_end) (kw_transaction)?
+~rollback_stmt = kw_rollback (kw_transaction)?
+                 (kw_to (kw_savepoint)? @variable{bare_ident_nonkw})?
+savepoint_stmt = kw_savepoint @variable{bare_ident_nonkw}
+release_stmt = kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
 
 # --- PRAGMA, admin statements, EXPLAIN, CREATE VIRTUAL TABLE ---------
 # EXPLAIN wraps statement_body rather than statement, so
@@ -413,23 +413,23 @@ release_stmt   =  kw_release (kw_savepoint)? @variable{bare_ident_nonkw}
 # the module is invoked, not merely referenced.
 
 # Trailing `(value)?` absorbed by `*^[;]`.
-~pragma_stmt    =  kw_pragma qualified_table_name
-                   (@operator{'='} pragma_value
-                    / @punctuation{'('} pragma_value @punctuation{')'})?
-pragma_value    =  signed_number / string_lit / @variable{bare_ident}
+~pragma_stmt = kw_pragma qualified_table_name
+               (@operator{'='} pragma_value
+                / @punctuation{'('} pragma_value @punctuation{')'})?
+pragma_value = signed_number / string_lit / @variable{bare_ident}
 
 # Trailing `(into)?` absorbed by `*^[;]`.
-~vacuum_stmt    =  kw_vacuum (@type{bare_ident_nonkw})? (kw_into string_lit)?
+~vacuum_stmt = kw_vacuum (@type{bare_ident_nonkw})? (kw_into string_lit)?
 
-attach_stmt     =  kw_attach (kw_database)? expr kw_as
-                   @type{bare_ident_nonkw}
-detach_stmt     =  kw_detach (kw_database)? @type{bare_ident_nonkw}
+attach_stmt = kw_attach (kw_database)? expr kw_as
+              @type{bare_ident_nonkw}
+detach_stmt = kw_detach (kw_database)? @type{bare_ident_nonkw}
 
 # Trailing `(target)?` absorbed by `*^[;]`.
-~reindex_stmt   =  kw_reindex (qualified_table_name)?
-~analyze_stmt   =  kw_analyze (qualified_table_name)?
+~reindex_stmt = kw_reindex (qualified_table_name)?
+~analyze_stmt = kw_analyze (qualified_table_name)?
 
-explain_stmt    =  kw_explain (kw_query kw_plan)? statement_body
+explain_stmt = kw_explain (kw_query kw_plan)? statement_body
 
 # Trailing `(args)?` absorbed by `*^[;]`.
 ~create_virtual_table_stmt =
@@ -438,106 +438,106 @@ explain_stmt    =  kw_explain (kw_query kw_plan)? statement_body
     qualified_table_name
     kw_using @function{bare_ident_nonkw}
     (@punctuation{'('} vtab_args? @punctuation{')'})?
-vtab_args       =  vtab_arg (@punctuation{','} vtab_arg)*
+vtab_args = vtab_arg (@punctuation{','} vtab_arg)*
 # Module args are deliberately permissive — fts5/rtree/etc have
 # module-specific mini-grammars that are not worth modelling.
-vtab_arg        =  (!@punctuation{','} !@punctuation{')'} .)+
+vtab_arg = (!@punctuation{','} !@punctuation{')'} .)+
 
 # --- Expressions (low → high precedence) -------------------------------
 # Classic precedence-climbing without left recursion. Each level either
 # matches the next-higher level or chains several of them with an
 # operator. No shared-prefix issues between levels.
 
-expr        =  or_expr
-or_expr     =  and_expr (kw_or and_expr)*
-and_expr    =  not_expr (kw_and not_expr)*
-not_expr    =  kw_not not_expr / cmp_expr
-cmp_expr    =  bit_expr cmp_tail*
-cmp_tail    =  kw_is (kw_not)? bit_expr
-             / (kw_not)? kw_between bit_expr kw_and bit_expr
-             / (kw_not)? kw_in @punctuation{'('} in_args? @punctuation{')'}
-             / (kw_not)? kw_like bit_expr (kw_escape bit_expr)?
-             / (kw_not)? kw_glob bit_expr
-             / (kw_not)? kw_match bit_expr
-             / (kw_not)? kw_regexp bit_expr
-             / cmp_op bit_expr
-in_args     =  select_stmt / expr (@punctuation{','} expr)*
-cmp_op      =  @operator{'=='} / @operator{'<='} / @operator{'>='}
-             / @operator{'!='} / @operator{'<>'} / @operator{'='}
-             / @operator{'<'} / @operator{'>'}
-bit_expr    =  add_expr (bit_op add_expr)*
-bit_op      =  @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
-add_expr    =  mul_expr (add_op mul_expr)*
-add_op      =  @operator{'+'} / @operator{'-'}
-mul_expr    =  concat_expr (mul_op concat_expr)*
-mul_op      =  @operator{'*'} / @operator{'/'} / @operator{'%'}
-concat_expr =  unary_expr (@operator{'||'} unary_expr)*
-unary_expr  =  (@operator{'-'} / @operator{'+'} / @operator{'~'}) unary_expr
-             / primary
+expr = or_expr
+or_expr = and_expr (kw_or and_expr)*
+and_expr = not_expr (kw_and not_expr)*
+not_expr = kw_not not_expr / cmp_expr
+cmp_expr = bit_expr cmp_tail*
+cmp_tail = kw_is (kw_not)? bit_expr
+         / (kw_not)? kw_between bit_expr kw_and bit_expr
+         / (kw_not)? kw_in @punctuation{'('} in_args? @punctuation{')'}
+         / (kw_not)? kw_like bit_expr (kw_escape bit_expr)?
+         / (kw_not)? kw_glob bit_expr
+         / (kw_not)? kw_match bit_expr
+         / (kw_not)? kw_regexp bit_expr
+         / cmp_op bit_expr
+in_args = select_stmt / expr (@punctuation{','} expr)*
+cmp_op = @operator{'=='} / @operator{'<='} / @operator{'>='}
+       / @operator{'!='} / @operator{'<>'} / @operator{'='}
+       / @operator{'<'} / @operator{'>'}
+bit_expr = add_expr (bit_op add_expr)*
+bit_op = @operator{'<<'} / @operator{'>>'} / @operator{'&'} / @operator{'|'}
+add_expr = mul_expr (add_op mul_expr)*
+add_op = @operator{'+'} / @operator{'-'}
+mul_expr = concat_expr (mul_op concat_expr)*
+mul_op = @operator{'*'} / @operator{'/'} / @operator{'%'}
+concat_expr = unary_expr (@operator{'||'} unary_expr)*
+unary_expr = (@operator{'-'} / @operator{'+'} / @operator{'~'}) unary_expr
+           / primary
 
 # Shared-prefix hotspots: function_call / qualified_column_ref /
 # column_ref_bare all start with an identifier — the classic packrat
 # motivator.
-primary     =  literal
-             / case_expr
-             / cast_expr
-             / exists_expr
-             / paren_primary
-             / function_call
-             / qualified_column_ref
-             / column_ref_bare
-             / bind_param
+primary = literal
+        / case_expr
+        / cast_expr
+        / exists_expr
+        / paren_primary
+        / function_call
+        / qualified_column_ref
+        / column_ref_bare
+        / bind_param
 
-paren_primary =  @punctuation{'('} (select_stmt / expr) @punctuation{')'}
+paren_primary = @punctuation{'('} (select_stmt / expr) @punctuation{')'}
 
 # Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
-~function_call =  @function{bare_ident_nonkw} @punctuation{'('} func_args? @punctuation{')'}
-                 (filter_clause)?
-                 (kw_over window_ref)?
-func_args   =  @operator{'*'}
-             / (kw_distinct)? expr (@punctuation{','} expr)*
+~function_call = @function{bare_ident_nonkw} @punctuation{'('} func_args? @punctuation{')'}
+                (filter_clause)?
+                (kw_over window_ref)?
+func_args = @operator{'*'}
+          / (kw_distinct)? expr (@punctuation{','} expr)*
 
-qualified_column_ref =  @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
-column_ref_bare      =  @variable{bare_ident_nonkw}
+qualified_column_ref = @variable{bare_ident_nonkw} @punctuation{'.'} @variable{bare_ident_nonkw}
+column_ref_bare = @variable{bare_ident_nonkw}
 
-case_expr   =  kw_case (expr)? (when_clause)+ (kw_else expr)? kw_end
-when_clause =  kw_when expr kw_then expr
+case_expr = kw_case (expr)? (when_clause)+ (kw_else expr)? kw_end
+when_clause = kw_when expr kw_then expr
 
-cast_expr   =  kw_cast @punctuation{'('} expr kw_as @type{bare_ident} @punctuation{')'}
+cast_expr = kw_cast @punctuation{'('} expr kw_as @type{bare_ident} @punctuation{')'}
 
-exists_expr =  kw_exists @punctuation{'('} select_stmt @punctuation{')'}
+exists_expr = kw_exists @punctuation{'('} select_stmt @punctuation{')'}
 
 # --- Literals ---------------------------------------------------------
 # Order matters: blob before string (X' prefix consumed first); number
 # tries hex / float / int in that order inside number_body.
 
-literal     =  blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
+literal = blob_lit / string_lit / @number{number_body} / null_lit / bool_lit
 
-%null_lit    =  @constant{null_body}
-%bool_lit    =  @constant{bool_body}
-*null_body   =  i"null"
-*bool_body   =  i"true" / i"false"
+%null_lit = @constant{null_body}
+%bool_lit = @constant{bool_body}
+*null_body = i"null"
+*bool_body = i"true" / i"false"
 
-*blob_lit    =  @string{blob_body}
-*blob_body   =  [xX] "'" [\da-fA-F]* "'"
-*string_lit  =  @string{string_body}
-*string_body =  "'" ("''" / !"'" .)* "'"
+*blob_lit = @string{blob_body}
+*blob_body = [xX] "'" [\da-fA-F]* "'"
+*string_lit = @string{string_body}
+*string_body = "'" ("''" / !"'" .)* "'"
 
 # Hex is a `%` rule so the compiler appends the `wb` boundary: hex
 # digits include a-f, so a hex run can butt against identifier chars
 # (`0x1Fg` must fall back to `0` + `x1Fg`, not lex `0x1F`). float/int
 # use `\d`, which can't, so they carry no boundary.
-number_body =  hex_body / float_body / int_body
-%hex_body   =  '0x' [\da-fA-F]+
-*float_body =  \d+ '.' \d+ ([eE] [+\-]? \d+)?
-            / \d+ [eE] [+\-]? \d+
-*int_body   =  \d+
+number_body = hex_body / float_body / int_body
+%hex_body = '0x' [\da-fA-F]+
+*float_body = \d+ '.' \d+ ([eE] [+\-]? \d+)?
+           / \d+ [eE] [+\-]? \d+
+*int_body = \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.
-*bind_param  =  @variable{bind_body}
-*bind_body   =  '?' \d*
-             / [:@$] ident_start ident_cont*
+*bind_param = @variable{bind_body}
+*bind_body = '?' \d*
+          / [:@$] ident_start ident_cont*
 
 # --- Identifiers ------------------------------------------------------
 # Four syntactic forms — bare, double-quoted, backtick, bracketed.
@@ -547,20 +547,20 @@ number_body =  hex_body / float_body / int_body
 # names and CTE heads where a keyword like INTEGER is actually the
 # content we want to capture as @type).
 
-*bare_ident_nonkw  =  quoted_ident / !reserved bare_raw
-*bare_ident        =  quoted_ident / bare_raw
-*quoted_ident      =  double_quoted_id / backtick_id / bracket_id
+*bare_ident_nonkw = quoted_ident / !reserved bare_raw
+*bare_ident = quoted_ident / bare_raw
+*quoted_ident = double_quoted_id / backtick_id / bracket_id
 
-*bare_raw          =  ident_start ident_cont*
+*bare_raw = ident_start ident_cont*
 # Per sqlite.org/draft/tokenreq.html ALPHABETIC + ALPHANUMERIC: the
 # ASCII letter/underscore range, the ASCII digits (continuation only),
 # `$` (continuation only), plus any code point above U+007F.
-*ident_start       =  [a-zA-Z_\u{80}-\u{10FFFF}]
-*ident_cont        =  [a-zA-Z\d_$\u{80}-\u{10FFFF}]
+*ident_start = [a-zA-Z_\u{80}-\u{10FFFF}]
+*ident_cont = [a-zA-Z\d_$\u{80}-\u{10FFFF}]
 
-*double_quoted_id  =  '"' ('""' / !'"' !\R .)* '"'
-*backtick_id       =  '`' ('``' / !'`' !\R .)* '`'
-*bracket_id        =  '[' .. (']' / \R) ']'
+*double_quoted_id = '"' ('""' / !'"' !\R .)* '"'
+*backtick_id = '`' ('``' / !'`' !\R .)* '`'
+*bracket_id = '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Each kw_* is a `%` reserved-word rule: the compiler appends a `wb`
@@ -568,155 +568,155 @@ number_body =  hex_body / float_body / int_body
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.
 
-%kw_select    =  @keyword{i"select"}
-%kw_from      =  @keyword{i"from"}
-%kw_where     =  @keyword{i"where"}
-%kw_group     =  @keyword{i"group"}
-%kw_by        =  @keyword{i"by"}
-%kw_having    =  @keyword{i"having"}
-%kw_order     =  @keyword{i"order"}
-%kw_asc       =  @keyword{i"asc"}
-%kw_desc      =  @keyword{i"desc"}
-%kw_limit     =  @keyword{i"limit"}
-%kw_offset    =  @keyword{i"offset"}
-%kw_join      =  @keyword{i"join"}
-%kw_inner     =  @keyword{i"inner"}
-%kw_left      =  @keyword{i"left"}
-%kw_right     =  @keyword{i"right"}
-%kw_full      =  @keyword{i"full"}
-%kw_outer     =  @keyword{i"outer"}
-%kw_cross     =  @keyword{i"cross"}
-%kw_natural   =  @keyword{i"natural"}
-%kw_on        =  @keyword{i"on"}
-%kw_using     =  @keyword{i"using"}
-%kw_as        =  @keyword{i"as"}
-%kw_distinct  =  @keyword{i"distinct"}
-%kw_all       =  @keyword{i"all"}
-%kw_union     =  @keyword{i"union"}
-%kw_intersect =  @keyword{i"intersect"}
-%kw_except    =  @keyword{i"except"}
-%kw_with      =  @keyword{i"with"}
-%kw_and       =  @keyword{i"and"}
-%kw_or        =  @keyword{i"or"}
-%kw_not       =  @keyword{i"not"}
-%kw_is        =  @keyword{i"is"}
-%kw_in        =  @keyword{i"in"}
-%kw_like      =  @keyword{i"like"}
-%kw_glob      =  @keyword{i"glob"}
-%kw_match     =  @keyword{i"match"}
-%kw_regexp    =  @keyword{i"regexp"}
-%kw_between   =  @keyword{i"between"}
-%kw_escape    =  @keyword{i"escape"}
-%kw_case      =  @keyword{i"case"}
-%kw_when      =  @keyword{i"when"}
-%kw_then      =  @keyword{i"then"}
-%kw_else      =  @keyword{i"else"}
-%kw_end       =  @keyword{i"end"}
-%kw_cast      =  @keyword{i"cast"}
-%kw_exists    =  @keyword{i"exists"}
-%kw_collate   =  @keyword{i"collate"}
+%kw_select = @keyword{i"select"}
+%kw_from = @keyword{i"from"}
+%kw_where = @keyword{i"where"}
+%kw_group = @keyword{i"group"}
+%kw_by = @keyword{i"by"}
+%kw_having = @keyword{i"having"}
+%kw_order = @keyword{i"order"}
+%kw_asc = @keyword{i"asc"}
+%kw_desc = @keyword{i"desc"}
+%kw_limit = @keyword{i"limit"}
+%kw_offset = @keyword{i"offset"}
+%kw_join = @keyword{i"join"}
+%kw_inner = @keyword{i"inner"}
+%kw_left = @keyword{i"left"}
+%kw_right = @keyword{i"right"}
+%kw_full = @keyword{i"full"}
+%kw_outer = @keyword{i"outer"}
+%kw_cross = @keyword{i"cross"}
+%kw_natural = @keyword{i"natural"}
+%kw_on = @keyword{i"on"}
+%kw_using = @keyword{i"using"}
+%kw_as = @keyword{i"as"}
+%kw_distinct = @keyword{i"distinct"}
+%kw_all = @keyword{i"all"}
+%kw_union = @keyword{i"union"}
+%kw_intersect = @keyword{i"intersect"}
+%kw_except = @keyword{i"except"}
+%kw_with = @keyword{i"with"}
+%kw_and = @keyword{i"and"}
+%kw_or = @keyword{i"or"}
+%kw_not = @keyword{i"not"}
+%kw_is = @keyword{i"is"}
+%kw_in = @keyword{i"in"}
+%kw_like = @keyword{i"like"}
+%kw_glob = @keyword{i"glob"}
+%kw_match = @keyword{i"match"}
+%kw_regexp = @keyword{i"regexp"}
+%kw_between = @keyword{i"between"}
+%kw_escape = @keyword{i"escape"}
+%kw_case = @keyword{i"case"}
+%kw_when = @keyword{i"when"}
+%kw_then = @keyword{i"then"}
+%kw_else = @keyword{i"else"}
+%kw_end = @keyword{i"end"}
+%kw_cast = @keyword{i"cast"}
+%kw_exists = @keyword{i"exists"}
+%kw_collate = @keyword{i"collate"}
 
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-%?kw_recursive=  @keyword{i"recursive"}
-%kw_window    =  @keyword{i"window"}
-%kw_over      =  @keyword{i"over"}
-%?kw_filter   =  @keyword{i"filter"}
-%?kw_partition=  @keyword{i"partition"}
-%?kw_range    =  @keyword{i"range"}
-%?kw_rows     =  @keyword{i"rows"}
-%?kw_groups   =  @keyword{i"groups"}
-%?kw_unbounded=  @keyword{i"unbounded"}
-%?kw_preceding=  @keyword{i"preceding"}
-%?kw_following=  @keyword{i"following"}
-%?kw_current  =  @keyword{i"current"}
-%?kw_row      =  @keyword{i"row"}
-%?kw_exclude  =  @keyword{i"exclude"}
-%?kw_ties     =  @keyword{i"ties"}
-%?kw_others   =  @keyword{i"others"}
-%kw_no        =  @keyword{i"no"}
+%?kw_recursive = @keyword{i"recursive"}
+%kw_window = @keyword{i"window"}
+%kw_over = @keyword{i"over"}
+%?kw_filter = @keyword{i"filter"}
+%?kw_partition = @keyword{i"partition"}
+%?kw_range = @keyword{i"range"}
+%?kw_rows = @keyword{i"rows"}
+%?kw_groups = @keyword{i"groups"}
+%?kw_unbounded = @keyword{i"unbounded"}
+%?kw_preceding = @keyword{i"preceding"}
+%?kw_following = @keyword{i"following"}
+%?kw_current = @keyword{i"current"}
+%?kw_row = @keyword{i"row"}
+%?kw_exclude = @keyword{i"exclude"}
+%?kw_ties = @keyword{i"ties"}
+%?kw_others = @keyword{i"others"}
+%kw_no = @keyword{i"no"}
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
 # rule goes here so UPSERT's DO UPDATE path can use it now.
-%kw_insert    =  @keyword{i"insert"}
-%kw_replace   =  @keyword{i"replace"}
-%kw_into      =  @keyword{i"into"}
-%kw_values    =  @keyword{i"values"}
-%kw_default   =  @keyword{i"default"}
-%kw_conflict  =  @keyword{i"conflict"}
-%?kw_do       =  @keyword{i"do"}
-%kw_nothing   =  @keyword{i"nothing"}
-%kw_rollback  =  @keyword{i"rollback"}
-%kw_abort     =  @keyword{i"abort"}
-%kw_fail      =  @keyword{i"fail"}
-%kw_ignore    =  @keyword{i"ignore"}
-%kw_set       =  @keyword{i"set"}
-%kw_returning =  @keyword{i"returning"}
-%kw_update    =  @keyword{i"update"}
-%kw_delete    =  @keyword{i"delete"}
+%kw_insert = @keyword{i"insert"}
+%kw_replace = @keyword{i"replace"}
+%kw_into = @keyword{i"into"}
+%kw_values = @keyword{i"values"}
+%kw_default = @keyword{i"default"}
+%kw_conflict = @keyword{i"conflict"}
+%?kw_do = @keyword{i"do"}
+%kw_nothing = @keyword{i"nothing"}
+%kw_rollback = @keyword{i"rollback"}
+%kw_abort = @keyword{i"abort"}
+%kw_fail = @keyword{i"fail"}
+%kw_ignore = @keyword{i"ignore"}
+%kw_set = @keyword{i"set"}
+%kw_returning = @keyword{i"returning"}
+%kw_update = @keyword{i"update"}
+%kw_delete = @keyword{i"delete"}
 
 # DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
-%kw_create    =  @keyword{i"create"}
-%kw_table     =  @keyword{i"table"}
-%kw_alter     =  @keyword{i"alter"}
-%kw_drop      =  @keyword{i"drop"}
-%kw_rename    =  @keyword{i"rename"}
-%kw_add       =  @keyword{i"add"}
-%kw_column    =  @keyword{i"column"}
-%kw_if        =  @keyword{i"if"}
-%kw_temp      =  @keyword{i"temp"}
-%kw_temporary =  @keyword{i"temporary"}
-%kw_primary   =  @keyword{i"primary"}
-%?kw_key      =  @keyword{i"key"}
-%kw_unique    =  @keyword{i"unique"}
-%kw_check     =  @keyword{i"check"}
-%kw_null      =  @keyword{i"null"}
-%kw_references =  @keyword{i"references"}
-%kw_generated =  @keyword{i"generated"}
-%kw_always    =  @keyword{i"always"}
-%kw_stored    =  @keyword{i"stored"}
-%kw_virtual   =  @keyword{i"virtual"}
-%kw_constraint=  @keyword{i"constraint"}
-%kw_foreign   =  @keyword{i"foreign"}
-%kw_action    =  @keyword{i"action"}
-%kw_cascade   =  @keyword{i"cascade"}
-%kw_restrict  =  @keyword{i"restrict"}
-%kw_deferrable=  @keyword{i"deferrable"}
-%kw_initially =  @keyword{i"initially"}
-%kw_immediate =  @keyword{i"immediate"}
-%kw_deferred  =  @keyword{i"deferred"}
-%kw_autoincrement =  @keyword{i"autoincrement"}
-%kw_rowid     =  @keyword{i"rowid"}
-%kw_strict    =  @keyword{i"strict"}
-%kw_without   =  @keyword{i"without"}
-%kw_to        =  @keyword{i"to"}
-%kw_index     =  @keyword{i"index"}
-%kw_view      =  @keyword{i"view"}
-%kw_trigger   =  @keyword{i"trigger"}
-%kw_before    =  @keyword{i"before"}
-%kw_after     =  @keyword{i"after"}
-%kw_instead   =  @keyword{i"instead"}
-%kw_of        =  @keyword{i"of"}
-%kw_for       =  @keyword{i"for"}
-%kw_each      =  @keyword{i"each"}
-%kw_begin     =  @keyword{i"begin"}
-%kw_commit    =  @keyword{i"commit"}
-%kw_transaction =  @keyword{i"transaction"}
-%kw_savepoint =  @keyword{i"savepoint"}
-%kw_release   =  @keyword{i"release"}
-%kw_exclusive =  @keyword{i"exclusive"}
-%kw_pragma    =  @keyword{i"pragma"}
-%kw_vacuum    =  @keyword{i"vacuum"}
-%kw_attach    =  @keyword{i"attach"}
-%kw_detach    =  @keyword{i"detach"}
-%kw_database  =  @keyword{i"database"}
-%kw_reindex   =  @keyword{i"reindex"}
-%kw_analyze   =  @keyword{i"analyze"}
-%kw_explain   =  @keyword{i"explain"}
-%kw_query     =  @keyword{i"query"}
-%kw_plan      =  @keyword{i"plan"}
+%kw_create = @keyword{i"create"}
+%kw_table = @keyword{i"table"}
+%kw_alter = @keyword{i"alter"}
+%kw_drop = @keyword{i"drop"}
+%kw_rename = @keyword{i"rename"}
+%kw_add = @keyword{i"add"}
+%kw_column = @keyword{i"column"}
+%kw_if = @keyword{i"if"}
+%kw_temp = @keyword{i"temp"}
+%kw_temporary = @keyword{i"temporary"}
+%kw_primary = @keyword{i"primary"}
+%?kw_key = @keyword{i"key"}
+%kw_unique = @keyword{i"unique"}
+%kw_check = @keyword{i"check"}
+%kw_null = @keyword{i"null"}
+%kw_references = @keyword{i"references"}
+%kw_generated = @keyword{i"generated"}
+%kw_always = @keyword{i"always"}
+%kw_stored = @keyword{i"stored"}
+%kw_virtual = @keyword{i"virtual"}
+%kw_constraint = @keyword{i"constraint"}
+%kw_foreign = @keyword{i"foreign"}
+%kw_action = @keyword{i"action"}
+%kw_cascade = @keyword{i"cascade"}
+%kw_restrict = @keyword{i"restrict"}
+%kw_deferrable = @keyword{i"deferrable"}
+%kw_initially = @keyword{i"initially"}
+%kw_immediate = @keyword{i"immediate"}
+%kw_deferred = @keyword{i"deferred"}
+%kw_autoincrement = @keyword{i"autoincrement"}
+%kw_rowid = @keyword{i"rowid"}
+%kw_strict = @keyword{i"strict"}
+%kw_without = @keyword{i"without"}
+%kw_to = @keyword{i"to"}
+%kw_index = @keyword{i"index"}
+%kw_view = @keyword{i"view"}
+%kw_trigger = @keyword{i"trigger"}
+%kw_before = @keyword{i"before"}
+%kw_after = @keyword{i"after"}
+%kw_instead = @keyword{i"instead"}
+%kw_of = @keyword{i"of"}
+%kw_for = @keyword{i"for"}
+%kw_each = @keyword{i"each"}
+%kw_begin = @keyword{i"begin"}
+%kw_commit = @keyword{i"commit"}
+%kw_transaction = @keyword{i"transaction"}
+%kw_savepoint = @keyword{i"savepoint"}
+%kw_release = @keyword{i"release"}
+%kw_exclusive = @keyword{i"exclusive"}
+%kw_pragma = @keyword{i"pragma"}
+%kw_vacuum = @keyword{i"vacuum"}
+%kw_attach = @keyword{i"attach"}
+%kw_detach = @keyword{i"detach"}
+%kw_database = @keyword{i"database"}
+%kw_reindex = @keyword{i"reindex"}
+%kw_analyze = @keyword{i"analyze"}
+%kw_explain = @keyword{i"explain"}
+%kw_query = @keyword{i"query"}
+%kw_plan = @keyword{i"plan"}
 
 # --- Whitespace & comments -------------------------------------------
 
-*comment       =  @comment{'--' .. \R / '/*' ..= '*/'}
+*comment = @comment{'--' .. \R / '/*' ..= '*/'}

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -26,29 +26,29 @@
 # `blank`: whitespace (incl. newlines) and comments, threaded by hand
 # — never auto-injected (TOML has no `trivia` rule). Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
-root          <- blank (entry (entry_sep entry)*)? blank
+root          =  blank (entry (entry_sep entry)*)? blank
 
-blank         <- (comment / \s)*
+blank         =  (comment / \s)*
 
-entry         <- array_of_tables_header / table_header / pair
-entry_sep     <- inline_space comment? \R blank
+entry         =  array_of_tables_header / table_header / pair
+entry_sep     =  inline_space comment? \R blank
 
 # Key-value pair: LHS key as @property, RHS value.
-pair          <- key inline_space @punctuation{'='} inline_space value
+pair          =  key inline_space @punctuation{'='} inline_space value
 
 # Section headers: path segments as @type.
-table_header              <- @punctuation{'['} inline_space key_path inline_space @punctuation{']'}
-array_of_tables_header    <- @punctuation{'[['} inline_space key_path inline_space @punctuation{']]'}
+table_header              =  @punctuation{'['} inline_space key_path inline_space @punctuation{']'}
+array_of_tables_header    =  @punctuation{'[['} inline_space key_path inline_space @punctuation{']]'}
 
 # Keys. Dotted keys are several segments joined by '.'. The two rules
 # differ only in the capture kind applied to each segment.
-key           <- key_seg_prop (inline_space @punctuation{'.'} inline_space key_seg_prop)*
-key_path      <- key_seg_type (inline_space @punctuation{'.'} inline_space key_seg_type)*
+key           =  key_seg_prop (inline_space @punctuation{'.'} inline_space key_seg_prop)*
+key_path      =  key_seg_type (inline_space @punctuation{'.'} inline_space key_seg_type)*
 
-key_seg_prop  <- @property{key_seg_body}
-key_seg_type  <- @type{key_seg_body}
-key_seg_body  <- bare_key / basic_string / literal_string
-bare_key      <- [A-Za-z\d_\-]+
+key_seg_prop  =  @property{key_seg_body}
+key_seg_type  =  @type{key_seg_body}
+key_seg_body  =  bare_key / basic_string / literal_string
+bare_key      =  [A-Za-z\d_\-]+
 
 # Values. Order matters: try longer-prefixed / more-specific alternatives
 # first so PEG's first-match semantics pick the right one.
@@ -56,7 +56,7 @@ bare_key      <- [A-Za-z\d_\-]+
 #   - inf_nan before number (share the optional sign)
 #   - float before integer (both start with digits; float distinguished
 #     by the frac/exp tail)
-value         <- @string{basic_multiline / literal_multiline / basic_string / literal_string}
+value         =  @string{basic_multiline / literal_multiline / basic_string / literal_string}
                / @constant{[+\-]? ('inf' / 'nan')}
                / @number{full_datetime / local_datetime / local_date / local_time}
                / @number{[+\-]? unsigned_dec (frac exp? / exp)}
@@ -69,44 +69,44 @@ value         <- @string{basic_multiline / literal_multiline / basic_string / li
 # Multi-line forms come first because their opening/closing delimiters
 # are longer than the single-line forms.
 
-basic_string  <- '"' ([^"\\\n\r] / escape)* '"'
-escape        <- '\\' (["\\bfnrt] / 'u' [\da-fA-F]{4} / 'U' [\da-fA-F]{8})
+basic_string  =  '"' ([^"\\\n\r] / escape)* '"'
+escape        =  '\\' (["\\bfnrt] / 'u' [\da-fA-F]{4} / 'U' [\da-fA-F]{8})
 
-basic_multiline <- '"""' ..= '"""'
+basic_multiline =  '"""' ..= '"""'
 
-literal_string  <- "'" [^'\n\r]* "'"
+literal_string  =  "'" [^'\n\r]* "'"
 
-literal_multiline <- "'''" ..= "'''"
+literal_multiline =  "'''" ..= "'''"
 
 # --- Numbers -----------------------------------------------------------
-dec_int       <- [+\-]? unsigned_dec
-unsigned_dec  <- '0' / [1-9] ('_'? \d)*
-hex_int       <- '0x' [\da-fA-F] ('_'? [\da-fA-F])*
-oct_int       <- '0o' [0-7] ('_'? [0-7])*
-bin_int       <- '0b' [01] ('_'? [01])*
+dec_int       =  [+\-]? unsigned_dec
+unsigned_dec  =  '0' / [1-9] ('_'? \d)*
+hex_int       =  '0x' [\da-fA-F] ('_'? [\da-fA-F])*
+oct_int       =  '0o' [0-7] ('_'? [0-7])*
+bin_int       =  '0b' [01] ('_'? [01])*
 
-frac          <- '.' \d ('_'? \d)*
-exp           <- [eE] [+\-]? \d ('_'? \d)*
+frac          =  '.' \d ('_'? \d)*
+exp           =  [eE] [+\-]? \d ('_'? \d)*
 
 # --- Datetime (RFC 3339 subset) ---------------------------------------
-full_datetime <- date date_time_sep time time_offset
-local_datetime <- date date_time_sep time
-local_date    <- date
-local_time    <- time
-date_time_sep <- 'T' / 't' / ' '
-date          <- \d{4} '-' \d{2} '-' \d{2}
-time          <- \d{2} ':' \d{2} ':' \d{2} ('.' \d+)?
-time_offset   <- 'Z' / 'z' / [+\-] \d{2} ':' \d{2}
+full_datetime =  date date_time_sep time time_offset
+local_datetime =  date date_time_sep time
+local_date    =  date
+local_time    =  time
+date_time_sep =  'T' / 't' / ' '
+date          =  \d{4} '-' \d{2} '-' \d{2}
+time          =  \d{2} ':' \d{2} ':' \d{2} ('.' \d+)?
+time_offset   =  'Z' / 'z' / [+\-] \d{2} ':' \d{2}
 
 # --- Arrays (multiline, trailing comma, interior comments allowed) -----
-array         <- @punctuation{'['} blank array_body? blank @punctuation{']'}
-array_body    <- value (blank @punctuation{','} blank value)* (blank @punctuation{','})?
+array         =  @punctuation{'['} blank array_body? blank @punctuation{']'}
+array_body    =  value (blank @punctuation{','} blank value)* (blank @punctuation{','})?
 
 # --- Inline tables (no newlines, no trailing comma per v1.0) ----------
-inline_table  <- @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
-inline_table_body <- inline_pair (inline_space @punctuation{','} inline_space inline_pair)*
-inline_pair   <- key inline_space @punctuation{'='} inline_space value
+inline_table  =  @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
+inline_table_body =  inline_pair (inline_space @punctuation{','} inline_space inline_pair)*
+inline_pair   =  key inline_space @punctuation{'='} inline_space value
 
 # --- Whitespace & comments --------------------------------------------
-inline_space  <- \h*
-comment       <- @comment{'#' .. \R}
+inline_space  =  \h*
+comment       =  @comment{'#' .. \R}

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -26,29 +26,29 @@
 # `blank`: whitespace (incl. newlines) and comments, threaded by hand
 # — never auto-injected (TOML has no `trivia` rule). Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
-root          =  blank (entry (entry_sep entry)*)? blank
+root = blank (entry (entry_sep entry)*)? blank
 
-blank         =  (comment / \s)*
+blank = (comment / \s)*
 
-entry         =  array_of_tables_header / table_header / pair
-entry_sep     =  inline_space comment? \R blank
+entry = array_of_tables_header / table_header / pair
+entry_sep = inline_space comment? \R blank
 
 # Key-value pair: LHS key as @property, RHS value.
-pair          =  key inline_space @punctuation{'='} inline_space value
+pair = key inline_space @punctuation{'='} inline_space value
 
 # Section headers: path segments as @type.
-table_header              =  @punctuation{'['} inline_space key_path inline_space @punctuation{']'}
-array_of_tables_header    =  @punctuation{'[['} inline_space key_path inline_space @punctuation{']]'}
+table_header = @punctuation{'['} inline_space key_path inline_space @punctuation{']'}
+array_of_tables_header = @punctuation{'[['} inline_space key_path inline_space @punctuation{']]'}
 
 # Keys. Dotted keys are several segments joined by '.'. The two rules
 # differ only in the capture kind applied to each segment.
-key           =  key_seg_prop (inline_space @punctuation{'.'} inline_space key_seg_prop)*
-key_path      =  key_seg_type (inline_space @punctuation{'.'} inline_space key_seg_type)*
+key = key_seg_prop (inline_space @punctuation{'.'} inline_space key_seg_prop)*
+key_path = key_seg_type (inline_space @punctuation{'.'} inline_space key_seg_type)*
 
-key_seg_prop  =  @property{key_seg_body}
-key_seg_type  =  @type{key_seg_body}
-key_seg_body  =  bare_key / basic_string / literal_string
-bare_key      =  [A-Za-z\d_\-]+
+key_seg_prop = @property{key_seg_body}
+key_seg_type = @type{key_seg_body}
+key_seg_body = bare_key / basic_string / literal_string
+bare_key = [A-Za-z\d_\-]+
 
 # Values. Order matters: try longer-prefixed / more-specific alternatives
 # first so PEG's first-match semantics pick the right one.
@@ -56,57 +56,57 @@ bare_key      =  [A-Za-z\d_\-]+
 #   - inf_nan before number (share the optional sign)
 #   - float before integer (both start with digits; float distinguished
 #     by the frac/exp tail)
-value         =  @string{basic_multiline / literal_multiline / basic_string / literal_string}
-               / @constant{[+\-]? ('inf' / 'nan')}
-               / @number{full_datetime / local_datetime / local_date / local_time}
-               / @number{[+\-]? unsigned_dec (frac exp? / exp)}
-               / @number{hex_int / oct_int / bin_int / dec_int}
-               / @constant{'true' / 'false'}
-               / array
-               / inline_table
+value = @string{basic_multiline / literal_multiline / basic_string / literal_string}
+      / @constant{[+\-]? ('inf' / 'nan')}
+      / @number{full_datetime / local_datetime / local_date / local_time}
+      / @number{[+\-]? unsigned_dec (frac exp? / exp)}
+      / @number{hex_int / oct_int / bin_int / dec_int}
+      / @constant{'true' / 'false'}
+      / array
+      / inline_table
 
 # --- Strings -----------------------------------------------------------
 # Multi-line forms come first because their opening/closing delimiters
 # are longer than the single-line forms.
 
-basic_string  =  '"' ([^"\\\n\r] / escape)* '"'
-escape        =  '\\' (["\\bfnrt] / 'u' [\da-fA-F]{4} / 'U' [\da-fA-F]{8})
+basic_string = '"' ([^"\\\n\r] / escape)* '"'
+escape = '\\' (["\\bfnrt] / 'u' [\da-fA-F]{4} / 'U' [\da-fA-F]{8})
 
-basic_multiline =  '"""' ..= '"""'
+basic_multiline = '"""' ..= '"""'
 
-literal_string  =  "'" [^'\n\r]* "'"
+literal_string = "'" [^'\n\r]* "'"
 
-literal_multiline =  "'''" ..= "'''"
+literal_multiline = "'''" ..= "'''"
 
 # --- Numbers -----------------------------------------------------------
-dec_int       =  [+\-]? unsigned_dec
-unsigned_dec  =  '0' / [1-9] ('_'? \d)*
-hex_int       =  '0x' [\da-fA-F] ('_'? [\da-fA-F])*
-oct_int       =  '0o' [0-7] ('_'? [0-7])*
-bin_int       =  '0b' [01] ('_'? [01])*
+dec_int = [+\-]? unsigned_dec
+unsigned_dec = '0' / [1-9] ('_'? \d)*
+hex_int = '0x' [\da-fA-F] ('_'? [\da-fA-F])*
+oct_int = '0o' [0-7] ('_'? [0-7])*
+bin_int = '0b' [01] ('_'? [01])*
 
-frac          =  '.' \d ('_'? \d)*
-exp           =  [eE] [+\-]? \d ('_'? \d)*
+frac = '.' \d ('_'? \d)*
+exp = [eE] [+\-]? \d ('_'? \d)*
 
 # --- Datetime (RFC 3339 subset) ---------------------------------------
-full_datetime =  date date_time_sep time time_offset
-local_datetime =  date date_time_sep time
-local_date    =  date
-local_time    =  time
-date_time_sep =  'T' / 't' / ' '
-date          =  \d{4} '-' \d{2} '-' \d{2}
-time          =  \d{2} ':' \d{2} ':' \d{2} ('.' \d+)?
-time_offset   =  'Z' / 'z' / [+\-] \d{2} ':' \d{2}
+full_datetime = date date_time_sep time time_offset
+local_datetime = date date_time_sep time
+local_date = date
+local_time = time
+date_time_sep = 'T' / 't' / ' '
+date = \d{4} '-' \d{2} '-' \d{2}
+time = \d{2} ':' \d{2} ':' \d{2} ('.' \d+)?
+time_offset = 'Z' / 'z' / [+\-] \d{2} ':' \d{2}
 
 # --- Arrays (multiline, trailing comma, interior comments allowed) -----
-array         =  @punctuation{'['} blank array_body? blank @punctuation{']'}
-array_body    =  value (blank @punctuation{','} blank value)* (blank @punctuation{','})?
+array = @punctuation{'['} blank array_body? blank @punctuation{']'}
+array_body = value (blank @punctuation{','} blank value)* (blank @punctuation{','})?
 
 # --- Inline tables (no newlines, no trailing comma per v1.0) ----------
-inline_table  =  @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
-inline_table_body =  inline_pair (inline_space @punctuation{','} inline_space inline_pair)*
-inline_pair   =  key inline_space @punctuation{'='} inline_space value
+inline_table = @punctuation{'{'} inline_space inline_table_body? inline_space @punctuation{'}'}
+inline_table_body = inline_pair (inline_space @punctuation{','} inline_space inline_pair)*
+inline_pair = key inline_space @punctuation{'='} inline_space value
 
 # --- Whitespace & comments --------------------------------------------
-inline_space  =  \h*
-comment       =  @comment{'#' .. \R}
+inline_space = \h*
+comment = @comment{'#' .. \R}

--- a/src/bin/pegdb.rs
+++ b/src/bin/pegdb.rs
@@ -448,7 +448,7 @@ fn run_recoveries_explain(args: &[String]) -> ExitCode {
     // carries a label — labeled catches (`^label`) use the author's
     // identifier; `*^` uses the intern of its `recovery_kind` string.
     // Trailing rule_stack frames marked trivia (reached from a
-    // `trivia <- …` reserved-name root) are popped before the key is
+    // `trivia = …` reserved-name root) are popped before the key is
     // built, so two diagnostics that bottom out in different trivia
     // merge into one cluster on the deepest semantic rule. BTreeMap
     // preserves a stable key order for deterministic output.
@@ -632,7 +632,7 @@ fn compute_recovery_span_aggregates(
 
 /// Pop trailing trivia frames from `stack`. A frame is trivia when its
 /// `MemoId.0` indexes a `true` slot in `rule_is_trivia` (cascaded from
-/// the reserved `trivia <- …` rule at compile time). Both
+/// the reserved `trivia = …` rule at compile time). Both
 /// `recoveries explain` and `recoveries dump` use this to keep the
 /// displayed leaf on a semantically interesting rule rather than `ws`
 /// or `line_comment`.

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -706,10 +706,10 @@ mod tests {
 
     #[test]
     fn smallest_program_round_trips() {
-        // Trivial one-rule grammar: `start <- "x"`. Compiles to a
+        // Trivial one-rule grammar: `start = "x"`. Compiles to a
         // bootstrap `Call` + `End` plus the rule body wrapped in
         // `RuleEnter`/`MemoClose`/`Return`.
-        let p = pegc::compile("root <- \"x\"").unwrap();
+        let p = pegc::compile("root = \"x\"").unwrap();
         assert_roundtrip(&p);
     }
 

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -21,8 +21,8 @@ what a grammar author writes. For the compiled-bytecode side
 A `.peg` file is a sequence of rule definitions:
 
 ```peg
-name  <-  body
-name2 <-  body2
+name  =  body
+name2 =  body2
 ```
 
 - Every grammar must define a **`root` rule** — that's the entry
@@ -34,13 +34,13 @@ name2 <-  body2
   between iterations of `*` / `+`. Without a `trivia` rule, no
   auto-insertion happens.
 - An optional **`wb` rule** is the word-boundary target consumed by
-  `%` rules (see below); it is typically `wb <- !ident_body`. Defining
+  `%` rules (see below); it is typically `wb = !ident_body`. Defining
   it is only required when the grammar has at least one `%` rule.
-- Rules may carry **prefix sigils**: `~name <-` for the intentional
-  leniency marker, `*name <-` for the atomic marker (no `trivia`
-  injected inside this rule's body), `%name <-` for the reserved-word
+- Rules may carry **prefix sigils**: `~name =` for the intentional
+  leniency marker, `*name =` for the atomic marker (no `trivia`
+  injected inside this rule's body), `%name =` for the reserved-word
   marker (atomic *and* appends a trailing `wb` call inside the rule's
-  terminal captures), and `%?name <-` for the preferred-word marker (a
+  terminal captures), and `%?name =` for the preferred-word marker (a
   sibling of `%` for identifier-eligible distinguished tokens). `~`
   composes with `*` / `%` / `%?` (`~*name`, `%~name`, …); `*` and
   `%` / `%?` are mutually exclusive — both make a rule atomic. The
@@ -77,9 +77,9 @@ catch      p1 ^label p2      p1 ^^label B      p1 ^^label
 choice     p1 / p2 / p3
 ```
 
-Rule definitions may carry a top-level `~name <-` decorator to mark
+Rule definitions may carry a top-level `~name =` decorator to mark
 the whole rule as intentionally lenient — see
-[`~name <-`](#name----intentional-leniency-marker) below.
+[`~name =`](#name----intentional-leniency-marker) below.
 
 ### Atoms
 
@@ -208,7 +208,7 @@ at compile time; the highlighter resolves it back via
 `Program::capture_kinds`.
 
 ```peg
-string_lit <- @string{ '"' (!'"' .)* '"' }
+string_lit = @string{ '"' (!'"' .)* '"' }
 ```
 
 Capture names may be any valid identifier. The built-in theme
@@ -227,7 +227,7 @@ first malformed sub-element — the mechanism behind multi-statement
 resyncing after a syntax error.
 
 ```peg
-sql_file <- ws (statement)*^ ws !.
+sql_file = ws (statement)*^ ws !.
 ```
 
 `p+^` desugars to `p (p*^)` — one inner success is required, then
@@ -269,7 +269,7 @@ capture is emitted per resync region — covering the skipped bytes plus
 the delimiter — instead of one capture per skipped byte.
 
 ```peg
-sql_file <- ws (statement)*^[;] ws !.
+sql_file = ws (statement)*^[;] ws !.
 ```
 
 On input like `INSERT INTO @@@ garbage @@@; SELECT 1;` the `*^[;]` form
@@ -319,10 +319,10 @@ Two worked examples:
 
 ```peg
 # Non-consuming: the newline is left for outer whitespace handling.
-line_comment <- '//' .. '\n'
+line_comment = '//' .. '\n'
 
 # Consuming: the closing `*/` is part of the comment.
-block_comment <- '/*' ..= '*/'
+block_comment = '/*' ..= '*/'
 ```
 
 Both operators are unary today — the LHS of the skip is always `.`
@@ -343,7 +343,7 @@ captures back into the live buffer (via `RecoverToScopedMax`) and runs
 `inner` fails; on success the catch behaves exactly like its inner.
 
 ```peg
-stmt <- (assign / call) ^bad_stmt @err{ (!';' .)* } ';'
+stmt = (assign / call) ^bad_stmt @err{ (!';' .)* } ';'
 ```
 
 The `label` is mandatory: it tags this scope so `pegdb
@@ -372,8 +372,8 @@ position) and runs recovery from there. Subsumes Yacc-style error
 productions:
 
 ```peg
-stmt <- alt1 / alt2 / error ';'              # error-production style
-stmt <- (alt1 / alt2) ^bad_stmt (!';' .)* ';'  # same idea with `^`
+stmt = alt1 / alt2 / error ';'              # error-production style
+stmt = (alt1 / alt2) ^bad_stmt (!';' .)* ';'  # same idea with `^`
 ```
 
 **Difference from `*^`.** No loop and no synthetic single-byte
@@ -431,7 +431,7 @@ prefix the rule needs to commit to. Writing the operator around the
 whole rule body — e.g.
 
 ```peg
-where_clause <- kw_where ws expr ^^bad_where (ws boundary)
+where_clause = kw_where ws expr ^^bad_where (ws boundary)
 ```
 
 — would let the operator fire even when `kw_where` itself fails (no
@@ -441,7 +441,7 @@ spurious empty `recovery` capture. Push the operator past the
 unconditional prefix:
 
 ```peg
-where_clause <- kw_where ws (expr ^^bad_where (ws boundary))
+where_clause = kw_where ws (expr ^^bad_where (ws boundary))
 ```
 
 so a missing prefix fails the rule cleanly with no catch involved.
@@ -488,7 +488,7 @@ Two ways it differs from `^^lbl B`:
 Worked example (the `block` rule from `grammars/rust.peg`):
 
 ```peg
-block <- @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
+block = @punctuation{'{'} ws (block_body ws @punctuation{'}'} ^^block_close ..= @punctuation{'}'})
 ```
 
 The catch fires when `block_body ws @punctuation{'}'}` fails (a
@@ -502,20 +502,20 @@ only `..=`, not `..` — the catch necessarily consumes its boundary,
 and `^^lbl .. B` would diverge from the standalone `..` non-consuming
 meaning. The parser rejects it with a hint pointing at `..=`.
 
-### `~name <-` — intentional-leniency marker
+### `~name =` — intentional-leniency marker
 
 The static `lint_partial_match` check flags trailing-nullable rules
 called unanchored — but on shipped grammars almost every flag is a
 "partial-match leniency intentionally absorbed by outer `*^`-style
 recovery" that the static analysis can't statically prove safe. The
-`~name <-` marker is the author's intent signal: "yes, this rule's
+`~name =` marker is the author's intent signal: "yes, this rule's
 leniency is known, don't flag any call to it." Wraps the rule's body
 in `Pattern::Lenient`, which the lint walker treats as an opaque
 barrier and the compiler treats as transparent (emits the inner's
 bytecode unchanged).
 
 ```peg
-~opt_semi <- (@punctuation{';'} ws)?
+~opt_semi = (@punctuation{';'} ws)?
 ```
 
 The marker must touch the name (no whitespace between `~` and the
@@ -536,7 +536,7 @@ them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
   body as `trivia? root_body trivia? !.` so end-of-input is always
   asserted, and a `trivia` rule (when present) pads the leading and
   trailing whitespace. The wrap means a grammar
-  source like `root <- value` parses whole inputs, not just longest
+  source like `root = value` parses whole inputs, not just longest
   prefixes — the implicit `!.` rejects trailing junk.
 
 - **`trivia`** — the optional auto-insertion target. When defined,
@@ -558,8 +558,8 @@ them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
   rules outside the `trivia` subgraph; only ignorable bytes go in.
 
   ```peg
-  trivia        <- (comment / \s)*
-  comment       <- @comment{'//' .. '\n' / '/*' ..= '*/'}
+  trivia        = (comment / \s)*
+  comment       = @comment{'//' .. '\n' / '/*' ..= '*/'}
   ```
 
   Grammars without a `trivia` rule (e.g. indent-sensitive shapes)
@@ -588,20 +588,20 @@ them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
   inter-iteration whitespace is sitting in front of it.
 
 - **`wb`** — the optional word-boundary target for `%` / `%?` rules.
-  Its body is a bare boundary predicate (typically `wb <- !ident_body`,
+  Its body is a bare boundary predicate (typically `wb = !ident_body`,
   or `!ident_cont` for a Unicode-aware continuation class). The
   compiler appends a `wb` call inside the terminal captures of every
-  `%` / `%?` rule (see [`%name <-`](#name----reserved-word-marker)); it
+  `%` / `%?` rule (see [`%name =`](#name----reserved-word-marker)); it
   is required only when the grammar has at least one such rule. Like
   `trivia`, `wb` is exempt from trivia auto-insertion and must sit in
   the reserved slots immediately after `root`. It is **not** part of
   the trivia diagnostic cascade.
 
   ```peg
-  wb            <- !ident_body
+  wb            = !ident_body
   ```
 
-### `*name <-` — atomic-rule marker
+### `*name =` — atomic-rule marker
 
 A `*` prefix on the rule name opts the rule out of `trivia`
 auto-insertion: the rewriter walks the body but does not splice
@@ -610,8 +610,8 @@ iterations. The two prefix sigils compose: `~*name` and `*~name`
 are both valid.
 
 ```peg
-*string_lit   <- '"' (str_escape / !'"' .)* '"'
-*ident        <- [A-Za-z_] [A-Za-z0-9_]*
+*string_lit   = '"' (str_escape / !'"' .)* '"'
+*ident        = [A-Za-z_] [A-Za-z0-9_]*
 ```
 
 Used on token-shape rules — string / number / char literals,
@@ -622,10 +622,10 @@ non-atomic rule called from inside an atomic body still gets
 auto-insertion in its own body.
 
 For a keyword rule that also needs a trailing word boundary, prefer
-the [`%name <-`](#name----reserved-word-marker) sibling below — it is
+the [`%name =`](#name----reserved-word-marker) sibling below — it is
 atomic *and* supplies the boundary, so you don't hand-write `!ident_body`.
 
-### `%name <-` — reserved-word marker
+### `%name =` — reserved-word marker
 
 A `%` prefix marks a rule as a **reserved word**: it is compiled
 atomic (like `*`) *and* the compiler appends a call to the `wb` rule
@@ -634,9 +634,9 @@ a word boundary. This keeps a keyword from firing on the prefix of a
 longer identifier — `if` must not match the start of `ifx`.
 
 ```peg
-wb            <- !ident_body
-%kw_if        <- @keyword{'if'}
-%storage_spec <- @keyword{'typedef'} / @keyword{'extern'} / @keyword{'static'}
+wb            = !ident_body
+%kw_if        = @keyword{'if'}
+%storage_spec = @keyword{'typedef'} / @keyword{'extern'} / @keyword{'static'}
 ```
 
 The `wb` call is pushed inside each leaf capture (and distributed
@@ -662,7 +662,7 @@ longest-first so maximal munch still holds.)
   (combining them is a parse error).
 - Rejected on the reserved rules `root` / `trivia` / `wb`.
 
-### `%?name <-` — preferred-word marker
+### `%?name =` — preferred-word marker
 
 A `%?` prefix (the `?` touches the `%`) is the sibling of `%` for
 **preferred words**: identifier-eligible distinguished tokens such as
@@ -674,8 +674,8 @@ synthesized set the rule's literals feed*: a `%?` rule's words go into
 identifiers.
 
 ```peg
-%?predeclared_type <- 'int8' / 'int16' / 'int'   # Go: shadowable
-%?kw_async         <- @keyword{'async'}          # JS: contextual
+%?predeclared_type = 'int8' / 'int16' / 'int'   # Go: shadowable
+%?kw_async         = @keyword{'async'}          # JS: contextual
 ```
 
 - Same requirements / composition / rejections as `%`.
@@ -692,7 +692,7 @@ The compiler synthesizes two rules from the `%` / `%?` rules above:
   identifier position without hand-maintaining a list:
 
   ```peg
-  *ident <- !reserved [A-Za-z_] [A-Za-z0-9_]*
+  *ident = !reserved [A-Za-z_] [A-Za-z0-9_]*
   ```
 
 - **`preferred`** — every literal of a `%?` rule. Materialized for
@@ -704,7 +704,7 @@ maximal-munch: `int` is reserved, but `integer` — a longer word that
 merely starts with it — is not. A rule whose body isn't a fixed keyword
 shape (it has a quantifier / wildcard / predicate, e.g. a number body
 like `'0x' [\da-fA-F]+`) contributes nothing; keep such boundary-only
-helpers as `*name <- … wb` rather than `%`. Authors **reference** these
+helpers as `*name = … wb` rather than `%`. Authors **reference** these
 two names but never **define** them (a definition is a parse error).
 
 ### Reserved syntax
@@ -732,8 +732,8 @@ concrete use case.
   is tried only if `p1` fails.
 - **Predicates consume no input.** `!p` and `&p` rewind any `sp`
   advance `p` would have made, and emit no captures.
-- **Left recursion is supported.** Both direct (`A <- A α / β`) and
-  indirect (`A <- B …; B <- A …`) shapes parse left-associatively via
+- **Left recursion is supported.** Both direct (`A = A α / β`) and
+  indirect (`A = B …; B = A …`) shapes parse left-associatively via
   bounded LR (Medeiros et al. 2014 §5; see
   [`src/pegvm/README.md`](../pegvm/README.md#left-recursion)). The
   compiler wraps every member of any non-trivial first-call SCC with
@@ -758,13 +758,13 @@ concrete use case.
 ## Errors
 
 - **`ParseError`** — source is malformed. Carries line and column.
-  Examples: unterminated string, missing `<-`, duplicate rule,
+  Examples: unterminated string, missing `=`, duplicate rule,
   character-class range out of order, unknown escape.
 - **`CompileError`** — source is well-formed but semantically invalid.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
   that doesn't exist, partial-match leniency on a call site that's
   neither anchored (`^^lbl B`) nor explicitly marked intentional
-  (`~name <-`), an `^^lbl` whose call-site FOLLOW set is empty
+  (`~name =`), an `^^lbl` whose call-site FOLLOW set is empty
   so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -13,7 +13,7 @@ use super::pattern::{Pattern, Span};
 use crate::pegvm::CharSet;
 
 /// Returns the set of rule names that are left-recursive — both direct
-/// (`A <- A α / β`) and indirect (`A <- B …; B <- A …`). Each such rule
+/// (`A = A α / β`) and indirect (`A = B …; B = A …`). Each such rule
 /// is emitted with `RuleEnter(_, RuleKind::Lr, _)` and closed with
 /// `LRTail` instead of `MemoClose`, so its packrat slot isn't written
 /// with a value that depends on an in-progress LR seed of a sibling in
@@ -636,7 +636,7 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         Pattern::Catch { inner, .. } => {
             out.extend(trailing_first(inner, nullable));
         }
-        // Definition-level `~name <-` opts the rule out of being a flag
+        // Definition-level `~name =` opts the rule out of being a flag
         // target: its `trailing_first` is empty regardless of body shape.
         Pattern::Lenient { .. } => {}
         _ => {}
@@ -1526,7 +1526,7 @@ pub fn inject_auto_trivia(grammar: &mut Grammar) {
         // The trivia rule itself is exempt: every `trivia_call` from
         // the rewriter calls back into it, so injecting trivia inside
         // its body would recurse the runtime indefinitely. Atomic
-        // rules opt out explicitly via the `*name <-` sigil.
+        // rules opt out explicitly via the `*name =` sigil.
         if atomic.contains(&name) || name == TRIVIA_ROOT_RULE {
             continue;
         }
@@ -1880,7 +1880,7 @@ pub fn synthesize_reserved_preferred(grammar: &mut Grammar) -> Result<(), Compil
 /// shape: a quantifier, wildcard, predicate, catch, or a reference that
 /// cycles or escapes the keyword shape. `NonTerminal`s are resolved
 /// through `rules` (with a `visiting` cycle guard) so wrappers like
-/// `%bool_lit <- @constant{bool_body}` reach their literals.
+/// `%bool_lit = @constant{bool_body}` reach their literals.
 fn keyword_entries(
     pat: &Pattern,
     rules: &HashMap<String, Pattern>,
@@ -1997,13 +1997,13 @@ mod tests {
 
     #[test]
     fn no_trivia_rule_leaves_all_bits_false() {
-        let bits = trivia_bits("root <- 'x'");
+        let bits = trivia_bits("root = 'x'");
         assert!(bits.values().all(|&b| !b));
     }
 
     #[test]
     fn trivia_rule_marks_itself_not_root() {
-        let bits = trivia_bits("root <- trivia 'x'\ntrivia <- ' '*");
+        let bits = trivia_bits("root = trivia 'x'\ntrivia = ' '*");
         assert!(bits["trivia"]);
         assert!(!bits["root"]);
     }
@@ -2011,10 +2011,10 @@ mod tests {
     #[test]
     fn trivia_cascade_reaches_transitive_callees() {
         let bits = trivia_bits(
-            "root <- trivia 'x'\n\
-             trivia <- ws\n\
-             ws <- (comment / ' ')*\n\
-             comment <- '#' (!'\\n' .)*",
+            "root = trivia 'x'\n\
+             trivia = ws\n\
+             ws = (comment / ' ')*\n\
+             comment = '#' (!'\\n' .)*",
         );
         assert!(bits["trivia"] && bits["ws"] && bits["comment"]);
         assert!(!bits["root"]);
@@ -2026,9 +2026,9 @@ mod tests {
         // is pinned out of the cascade — keeping its frame visible in
         // `pegdb recoveries explain`.
         let bits = trivia_bits(
-            "root <- trivia 'x'\n\
-             trivia <- (victim / ' ')*\n\
-             victim <- 'a' ^bad 'b'",
+            "root = trivia 'x'\n\
+             trivia = (victim / ' ')*\n\
+             victim = 'a' ^bad 'b'",
         );
         assert!(bits["trivia"]);
         assert!(!bits["victim"], "catch-bearing rule must not cascade");
@@ -2037,9 +2037,9 @@ mod tests {
     #[test]
     fn trivia_cascade_terminates_on_recursion() {
         let bits = trivia_bits(
-            "root <- trivia 'x'\n\
-             trivia <- ws\n\
-             ws <- (ws / ' ')*",
+            "root = trivia 'x'\n\
+             trivia = ws\n\
+             ws = (ws / ' ')*",
         );
         assert!(bits["trivia"] && bits["ws"]);
     }
@@ -2079,7 +2079,7 @@ mod tests {
 
     #[test]
     fn capture_less_charclass_choice_gets_one_trailing_wb() {
-        // `%t <- [ab] / [cd]` — capture-less but not all-literal, so the
+        // `%t = [ab] / [cd]` — capture-less but not all-literal, so the
         // trie path is skipped and a single trailing `wb` follows the
         // whole choice, not one per branch.
         let body = Pattern::choice(vec![
@@ -2091,7 +2091,7 @@ mod tests {
 
     #[test]
     fn capture_less_literal_choice_factors_into_trie() {
-        // `%t <- 'do' / 'double'` — all-literal, so it folds into a
+        // `%t = 'do' / 'double'` — all-literal, so it folds into a
         // longest-match trie: `do` shared, then `uble` accept vs the bare
         // `do` accept. Two accepts → two `wb`s.
         let body = Pattern::choice(vec![Pattern::literal("do"), Pattern::literal("double")]);
@@ -2108,7 +2108,7 @@ mod tests {
 
     #[test]
     fn capture_choice_distributes_wb_per_branch() {
-        // `%t <- @k{'a'} / @k{'b'}` — each capture must keep `wb` inside
+        // `%t = @k{'a'} / @k{'b'}` — each capture must keep `wb` inside
         // so a committed keyword can't leak through recovery.
         let body = Pattern::choice(vec![
             Pattern::capture("k", Pattern::literal("a")),

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -410,7 +410,7 @@ pub(crate) fn compile_rules(rules: &HashMap<String, Pattern>) -> Result<Program,
     // Identify left-recursive rules (direct and indirect).
     let lr_rules = analyze_left_recursion(rules)?;
 
-    // Compute the per-rule trivia bit by cascading from any `trivia <- …`
+    // Compute the per-rule trivia bit by cascading from any `trivia = …`
     // reserved-name root the grammar defines. Catch-bearing rules are
     // pinned out of the cascade so their frames stay visible in
     // `pegdb recoveries explain`.

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -45,7 +45,7 @@ pub const ROOT_RULE: &str = "root";
 pub const TRIVIA_RULE: &str = "trivia";
 
 /// Reserved rule name for the (optional) word-boundary target. A rule
-/// marked with the `%name <- …` sigil is compiled atomic and has a
+/// marked with the `%name = …` sigil is compiled atomic and has a
 /// trailing call to [`WB_RULE`] appended inside its terminal captures by
 /// [`append_wb_check`](super::analysis::append_wb_check), so a keyword
 /// can't fire on the prefix of a longer identifier. Defining `wb` is
@@ -76,22 +76,22 @@ const MAX_REPEAT_COUNT: usize = 1024;
 #[derive(Debug, Clone)]
 pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
-    /// Names of rules marked atomic with the `*name <- body` sigil. The
+    /// Names of rules marked atomic with the `*name = body` sigil. The
     /// auto-insertion rewriter skips these rules: `Sequence` items inside
     /// an atomic body don't get a synthesized `trivia` call spliced
     /// between them. The `trivia` rule itself never appears here — it
     /// carries no qualifiers; auto-insertion is disabled by omitting
     /// the rule, not by marking it.
     pub atomic_rules: HashSet<String>,
-    /// Names of rules marked with the `%name <- body` reserved-word
-    /// sigil (and the `%?name <- body` preferred-word sigil, which is a
+    /// Names of rules marked with the `%name = body` reserved-word
+    /// sigil (and the `%?name = body` preferred-word sigil, which is a
     /// subset — every `%?` rule is also here so it still gets a
     /// boundary). Each such rule is also in `atomic_rules` (so trivia is
     /// not auto-inserted inside it); membership here additionally drives
     /// [`append_wb_check`](super::analysis::append_wb_check), which
     /// appends a [`WB_RULE`] call inside the rule's terminal captures.
     pub percent_rules: HashSet<String>,
-    /// Names of rules marked with the `%?name <- body` preferred-word
+    /// Names of rules marked with the `%?name = body` preferred-word
     /// sigil — identifier-eligible distinguished tokens (Go predeclared
     /// `int` / `len`, JS contextual `async` / `let`). A strict subset of
     /// `percent_rules`: a `%?` rule still gets the [`WB_RULE`] boundary,
@@ -115,7 +115,7 @@ pub struct RuleHeader {
     pub name: String,
     /// Byte offset of the rule's identifier (after any leading `~` / `*`).
     pub name_byte: usize,
-    /// Byte offset of the first non-whitespace byte after `<-`.
+    /// Byte offset of the first non-whitespace byte after `=`.
     pub body_byte_start: usize,
     /// Byte offset just past the last byte consumed for the body.
     pub body_byte_end: usize,
@@ -165,7 +165,7 @@ impl Grammar {
     /// 2. Run [`lint_partial_match`]; any finding is a fatal
     ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
     ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with `~`
-    ///    at the call site or `~name <- body` at the rule definition.
+    ///    at the call site or `~name = body` at the rule definition.
     /// 3. Inject auto-trivia calls into every non-atomic rule's body
     ///    (no-op when the grammar has no `trivia` rule).
     /// 4. Wrap `root`'s body with `trivia? body trivia? !.` (the
@@ -308,26 +308,26 @@ impl<'a> Parser<'a> {
         let mut preferred_rules: HashSet<String> = HashSet::new();
         let mut rule_headers: Vec<RuleHeader> = Vec::new();
         while self.pos < self.src.len() {
-            // Definition-level lenient marker: `~name <- body` declares
+            // Definition-level lenient marker: `~name = body` declares
             // that every call to `name` is intentionally lenient and
             // suppresses `lint_partial_match` findings at every call site
             // of `name`. The marker touches the name (no whitespace);
             // the rule's body is wrapped with `Pattern::Lenient` so the
             // lint walker sees the same shape as a per-call-site `~p`.
             //
-            // The atomic marker `*name <- body` (sibling of `~`) opts
+            // The atomic marker `*name = body` (sibling of `~`) opts
             // the rule out of trivia auto-insertion: the rewriter walks
             // the body but does not splice `trivia` between `Sequence`
             // items. The `trivia` rule carries no qualifiers; omitting it
             // (not marking it) is what disables auto-insertion.
             //
-            // The reserved-word marker `%name <- body` implies atomic and
+            // The reserved-word marker `%name = body` implies atomic and
             // additionally appends a `wb` boundary call inside the rule's
             // terminal captures (see `append_wb_check`). `%` composes with
             // `~` but is mutually exclusive with `*` — both make a rule
             // atomic, so combining them is always a mistake.
             //
-            // The preferred-word marker `%?name <- body` (the `?` touches
+            // The preferred-word marker `%?name = body` (the `?` touches
             // the `%`) is a sibling of `%`: same atomic + `wb` behavior,
             // but the rule's literals are *excluded* from the synthesized
             // `reserved` set and collected into `preferred` instead, so a
@@ -373,7 +373,7 @@ impl<'a> Parser<'a> {
             let name_byte = self.pos;
             let name = self.parse_ident()?;
             self.skip_ws();
-            self.expect_str("<-")?;
+            self.expect_str("=")?;
             self.skip_ws();
             let body_byte_start = self.pos;
             let mut pat = self.parse_choice()?;
@@ -626,7 +626,7 @@ impl<'a> Parser<'a> {
         match self.peek() {
             None => false,
             Some(b'/') | Some(b')') | Some(b'}') => false,
-            Some(b'<') => false, // start of next rule's "<-"
+            Some(b'=') => false, // start of next rule's "="
             // `^` is the catch operator at infix position — leave it
             // for `parse_catch`. Future overlays (e.g. `^!lbl` throw
             // atom, `^_` anonymous catch) live in the reserved
@@ -636,7 +636,7 @@ impl<'a> Parser<'a> {
             // `~` is a definition-level marker on the NEXT rule. There
             // is no call-site form, so `~` is never a valid in-body
             // atom-start: fall through and let the sequence terminate
-            // here, letting `parse_grammar` consume `~name <- ...`.
+            // here, letting `parse_grammar` consume `~name = ...`.
             Some(b'~') => false,
             Some(c) if is_ident_start(c) => !self.looks_like_rule_def(),
             Some(c) => is_atom_start(c),
@@ -644,7 +644,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Look ahead from the current position to determine whether what follows is
-    /// `ident <- ...` (a new rule definition) rather than a non-terminal reference
+    /// `ident = ...` (a new rule definition) rather than a non-terminal reference
     /// in an expression. Does not consume input.
     fn looks_like_rule_def(&self) -> bool {
         let mut p = self.pos;
@@ -669,7 +669,7 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        p + 1 < self.src.len() && &self.src[p..p + 2] == b"<-"
+        p < self.src.len() && self.src[p] == b'='
     }
 
     fn parse_prefix(&mut self) -> Result<Pattern, ParseError> {
@@ -867,7 +867,7 @@ impl<'a> Parser<'a> {
             Some(b'@') => self.parse_capture(),
             Some(b'\\') => self.parse_backslash_atom(),
             Some(c) if is_ident_start(c) => {
-                // Disambiguation against `name <- ...` is handled by at_prefix_start.
+                // Disambiguation against `name = ...` is handled by at_prefix_start.
                 let name = self.parse_ident()?;
                 Ok(Pattern::NonTerminal { name, span })
             }

--- a/src/pegvm/README.md
+++ b/src/pegvm/README.md
@@ -187,7 +187,7 @@ A grammar that opts into the `*^` recovery operator on a top-level repetition ca
 
 ## Left recursion
 
-The compiler detects left-recursive rules — both direct (`A <- A α / β`) and indirect (`A <- B …; B <- A …`) — by finding strongly connected components in the first-call graph (see `analyze_left_recursion` in `src/pegc/analysis.rs`). Every member of any non-trivial SCC, plus any size-1 SCC with a self-edge, emits its `RuleEnter` with `RuleKind::Lr` and closes its body with `LRTail` instead of `MemoClose`. Cross-rule cycles need no extra runtime support: `RuleEnter`'s LR miss-path lookup walks the stack and finds the right `LFrame` regardless of how many other rules sit between the call site and the frame.
+The compiler detects left-recursive rules — both direct (`A = A α / β`) and indirect (`A = B …; B = A …`) — by finding strongly connected components in the first-call graph (see `analyze_left_recursion` in `src/pegc/analysis.rs`). Every member of any non-trivial SCC, plus any size-1 SCC with a self-edge, emits its `RuleEnter` with `RuleKind::Lr` and closes its body with `LRTail` instead of `MemoClose`. Cross-rule cycles need no extra runtime support: `RuleEnter`'s LR miss-path lookup walks the stack and finds the right `LFrame` regardless of how many other rules sit between the call site and the frame.
 
 Bytecode shape for an LR rule:
 

--- a/src/pegvm/program.rs
+++ b/src/pegvm/program.rs
@@ -34,7 +34,7 @@ pub struct Program {
     /// that don't use labeled failures.
     pub label_kinds: Vec<String>,
     /// Per-rule trivia flags, indexed by `MemoId.0`. `true` when the
-    /// rule is reachable from a `trivia <- …` reserved-name root in
+    /// rule is reachable from a `trivia = …` reserved-name root in
     /// the grammar; a rule containing a recovery catch is pinned out
     /// of inference so the catch's frame stays visible. The
     /// `recoveries` subcommands consult this to drop trailing trivia

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1764,7 +1764,7 @@ mod examined_max_tests {
 
     #[test]
     fn and_predicate_success_records_examined_past_end_sp() {
-        // root <- consumer &"y"; consumer <- "x"   against "xy"
+        // root = consumer &"y"; consumer = "x"   against "xy"
         // `consumer`'s memo entry is the focus: end_sp=1 (matched "x")
         // but examined_max must be 1 (only position 0 was read inside
         // consumer). `root`'s subsequent `&"y"` is a sibling of the
@@ -1798,7 +1798,7 @@ mod examined_max_tests {
 
     #[test]
     fn and_predicate_failure_records_examined_up_to_failed_read() {
-        // start <- "x" &"z"   against "xy"
+        // start = "x" &"z"   against "xy"
         // "x" succeeds (sp=1), then &"z" reads 'y' at sp=1 and fails.
         // The failure entry for start at sp=0 must remember that
         // position 1 was examined, so an edit there can invalidate it.
@@ -1828,8 +1828,8 @@ mod examined_max_tests {
 
     #[test]
     fn nested_rule_examined_max_propagates_to_caller() {
-        // root <- inner "y"
-        // inner <- "x"
+        // root = inner "y"
+        // inner = "x"
         // against "xy".  inner's entry: end_sp=1, examined_max=1.
         // root's entry: end_sp=2 (the body span), but examined_max=3
         // because the synthesized `!.` at root's tail reads one byte
@@ -1873,8 +1873,8 @@ mod examined_max_tests {
         // whichever rule encloses the call.
         //
         // Grammar:
-        //   start <- (X "aa") / (X "bb")
-        //   X <- "a"
+        //   start = (X "aa") / (X "bb")
+        //   X = "a"
         // Input: "abb" — first alt fails after X matches "a" and "aa"
         // fails on "bb"; backtrack to second alt, which hits X's cache
         // and then matches "bb".
@@ -1911,7 +1911,7 @@ mod examined_max_tests {
 
     #[test]
     fn recover_repeat_propagates_examined_max_through_loop_iterations() {
-        // start <- ("ab")*^   against "abxab"
+        // start = ("ab")*^   against "abxab"
         //
         // The recovery loop runs entirely inside start's memo entry.
         // Across iterations the loop reads positions 0, 1 (success),
@@ -1965,7 +1965,7 @@ mod recovery_diagnostic_tests {
     #[test]
     fn diagnostics_empty_when_knob_off() {
         // Grammar that triggers recovery but no opt-in to diagnostics.
-        let prog = pegc::compile("root <- ([a-z]+)*^").unwrap();
+        let prog = pegc::compile("root = ([a-z]+)*^").unwrap();
         let result = VM::new_from_program(&prog, b"abc!!def").run();
         assert!(result.complete);
         assert!(
@@ -1985,7 +1985,7 @@ mod recovery_diagnostic_tests {
 
     #[test]
     fn diagnostics_one_per_recovery_byte_when_knob_on() {
-        let prog = pegc::compile("root <- ([a-z]+)*^").unwrap();
+        let prog = pegc::compile("root = ([a-z]+)*^").unwrap();
         let result = VM::new_from_program(&prog, b"abc!!def")
             .with_track_recovery_diagnostics(true)
             .run();
@@ -2029,9 +2029,9 @@ mod recovery_diagnostic_tests {
         // reached deepest *inside* `inner`, so the recorded rule_stack
         // must include `inner`.
         let src = "\
-            root <- (item)*^\n\
-            item <- inner\n\
-            inner <- [a-z]+\n";
+            root = (item)*^\n\
+            item = inner\n\
+            inner = [a-z]+\n";
         let prog = pegc::compile(src).unwrap();
         let result = VM::new_from_program(&prog, b"abc!!def")
             .with_track_recovery_diagnostics(true)

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -446,8 +446,8 @@ fn recover_repeat_drops_unclosed_capture_from_failed_inner_attempt() {
 
 #[test]
 fn recover_repeat_inside_called_rule_returns_cleanly() {
-    // root <- "PRE" loop
-    // loop  <- "a"*^
+    // root = "PRE" loop
+    // loop  = "a"*^
     //
     // Against "PREaxa": the *^ runs to EOF, then start's Return must
     // pop a Return frame — not a Backtrack frame leaked from the loop.
@@ -784,8 +784,8 @@ fn nested_captures_flow_through_compile() {
 
 #[test]
 fn grammar_with_nonterminals() {
-    // root  <- digit+
-    // digit <- [0-9]
+    // root  = digit+
+    // digit = [0-9]
     // The `root` wrap supplies the implicit end-of-input assertion;
     // trailing non-digits now produce `complete=false`. `matched`
     // reports the deepest position reached: `!.`'s lookahead reads one
@@ -911,7 +911,7 @@ fn recover_repeat_labeled_interns_author_label() {
     // the capture kind at its hardcoded `"recovery"` — the catch
     // scope is renamed (so pegdb recoveries explain clusters under
     // "bad_thing"), but theme styling is unaffected.
-    let prog = syntax_highlighter::pegc::compile("root <- 'a'*^:bad_thing").unwrap();
+    let prog = syntax_highlighter::pegc::compile("root = 'a'*^:bad_thing").unwrap();
     assert_eq!(prog.capture_kinds, vec!["recovery".to_string()]);
     assert_eq!(prog.label_kinds, vec!["bad_thing".to_string()]);
 }
@@ -1000,8 +1000,8 @@ fn sync_set_terminates_cleanly_at_eof_without_delim() {
 
 #[test]
 fn grammar_rules_are_wrapped_in_memo_open_close() {
-    // root  <- "a"
-    // other <- "b"
+    // root  = "a"
+    // other = "b"
     // Layout (root's body wraps with `!.` for the implicit
     // end-of-input assertion: Choice / Any / FailTwice for the
     // NotPredicate):
@@ -1045,7 +1045,7 @@ fn grammar_rules_are_wrapped_in_memo_open_close() {
 
 #[test]
 fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
-    // root <- root "+" "n" / "n"
+    // root = root "+" "n" / "n"
     // Layout (no MemoClose for an LR rule — LRTail closes the body):
     //   0: Call(2)
     //   1: End
@@ -1110,7 +1110,7 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
 
 #[test]
 fn right_recursive_rule_is_not_marked_lr() {
-    // root <- "n" "+" start / "n"
+    // root = "n" "+" start / "n"
     // The recursive call is not in first-call position — "n" consumes
     // input first. Compile must use the standard Memo-kind RuleEnter
     // and MemoClose.
@@ -1146,8 +1146,8 @@ fn right_recursive_rule_is_not_marked_lr() {
 
 #[test]
 fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
-    // a <- b "x" / "y"
-    // b <- a "z" / "w"
+    // a = b "x" / "y"
+    // b = a "z" / "w"
     // First-call SCC {a, b}; both rules must be wrapped as LR.
     let mut rules = HashMap::new();
     rules.insert(
@@ -1179,7 +1179,7 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
     assert_eq!(lr_bodies, 2, "both SCC members must emit Lr-kind RuleEnter");
     assert_eq!(lr_tails, 2, "both SCC members must emit LRTail");
     // `a` and `b` (the SCC) must not be Memo-kind. The synthesized
-    // `root <- a` wrapper is itself Memo (root isn't in any cycle); that's
+    // `root = a` wrapper is itself Memo (root isn't in any cycle); that's
     // fine — the assertion is about the cycle members.
     let a_idx = prog.rule_names.iter().position(|n| n == "a").unwrap();
     let b_idx = prog.rule_names.iter().position(|n| n == "b").unwrap();
@@ -1203,9 +1203,9 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
 
 #[test]
 fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
-    // a <- b "x" / "p"
-    // b <- c "y" / "q"
-    // c <- a "z" / "r"
+    // a = b "x" / "p"
+    // b = c "y" / "q"
+    // c = a "z" / "r"
     // First-call SCC {a, b, c}; all three rules must be wrapped as LR.
     let mut rules = HashMap::new();
     rules.insert(
@@ -1247,7 +1247,7 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
     );
     assert_eq!(lr_tails, 3, "all three SCC members must emit LRTail");
     // `a`, `b`, `c` (the SCC) must not be Memo-kind; the synthesized
-    // `root <- a` rule is Memo and that's fine.
+    // `root = a` rule is Memo and that's fine.
     let cycle: Vec<usize> = ["a", "b", "c"]
         .iter()
         .map(|n| prog.rule_names.iter().position(|r| r == *n).unwrap())
@@ -1272,8 +1272,8 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
 
 #[test]
 fn right_recursive_two_rule_grammar_is_not_marked_lr() {
-    // a <- "x" b / "y"
-    // b <- "z" a / "w"
+    // a = "x" b / "y"
+    // b = "z" a / "w"
     // Each call site is preceded by a literal — no first-call edges, so
     // no SCC and no LR wrapping. Sanity check that the analysis isn't
     // over-eager about cross-rule recursion.
@@ -1310,8 +1310,8 @@ fn right_recursive_two_rule_grammar_is_not_marked_lr() {
 
 #[test]
 fn lr_through_nullable_prefix_is_detected() {
-    // root <- opt root "+" "n" / "n"
-    // opt   <- "x"?
+    // root = opt root "+" "n" / "n"
+    // opt   = "x"?
     // The recursive call is gated by an optional prefix; nullability
     // analysis must propagate the first-call through `opt`.
     let mut rules = HashMap::new();
@@ -1354,7 +1354,7 @@ fn cap_lit(kind: &str, s: &str) -> FollowElement {
 
 #[test]
 fn follow_set_single_rule_tail() {
-    // root <- a; a <- 'x'
+    // root = a; a = 'x'
     let mut rules = HashMap::new();
     rules.insert("root".into(), Pattern::nt("a"));
     rules.insert("a".into(), Pattern::literal("x"));
@@ -1366,7 +1366,7 @@ fn follow_set_single_rule_tail() {
 
 #[test]
 fn follow_set_sequence_after() {
-    // root <- a 'y'; a <- 'x'
+    // root = a 'y'; a = 'x'
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1380,7 +1380,7 @@ fn follow_set_sequence_after() {
 
 #[test]
 fn follow_set_choice_tail() {
-    // root <- a / b; a <- 'x'; b <- 'y'
+    // root = a / b; a = 'x'; b = 'y'
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1397,7 +1397,7 @@ fn follow_set_choice_tail() {
 
 #[test]
 fn follow_set_repeat_self() {
-    // root <- a*; a <- 'x'
+    // root = a*; a = 'x'
     let mut rules = HashMap::new();
     rules.insert("root".into(), Pattern::repeat(Pattern::nt("a")));
     rules.insert("a".into(), Pattern::literal("x"));
@@ -1418,7 +1418,7 @@ fn follow_set_repeat_self() {
 
 #[test]
 fn follow_set_nullable_skip() {
-    // root <- a b 'z'; a <- 'x'; b <- 'y'?
+    // root = a b 'z'; a = 'x'; b = 'y'?
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1447,7 +1447,7 @@ fn follow_set_nullable_skip() {
 
 #[test]
 fn follow_set_recursive() {
-    // list <- 'x' (',' list)?
+    // list = 'x' (',' list)?
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1469,7 +1469,7 @@ fn follow_set_recursive() {
 
 #[test]
 fn follow_set_capture_preserved() {
-    // root <- a @punctuation{','}; a <- 'x'
+    // root = a @punctuation{','}; a = 'x'
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1490,7 +1490,7 @@ fn follow_set_capture_preserved() {
 
 #[test]
 fn follow_set_predicate_lookahead() {
-    // root <- a &'y' 'z'; a <- 'x'
+    // root = a &'y' 'z'; a = 'x'
     let mut rules = HashMap::new();
     rules.insert(
         "root".into(),
@@ -1570,7 +1570,7 @@ fn finding(rule: &str, caller: &str) -> LintFinding {
 
 #[test]
 fn lint_partial_match_trailing_optional_with_eof_validator() {
-    // root <- a; a <- 'x' 'y'?
+    // root = a; a = 'x' 'y'?
     // a is called from the start rule, whose only continuation is Eof.
     // Eof rejects any non-empty leftover bytes — a validator. No flag.
     let mut rules = HashMap::new();
@@ -1588,7 +1588,7 @@ fn lint_partial_match_trailing_optional_with_eof_validator() {
 
 #[test]
 fn lint_partial_match_no_trailing_nullable_skipped() {
-    // root <- a; a <- 'x' 'y' — no trailing optional/nullable.
+    // root = a; a = 'x' 'y' — no trailing optional/nullable.
     let mut rules = HashMap::new();
     rules.insert("root".into(), Pattern::nt("a"));
     rules.insert(
@@ -1601,7 +1601,7 @@ fn lint_partial_match_no_trailing_nullable_skipped() {
 
 #[test]
 fn lint_partial_match_anchored_via_andpredicate() {
-    // root <- a &'y' 'y'; a <- 'x' 'y'?
+    // root = a &'y' 'y'; a = 'x' 'y'?
     // The AndPredicate anchors the call to a even though a's trailing
     // overlaps with what follows.
     let mut rules = HashMap::new();
@@ -1629,7 +1629,7 @@ fn lint_partial_match_anchored_via_andpredicate() {
 
 #[test]
 fn lint_partial_match_validated_by_disjoint_consumer() {
-    // root <- a 'z'; a <- 'x' 'y'?
+    // root = a 'z'; a = 'x' 'y'?
     // 'z' after a is a non-nullable consumer with FIRST={'z'} disjoint
     // from a's trailing {'y'}. The consumer validates.
     let mut rules = HashMap::new();
@@ -1650,8 +1650,8 @@ fn lint_partial_match_validated_by_disjoint_consumer() {
 
 #[test]
 fn lint_partial_match_absorbed_by_outer_catch_flagged() {
-    // root <- (a)*^[;]
-    // a <- 'x' 'y'?
+    // root = (a)*^[;]
+    // a = 'x' 'y'?
     // a's leniency at the call site is absorbed by the *^ recovery
     // wrapper — exactly the PR #101 shape.
     let mut rules = HashMap::new();
@@ -1723,14 +1723,14 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
     );
 }
 
-// ---- Definition-level lenient marker (~rule_name <- body) -----
+// ---- Definition-level lenient marker (~rule_name = body) -----
 
 #[test]
 fn definition_lenient_marker_wraps_rule_body() {
-    // `~rule <- body` parses the body with a top-level `Pattern::Lenient`
+    // `~rule = body` parses the body with a top-level `Pattern::Lenient`
     // wrap, exposing the intent to the lint via the same AST node the
     // call-site `~p` form produces.
-    let g = parse("~r <- 'a'?").expect("parse");
+    let g = parse("~r = 'a'?").expect("parse");
     assert_eq!(
         g.rules["r"].strip_spans(),
         Pattern::lenient(Pattern::optional(Pattern::literal("a"))),
@@ -1739,7 +1739,7 @@ fn definition_lenient_marker_wraps_rule_body() {
 
 #[test]
 fn definition_lenient_marker_requires_touching_name() {
-    let err = parse("~ r <- 'a'?").expect_err("space between `~` and name must error");
+    let err = parse("~ r = 'a'?").expect_err("space between `~` and name must error");
     assert!(
         err.message.contains("expected identifier"),
         "unexpected error: {}",
@@ -1751,7 +1751,7 @@ fn definition_lenient_marker_requires_touching_name() {
 fn definition_lenient_suppresses_lint_at_every_call_site() {
     // Use the Catch-absorbed shape the lint reliably flags: a
     // top-level `*^[;]` recovery loop calling a trailing-Optional rule.
-    let unmarked = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse unmarked");
+    let unmarked = parse("root = (r)*^[;]\nr = 'x' 'y'?").expect("parse unmarked");
     assert!(
         lint_partial_match(&unmarked)
             .iter()
@@ -1759,7 +1759,7 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
         "baseline: unmarked grammar should flag r"
     );
 
-    let marked = parse("root <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse marked");
+    let marked = parse("root = (r)*^[;]\n~r = 'x' 'y'?").expect("parse marked");
     let findings = lint_partial_match(&marked);
     assert!(
         !findings.iter().any(|f| f.rule == "r"),
@@ -1769,14 +1769,14 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
 
 #[test]
 fn definition_lenient_marker_is_runtime_transparent() {
-    // The `~name <-` wrap compiles to the same bytecode as the bare
+    // The `~name =` wrap compiles to the same bytecode as the bare
     // form. The marker rides a non-special helper rule — `root` (like
     // `trivia` / `wb`) rejects every qualifier.
-    let plain = parse("root <- r\nr <- 'x'+")
+    let plain = parse("root = r\nr = 'x'+")
         .expect("parse plain")
         .compile()
         .expect("compile plain");
-    let marked = parse("root <- r\n~r <- 'x'+")
+    let marked = parse("root = r\n~r = 'x'+")
         .expect("parse marked")
         .compile()
         .expect("compile marked");
@@ -1788,7 +1788,7 @@ fn definition_lenient_marker_is_runtime_transparent() {
 #[test]
 fn compile_errors_on_partial_match_leniency() {
     // `*^[;]` Catch-absorbed shape — the lint reliably flags this.
-    let g = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let g = parse("root = (r)*^[;]\nr = 'x' 'y'?").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     match err {
         syntax_highlighter::pegc::CompileError::PartialMatchLeniency(findings) => {
@@ -1803,7 +1803,7 @@ fn compile_errors_on_partial_match_leniency() {
 
 #[test]
 fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
-    let g = parse("root <- (r)*^[;]\n~r <- 'x' 'y'?").expect("parse");
+    let g = parse("root = (r)*^[;]\n~r = 'x' 'y'?").expect("parse");
     g.compile()
         .expect("compile should succeed with definition-level `~r`");
 }
@@ -1812,7 +1812,7 @@ fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
 fn compile_succeeds_with_boundary_catch_anchor() {
     // `^^bad ';'` lowers to `Catch { Seq(a, &';'), bad, recovery }` —
     // anchoring `a` by lookahead so the lint sees no leniency.
-    let g = parse("root <- (a ^^bad ';')*\na <- 'x' 'y'?").expect("parse");
+    let g = parse("root = (a ^^bad ';')*\na = 'x' 'y'?").expect("parse");
     g.compile()
         .expect("compile should succeed with `^^bad ';'` anchor");
 }
@@ -1823,7 +1823,7 @@ fn compile_succeeds_with_bracketed_close_catch_sugar() {
     // and whose recovery is `Seq(@recovery{(!'}' .)*}, '}')`. The
     // inner ends in `'}'` (a hard terminator), so `lint_partial_match`
     // sees no trailing-nullable shape and compilation succeeds.
-    let g = parse("root <- ('{' a '}' ^^bad ..= '}')*\na <- 'x'+").expect("parse");
+    let g = parse("root = ('{' a '}' ^^bad ..= '}')*\na = 'x'+").expect("parse");
     g.compile()
         .expect("compile should succeed with `^^bad ..= '}'` sugar");
 }
@@ -1837,7 +1837,7 @@ fn bracketed_close_catch_runs_recovery_path() {
     // exercises the recovery: skip captures `garbage` and `}` is
     // captured as `@punctuation`.
     let g = parse(
-        "root <- @punctuation{'{'} (body @punctuation{'}'} ^^bad ..= @punctuation{'}'})\nbody <- 'x'",
+        "root = @punctuation{'{'} (body @punctuation{'}'} ^^bad ..= @punctuation{'}'})\nbody = 'x'",
     )
     .expect("parse");
     let prog = g.compile().expect("compile");
@@ -1858,7 +1858,7 @@ fn bracketed_close_catch_runs_recovery_path() {
 
 #[test]
 fn compile_error_display_lists_findings() {
-    let g = parse("root <- (r)*^[;]\nr <- 'x' 'y'?").expect("parse");
+    let g = parse("root = (r)*^[;]\nr = 'x' 'y'?").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     let msg = format!("{err}");
     assert!(msg.contains("partial-match leniency"));
@@ -1871,7 +1871,7 @@ fn compile_errors_on_uninferable_boundary() {
     // The start rule has no FOLLOW context other than EOF — for a
     // rule with no callers at all, the inferred boundary would be
     // empty. Construct that case via a non-start unreachable rule.
-    let g = parse("root <- 'x'\norphan <- 'a' ^^bad").expect("parse");
+    let g = parse("root = 'x'\norphan = 'a' ^^bad").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     assert!(
         matches!(
@@ -1890,8 +1890,8 @@ fn auto_trivia_handles_inter_repeat_whitespace() {
     // already covers). Without the prepend, ` , 2 , 3` would fail on
     // the second iteration's leading space.
     let prog = parse(
-        "root   <- 'x' (',' 'x')*\n\
-         trivia <- ' '*",
+        "root   = 'x' (',' 'x')*\n\
+         trivia = ' '*",
     )
     .expect("parse")
     .compile()
@@ -1905,7 +1905,7 @@ fn auto_trivia_handles_inter_repeat_whitespace() {
 fn backslash_cap_r_matches_crlf_atomically() {
     // `\R` lowers to `'\r\n' / '\n' / '\r'` — CRLF is matched as one
     // two-byte unit, not two separate line breaks.
-    let g = parse("root <- \\R").expect("parse");
+    let g = parse("root = \\R").expect("parse");
     let prog = g.compile().expect("compile");
     let r = VM::new_from_program(&prog, b"\r\n").run();
     assert!(r.complete, "\\R should match CRLF");
@@ -1924,7 +1924,7 @@ fn backslash_cap_r_matches_crlf_atomically() {
 fn not_any_matches_eof() {
     // `!.` is the explicit end-of-input assertion. Verify it succeeds
     // at end-of-input and fails otherwise.
-    let g = parse("root <- !.").expect("parse");
+    let g = parse("root = !.").expect("parse");
     let prog = g.compile().expect("compile");
     let r = VM::new_from_program(&prog, b"").run();
     assert!(r.complete, "!. should match empty input");
@@ -1940,7 +1940,7 @@ fn repeat_count_matches_exact_length() {
     // produces the same VM behavior as four hand-written `\d`s.
     // The `root` wrap supplies the trailing end-of-input assertion
     // implicitly.
-    let g = parse("root <- \\d{4}").expect("parse");
+    let g = parse("root = \\d{4}").expect("parse");
     let prog = g.compile().expect("compile");
 
     let r = VM::new_from_program(&prog, b"1234").run();
@@ -1986,16 +1986,16 @@ fn all_shipped_grammars_compile_clean() {
 #[test]
 fn partial_match_leniency_carries_call_site_span_in_display() {
     // `(r)*^[;]` is the catch-absorbed shape that reliably flags — the
-    // `r` reference at line 1, col 11 is the call site the lint
+    // `r` reference at line 1, col 9 is the call site the lint
     // surfaces. The rendered Display must include `{line}:{col}` so
     // grammar authors can jump to the unanchored call directly.
-    let src = "root <- (r)*^[;]\nr <- 'x' 'y'?";
+    let src = "root = (r)*^[;]\nr = 'x' 'y'?";
     let g = parse(src).expect("parses");
     let err = g.compile().expect_err("partial-match leniency expected");
     let rendered = format!("{err}");
     assert!(
-        rendered.contains("1:10:"),
-        "expected call-site `1:10:` (the `r` reference on line 1, col 10), got:\n{rendered}",
+        rendered.contains("1:9:"),
+        "expected call-site `1:9:` (the `r` reference on line 1, col 9), got:\n{rendered}",
     );
 }
 
@@ -2005,14 +2005,14 @@ fn partial_match_leniency_finding_carries_call_site_span() {
     // the Display impl is a thin formatting layer over it. Pin the
     // structured field directly so callers (e.g. editor diagnostics)
     // get the same position the rendered text reports.
-    let src = "root <- (r)*^[;]\nr <- 'x' 'y'?";
+    let src = "root = (r)*^[;]\nr = 'x' 'y'?";
     let g = parse(src).expect("parses");
     let findings = lint_partial_match(&g);
     let f = findings
         .iter()
         .find(|f| f.rule == "r" && f.caller == "root")
         .expect("r/root finding present");
-    assert_eq!(f.call_site, Span { line: 1, col: 10 });
+    assert_eq!(f.call_site, Span { line: 1, col: 9 });
 }
 
 #[test]
@@ -2020,21 +2020,21 @@ fn cannot_infer_boundary_carries_placeholder_span_in_display() {
     // The start rule's FOLLOW seeds with EOF, so a top-level `^^lbl`
     // there resolves successfully. An unreachable rule has empty FOLLOW
     // and triggers `CannotInferBoundary` — the placeholder's span at
-    // line 2, col 15 (start of `^^bad`) surfaces through both the
+    // line 2, col 14 (start of `^^bad`) surfaces through both the
     // structured error and its Display rendering.
-    let src = "root <- 'x'\norphan <- 'a' ^^bad";
+    let src = "root = 'x'\norphan = 'a' ^^bad";
     let g = parse(src).expect("parses");
     let err = g.compile().expect_err("CannotInferBoundary expected");
     match &err {
         syntax_highlighter::pegc::CompileError::CannotInferBoundary { span, .. } => {
-            assert_eq!(*span, Span { line: 2, col: 15 });
+            assert_eq!(*span, Span { line: 2, col: 14 });
         }
         other => panic!("expected CannotInferBoundary, got: {other:?}"),
     }
     let rendered = format!("{err}");
     assert!(
-        rendered.starts_with("2:15:"),
-        "expected `2:15:` prefix, got: {rendered}",
+        rendered.starts_with("2:14:"),
+        "expected `2:14:` prefix, got: {rendered}",
     );
 }
 
@@ -2046,22 +2046,22 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     // Operator: `Optional` span inherits its operand's span.
     // Operator: `Capture` span = position of the `@`.
     // Operator: `Catch` span = position of the leading `^`.
-    let src = "r <- @kind{'a'?} ^lbl 'b'";
+    let src = "r = @kind{'a'?} ^lbl 'b'";
     let g = parse(src).expect("parses");
     let body = &g.rules["r"];
 
-    // Top-level is a `Catch`: span at the `^` (column 18 — `^lbl` follows
+    // Top-level is a `Catch`: span at the `^` (column 17 — `^lbl` follows
     // `@kind{'a'?} `).
     let Pattern::Catch { inner, span, .. } = body else {
         panic!("expected Catch at root, got: {body:?}");
     };
     assert_eq!(
         *span,
-        Span { line: 1, col: 18 },
+        Span { line: 1, col: 17 },
         "Catch span should anchor at `^`"
     );
 
-    // Inner is a `Capture`: span at the `@` (column 6).
+    // Inner is a `Capture`: span at the `@` (column 5).
     let Pattern::Capture {
         inner: cap_inner,
         span: cap_span,
@@ -2072,12 +2072,12 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     };
     assert_eq!(
         *cap_span,
-        Span { line: 1, col: 6 },
+        Span { line: 1, col: 5 },
         "Capture span should anchor at `@`"
     );
 
     // Inside the capture: `Optional` whose span inherits the operand's
-    // start position — the operand is `'a'` literal at column 12.
+    // start position — the operand is `'a'` literal at column 11.
     let Pattern::Optional {
         inner: opt_inner,
         span: opt_span,
@@ -2087,13 +2087,13 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     };
     assert_eq!(
         *opt_span,
-        Span { line: 1, col: 12 },
+        Span { line: 1, col: 11 },
         "Optional span should inherit operand's start (the `'`)"
     );
     let Pattern::Literal { span: lit_span, .. } = opt_inner.as_ref() else {
         panic!("expected Literal inside Optional, got: {opt_inner:?}");
     };
-    assert_eq!(*lit_span, Span { line: 1, col: 12 });
+    assert_eq!(*lit_span, Span { line: 1, col: 11 });
 }
 
 // ---- `%` reserved-word sigil + `wb` special rule -------------------
@@ -2119,7 +2119,7 @@ fn run_grammar<'a>(src: &str, input: &'a str) -> Vec<(String, &'a str)> {
 
 #[test]
 fn percent_sigil_populates_percent_and_atomic_sets() {
-    let g = parse("root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%r <- @keyword{'if'}").expect("parse");
+    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\n%r = @keyword{'if'}").expect("parse");
     assert!(
         g.percent_rules.contains("r"),
         "`%r` should be a percent rule"
@@ -2140,7 +2140,7 @@ fn qualifier_on_special_rule_is_rejected() {
     // not by qualifying it.
     for name in ["root", "trivia", "wb"] {
         for qual in ["*", "~", "%", "%?"] {
-            let src = format!("{qual}{name} <- 'a'");
+            let src = format!("{qual}{name} = 'a'");
             let err = parse(&src).expect_err("a qualifier on a special rule must error");
             assert!(
                 err.message.contains("cannot carry a qualifier"),
@@ -2162,8 +2162,8 @@ fn percent_composes_with_lenient() {
     // `~%name` and `%~name` both parse: `~` (lenient) and `%`
     // (reserved-word) are independent markers.
     for src in [
-        "root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n~%r <- @keyword{'if'}",
-        "root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%~r <- @keyword{'if'}",
+        "root = r\ntrivia = (\\s)*\nwb = !'x'\n~%r = @keyword{'if'}",
+        "root = r\ntrivia = (\\s)*\nwb = !'x'\n%~r = @keyword{'if'}",
     ] {
         let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
         assert!(
@@ -2177,13 +2177,13 @@ fn percent_composes_with_lenient() {
 fn percent_rule_appends_wb_inside_capture() {
     // `%kw_if` must match the keyword `if` but not fire on `ifx`, and
     // (the leak guard) must leave no stray `if` capture behind on `ifx`.
-    let src = "root <- (token)*^\n\
-               trivia <- (\\s)*\n\
-               wb <- !ident_body\n\
-               token <- kw_if / @variable{ident}\n\
-               %kw_if <- @keyword{'if'}\n\
-               *ident <- [a-z] ident_body*\n\
-               ident_body <- [a-z0-9_]";
+    let src = "root = (token)*^\n\
+               trivia = (\\s)*\n\
+               wb = !ident_body\n\
+               token = kw_if / @variable{ident}\n\
+               %kw_if = @keyword{'if'}\n\
+               *ident = [a-z] ident_body*\n\
+               ident_body = [a-z0-9_]";
     assert_eq!(
         run_grammar(src, "if ifx if"),
         vec![
@@ -2198,7 +2198,7 @@ fn percent_rule_appends_wb_inside_capture() {
 fn percent_without_wb_errors_undefined_rule() {
     // A `%` rule emits a `NonTerminal("wb")`; with no `wb` defined the
     // reference surfaces as `UndefinedRule("wb")`.
-    let g = parse("root <- r\ntrivia <- (\\s)*\n%r <- @keyword{'if'}").expect("parse");
+    let g = parse("root = r\ntrivia = (\\s)*\n%r = @keyword{'if'}").expect("parse");
     match g.compile().expect_err("compile should fail without wb") {
         syntax_highlighter::pegc::CompileError::UndefinedRule(name) => assert_eq!(name, "wb"),
         other => panic!("expected UndefinedRule(\"wb\"), got: {other:?}"),
@@ -2207,7 +2207,7 @@ fn percent_without_wb_errors_undefined_rule() {
 
 #[test]
 fn percent_and_atomic_combined_is_parse_error() {
-    for src in ["%*r <- 'a'", "*%r <- 'a'"] {
+    for src in ["%*r = 'a'", "*%r = 'a'"] {
         let err = parse(src).expect_err("combining `%` and `*` must error");
         assert!(
             err.message.contains("cannot be combined"),
@@ -2220,7 +2220,7 @@ fn percent_and_atomic_combined_is_parse_error() {
 #[test]
 fn wb_must_sit_in_the_reserved_slots() {
     // `wb` after a non-reserved rule (not contiguous with `root`) errors.
-    let err = parse("root <- r\nr <- 'a'\nwb <- !'x'").expect_err("misplaced wb must error");
+    let err = parse("root = r\nr = 'a'\nwb = !'x'").expect_err("misplaced wb must error");
     assert!(
         err.message.contains("reserved slots"),
         "unexpected error: {}",
@@ -2231,14 +2231,14 @@ fn wb_must_sit_in_the_reserved_slots() {
 #[test]
 fn wb_and_trivia_compose_in_either_order() {
     // Both orderings of the two reserved slots after `root` are accepted.
-    parse("root <- 'a'\ntrivia <- (\\s)*\nwb <- !'x'").expect("trivia then wb");
-    parse("root <- 'a'\nwb <- !'x'\ntrivia <- (\\s)*").expect("wb then trivia");
+    parse("root = 'a'\ntrivia = (\\s)*\nwb = !'x'").expect("trivia then wb");
+    parse("root = 'a'\nwb = !'x'\ntrivia = (\\s)*").expect("wb then trivia");
 }
 
 #[test]
 fn wb_without_trivia_is_valid() {
     // `wb` does not require `trivia`; a grammar may define only `wb`.
-    parse("root <- r\nwb <- !'x'\n%r <- @keyword{'if'}")
+    parse("root = r\nwb = !'x'\n%r = @keyword{'if'}")
         .expect("parse")
         .compile()
         .expect("compile");
@@ -2252,8 +2252,7 @@ fn preferred_sigil_populates_preferred_and_percent_sets() {
     // also in `percent_rules` + `atomic_rules` (it still gets the `wb`
     // boundary; it differs from `%` only in which synthesized set it
     // feeds).
-    let g =
-        parse("root <- r\ntrivia <- (\\s)*\nwb <- !'x'\n%?r <- @keyword{'async'}").expect("parse");
+    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\n%?r = @keyword{'async'}").expect("parse");
     assert!(g.preferred_rules.contains("r"), "`%?r` should be preferred");
     assert!(
         g.percent_rules.contains("r"),
@@ -2264,7 +2263,7 @@ fn preferred_sigil_populates_preferred_and_percent_sets() {
 
 #[test]
 fn preferred_and_atomic_combined_is_parse_error() {
-    for src in ["%?*r <- 'a'", "*%?r <- 'a'"] {
+    for src in ["%?*r = 'a'", "*%?r = 'a'"] {
         let err = parse(src).expect_err("combining `%?` and `*` must error");
         assert!(
             err.message.contains("cannot be combined"),
@@ -2279,10 +2278,10 @@ fn defining_synthesized_rule_is_parse_error() {
     // `reserved` / `preferred` are compiler-generated; an explicit
     // definition (with or without a sigil) is rejected.
     for src in [
-        "reserved <- 'a'",
-        "%reserved <- 'a'",
-        "preferred <- 'a'",
-        "%?preferred <- 'a'",
+        "reserved = 'a'",
+        "%reserved = 'a'",
+        "preferred = 'a'",
+        "%?preferred = 'a'",
     ] {
         let err = parse(src).expect_err("defining a synthesized rule must error");
         assert!(
@@ -2297,7 +2296,7 @@ fn defining_synthesized_rule_is_parse_error() {
 fn reserved_preferred_conflict_errors() {
     // The same literal marked `%` (reserved) in one rule and `%?`
     // (preferred) in another is a contradiction — compile rejects it.
-    let err = parse("root <- 'x'\nwb <- !'y'\n%a <- 'int'\n%?b <- 'int'")
+    let err = parse("root = 'x'\nwb = !'y'\n%a = 'int'\n%?b = 'int'")
         .expect("parse")
         .compile()
         .expect_err("conflicting reserved/preferred must error");
@@ -2316,14 +2315,14 @@ fn synthesized_reserved_trie_and_preferred_membership() {
     // still matches `int8` maximally (#13 fixed structurally). `%?pre`
     // (`len`) is preferred, so it is excluded from `reserved` and stays
     // usable as an identifier.
-    let src = "root <- (token)*^\n\
-               trivia <- (\\s)*\n\
-               wb <- !ident_body\n\
-               token <- @keyword{kw_word} / @variable{ident}\n\
-               %kw_word <- 'int' / 'int8'\n\
-               %?pre <- 'len'\n\
-               *ident <- !reserved [a-z] ident_body*\n\
-               ident_body <- [a-z0-9]";
+    let src = "root = (token)*^\n\
+               trivia = (\\s)*\n\
+               wb = !ident_body\n\
+               token = @keyword{kw_word} / @variable{ident}\n\
+               %kw_word = 'int' / 'int8'\n\
+               %?pre = 'len'\n\
+               *ident = !reserved [a-z] ident_body*\n\
+               ident_body = [a-z0-9]";
     assert_eq!(
         run_grammar(src, "int8 len int"),
         vec![

--- a/tests/fixtures/stats_canary.peg
+++ b/tests/fixtures/stats_canary.peg
@@ -1,1 +1,1 @@
-root =  'a' / @keyword{'b'}
+root = 'a' / @keyword{'b'}

--- a/tests/fixtures/stats_canary.peg
+++ b/tests/fixtures/stats_canary.peg
@@ -1,1 +1,1 @@
-root <- 'a' / @keyword{'b'}
+root =  'a' / @keyword{'b'}

--- a/tests/fixtures/stats_refs_canary.peg
+++ b/tests/fixtures/stats_refs_canary.peg
@@ -1,3 +1,3 @@
-root <- a a b
-a <- 'x'
-b <- a / 'y'
+root =  a a b
+a =  'x'
+b =  a / 'y'

--- a/tests/fixtures/stats_refs_canary.peg
+++ b/tests/fixtures/stats_refs_canary.peg
@@ -1,3 +1,3 @@
-root =  a a b
-a =  'x'
-b =  a / 'y'
+root = a a b
+a = 'x'
+b = a / 'y'

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -626,7 +626,7 @@ fn attach_with_unknown_key_clause_keeps_prefix_kinded() {
     // ` KEY '';` suffix and must be `recovery`. Pre-fix,
     // `RecoverToScopedMax` phantom-closed every still-open capture in
     // `scoped_saved_above` at `scoped_max_sp`, producing fragments
-    // like `keyword(56,59)="rep"` (from `replace_body <- [rR][eE][pP]
+    // like `keyword(56,59)="rep"` (from `replace_body = [rR][eE][pP]
     // [lL]…` matching half of `repository` in the original SQLite
     // repro). With the unclosed-production filter in
     // `RecoverToScopedMax`, the tail contains only one-byte recovery

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -19,7 +19,7 @@ fn parse(src: &str) -> syntax_highlighter::pegc::Grammar {
 
 #[test]
 fn simple_rule() {
-    let g = parse("foo <- \"hi\"");
+    let g = parse("foo = \"hi\"");
     let order: Vec<&str> = g.rule_headers.iter().map(|h| h.name.as_str()).collect();
     assert_eq!(order, vec!["foo"]);
     assert_eq!(g.rules["foo"], Pattern::literal("hi"));
@@ -27,7 +27,7 @@ fn simple_rule() {
 
 #[test]
 fn rule_order_preserved() {
-    let g = parse("first <- 'a'\nsecond <- 'b'");
+    let g = parse("first = 'a'\nsecond = 'b'");
     let order: Vec<&str> = g.rule_headers.iter().map(|h| h.name.as_str()).collect();
     assert_eq!(order, vec!["first", "second"]);
     assert_eq!(g.rules.len(), 2);
@@ -35,7 +35,7 @@ fn rule_order_preserved() {
 
 #[test]
 fn ordered_choice_in_grammar() {
-    let g = parse("r <- 'a' / 'b' / 'c'");
+    let g = parse("r = 'a' / 'b' / 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::choice(vec![
@@ -48,7 +48,7 @@ fn ordered_choice_in_grammar() {
 
 #[test]
 fn sequence_in_grammar() {
-    let g = parse("r <- 'a' 'b' 'c'");
+    let g = parse("r = 'a' 'b' 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -61,7 +61,7 @@ fn sequence_in_grammar() {
 
 #[test]
 fn postfix_operators() {
-    let g = parse("a <- 'x'*\nb <- 'x'+\nc <- 'x'?");
+    let g = parse("a = 'x'*\nb = 'x'+\nc = 'x'?");
     assert_eq!(g.rules["a"], Pattern::repeat(Pattern::literal("x")));
     assert_eq!(g.rules["b"], Pattern::repeat_one(Pattern::literal("x")));
     assert_eq!(g.rules["c"], Pattern::optional(Pattern::literal("x")));
@@ -70,13 +70,13 @@ fn postfix_operators() {
 #[test]
 fn postfix_repeat_count_single() {
     // `p{1}` is the bare atom — `Pattern::seq()` unwraps singletons.
-    let g = parse("r <- 'x'{1}");
+    let g = parse("r = 'x'{1}");
     assert_eq!(g.rules["r"], Pattern::literal("x"));
 }
 
 #[test]
 fn postfix_repeat_count_multiple() {
-    let g = parse("r <- 'x'{4}");
+    let g = parse("r = 'x'{4}");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -90,7 +90,7 @@ fn postfix_repeat_count_multiple() {
 
 #[test]
 fn postfix_repeat_count_on_backslash_atom() {
-    let g = parse("r <- \\d{4}");
+    let g = parse("r = \\d{4}");
     let digit = Pattern::char_class(CharSet::from_ranges(&[('0', '9')]).unwrap());
     assert_eq!(
         g.rules["r"],
@@ -100,7 +100,7 @@ fn postfix_repeat_count_on_backslash_atom() {
 
 #[test]
 fn postfix_repeat_count_on_group() {
-    let g = parse("r <- ('a' / 'b'){3}");
+    let g = parse("r = ('a' / 'b'){3}");
     let choice = Pattern::choice(vec![Pattern::literal("a"), Pattern::literal("b")]);
     assert_eq!(
         g.rules["r"],
@@ -112,7 +112,7 @@ fn postfix_repeat_count_on_group() {
 fn postfix_repeat_count_chains_with_star() {
     // `p{n}*` parses as `(p{n})*` — the postfix loop applies the `*`
     // to the already-desugared sequence.
-    let g = parse("r <- 'x'{2}*");
+    let g = parse("r = 'x'{2}*");
     assert_eq!(
         g.rules["r"],
         Pattern::repeat(Pattern::seq(vec![
@@ -125,7 +125,7 @@ fn postfix_repeat_count_chains_with_star() {
 #[test]
 fn postfix_repeat_count_at_maximum_accepted() {
     // Boundary case: 1024 is the cap, must be accepted.
-    let g = parse("r <- 'x'{1024}");
+    let g = parse("r = 'x'{1024}");
     match &g.rules["r"] {
         Pattern::Sequence { items, .. } => assert_eq!(items.len(), 1024),
         other => panic!("expected Sequence of 1024 items, got: {other:?}"),
@@ -134,7 +134,7 @@ fn postfix_repeat_count_at_maximum_accepted() {
 
 #[test]
 fn postfix_repeat_count_zero_rejected() {
-    let err = parse_src("r <- 'x'{0}").unwrap_err();
+    let err = parse_src("r = 'x'{0}").unwrap_err();
     assert!(
         err.message.contains("positive"),
         "expected positive-required message, got: {}",
@@ -144,7 +144,7 @@ fn postfix_repeat_count_zero_rejected() {
 
 #[test]
 fn postfix_repeat_count_empty_rejected() {
-    let err = parse_src("r <- 'x'{}").unwrap_err();
+    let err = parse_src("r = 'x'{}").unwrap_err();
     assert!(
         err.message.contains("expected positive integer"),
         "expected integer-required message, got: {}",
@@ -154,7 +154,7 @@ fn postfix_repeat_count_empty_rejected() {
 
 #[test]
 fn postfix_repeat_count_unterminated_rejected() {
-    let err = parse_src("r <- 'x'{4").unwrap_err();
+    let err = parse_src("r = 'x'{4").unwrap_err();
     assert!(
         err.message.contains("'}'"),
         "expected closing-brace message, got: {}",
@@ -166,7 +166,7 @@ fn postfix_repeat_count_unterminated_rejected() {
 fn postfix_repeat_count_non_decimal_rejected() {
     // The digit scan stops at `a`, leaving zero digits read — same error
     // path as `{}`.
-    let err = parse_src("r <- 'x'{a}").unwrap_err();
+    let err = parse_src("r = 'x'{a}").unwrap_err();
     assert!(
         err.message.contains("expected positive integer"),
         "expected integer-required message, got: {}",
@@ -176,7 +176,7 @@ fn postfix_repeat_count_non_decimal_rejected() {
 
 #[test]
 fn postfix_repeat_count_exceeds_maximum_rejected() {
-    let err = parse_src("r <- 'x'{1025}").unwrap_err();
+    let err = parse_src("r = 'x'{1025}").unwrap_err();
     assert!(
         err.message.contains("exceeds maximum 1024"),
         "expected exceeds-maximum message, got: {}",
@@ -188,7 +188,7 @@ fn postfix_repeat_count_exceeds_maximum_rejected() {
 fn postfix_repeat_count_whitespace_inside_braces_rejected() {
     // `{n}` is tight, matching the rest of the postfix tier — interior
     // whitespace makes the digit scan see zero digits.
-    let err = parse_src("r <- 'x'{ 4 }").unwrap_err();
+    let err = parse_src("r = 'x'{ 4 }").unwrap_err();
     assert!(
         err.message.contains("expected positive integer"),
         "expected integer-required message, got: {}",
@@ -200,7 +200,7 @@ fn postfix_repeat_count_whitespace_inside_braces_rejected() {
 fn repeat_count_in_string_literal_is_literal() {
     // `'p{4}'` is the literal byte sequence `p{4}`, not a quantified
     // literal — string-literal escapes are not affected by this PR.
-    let g = parse("r <- 'p{4}'");
+    let g = parse("r = 'p{4}'");
     assert_eq!(g.rules["r"], Pattern::literal("p{4}"));
 }
 
@@ -230,7 +230,7 @@ fn desugared_recover_repeat_with_label(
 #[test]
 fn recover_repeat_postfix_star_caret() {
     // `p*^` desugars to `(p ^recovery @recovery{.})*` at parse time.
-    let g = parse("r <- 'x'*^");
+    let g = parse("r = 'x'*^");
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char())
@@ -240,7 +240,7 @@ fn recover_repeat_postfix_star_caret() {
 #[test]
 fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
     // p+^  ≡  p (p*^)  — at least one inner success required.
-    let g = parse("r <- 'x'+^");
+    let g = parse("r = 'x'+^");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -254,7 +254,7 @@ fn recover_repeat_postfix_plus_caret_lowers_to_seq() {
 fn sync_set_postfix_star_caret_charset() {
     // `p*^[;]` desugars to `(p ^recovery @recovery{(![;] .)* [;]})*`.
     let semi = CharSet::from_chars(&[';']);
-    let g = parse("r <- 'x'*^[;]");
+    let g = parse("r = 'x'*^[;]");
     let skip_loop = Pattern::repeat(Pattern::seq(vec![
         Pattern::not_predicate(Pattern::char_class(semi.clone())),
         Pattern::any_char(),
@@ -270,7 +270,7 @@ fn sync_set_postfix_star_caret_charset() {
 fn sync_set_postfix_plus_caret_charset() {
     // `p+^[;]` lowers to `p (p*^[;])`.
     let semi = CharSet::from_chars(&[';']);
-    let g = parse("r <- 'x'+^[;]");
+    let g = parse("r = 'x'+^[;]");
     let skip_loop = Pattern::repeat(Pattern::seq(vec![
         Pattern::not_predicate(Pattern::char_class(semi.clone())),
         Pattern::any_char(),
@@ -290,7 +290,7 @@ fn sync_set_requires_no_whitespace_before_bracket() {
     // `*^ [;]` is `*^` (plain) followed by a separate atom `[;]` in
     // the enclosing sequence, NOT a sync set. The whitespace breaks
     // the postfix glue.
-    let g = parse("r <- 'x'*^ [;]");
+    let g = parse("r = 'x'*^ [;]");
     let semi = CharSet::from_chars(&[';']);
     assert_eq!(
         g.rules["r"],
@@ -306,7 +306,7 @@ fn sync_set_accepts_negated_and_ranges() {
     // The sync set parses via the same `parse_charclass` path as a
     // normal `[...]` atom — ranges (`a-z`) and negation (`[^...]`)
     // are both supported.
-    let g = parse("r <- 'x'*^[^a-z]");
+    let g = parse("r = 'x'*^[^a-z]");
     let alpha = CharSet::single_range('a', 'z').unwrap();
     let neg_alpha = alpha.negate();
     let skip_loop = Pattern::repeat(Pattern::seq(vec![
@@ -324,7 +324,7 @@ fn sync_set_accepts_negated_and_ranges() {
 fn recover_repeat_postfix_star_caret_with_label() {
     // `p*^:bad` interns label "bad" instead of the default "recovery";
     // the capture name is unchanged.
-    let g = parse("r <- 'x'*^:bad");
+    let g = parse("r = 'x'*^:bad");
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::any_char(), "bad")
@@ -335,7 +335,7 @@ fn recover_repeat_postfix_star_caret_with_label() {
 fn recover_repeat_postfix_plus_caret_with_label() {
     // `p+^:bad` lowers to `p (p*^:bad)` — the label flows through the
     // tail `*^` only; the head `p` is the unguarded one-iteration prefix.
-    let g = parse("r <- 'x'+^:bad");
+    let g = parse("r = 'x'+^:bad");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -350,7 +350,7 @@ fn sync_set_postfix_star_caret_charset_with_label() {
     // `p*^[;]:bad_stmt` interns label "bad_stmt"; recovery body
     // (sync-set skip) is unchanged.
     let semi = CharSet::from_chars(&[';']);
-    let g = parse("r <- 'x'*^[;]:bad_stmt");
+    let g = parse("r = 'x'*^[;]:bad_stmt");
     let skip_loop = Pattern::repeat(Pattern::seq(vec![
         Pattern::not_predicate(Pattern::char_class(semi.clone())),
         Pattern::any_char(),
@@ -366,7 +366,7 @@ fn sync_set_postfix_star_caret_charset_with_label() {
 fn sync_set_postfix_plus_caret_charset_with_label() {
     // `p+^[;]:bad_stmt` lowers to `p (p*^[;]:bad_stmt)`.
     let semi = CharSet::from_chars(&[';']);
-    let g = parse("r <- 'x'+^[;]:bad_stmt");
+    let g = parse("r = 'x'+^[;]:bad_stmt");
     let skip_loop = Pattern::repeat(Pattern::seq(vec![
         Pattern::not_predicate(Pattern::char_class(semi.clone())),
         Pattern::any_char(),
@@ -387,7 +387,7 @@ fn recovery_label_default_is_recovery() {
     // exactly as before — the helper's default already encodes this,
     // so the existing tests cover it; this is a self-documenting
     // sentinel that the default has not drifted.
-    let g = parse("r <- 'x'*^");
+    let g = parse("r = 'x'*^");
     let Pattern::Repeat { inner, .. } = &g.rules["r"] else {
         panic!("expected Repeat, got {:?}", g.rules["r"]);
     };
@@ -404,7 +404,7 @@ fn recovery_label_rejects_whitespace_before_colon() {
     // valid sequence atom, and the parser falls through to the next
     // rule-start where `:` fails `parse_ident` with "expected
     // identifier".
-    let err = parse_src("r <- 'x'*^ :lbl").unwrap_err();
+    let err = parse_src("r = 'x'*^ :lbl").unwrap_err();
     assert!(
         err.message.contains("expected identifier"),
         "expected an identifier-required error at top level, got: {}",
@@ -415,7 +415,7 @@ fn recovery_label_rejects_whitespace_before_colon() {
 #[test]
 fn recovery_label_rejects_whitespace_after_colon() {
     // `*^: lbl` — the identifier must touch `:`.
-    let err = parse_src("r <- 'x'*^: lbl").unwrap_err();
+    let err = parse_src("r = 'x'*^: lbl").unwrap_err();
     assert!(
         err.message.contains("expected label identifier"),
         "expected a label-identifier error, got: {}",
@@ -427,7 +427,7 @@ fn recovery_label_rejects_whitespace_after_colon() {
 fn recovery_label_rejects_underscore() {
     // Bare `_` mirrors `^_`'s reservation for future anonymous-catch
     // syntax.
-    let err = parse_src("r <- 'x'*^:_").unwrap_err();
+    let err = parse_src("r = 'x'*^:_").unwrap_err();
     assert!(
         err.message.contains("reserved"),
         "expected a reserved-label error, got: {}",
@@ -442,7 +442,7 @@ fn recovery_label_after_sync_set_requires_no_space_before_colon() {
     // valid sequence atom, and the parser falls through to the next
     // rule-start where `:` fails `parse_ident` with "expected
     // identifier".
-    let err = parse_src("r <- 'x'*^[;] :lbl").unwrap_err();
+    let err = parse_src("r = 'x'*^[;] :lbl").unwrap_err();
     assert!(
         err.message.contains("expected identifier"),
         "expected an identifier-required error at top level, got: {}",
@@ -454,7 +454,7 @@ fn recovery_label_after_sync_set_requires_no_space_before_colon() {
 fn recovery_label_accepts_underscore_prefixed_identifier() {
     // `_foo` (underscore prefix, not bare `_`) stays a valid label,
     // mirroring `parse_catch`.
-    let g = parse("r <- 'x'*^:_foo");
+    let g = parse("r = 'x'*^:_foo");
     assert_eq!(
         g.rules["r"],
         desugared_recover_repeat_with_label(Pattern::literal("x"), Pattern::any_char(), "_foo")
@@ -463,7 +463,7 @@ fn recovery_label_accepts_underscore_prefixed_identifier() {
 
 #[test]
 fn catch_basic_parses_to_pattern_catch() {
-    let g = parse("r <- 'a' ^lbl 'b'");
+    let g = parse("r = 'a' ^lbl 'b'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -478,7 +478,7 @@ fn catch_basic_parses_to_pattern_catch() {
 #[test]
 fn catch_binds_tighter_than_choice() {
     // 'a' ^lbl 'b' / 'c'   ≡   ('a' ^lbl 'b') / 'c'
-    let g = parse("r <- 'a' ^lbl 'b' / 'c'");
+    let g = parse("r = 'a' ^lbl 'b' / 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::choice(vec![
@@ -496,7 +496,7 @@ fn catch_binds_tighter_than_choice() {
 #[test]
 fn catch_binds_looser_than_sequence() {
     // 'a' 'b' ^lbl 'c' 'd'   ≡   ('a' 'b') ^lbl ('c' 'd')
-    let g = parse("r <- 'a' 'b' ^lbl 'c' 'd'");
+    let g = parse("r = 'a' 'b' ^lbl 'c' 'd'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -517,7 +517,7 @@ fn catch_binds_looser_than_sequence() {
 #[test]
 fn catch_is_left_associative() {
     // 'a' ^l1 'b' ^l2 'c'   ≡   ('a' ^l1 'b') ^l2 'c'
-    let g = parse("r <- 'a' ^l1 'b' ^l2 'c'");
+    let g = parse("r = 'a' ^l1 'b' ^l2 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -540,7 +540,7 @@ fn catch_does_not_collide_with_star_caret() {
     // whitespace between `*` and `^`). `'x'* ^lbl 'y'` is a Catch of
     // Repeat over a separate recovery branch — whitespace before `^`
     // breaks the postfix glue.
-    let g = parse("a <- 'x'*^\nb <- 'x'* ^lbl 'y'");
+    let g = parse("a = 'x'*^\nb = 'x'* ^lbl 'y'");
     assert_eq!(
         g.rules["a"],
         desugared_recover_repeat(Pattern::literal("x"), Pattern::any_char())
@@ -561,7 +561,7 @@ fn catch_parens_force_grouping_on_recovery() {
     // Default `'a' ^lbl 'b' / 'c'` is `('a' ^lbl 'b') / 'c'` (catch
     // tighter than choice); to put a choice in the recovery branch
     // the author must parenthesize.
-    let g = parse("r <- 'a' ^lbl ('b' / 'c')");
+    let g = parse("r = 'a' ^lbl ('b' / 'c')");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -581,8 +581,8 @@ fn catch_label_touches_caret_whitespace_insensitive_on_left() {
     // `foo ^lbl bar` and `foo^lbl bar` both parse identically — `^`
     // is whitespace-insensitive on its *left* (same as today's other
     // infix operators).
-    let with_space = parse("r <- 'a' ^lbl 'b'");
-    let glued = parse("r <- 'a'^lbl 'b'");
+    let with_space = parse("r = 'a' ^lbl 'b'");
+    let glued = parse("r = 'a'^lbl 'b'");
     let expected = Pattern::Catch {
         inner: Box::new(Pattern::literal("a")),
         label: "lbl".into(),
@@ -598,7 +598,7 @@ fn catch_requires_label_without_whitespace() {
     // `foo ^ bar` (whitespace between `^` and the label) is rejected
     // — `^<non-ident-byte>` is a reserved syntactic slot for future
     // overlays.
-    let err = parse_src("r <- 'a' ^ 'b'").unwrap_err();
+    let err = parse_src("r = 'a' ^ 'b'").unwrap_err();
     assert!(
         err.message.contains("label identifier"),
         "expected a label-identifier error, got: {}",
@@ -610,7 +610,7 @@ fn catch_requires_label_without_whitespace() {
 fn catch_rejects_reserved_underscore_label() {
     // Bare `_` as a label name is reserved for future use (anonymous
     // catch).
-    let err = parse_src("r <- 'a' ^_ 'b'").unwrap_err();
+    let err = parse_src("r = 'a' ^_ 'b'").unwrap_err();
     assert!(
         err.message.contains("reserved"),
         "expected a reserved-label error, got: {}",
@@ -639,7 +639,7 @@ fn lowered_boundary_catch(inner: Pattern, label: &str, boundary: Pattern) -> Pat
 
 #[test]
 fn boundary_catch_lowers_to_anchored_catch_with_recovery_loop() {
-    let g = parse("r <- 'a' ^^lbl 'b'");
+    let g = parse("r = 'a' ^^lbl 'b'");
     assert_eq!(
         g.rules["r"],
         lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
@@ -648,7 +648,7 @@ fn boundary_catch_lowers_to_anchored_catch_with_recovery_loop() {
 
 #[test]
 fn boundary_catch_with_rule_boundary() {
-    let g = parse("r <- 'a' ^^lbl b\nb <- 'x'");
+    let g = parse("r = 'a' ^^lbl b\nb = 'x'");
     assert_eq!(
         g.rules["r"],
         lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::nt("b")),
@@ -657,7 +657,7 @@ fn boundary_catch_with_rule_boundary() {
 
 #[test]
 fn boundary_catch_with_charset_boundary() {
-    let g = parse("r <- 'a' ^^lbl [,;)]");
+    let g = parse("r = 'a' ^^lbl [,;)]");
     let delim = CharSet::from_chars(&[',', ';', ')']);
     assert_eq!(
         g.rules["r"],
@@ -667,7 +667,7 @@ fn boundary_catch_with_charset_boundary() {
 
 #[test]
 fn boundary_catch_with_grouped_boundary() {
-    let g = parse("r <- 'a' ^^lbl (b c)\nb <- 'x'\nc <- 'y'");
+    let g = parse("r = 'a' ^^lbl (b c)\nb = 'x'\nc = 'y'");
     let boundary = Pattern::seq(vec![Pattern::nt("b"), Pattern::nt("c")]);
     assert_eq!(
         g.rules["r"],
@@ -680,12 +680,12 @@ fn boundary_catch_label_touches_second_caret() {
     // `^^lbl B` with no whitespace between the carets and the label
     // is the canonical form; `^^ lbl B` (space) errors with the
     // "expected label identifier" message.
-    let g = parse("r <- 'a' ^^lbl 'b'");
+    let g = parse("r = 'a' ^^lbl 'b'");
     assert_eq!(
         g.rules["r"],
         lowered_boundary_catch(Pattern::literal("a"), "lbl", Pattern::literal("b")),
     );
-    let err = parse_src("r <- 'a' ^^ lbl 'b'").unwrap_err();
+    let err = parse_src("r = 'a' ^^ lbl 'b'").unwrap_err();
     assert!(
         err.message.contains("expected label identifier"),
         "expected a label-identifier error, got: {}",
@@ -697,7 +697,7 @@ fn boundary_catch_label_touches_second_caret() {
 fn boundary_catch_does_not_swallow_trailing_atoms() {
     // The boundary is one atom-with-prefix-postfix; trailing atoms
     // belong to the enclosing sequence: `A ^^lbl B C` is `(A ^^lbl B) C`.
-    let g = parse("r <- 'a' ^^lbl 'b' 'c'");
+    let g = parse("r = 'a' ^^lbl 'b' 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -711,7 +711,7 @@ fn boundary_catch_does_not_swallow_trailing_atoms() {
 fn bare_catch_with_capture_rhs_still_parses() {
     // Regression guard: single `^` is bare, `@kind{...}` is the RHS.
     // The doubled-caret discriminator must not consume `@`.
-    let g = parse("r <- 'a' ^lbl @rec{'b'}");
+    let g = parse("r = 'a' ^lbl @rec{'b'}");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -725,7 +725,7 @@ fn bare_catch_with_capture_rhs_still_parses() {
 
 #[test]
 fn boundary_catch_rejects_reserved_underscore_label() {
-    let err = parse_src("r <- 'a' ^^_ 'b'").unwrap_err();
+    let err = parse_src("r = 'a' ^^_ 'b'").unwrap_err();
     assert!(
         err.message.contains("reserved"),
         "expected reserved-label error, got: {}",
@@ -735,7 +735,7 @@ fn boundary_catch_rejects_reserved_underscore_label() {
 
 #[test]
 fn boundary_catch_rejects_throw_atom_shape() {
-    let err = parse_src("r <- 'a' ^^!lbl 'b'").unwrap_err();
+    let err = parse_src("r = 'a' ^^!lbl 'b'").unwrap_err();
     assert!(
         err.message.contains("reserved") || err.message.contains("expected label identifier"),
         "expected reserved-or-label error, got: {}",
@@ -745,7 +745,7 @@ fn boundary_catch_rejects_throw_atom_shape() {
 
 #[test]
 fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
-    let g = parse("r <- 'a' ^^lbl");
+    let g = parse("r = 'a' ^^lbl");
     assert_eq!(
         g.rules["r"],
         Pattern::InferBoundaryCatch {
@@ -758,7 +758,7 @@ fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
 
 #[test]
 fn inferred_catch_before_choice_separator() {
-    let g = parse("r <- 'a' ^^lbl / 'b'");
+    let g = parse("r = 'a' ^^lbl / 'b'");
     assert_eq!(
         g.rules["r"],
         Pattern::choice(vec![
@@ -774,7 +774,7 @@ fn inferred_catch_before_choice_separator() {
 
 #[test]
 fn inferred_catch_before_paren_close() {
-    let g = parse("r <- ('a' ^^lbl) 'c'");
+    let g = parse("r = ('a' ^^lbl) 'c'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -793,7 +793,7 @@ fn inferred_vs_explicit_no_ambiguity() {
     // Disambiguation is purely by `at_prefix_start`: `^^lbl B C` is
     // explicit (B is the boundary, C is the trailing sequence atom);
     // `^^lbl / B` is inferred (`/` is not an atom-start).
-    let explicit = parse("r <- 'a' ^^lbl 'b' 'c'");
+    let explicit = parse("r = 'a' ^^lbl 'b' 'c'");
     assert_eq!(
         explicit.rules["r"],
         Pattern::seq(vec![
@@ -801,7 +801,7 @@ fn inferred_vs_explicit_no_ambiguity() {
             Pattern::literal("c"),
         ]),
     );
-    let inferred = parse("r <- 'a' ^^lbl / 'b'");
+    let inferred = parse("r = 'a' ^^lbl / 'b'");
     assert_eq!(
         inferred.rules["r"],
         Pattern::choice(vec![
@@ -817,7 +817,7 @@ fn inferred_vs_explicit_no_ambiguity() {
 
 // ---- Lenient marker (definition-level only) -------------------
 //
-// Definition-level `~name <- body` parsing is verified end-to-end by
+// Definition-level `~name = body` parsing is verified end-to-end by
 // the `definition_lenient_marker_*` tests in `tests/compiler_tests.rs`.
 // The call-site `~p` form was considered during design and dropped
 // before landing: empirically zero shipped grammars used it after the
@@ -826,7 +826,7 @@ fn inferred_vs_explicit_no_ambiguity() {
 #[test]
 fn catch_accepts_underscore_prefixed_labels() {
     // `_foo` (underscore prefix, not bare `_`) stays a valid label.
-    let g = parse("r <- 'a' ^_foo 'b'");
+    let g = parse("r = 'a' ^_foo 'b'");
     assert_eq!(
         g.rules["r"],
         Pattern::Catch {
@@ -840,7 +840,7 @@ fn catch_accepts_underscore_prefixed_labels() {
 
 #[test]
 fn predicate_operators() {
-    let g = parse("a <- !'x' .\nb <- &'y' 'y'");
+    let g = parse("a = !'x' .\nb = &'y' 'y'");
     assert_eq!(
         g.rules["a"],
         Pattern::seq(vec![
@@ -859,7 +859,7 @@ fn predicate_operators() {
 
 #[test]
 fn char_class_with_range() {
-    let g = parse("d <- [0-9]");
+    let g = parse("d = [0-9]");
     assert_eq!(
         g.rules["d"],
         Pattern::char_class(CharSet::from_ranges(&[('0', '9')]).unwrap())
@@ -868,21 +868,21 @@ fn char_class_with_range() {
 
 #[test]
 fn char_class_negated() {
-    let g = parse("nq <- [^\"\\\\]");
+    let g = parse("nq = [^\"\\\\]");
     let excluded = CharSet::from_chars(&['"', '\\']);
     assert_eq!(g.rules["nq"], Pattern::char_class(excluded.negate()));
 }
 
 #[test]
 fn char_class_mixed_chars_and_ranges() {
-    let g = parse("alnum <- [a-zA-Z0-9_]");
+    let g = parse("alnum = [a-zA-Z0-9_]");
     let expected = CharSet::from_ranges(&[('a', 'z'), ('A', 'Z'), ('0', '9'), ('_', '_')]).unwrap();
     assert_eq!(g.rules["alnum"], Pattern::char_class(expected));
 }
 
 #[test]
 fn capture_annotation() {
-    let g = parse("r <- @keyword{'while'}");
+    let g = parse("r = @keyword{'while'}");
     assert_eq!(
         g.rules["r"],
         Pattern::capture("keyword", Pattern::literal("while"))
@@ -893,9 +893,9 @@ fn capture_annotation() {
 fn comments_and_blank_lines() {
     let src = "
         # this is a top-level comment
-        first <- 'a'   # trailing comment
+        first = 'a'   # trailing comment
         # another comment
-        second <- 'b'
+        second = 'b'
     ";
     let g = parse(src);
     assert_eq!(g.rules.len(), 2);
@@ -906,7 +906,7 @@ fn comments_and_blank_lines() {
 #[test]
 fn parens_and_precedence() {
     // 'a' ('b' / 'c') 'd'
-    let g = parse("r <- 'a' ('b' / 'c') 'd'");
+    let g = parse("r = 'a' ('b' / 'c') 'd'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -919,13 +919,13 @@ fn parens_and_precedence() {
 
 #[test]
 fn nonterminal_reference() {
-    let g = parse("a <- b\nb <- 'x'");
+    let g = parse("a = b\nb = 'x'");
     assert_eq!(g.rules["a"], Pattern::nt("b"));
 }
 
 #[test]
 fn escape_sequences_in_string() {
-    let g = parse("r <- '\\n\\t\\\\'");
+    let g = parse("r = '\\n\\t\\\\'");
     assert_eq!(
         g.rules["r"],
         Pattern::literal_bytes(vec![b'\n', b'\t', b'\\'])
@@ -934,14 +934,14 @@ fn escape_sequences_in_string() {
 
 #[test]
 fn dash_in_class_at_end_is_literal() {
-    let g = parse("r <- [+\\-]");
+    let g = parse("r = [+\\-]");
     let s = CharSet::from_chars(&['+', '-']);
     assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
 fn backslash_d_atom() {
-    let g = parse("r <- \\d");
+    let g = parse("r = \\d");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_ranges(&[('0', '9')]).unwrap())
@@ -950,7 +950,7 @@ fn backslash_d_atom() {
 
 #[test]
 fn backslash_d_negated_atom() {
-    let g = parse("r <- \\D");
+    let g = parse("r = \\D");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_ranges(&[('0', '9')]).unwrap().negate())
@@ -959,7 +959,7 @@ fn backslash_d_negated_atom() {
 
 #[test]
 fn backslash_s_atom() {
-    let g = parse("r <- \\s");
+    let g = parse("r = \\s");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_chars(&[' ', '\t', '\n', '\r']))
@@ -968,7 +968,7 @@ fn backslash_s_atom() {
 
 #[test]
 fn backslash_s_negated_atom() {
-    let g = parse("r <- \\S");
+    let g = parse("r = \\S");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_chars(&[' ', '\t', '\n', '\r']).negate())
@@ -977,7 +977,7 @@ fn backslash_s_negated_atom() {
 
 #[test]
 fn backslash_h_atom() {
-    let g = parse("r <- \\h");
+    let g = parse("r = \\h");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_chars(&[' ', '\t']))
@@ -986,7 +986,7 @@ fn backslash_h_atom() {
 
 #[test]
 fn backslash_h_negated_atom() {
-    let g = parse("r <- \\H");
+    let g = parse("r = \\H");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_chars(&[' ', '\t']).negate())
@@ -995,7 +995,7 @@ fn backslash_h_negated_atom() {
 
 #[test]
 fn backslash_cap_r_linebreak_atom() {
-    let g = parse("r <- \\R");
+    let g = parse("r = \\R");
     assert_eq!(
         g.rules["r"],
         Pattern::choice(vec![
@@ -1008,7 +1008,7 @@ fn backslash_cap_r_linebreak_atom() {
 
 #[test]
 fn backslash_d_in_class_unions_digits() {
-    let g = parse("r <- [\\d_]");
+    let g = parse("r = [\\d_]");
     let s = CharSet::from_ranges(&[('0', '9'), ('_', '_')]).unwrap();
     assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
@@ -1016,14 +1016,14 @@ fn backslash_d_in_class_unions_digits() {
 #[test]
 fn backslash_d_in_class_with_range_neighbor() {
     // Mixed class: `[\da-fA-F]` is the hex-digit set.
-    let g = parse("r <- [\\da-fA-F]");
+    let g = parse("r = [\\da-fA-F]");
     let s = CharSet::from_ranges(&[('0', '9'), ('a', 'f'), ('A', 'F')]).unwrap();
     assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
 
 #[test]
 fn backslash_s_in_class_unions_whitespace() {
-    let g = parse("r <- [\\sX]");
+    let g = parse("r = [\\sX]");
     let s = CharSet::from_chars(&[' ', '\t', '\n', '\r', 'X']);
     assert_eq!(g.rules["r"], Pattern::char_class(s));
 }
@@ -1031,7 +1031,7 @@ fn backslash_s_in_class_unions_whitespace() {
 #[test]
 fn backslash_d_in_negated_class() {
     // `[^\d]` is the complement of `\d`, i.e. `\D`.
-    let g = parse("r <- [^\\d]");
+    let g = parse("r = [^\\d]");
     assert_eq!(
         g.rules["r"],
         Pattern::char_class(CharSet::from_ranges(&[('0', '9')]).unwrap().negate())
@@ -1042,7 +1042,7 @@ fn backslash_d_in_negated_class() {
 fn backslash_d_in_string_still_errors() {
     // String literals keep their byte-only escape contract; `\d` is
     // not a single byte, so it's still an unknown string escape.
-    let err = parse_src("r <- '\\d'").unwrap_err();
+    let err = parse_src("r = '\\d'").unwrap_err();
     assert!(
         err.message.contains("unknown escape"),
         "expected unknown-escape error in string, got: {}",
@@ -1052,7 +1052,7 @@ fn backslash_d_in_string_still_errors() {
 
 #[test]
 fn backslash_cap_r_in_class_rejected() {
-    let err = parse_src("r <- [\\R]").unwrap_err();
+    let err = parse_src("r = [\\R]").unwrap_err();
     assert!(
         err.message.contains("multi-byte") && err.message.contains("\\R"),
         "expected tailored multi-byte error for \\R in class, got: {}",
@@ -1063,7 +1063,7 @@ fn backslash_cap_r_in_class_rejected() {
 #[test]
 fn backslash_d_range_start_rejected() {
     // Shortcuts are sets, not bounds — `[\d-z]` is meaningless.
-    let err = parse_src("r <- [\\d-z]").unwrap_err();
+    let err = parse_src("r = [\\d-z]").unwrap_err();
     assert!(
         err.message.contains("range can't start with a shortcut"),
         "expected shortcut-in-range error, got: {}",
@@ -1073,7 +1073,7 @@ fn backslash_d_range_start_rejected() {
 
 #[test]
 fn unknown_backslash_atom_errors() {
-    let err = parse_src("r <- \\q").unwrap_err();
+    let err = parse_src("r = \\q").unwrap_err();
     assert!(
         err.message.contains("unknown atom") && err.message.contains("\\q"),
         "expected unknown-atom error, got: {}",
@@ -1084,7 +1084,7 @@ fn unknown_backslash_atom_errors() {
 #[test]
 fn end_to_end_grammar_compile_run() {
     use syntax_highlighter::pegvm::VM;
-    let g = parse("root <- number\nnumber <- [0-9]+");
+    let g = parse("root = number\nnumber = [0-9]+");
     let prog = g.compile().unwrap();
     let r = VM::new_from_program(&prog, b"42abc").run();
     // `root`'s implicit `!.` rejects the trailing 'a'; the parse no
@@ -1098,7 +1098,7 @@ fn end_to_end_recover_repeat_compile_run() {
     use syntax_highlighter::pegvm::VM;
     // Top-level `*^` resyncs past garbage one byte at a time; the parse
     // completes at EOF, with one "recovery"-tagged capture per skipped byte.
-    let g = parse("root <- doc\ndoc <- @kw{\"foo\"}*^");
+    let g = parse("root = doc\ndoc = @kw{\"foo\"}*^");
     let prog = g.compile().unwrap();
     let r = VM::new_from_program(&prog, b"fooXXfoo").run();
     assert!(r.complete);
@@ -1123,11 +1123,11 @@ fn end_to_end_inferred_catch_matches_explicit_behavior() {
     // bytecode isn't expected (label numbering shifts), but the
     // MatchResult on the same input must agree.
     use syntax_highlighter::pegvm::VM;
-    let inferred = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let inferred = parse("root = list\nlist = aliased (',' aliased)*\naliased = 'x' ^^bad")
         .compile()
         .unwrap();
     let explicit =
-        parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad (',' / !.)")
+        parse("root = list\nlist = aliased (',' aliased)*\naliased = 'x' ^^bad (',' / !.)")
             .compile()
             .unwrap();
     for input in [&b"x,x"[..], b"xy,x", b"x"].iter() {
@@ -1147,12 +1147,12 @@ fn end_to_end_inferred_catch_matches_explicit_behavior() {
 #[test]
 fn end_to_end_inferred_catch_fires_on_partial_match() {
     use syntax_highlighter::pegvm::VM;
-    // `aliased <- 'x' ^^bad` lowers to a catch that anchors `x` to
+    // `aliased = 'x' ^^bad` lowers to a catch that anchors `x` to
     // FOLLOW(aliased). FOLLOW contains `,` from the call site in
     // `list`. Input `xy,x` — the first `x` succeeds but the next
     // byte `y` is not in FOLLOW; the catch fires, recovery skips
     // `y` until it sees `,`, and parsing resumes with the second `x`.
-    let prog = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let prog = parse("root = list\nlist = aliased (',' aliased)*\naliased = 'x' ^^bad")
         .compile()
         .unwrap();
     let r = VM::new_from_program(&prog, b"xy,x").run();
@@ -1162,7 +1162,7 @@ fn end_to_end_inferred_catch_fires_on_partial_match() {
 #[test]
 fn end_to_end_inferred_catch_clean_input_no_recovery() {
     use syntax_highlighter::pegvm::VM;
-    let prog = parse("root <- list\nlist <- aliased (',' aliased)*\naliased <- 'x' ^^bad")
+    let prog = parse("root = list\nlist = aliased (',' aliased)*\naliased = 'x' ^^bad")
         .compile()
         .unwrap();
     let r = VM::new_from_program(&prog, b"x,x").run();
@@ -1180,8 +1180,8 @@ fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
     // The marker rides a non-special helper rule — `root` (like
     // `trivia` / `wb`) rejects every qualifier.
-    let plain = parse("root <- r\nr <- 'x'+").compile().unwrap();
-    let lenient = parse("root <- r\n~r <- 'x'+").compile().unwrap();
+    let plain = parse("root = r\nr = 'x'+").compile().unwrap();
+    let lenient = parse("root = r\n~r = 'x'+").compile().unwrap();
     assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
     let r = VM::new(&lenient.code, b"xxx").run();
     assert!(r.complete);
@@ -1196,7 +1196,7 @@ fn end_to_end_recover_repeat_with_label_intern() {
     // identical to the unlabeled form (one recovery capture per
     // skipped byte, clean exit at EOF). pegdb recoveries explain
     // clusters by this label.
-    let g = parse("root <- doc\ndoc <- @kw{\"foo\"}*^:bad_doc");
+    let g = parse("root = doc\ndoc = @kw{\"foo\"}*^:bad_doc");
     let prog = g.compile().unwrap();
     assert_eq!(prog.label_kinds, vec!["bad_doc"]);
     let r = VM::new_from_program(&prog, b"fooXXfoo").run();
@@ -1213,7 +1213,7 @@ fn end_to_end_catch_compile_run() {
     // semicolon. Input is malformed (no FROM), so the inner fails and
     // the recovery branch fires.
     let g = parse(
-        "root <- stmt\nstmt <- (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^bad_select @err{(!';' .)*} ';'",
+        "root = stmt\nstmt = (@kw{'SELECT'} ' ' @kw{'FROM'} ' ' 'x' ';') ^bad_select @err{(!';' .)*} ';'",
     );
     let prog = g.compile().unwrap();
     let r = VM::new_from_program(&prog, b"SELECT bogus;").run();
@@ -1235,7 +1235,7 @@ fn end_to_end_catch_compile_run() {
 
 #[test]
 fn duplicate_rule_errors() {
-    let err = parse_src("a <- 'x'\na <- 'y'").unwrap_err();
+    let err = parse_src("a = 'x'\na = 'y'").unwrap_err();
     assert!(err.message.contains("twice"), "got: {}", err.message);
 }
 
@@ -1258,7 +1258,7 @@ fn desugared_until_inclusive(stop: Pattern) -> Pattern {
 
 #[test]
 fn skip_until_exclusive_lowers_to_repeat() {
-    let g = parse("r <- .. 'b'");
+    let g = parse("r = .. 'b'");
     assert_eq!(
         g.rules["r"],
         desugared_until_exclusive(Pattern::literal("b"))
@@ -1267,7 +1267,7 @@ fn skip_until_exclusive_lowers_to_repeat() {
 
 #[test]
 fn skip_until_inclusive_lowers_with_trailing_consume() {
-    let g = parse("r <- ..= 'b'");
+    let g = parse("r = ..= 'b'");
     assert_eq!(
         g.rules["r"],
         desugared_until_inclusive(Pattern::literal("b"))
@@ -1277,14 +1277,14 @@ fn skip_until_inclusive_lowers_with_trailing_consume() {
 #[test]
 fn skip_until_inclusive_vs_exclusive_distinction() {
     // Same stop pattern; ASTs differ exactly in the trailing consume.
-    let excl = parse("r <- .. 'b'").rules["r"].clone();
-    let incl = parse("r <- ..= 'b'").rules["r"].clone();
+    let excl = parse("r = .. 'b'").rules["r"].clone();
+    let incl = parse("r = ..= 'b'").rules["r"].clone();
     assert_eq!(incl, Pattern::seq(vec![excl, Pattern::literal("b")]));
 }
 
 #[test]
 fn skip_until_inside_sequence() {
-    let g = parse("r <- 'x' .. 'b' 'y'");
+    let g = parse("r = 'x' .. 'b' 'y'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1298,7 +1298,7 @@ fn skip_until_inside_sequence() {
 #[test]
 fn skip_until_requires_adjacent_dots() {
     // `. . 'b'` (space between dots) is three atoms, not `..`.
-    let g = parse("r <- . . 'b'");
+    let g = parse("r = . . 'b'");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1314,7 +1314,7 @@ fn skip_until_inclusive_requires_adjacent_equals() {
     // `.. = 'b'` (space between `..` and `=`) is `..` whose stop is
     // `=`, then `'b'` as a trailing atom. Since `=` isn't a valid
     // atom-starter, the parse should fail at `=`.
-    let err = parse_src("r <- .. = 'b'").unwrap_err();
+    let err = parse_src("r = .. = 'b'").unwrap_err();
     assert!(
         err.message.contains("unexpected") || err.message.contains("expected"),
         "expected parse error on `=`, got: {}",
@@ -1324,17 +1324,17 @@ fn skip_until_inclusive_requires_adjacent_equals() {
 
 #[test]
 fn skip_until_whitespace_after_operator_ok() {
-    let a = parse("r <- ..'b'").rules["r"].clone();
-    let b = parse("r <- ..  'b'").rules["r"].clone();
+    let a = parse("r = ..'b'").rules["r"].clone();
+    let b = parse("r = ..  'b'").rules["r"].clone();
     assert_eq!(a, b);
-    let c = parse("r <- ..='b'").rules["r"].clone();
-    let d = parse("r <- ..=  'b'").rules["r"].clone();
+    let c = parse("r = ..='b'").rules["r"].clone();
+    let d = parse("r = ..=  'b'").rules["r"].clone();
     assert_eq!(c, d);
 }
 
 #[test]
 fn skip_until_with_charclass_stop() {
-    let g = parse("r <- .. [;]");
+    let g = parse("r = .. [;]");
     let stop = Pattern::char_class(CharSet::from_chars(&[';']));
     assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
 }
@@ -1342,14 +1342,14 @@ fn skip_until_with_charclass_stop() {
 #[test]
 fn skip_until_inclusive_with_grouped_stop() {
     // Mirrors the sqlite `bracket_id` shape: stop is an OrderedChoice.
-    let g = parse("r <- ..= (']' / 'x')");
+    let g = parse("r = ..= (']' / 'x')");
     let stop = Pattern::choice(vec![Pattern::literal("]"), Pattern::literal("x")]);
     assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
 }
 
 #[test]
 fn skip_until_requires_right_operand() {
-    let err = parse_src("r <- ..").unwrap_err();
+    let err = parse_src("r = ..").unwrap_err();
     assert!(
         err.message.contains("unexpected") || err.message.contains("expected"),
         "expected parse error at end of `..`, got: {}",
@@ -1362,14 +1362,14 @@ fn skip_until_inclusive_with_capture_stop() {
     // The stop pattern's capture survives lowering: the trailing
     // consume in `..= S` retains the same capture kind so themes
     // render the consumed delimiter consistently.
-    let g = parse("r <- ..= @punctuation{'}'}");
+    let g = parse("r = ..= @punctuation{'}'}");
     let stop = Pattern::capture("punctuation", Pattern::literal("}"));
     assert_eq!(g.rules["r"], desugared_until_inclusive(stop));
 }
 
 #[test]
 fn skip_until_with_capture_stop_exclusive() {
-    let g = parse("r <- .. @comment{'#'}");
+    let g = parse("r = .. @comment{'#'}");
     let stop = Pattern::capture("comment", Pattern::literal("#"));
     assert_eq!(g.rules["r"], desugared_until_exclusive(stop));
 }
@@ -1394,7 +1394,7 @@ fn desugared_bracketed_close_catch(inner: Pattern, label: &str, boundary: Patter
 
 #[test]
 fn bracketed_close_catch_lowers_without_inner_anchor() {
-    let g = parse("r <- 'a' ^^lbl ..= '}'");
+    let g = parse("r = 'a' ^^lbl ..= '}'");
     assert_eq!(
         g.rules["r"],
         desugared_bracketed_close_catch(Pattern::literal("a"), "lbl", Pattern::literal("}"))
@@ -1406,7 +1406,7 @@ fn bracketed_close_catch_with_capture_boundary() {
     // The boundary's capture kind is preserved on the trailing
     // consume — `}` is captured as `@punctuation` in both happy and
     // recovery paths.
-    let g = parse("r <- 'a' ^^lbl ..= @punctuation{'}'}");
+    let g = parse("r = 'a' ^^lbl ..= @punctuation{'}'}");
     let boundary = Pattern::capture("punctuation", Pattern::literal("}"));
     assert_eq!(
         g.rules["r"],
@@ -1418,8 +1418,8 @@ fn bracketed_close_catch_with_capture_boundary() {
 fn bracketed_close_catch_vs_boundary_catch_distinction() {
     // `^^lbl B`   — anchors INNER with `&B`; recovery is just `@recovery{(!B .)*}` (B left for outer).
     // `^^lbl ..= B` — no inner anchor; recovery is `Seq(@recovery{(!B .)*}, B)` (B consumed by recovery).
-    let anchored = parse("r <- 'a' ^^lbl '}'").rules["r"].clone();
-    let bracketed = parse("r <- 'a' ^^lbl ..= '}'").rules["r"].clone();
+    let anchored = parse("r = 'a' ^^lbl '}'").rules["r"].clone();
+    let bracketed = parse("r = 'a' ^^lbl ..= '}'").rules["r"].clone();
     match (&anchored, &bracketed) {
         (
             Pattern::Catch {
@@ -1461,7 +1461,7 @@ fn bracketed_close_catch_vs_boundary_catch_distinction() {
 fn bracketed_close_catch_rejects_non_consuming_form() {
     // `^^lbl .. B` is inconsistent (catch necessarily consumes B); the
     // parser rejects it with a hint at `..=`.
-    let err = parse_src("r <- 'a' ^^lbl .. '}'").unwrap_err();
+    let err = parse_src("r = 'a' ^^lbl .. '}'").unwrap_err();
     assert!(
         err.message.contains("..=") || err.message.contains("consume"),
         "expected hint about `..=`, got: {}",
@@ -1473,7 +1473,7 @@ fn bracketed_close_catch_rejects_non_consuming_form() {
 fn bracketed_close_catch_does_not_swallow_trailing_atoms() {
     // The catch sugar consumes its boundary in the recovery; any atoms
     // after the boundary belong to the enclosing sequence.
-    let g = parse("r <- 'a' ^^lbl ..= '}' 'c'");
+    let g = parse("r = 'a' ^^lbl ..= '}' 'c'");
     match &g.rules["r"] {
         Pattern::Sequence { items, .. } => {
             assert_eq!(items.len(), 2, "expected Seq(catch, 'c'), got: {items:?}");
@@ -1500,7 +1500,7 @@ fn ci_class(lower: char, upper: char) -> Pattern {
 
 #[test]
 fn case_insensitive_literal_basic() {
-    let g = parse("r <- i\"select\"");
+    let g = parse("r = i\"select\"");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1518,22 +1518,22 @@ fn case_insensitive_literal_basic() {
 fn case_insensitive_literal_equivalent_to_manual_form() {
     // The drop-in invariant: `i"select"` and `[sS][eE][lL][eE][cC][tT]`
     // parse to byte-identical AST shapes (modulo spans, stripped here).
-    let g_sugared = parse("r <- i\"select\"");
-    let g_manual = parse("r <- [sS][eE][lL][eE][cC][tT]");
+    let g_sugared = parse("r = i\"select\"");
+    let g_manual = parse("r = [sS][eE][lL][eE][cC][tT]");
     assert_eq!(g_sugared.rules["r"], g_manual.rules["r"]);
 }
 
 #[test]
 fn case_insensitive_literal_single_quoted() {
     // Both quote flavours work, mirroring `parse_string`.
-    let g_double = parse("r <- i\"abc\"");
-    let g_single = parse("r <- i'abc'");
+    let g_double = parse("r = i\"abc\"");
+    let g_single = parse("r = i'abc'");
     assert_eq!(g_double.rules["r"], g_single.rules["r"]);
 }
 
 #[test]
 fn case_insensitive_literal_non_letter_codepoints_stay_singletons() {
-    let g = parse("r <- i\"a1_z\"");
+    let g = parse("r = i\"a1_z\"");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1549,13 +1549,13 @@ fn case_insensitive_literal_non_letter_codepoints_stay_singletons() {
 fn case_insensitive_literal_empty_is_empty_literal() {
     // Matches `parse_string`'s treatment of `""`: no atoms to fold, so
     // the result is the empty `Literal` (matches the empty string).
-    let g = parse("r <- i\"\"");
+    let g = parse("r = i\"\"");
     assert_eq!(g.rules["r"], Pattern::literal(""));
 }
 
 #[test]
 fn case_insensitive_literal_no_letters_is_singletons() {
-    let g = parse("r <- i\"123\"");
+    let g = parse("r = i\"123\"");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1570,7 +1570,7 @@ fn case_insensitive_literal_no_letters_is_singletons() {
 fn case_insensitive_literal_handles_escapes() {
     // Same escape handling as `parse_string`: `\n` is the literal byte,
     // not a letter, so it stays a singleton.
-    let g = parse("r <- i\"a\\nb\"");
+    let g = parse("r = i\"a\\nb\"");
     assert_eq!(
         g.rules["r"],
         Pattern::seq(vec![
@@ -1586,13 +1586,13 @@ fn case_insensitive_literal_disambiguates_against_identifier() {
     // `i` followed by a non-quote byte must still parse as the start of
     // a `NonTerminal` — otherwise grammars with identifiers like
     // `ident_char` would suddenly become parse errors.
-    let g = parse("r <- ident_char");
+    let g = parse("r = ident_char");
     assert_eq!(g.rules["r"], Pattern::nt("ident_char"));
 }
 
 #[test]
 fn case_insensitive_literal_inside_capture() {
-    let g = parse("r <- @keyword{i\"select\"}");
+    let g = parse("r = @keyword{i\"select\"}");
     let body = Pattern::seq(vec![
         ci_class('s', 'S'),
         ci_class('e', 'E'),
@@ -1606,7 +1606,7 @@ fn case_insensitive_literal_inside_capture() {
 
 #[test]
 fn case_insensitive_literal_composes_with_postfix_and_lookahead() {
-    let g = parse("r <- i\"a\"*\ns <- !i\"a\"");
+    let g = parse("r = i\"a\"*\ns = !i\"a\"");
     let body = ci_class('a', 'A');
     assert_eq!(g.rules["r"], Pattern::repeat(body.clone()));
     assert_eq!(g.rules["s"], Pattern::not_predicate(body));
@@ -1614,7 +1614,7 @@ fn case_insensitive_literal_composes_with_postfix_and_lookahead() {
 
 #[test]
 fn case_insensitive_literal_unterminated_errors() {
-    let err = parse_src("r <- i\"select").unwrap_err();
+    let err = parse_src("r = i\"select").unwrap_err();
     assert!(
         err.message.contains("unterminated"),
         "expected unterminated-literal error, got: {}",

--- a/tests/incremental_tests.rs
+++ b/tests/incremental_tests.rs
@@ -25,8 +25,8 @@ use syntax_highlighter::pegc::{Grammar, Pattern};
 use syntax_highlighter::pegvm::{CharSet, MatchResult, MemoCache, VM};
 
 fn two_rule_grammar() -> syntax_highlighter::pegvm::Program {
-    // start <- word word
-    // word  <- [a-z]+
+    // start = word word
+    // word  = [a-z]+
     // The outer rule has enough span that default threshold (128) would
     // skip its entry on small inputs; tests pin threshold=0 to exercise
     // the mechanism regardless.
@@ -115,7 +115,7 @@ fn lr_cache_entry_invalidated_by_edit_inside_examined_range() {
     // seed-and-grow loop looked at.
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::Edit;
-    let prog = pegc::compile("root <- expr\n        expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+    let prog = pegc::compile("root = expr\n        expr = expr '+' [0-9]+ / [0-9]+").unwrap();
 
     let (_, _, mut cache) = VM::new_from_program(&prog, b"1+2+3")
         .with_memo_threshold(0)
@@ -148,7 +148,7 @@ fn lr_cache_round_trip_after_edit_matches_fresh_parse() {
     // gives an equivalent fresh-parse result on every edit).
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::Edit;
-    let prog = pegc::compile("root <- expr\n        expr <- expr '+' [0-9]+ / [0-9]+").unwrap();
+    let prog = pegc::compile("root = expr\n        expr = expr '+' [0-9]+ / [0-9]+").unwrap();
 
     let (_, _, mut cache) = VM::new_from_program(&prog, b"1+2+3")
         .with_memo_threshold(0)

--- a/tests/lr_tests.rs
+++ b/tests/lr_tests.rs
@@ -30,8 +30,8 @@ fn left_associative_addition() {
     // Standard left-associative arithmetic. Each '+' operand under the
     // 'op' tag, each leaf number under 'num'.
     let src = r#"
-        root <- expr
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = expr
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
     let r = VM::new_from_program(&prog, b"1+2+3").run();
@@ -58,8 +58,8 @@ fn left_associative_with_distinct_operators() {
     // semantics are wrong. The capture forest itself doesn't encode
     // associativity, but the seed-and-grow loop produces this ordering.
     let src = r#"
-        root <- expr
-        expr <- expr @minus{'-'} @num{[0-9]+} / @num{[0-9]+}
+        root = expr
+        expr = expr @minus{'-'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"9-1-2");
     assert!(r.complete);
@@ -68,16 +68,16 @@ fn left_associative_with_distinct_operators() {
 
 #[test]
 fn precedence_via_two_lr_layers() {
-    // expr <- expr '+' term / term
-    // term <- term '*' factor / factor
-    // factor <- [0-9]+ / '(' expr ')'
+    // expr = expr '+' term / term
+    // term = term '*' factor / factor
+    // factor = [0-9]+ / '(' expr ')'
     // Both expr and term are directly LR. The compiler must accept
     // both; the parse must reflect '*' binding tighter than '+'.
     let src = r#"
-        root   <- expr
-        expr   <- expr @plus{'+'} term / term
-        term   <- term @star{'*'} factor / factor
-        factor <- @num{[0-9]+} / '(' expr ')'
+        root   = expr
+        expr   = expr @plus{'+'} term / term
+        term   = term @star{'*'} factor / factor
+        factor = @num{[0-9]+} / '(' expr ')'
     "#;
     let r = run(src, b"1+2*3");
     assert!(r.complete);
@@ -102,10 +102,10 @@ fn precedence_via_two_lr_layers() {
 #[test]
 fn lr_with_parenthesised_subexpression() {
     let src = r#"
-        root   <- expr
-        expr   <- expr @plus{'+'} term / term
-        term   <- term @star{'*'} factor / factor
-        factor <- @num{[0-9]+} / '(' expr ')'
+        root   = expr
+        expr   = expr @plus{'+'} term / term
+        term   = term @star{'*'} factor / factor
+        factor = @num{[0-9]+} / '(' expr ')'
     "#;
     let r = run(src, b"(1+2)*3");
     assert!(r.complete);
@@ -116,8 +116,8 @@ fn lr_with_parenthesised_subexpression() {
 fn lr_failure_returns_partial() {
     // Input doesn't even start with a valid leaf.
     let src = r#"
-        root <- expr
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = expr
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"x");
     assert!(!r.complete);
@@ -133,9 +133,9 @@ fn lr_partial_chain_returns_longest_prefix() {
     // surrounding parse must report the deepest sp reached, which is
     // past the LR seed's growth.
     let src = r#"
-        root    <- wrapper
-        wrapper <- expr '!'
-        expr    <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root    = wrapper
+        wrapper = expr '!'
+        expr    = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"1+2");
     assert!(!r.complete);
@@ -144,7 +144,7 @@ fn lr_partial_chain_returns_longest_prefix() {
 
 #[test]
 fn nullable_lr_terminates() {
-    // Pathological nullable LR: A <- A / "x". Without LR support this
+    // Pathological nullable LR: A = A / "x". Without LR support this
     // would be an infinite Call → Call loop. Bounded LR semantics
     // accept the empty match (seed=None, body succeeds with sp
     // unchanged ⇒ no growth ⇒ commit empty seed). For input "x" the
@@ -155,8 +155,8 @@ fn nullable_lr_terminates() {
     // growth past seed); LRTail commits at sp=1. Just assert it
     // terminates and matched is 1.
     let src = r#"
-        root <- a
-        a <- a / 'x'
+        root = a
+        a = a / 'x'
     "#;
     let r = run(src, b"x");
     assert!(r.complete);
@@ -170,8 +170,8 @@ fn nullable_lr_on_empty_input_terminates() {
     // body fails on first iteration with seed None, so the LR rule
     // fails — partial parse at sp=0.
     let src = r#"
-        root <- a
-        a <- a / 'x'
+        root = a
+        a = a / 'x'
     "#;
     let r = run(src, b"");
     assert!(!r.complete);
@@ -185,8 +185,8 @@ fn right_recursive_grammar_is_not_marked_lr() {
     // assertion is in compiler_tests; here we just confirm runtime
     // behavior is unchanged.
     let src = r#"
-        root <- list
-        list <- @num{[0-9]+} (',' list)?
+        root = list
+        list = @num{[0-9]+} (',' list)?
     "#;
     let r = run(src, b"1,2,3");
     assert!(r.complete);
@@ -198,9 +198,9 @@ fn indirect_lr_cycle_of_2_runs() {
     // SCC {a, b}; both rules are wrapped as LR. Input "y" matches via
     // a's base alternative on the first iteration; no growth occurs.
     let src = r#"
-        root <- a
-        a <- b 'x' / 'y'
-        b <- a 'z' / 'w'
+        root = a
+        a = b 'x' / 'y'
+        b = a 'z' / 'w'
     "#;
     let r = run(src, b"y");
     assert!(r.complete);
@@ -213,9 +213,9 @@ fn indirect_lr_cycle_of_2_grows_through_chain() {
     // through the indirect cycle: a's seed grows from {y at sp=1} to
     // {b'x' at sp=3} where b in turn used a's seed to match "yz".
     let src = r#"
-        root <- a
-        a <- b 'x' / 'y'
-        b <- a 'z' / 'w'
+        root = a
+        a = b 'x' / 'y'
+        b = a 'z' / 'w'
     "#;
     let r = run(src, b"yzx");
     assert!(r.complete);
@@ -228,10 +228,10 @@ fn indirect_lr_cycle_of_3_runs() {
     // wrapped as LR. Input "p" matches via a's base alt; the test
     // confirms that cycles longer than 2 compile and run.
     let src = r#"
-        root <- a
-        a <- b 'x' / 'p'
-        b <- c 'y' / 'q'
-        c <- a 'z' / 'r'
+        root = a
+        a = b 'x' / 'p'
+        b = c 'y' / 'q'
+        c = a 'z' / 'r'
     "#;
     let r = run(src, b"p");
     assert!(r.complete);
@@ -240,8 +240,8 @@ fn indirect_lr_cycle_of_3_runs() {
 
 #[test]
 fn lr_inside_recover_repeat_resyncs_cleanly() {
-    // top <- (expr ';')*^ !.
-    // expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+    // top = (expr ';')*^ !.
+    // expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     //
     // Input "1+2;BAD;3+4;" — the middle "BAD" can't parse as an expr,
     // so the *^ recovery branch consumes one byte at a time. The
@@ -249,9 +249,9 @@ fn lr_inside_recover_repeat_resyncs_cleanly() {
     // seed (or its first-iteration failure must propagate cleanly so
     // *^'s outer Choice/Commit catches it).
     let src = r#"
-        root <- top
-        top  <- (expr ';')*^ !.
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = top
+        top  = (expr ';')*^ !.
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let r = run(src, b"1+2;BAD;3+4;");
     assert!(
@@ -287,8 +287,8 @@ fn cached_lr_seed_matches_uncached_run() {
     // additive: enabling it (threshold=0) must produce the same
     // MatchResult as disabling it (threshold=usize::MAX).
     let src = r#"
-        root <- expr
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = expr
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
     let cached = VM::new_from_program(&prog, b"1+2+3")
@@ -312,8 +312,8 @@ fn lr_seed_caches_below_memo_threshold() {
     // a generous threshold (1024), a `Memo`-kind rule of the same
     // shape would not cache, but the LR rule must.
     let src = r#"
-        root <- expr
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = expr
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
     let (_, stats) = VM::new_from_program(&prog, b"1")
@@ -331,9 +331,9 @@ fn lr_inside_outer_repetition_matches_uncached_run() {
     // distinct sps; the new cache write at LRTail must not perturb the
     // surrounding pattern.
     let src = r#"
-        root <- top
-        top  <- (expr ',')* expr
-        expr <- expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
+        root = top
+        top  = (expr ',')* expr
+        expr = expr @op{'+'} @num{[0-9]+} / @num{[0-9]+}
     "#;
     let prog = pegc::compile(src).expect("compile");
     let cached = VM::new_from_program(&prog, b"1+2,3+4,5")

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -21,7 +21,7 @@ fn cap(kind: u16, start: usize, end: usize) -> Capture {
     }
 }
 
-/// `start <- (X "aa") / (X "bb")`, `X <- [a-z]`.
+/// `start = (X "aa") / (X "bb")`, `X = [a-z]`.
 ///
 /// On input "ab" the first alternative fails after X matches at sp=0, the VM
 /// backtracks to sp=0, and the second alternative re-calls X at the same
@@ -86,9 +86,9 @@ fn memo_table_populates_on_success() {
 /// rather than mis-closing a replayed entry.
 ///
 /// Grammar:
-///   start <- outer
-///   outer <- @outer{ Inner Inner }   # two calls to Inner inside a capture
-///   Inner <- @inner{ [a-z] }
+///   start = outer
+///   outer = @outer{ Inner Inner }   # two calls to Inner inside a capture
+///   Inner = @inner{ [a-z] }
 ///
 /// On "aa": first Inner call at sp=0 produces `@inner{"a"}`. Second Inner
 /// call at sp=1 is a distinct entry (different sp) — but the structure
@@ -96,9 +96,9 @@ fn memo_table_populates_on_success() {
 /// @outer correctly.
 ///
 /// To force a true replay at the same sp, we instead use:
-///   start <- outer
-///   outer <- @outer{ (Inner "x") / (Inner "y") }
-///   Inner <- @inner{ [a-z] }
+///   start = outer
+///   outer = @outer{ (Inner "x") / (Inner "y") }
+///   Inner = @inner{ [a-z] }
 /// On "ay": first alternative fails ("ay" doesn't have trailing "x"),
 /// Inner's cached result is reused in the second alternative. The critical
 /// assertion is that the outer capture closes at sp=2 (not at sp=1 — which
@@ -160,7 +160,7 @@ fn memo_hit_inside_outer_capture_preserves_nesting() {
     assert!(stats.hits >= 1, "expected a cache hit, got {}", stats.hits);
 }
 
-/// `start <- (!A "b") / (!A "c")`, `A <- "a"`.
+/// `start = (!A "b") / (!A "c")`, `A = "a"`.
 ///
 /// On input "cx" the first alternative's `!A` succeeds because A fails at
 /// sp=0, but "b" fails at sp=0, forcing backtrack. The second alternative's
@@ -197,7 +197,7 @@ fn cached_failure_short_circuits_not_predicate() {
 }
 
 /// Nested memoized rules both failing must both land failure entries in the
-/// table — not just the innermost one. `outer <- inner "b"`, `inner <- "a"`.
+/// table — not just the innermost one. `outer = inner "b"`, `inner = "a"`.
 /// On input "x": inner fails, outer has no backtrack machinery so it also
 /// fails. Both failures must be cached.
 #[test]
@@ -232,7 +232,7 @@ fn nested_memoized_rule_failures_both_cached() {
 /// (not the `Memo` frame from the successful rule call, which `MemoClose`
 /// has already popped).
 ///
-/// `start <- (&A "z") / (&A "y")`, `A <- [a-z]`. On input "y": &A peeks and
+/// `start = (&A "z") / (&A "y")`, `A = [a-z]`. On input "y": &A peeks and
 /// succeeds at sp=0, "z" fails at sp=0, backtrack to the second alternative,
 /// &A peeks again at sp=0 (memo hit), "y" matches.
 #[test]
@@ -272,8 +272,8 @@ fn lr_converged_seed_persists_across_parses() {
     use syntax_highlighter::pegc;
     use syntax_highlighter::pegvm::MemoCache;
     let src = r#"
-        root <- expr
-        expr <- expr '+' [0-9]+ / [0-9]+
+        root = expr
+        expr = expr '+' [0-9]+ / [0-9]+
     "#;
     let prog = pegc::compile(src).expect("compile");
     let input = b"1+2+3";

--- a/tests/parse_go_tests.rs
+++ b/tests/parse_go_tests.rs
@@ -72,7 +72,7 @@ fn nil_is_constant() {
 
 #[test]
 fn qualified_ident_dot_is_nested_punctuation() {
-    // Go's `qualified_ident <- ident (@punctuation{'.'} ident)?` wrapped
+    // Go's `qualified_ident = ident (@punctuation{'.'} ident)?` wrapped
     // by `@type{...}` produces a punctuation capture nested inside a
     // type capture. The walker resolves to the innermost kind, so the
     // dot's byte should report `punctuation`, not `type`.

--- a/tests/pegb_roundtrip_tests.rs
+++ b/tests/pegb_roundtrip_tests.rs
@@ -155,5 +155,5 @@ fn labeled_catch_program_round_trips() {
     // table. Input drives the catch through both success and recovery
     // branches in case any future encoder change depends on runtime
     // state.
-    assert_grammar("labeled_catch", "root <- 'a' ^lbl 'b'", b"ab");
+    assert_grammar("labeled_catch", "root = 'a' ^lbl 'b'", b"ab");
 }

--- a/tests/pegc_tests.rs
+++ b/tests/pegc_tests.rs
@@ -118,7 +118,7 @@ fn stats_json_grammar_emits_expected_record() {
 }
 
 // `tests/fixtures/stats_canary.peg` is a deliberately tiny grammar
-// (`root <- 'a' / @keyword{'b'}`) whose only purpose is pinning
+// (`root = 'a' / @keyword{'b'}`) whose only purpose is pinning
 // `stats`'s scalar output. The instruction count shifts only if pegc's
 // bytecode lowering for literals / alternation / capture wrapping
 // changes — a real signal worth catching. Shipped-grammar drift

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -349,7 +349,7 @@ fn recoveries_dump_carries_label_pos_rule_stack_literal() {
 
 #[test]
 fn recoveries_dump_skips_trivia_in_leaf() {
-    // Same `trivia <- ws` cascade story as `recoveries explain`: the
+    // Same `trivia = ws` cascade story as `recoveries explain`: the
     // displayed leaf (last element of `rule_stack`) must not be a
     // trivia rule.
     let (code, stdout, _) = run_stdin(
@@ -620,7 +620,7 @@ fn recoveries_explain_uses_author_supplied_recovery_label() {
         "pegdb_recoveries_explain_label_{}.peg",
         std::process::id()
     ));
-    let grammar = b"root <- 'x'*^:bad_doc\n";
+    let grammar = b"root = 'x'*^:bad_doc\n";
     let mut f = std::fs::File::create(&path).expect("create temp grammar");
     f.write_all(grammar).expect("write temp grammar");
     drop(f);

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -463,14 +463,14 @@ fn partial_match_captures_survive_backtrack_below_watermark() {
     //  1: CaptureBegin 0
     //  2: Char a
     //  3: Char b
-    //  4: Char c       <- fails here on 'd', sp was 2 → max_sp=2,
+    //  4: Char c       = fails here on 'd', sp was 2 → max_sp=2,
     //                     captures=[{kind:0,start:0,end:None}]
     //  5: CaptureEnd
     //  6: Commit L2 (=11) — unreached; Char c failure triggers Backtrack
     //                         unwind that truncates captures to 0.
     //  7: Char a     (L1, second alternative)
     //  8: Char b
-    //  9: Char x      <- fails here on 'd'
+    //  9: Char x      = fails here on 'd'
     // 10: End        (L2, unreached)
     //
     // Expect: complete=false, matched=2, one capture (kind=0, 0..2).
@@ -497,7 +497,7 @@ fn partial_match_captures_survive_backtrack_below_watermark() {
 // VM-level semantics on a raw program so VM changes can be validated
 // without going through the compiler. Equivalent grammar:
 //
-//     expr <- expr "+" "n" / "n"
+//     expr = expr "+" "n" / "n"
 //
 // Code layout:
 //

--- a/tests/walk_invariants_tests.rs
+++ b/tests/walk_invariants_tests.rs
@@ -10,11 +10,11 @@ mod common;
 use common::segments;
 
 /// Inner capture's `end` coincides with the outer's:
-/// `start <- @outer{body}`, `body <- 'aaa' @inner{'bbb'}`.
+/// `start = @outer{body}`, `body = 'aaa' @inner{'bbb'}`.
 /// On input `aaabbb`, outer covers 0..6 and inner covers 3..6.
 const SHARED_END_GRAMMAR: &str = "\
-root <- @outer{body}
-body <- 'aaa' @inner{'bbb'}
+root = @outer{body}
+body = 'aaa' @inner{'bbb'}
 ";
 
 #[test]


### PR DESCRIPTION
First step of the staged `.peg` surface-syntax redesign: rule definitions now use `=` instead of `<-`, matching the convention readers know from Peggy and pest and reading more naturally as "this name *is* this pattern". The ordered-choice operator stays `/` — only the definition arrow changes.

The parser change is small (the definition token and the two rule-boundary lookaheads in `looks_like_rule_def` / `at_prefix_start`); the bulk of the diff is the mechanical port of every shipped grammar, fixture, inline test grammar, and doc example. Go's channel-receive literal `@operator{'<-'}` is untouched — only the bare definition arrow was rewritten, never a quoted `<-`.

A follow-on commit drops the column alignment of the `=` signs. Aligned operators couple every rule to its siblings — adding or renaming one rule forced a re-pad of the whole block, burying real changes in whitespace noise. Definitions now use a single space (`name = body`); multi-line choices keep their continuations aligned under the first alternative, and trailing-form rules keep their hanging indent.
