### PR TITLE
pegc: replace rule sigils with postfix ascriptions

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -17,7 +17,7 @@ A periodic cleanup sweep over `grammars/*.peg`. Each sweep tends to harvest a sm
 Each candidate falls into one of four categories. The first two are mechanical, the next two are judgment calls.
 
 1. **Char-class re-aliases (mechanical).** A rule whose body is just `[...]` (one or two character classes in sequence), and the rule name doesn't carry documentary intent beyond "this char class." Inline the class at use sites unless the name appears at many sites — a high-ref alias *is* the documentation.
-2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. a grammar carrying both `*ident_cont = [a-zA-Z\d_]` and a separate `*ident_char = [a-zA-Z\d_]` boundary class. Merge to one name unless the dual naming documents a future divergence.
+2. **Duplicate-body rules (mechanical).** Two atomic rules with byte-identical bodies under different names — e.g. a grammar carrying both `ident_cont: atomic = [a-zA-Z\d_]` and a separate `ident_char: atomic = [a-zA-Z\d_]` boundary class. Merge to one name unless the dual naming documents a future divergence.
 3. **Refs=1 single-use rules (judgment).** Many rules are referenced once. Most are NOT inline candidates — they exist to name a multi-line cascade entry, an alternation, or a spec-significant phrase. Only inline when the body is a single `name+` / `name*` / `name` / `[...]` / literal — i.e. a textbook thin wrapper.
 4. **Name ≥ body (judgment).** When the rule name is at least as long as the body string, the indirection isn't paying its way. Same evaluation as refs=1: only inline trivial wrappers.
 
@@ -47,7 +47,7 @@ grep -n -E '^\s*\*?[a-z_]+\s*=\s*\[[^]]+\]\s*$' grammars/*.peg
 
 **Duplicate atomic-rule bodies (same body, different names):**
 
-Walk each grammar, normalize the body source (strip leading `*` and the `=`), group by body string, flag groups of size > 1.
+Walk each grammar, normalize the body source (strip the name, any `: ascription` clause, and the `=`), group by body string, flag groups of size > 1.
 
 **Refs=1 (single-use) and name ≥ body:**
 
@@ -62,7 +62,7 @@ for f in /tmp/grammar-refactor/*.ndjson; do
 done
 ```
 
-`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. `reserved` and `preferred` are compiler-*synthesized* (from the `%` / `%?` rules) and can't be defined at all. A `%`- or `%?`-marked rule is also off-limits to inlining: see the *Atomicity check* below.
+`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. `reserved` and `preferred` are compiler-*synthesized* (from the `reserved` / `preferred` rules) and can't be defined at all. A `reserved`- or `preferred`-ascribed rule is also off-limits to inlining: see the *Atomicity check* below.
 
 ### 3. For each candidate, evaluate
 
@@ -84,9 +84,9 @@ Inlining changes which rule the auto-trivia rewriter is walking. From `src/pegc/
 Safe shapes regardless of atomicity:
 - Body is a single char class, single literal, single NonTerminal, or single Repeat-of-NonTerminal — no internal Sequence, so no internal trivia injection to gain or lose.
 
-When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `*` sigil on both rule headers before changing anything.
+When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `atomic` (or `reserved` / `preferred`) ascription on both rule headers before changing anything.
 
-**`%` / `%?` reserved-word rules are never inline candidates.** A `%name =` (or `%?name =`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `%` / `%?` rules (and the `wb` rule itself) alone.
+**`reserved` / `preferred` rules are never inline candidates.** A `name: reserved =` (or `name: preferred =`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `reserved` / `preferred` rules (and the `wb` rule itself) alone.
 
 ### 5. Report
 
@@ -109,8 +109,8 @@ The applied edit is mechanical at this point — the judgment was the previous s
 - **Bulk-inlining all refs=1 rules.** Most refs=1 rules are spec-significant cascade entries (every binary-precedence level, every statement form, every type-position-specific entry). Inlining them produces an unreadable wall of alternation.
 - **Inlining across atomicity boundaries without checking.** Will silently change parsing behavior — usually in a way that's not caught by the unit tests but shows up in the highlighter fixtures or recovery baselines.
 - **Forgetting to update the grammar header comment** when removing a rule that's named there.
-- **Touching `root`, `trivia`, `wb`, `reserved`, `preferred`, or any `%` / `%?` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `reserved` / `preferred` are compiler-synthesized (defining them is a parse error); `%` / `%?` rules carry an invisible trailing `wb` boundary that inlining would drop *and* feed the synthesized sets. Filter all of these out before evaluating.
-- **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention. The `%kw_*` literals are also the source of the synthesized `reserved` set (the no-keyword-as-identifier lookahead, `!reserved`); window-vocabulary keywords are `%?kw_*` so they stay usable as identifiers. Don't sweep these.
+- **Touching `root`, `trivia`, `wb`, `reserved`, `preferred`, or any `reserved` / `preferred` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `reserved` / `preferred` are compiler-synthesized (defining them is a parse error); `reserved` / `preferred` rules carry an invisible trailing `wb` boundary that inlining would drop *and* feed the synthesized sets. Filter all of these out before evaluating.
+- **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention. The `kw_*: reserved` literals are also the source of the synthesized `reserved` set (the no-keyword-as-identifier lookahead, `!reserved`); window-vocabulary keywords are `kw_*: preferred` so they stay usable as identifiers. Don't sweep these.
 
 ## Reference PRs
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -40,9 +40,9 @@ wb = !ident_body
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
 pp_line = @keyword pp_body
-*pp_body = '#' (pp_cont / [^\n])*
-*pp_cont = '\\' '\n'
-          / '\\' '\r' '\n'
+pp_body: atomic = '#' (pp_cont / [^\n])*
+pp_cont: atomic = '\\' '\n'
+                 / '\\' '\r' '\n'
 
 # --- External declarations -------------------------------------------
 
@@ -68,38 +68,38 @@ decl_spec = storage_spec
 # appended inside each keyword capture. A keyword can't fire on a longer
 # identifier that merely starts with it (`static MyType`, `typedefx`),
 # and a rejected keyword leaves no stray capture for recovery to surface.
-%storage_spec = @keyword 'typedef'
-              / @keyword 'extern'
-              / @keyword 'static'
-              / @keyword 'auto'
-              / @keyword 'register'
-              / @keyword '_Thread_local'
-%type_qualifier = @keyword 'const'
-                / @keyword 'volatile'
-                / @keyword 'restrict'
-                / @keyword '_Atomic'
-%fn_spec = @keyword 'inline'
-         / @keyword '_Noreturn'
+storage_spec: reserved = @keyword 'typedef'
+                       / @keyword 'extern'
+                       / @keyword 'static'
+                       / @keyword 'auto'
+                       / @keyword 'register'
+                       / @keyword '_Thread_local'
+type_qualifier: reserved = @keyword 'const'
+                         / @keyword 'volatile'
+                         / @keyword 'restrict'
+                         / @keyword '_Atomic'
+fn_spec: reserved = @keyword 'inline'
+                  / @keyword '_Noreturn'
 
 # Embedded keyword tokens: one `%` rule per keyword, referenced wherever
 # the keyword appears so the `wb` boundary is applied uniformly.
-%kw_struct = @keyword 'struct'
-%kw_union = @keyword 'union'
-%kw_enum = @keyword 'enum'
-%kw_case = @keyword 'case'
-%kw_default = @keyword 'default'
-%kw_if = @keyword 'if'
-%kw_else = @keyword 'else'
-%kw_for = @keyword 'for'
-%kw_while = @keyword 'while'
-%kw_do = @keyword 'do'
-%kw_switch = @keyword 'switch'
-%kw_return = @keyword 'return'
-%kw_break = @keyword 'break'
-%kw_continue = @keyword 'continue'
-%kw_goto = @keyword 'goto'
-%kw_sizeof = @keyword 'sizeof'
-%kw_alignof = @keyword '_Alignof'
+kw_struct: reserved = @keyword 'struct'
+kw_union: reserved = @keyword 'union'
+kw_enum: reserved = @keyword 'enum'
+kw_case: reserved = @keyword 'case'
+kw_default: reserved = @keyword 'default'
+kw_if: reserved = @keyword 'if'
+kw_else: reserved = @keyword 'else'
+kw_for: reserved = @keyword 'for'
+kw_while: reserved = @keyword 'while'
+kw_do: reserved = @keyword 'do'
+kw_switch: reserved = @keyword 'switch'
+kw_return: reserved = @keyword 'return'
+kw_break: reserved = @keyword 'break'
+kw_continue: reserved = @keyword 'continue'
+kw_goto: reserved = @keyword 'goto'
+kw_sizeof: reserved = @keyword 'sizeof'
+kw_alignof: reserved = @keyword '_Alignof'
 
 type_spec = struct_or_union_spec
           / enum_spec
@@ -107,18 +107,18 @@ type_spec = struct_or_union_spec
           / @type typedef_name
 
 predef_type = @type predef_type_name
-%predef_type_name = 'void' / 'char' / 'short' / 'long long' / 'long'
-                  / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
-                  / '_Bool' / '_Complex' / '_Imaginary'
+predef_type_name: reserved = 'void' / 'char' / 'short' / 'long long' / 'long'
+                           / 'int' / 'float' / 'double' / 'signed' / 'unsigned'
+                           / '_Bool' / '_Complex' / '_Imaginary'
 
 # Heuristic typedef-name: PascalCase or `*_t` tail. If this mismatches
 # an actual declaration, the decl path will fail and we fall back to
 # expression statement. The `_t` arm uses the standard PEG non-greedy
 # idiom `(!end_t ident_body)*` because PEG `*` is possessive — a
 # greedy `ident_body*` would swallow the trailing `_t`.
-*typedef_name = [A-Z] ident_body*
-              / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-*typedef_t_end = '_t' wb
+typedef_name: atomic = [A-Z] ident_body*
+                     / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
+typedef_t_end: atomic = '_t' wb
 
 struct_or_union_spec = (kw_struct / kw_union)
                       (@type ident)? (@punctuation '{' struct_decl* @punctuation '}')?
@@ -195,8 +195,8 @@ labeled_stmt = @variable ident @punctuation ':' stmt
              / kw_case expr_cond @punctuation ':' stmt
              / kw_default @punctuation ':' stmt
 # Trailing `(else stmt)?` leniency absorbed by top-level `*^` and `^block_close`.
-~if_stmt = kw_if @punctuation '(' expr @punctuation ')' stmt
-           (kw_else stmt)?
+if_stmt: partial = kw_if @punctuation '(' expr @punctuation ')' stmt
+                   (kw_else stmt)?
 for_stmt = kw_for @punctuation '(' for_init expr? @punctuation ';' expr? @punctuation ')' stmt
 for_init = decl
          / expr? @punctuation ';'
@@ -231,7 +231,7 @@ assign_op = @operator '<<=' / @operator '>>='
           / @operator '=' !'='
 
 # Trailing ternary `?` leniency absorbed by top-level `*^`.
-~expr_cond = expr_lor (@operator '?' expr @punctuation ':' expr_assign)?
+expr_cond: partial = expr_lor (@operator '?' expr @punctuation ':' expr_assign)?
 
 expr_lor = expr_lor @operator '||' expr_land / expr_land
 expr_land = expr_land @operator '&&' expr_bor / expr_bor
@@ -281,9 +281,9 @@ expr_primary = string_lit
 
 # Boolean / null constants as a `%?` preferred-word alternation so the
 # `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
-%?lit_const = @constant 'true'
-            / @constant 'false'
-            / @constant 'NULL'
+lit_const: preferred = @constant 'true'
+                     / @constant 'false'
+                     / @constant 'NULL'
 
 # `sizeof(T)` must eat the whole type-name expression as a sizeof argument.
 sizeof_type = kw_sizeof @punctuation '(' type_name @punctuation ')'
@@ -300,24 +300,24 @@ call_ident = @function ident &(@punctuation '(')
 # --- Literals --------------------------------------------------------
 
 string_lit = @string (string_piece+)
-*string_piece = ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
+string_piece: atomic = ('L' / 'u8' / 'u' / 'U')? '"' ('\\' . / !'"' !'\n' .)* '"'
 
 char_lit = @string char_body
-*char_body = ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
+char_body: atomic = ('L' / 'u' / 'U')? "'" ('\\' . / !"'" .)* "'"
 
 number_lit = @number num_body
-*num_body = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
-          / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
-          / '0b' bin_digits int_suffix?
-          / '0' [0-7]* int_suffix?
-          / digit_seq '.' digit_seq? exp_part? float_suffix?
-          / '.' digit_seq exp_part? float_suffix?
-          / digit_seq exp_part float_suffix?
-          / digit_seq int_suffix?
-*digit_seq = \d [\d']*
-*hex_digits = [\da-fA-F] [\da-fA-F']*
-*bin_digits = [01] [01']*
-*exp_part = [eE] [+\-]? \d+
+num_body: atomic = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+                 / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? int_suffix?
+                 / '0b' bin_digits int_suffix?
+                 / '0' [0-7]* int_suffix?
+                 / digit_seq '.' digit_seq? exp_part? float_suffix?
+                 / '.' digit_seq exp_part? float_suffix?
+                 / digit_seq exp_part float_suffix?
+                 / digit_seq int_suffix?
+digit_seq: atomic = \d [\d']*
+hex_digits: atomic = [\da-fA-F] [\da-fA-F']*
+bin_digits: atomic = [01] [01']*
+exp_part: atomic = [eE] [+\-]? \d+
 int_suffix = ('ULL' / 'ull' / 'LL' / 'll' / 'UL' / 'ul' / 'LU' / 'lu' / 'U' / 'u' / 'L' / 'l')
 float_suffix = [fFlL]
 
@@ -327,10 +327,10 @@ float_suffix = [fFlL]
 # | digit)*; nondigit = `_ A-Z a-z` | universal-character-name (UCN);
 # UCNs are `\uHHHH` (4 hex) or `\UHHHHHHHH` (8 hex). C23 §6.4.3 also
 # admits raw non-ASCII letters (General_Category=L) directly.
-*ident = !reserved ([\p{L}_] / ucn) ident_body*
+ident: atomic = !reserved ([\p{L}_] / ucn) ident_body*
 ident_body = [\p{L}\p{Nd}_] / ucn
 ucn = '\\u' [0-9A-Fa-f]{4} / '\\U' [0-9A-Fa-f]{8}
 
 # --- Whitespace / comments ------------------------------------------
 
-*comment = @comment ('//' .. '\n' / '/*' ..= '*/')
+comment: atomic = @comment ('//' .. '\n' / '/*' ..= '*/')

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -33,7 +33,7 @@ statement = at_rule
 # --- At-rules --------------------------------------------------------
 
 at_rule = at_name prelude (block / @punctuation ';')
-*at_name = @keyword ('@' ident_body+)
+at_name: atomic = @keyword ('@' ident_body+)
 
 # Prelude: tokens up to `{` or `;` — sequences of value-like tokens.
 prelude = prelude_token*
@@ -64,16 +64,16 @@ combinator_and_next = @operator '>' compound_selector
                     / compound_selector
 
 compound_selector = selector_atom+
-*selector_atom = @property ('.' ident)
-               / @constant ('#' ident)
-               / @function ('::' ident pseudo_args?)
-               / @function (':' ident pseudo_args?)
-               / @punctuation '[' (.. ']') @punctuation ']'
-               / @punctuation '&'
-               / @punctuation '*'
-               / @type ident
+selector_atom: atomic = @property ('.' ident)
+                      / @constant ('#' ident)
+                      / @function ('::' ident pseudo_args?)
+                      / @function (':' ident pseudo_args?)
+                      / @punctuation '[' (.. ']') @punctuation ']'
+                      / @punctuation '&'
+                      / @punctuation '*'
+                      / @type ident
 
-*pseudo_args = '(' ..= ')'
+pseudo_args: atomic = '(' ..= ')'
 
 # --- Blocks & declarations ------------------------------------------
 
@@ -84,11 +84,11 @@ block_item = at_rule
             / @punctuation ';'
 
 # Trailing `important? (';' / &'}')` leniency is absorbed by `block`'s `^block_close`.
-~declaration = @property prop_ident @punctuation ':' value_list
-               @keyword '!important'? (@punctuation ';' / &'}')
+declaration: partial = @property prop_ident @punctuation ':' value_list
+                       @keyword '!important'? (@punctuation ';' / &'}')
 
-*prop_ident = '--' ident_body+
-             / '-'? ident
+prop_ident: atomic = '--' ident_body+
+                    / '-'? ident
 
 # --- Values ---------------------------------------------------------
 
@@ -113,21 +113,21 @@ url_unquoted = @function 'url' @punctuation '(' @string (.. ')') @punctuation ')
 
 # --- Literals -------------------------------------------------------
 
-*hex_color = @constant ('#' [\da-fA-F]+)
+hex_color: atomic = @constant ('#' [\da-fA-F]+)
 
 number_with_unit = @number num_body
 
 # Trailing `num_unit?` leniency: unitless numbers stop at the next non-unit byte; outer recovery handles malformed values.
-*~num_body = [+\-]? (num_float / \d+) num_unit?
-*num_float = \d* '.' \d+
-            / \d+ '.' \d*
+num_body: partial atomic = [+\-]? (num_float / \d+) num_unit?
+num_float: atomic = \d* '.' \d+
+                   / \d+ '.' \d*
 num_unit = '%'
           / ident
 
 string_lit = @string (dq_string / sq_string)
-*dq_string = '"' (str_escape / !'"' !'\n' .)* '"'
-*sq_string = "'" (str_escape / !"'" !'\n' .)* "'"
-*str_escape = '\\' .
+dq_string: atomic = '"' (str_escape / !'"' !'\n' .)* '"'
+sq_string: atomic = "'" (str_escape / !"'" !'\n' .)* "'"
+str_escape: atomic = '\\' .
 
 # --- Identifiers ----------------------------------------------------
 
@@ -135,7 +135,7 @@ string_lit = @string (dq_string / sq_string)
 # code point (≥ U+0080) | css_escape; ident code point = ident-start |
 # digit | -. The escape is `\` followed by 1-6 hex digits and an
 # optional trailing whitespace (consumed by the escape, not the ident).
-*ident = (ident_start_char / css_escape) (ident_body_char / css_escape)*
+ident: atomic = (ident_start_char / css_escape) (ident_body_char / css_escape)*
 ident_start_char = [A-Za-z_\-\u{80}-\u{10FFFF}]
 ident_body_char = [A-Za-z\d_\-\u{80}-\u{10FFFF}]
 ident_body = ident_body_char / css_escape
@@ -145,10 +145,10 @@ ident_body = ident_body_char / css_escape
 # cases for highlighter purposes; encoding the hex-digit-count
 # refinement separately would force a partial-match call site that
 # trips the lint.
-*css_escape = '\\' !\R .
+css_escape: atomic = '\\' !\R .
 
 # --- Whitespace / comments -----------------------------------------
 #
 # CSS has only block comments.
 
-*comment = @comment ('/*' ..= '*/')
+comment: atomic = @comment ('/*' ..= '*/')

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -37,31 +37,31 @@ wb = !ident_body
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`funcx`).
-%kw_package = @keyword 'package'
-%kw_import = @keyword 'import'
-%kw_var = @keyword 'var'
-%kw_const = @keyword 'const'
-%kw_type = @keyword 'type'
-%kw_map = @keyword 'map'
-%kw_chan = @keyword 'chan'
-%kw_func = @keyword 'func'
-%kw_struct = @keyword 'struct'
-%kw_interface = @keyword 'interface'
-%kw_if = @keyword 'if'
-%kw_else = @keyword 'else'
-%kw_for = @keyword 'for'
-%kw_range = @keyword 'range'
-%kw_switch = @keyword 'switch'
-%kw_case = @keyword 'case'
-%kw_default = @keyword 'default'
-%kw_select = @keyword 'select'
-%kw_go = @keyword 'go'
-%kw_defer = @keyword 'defer'
-%kw_return = @keyword 'return'
-%kw_break = @keyword 'break'
-%kw_continue = @keyword 'continue'
-%kw_goto = @keyword 'goto'
-%kw_fallthrough = @keyword 'fallthrough'
+kw_package: reserved = @keyword 'package'
+kw_import: reserved = @keyword 'import'
+kw_var: reserved = @keyword 'var'
+kw_const: reserved = @keyword 'const'
+kw_type: reserved = @keyword 'type'
+kw_map: reserved = @keyword 'map'
+kw_chan: reserved = @keyword 'chan'
+kw_func: reserved = @keyword 'func'
+kw_struct: reserved = @keyword 'struct'
+kw_interface: reserved = @keyword 'interface'
+kw_if: reserved = @keyword 'if'
+kw_else: reserved = @keyword 'else'
+kw_for: reserved = @keyword 'for'
+kw_range: reserved = @keyword 'range'
+kw_switch: reserved = @keyword 'switch'
+kw_case: reserved = @keyword 'case'
+kw_default: reserved = @keyword 'default'
+kw_select: reserved = @keyword 'select'
+kw_go: reserved = @keyword 'go'
+kw_defer: reserved = @keyword 'defer'
+kw_return: reserved = @keyword 'return'
+kw_break: reserved = @keyword 'break'
+kw_continue: reserved = @keyword 'continue'
+kw_goto: reserved = @keyword 'goto'
+kw_fallthrough: reserved = @keyword 'fallthrough'
 
 # --- Package / imports ----------------------------------------------
 
@@ -82,12 +82,12 @@ top_decl = decl
 
 # Every alt below has trailing-optional leniency (opt_semi or block?)
 # absorbed by `go_file`'s `*^` and `block`'s `^block_close`.
-~decl = kw_var var_spec_group
-      / kw_var var_spec opt_semi
-      / kw_const const_spec_group
-      / kw_const const_spec opt_semi
-      / kw_type type_spec_group
-      / kw_type type_spec opt_semi
+decl: partial = kw_var var_spec_group
+              / kw_var var_spec opt_semi
+              / kw_const const_spec_group
+              / kw_const const_spec opt_semi
+              / kw_type type_spec_group
+              / kw_type type_spec opt_semi
 
 var_spec_group = @punctuation '(' (var_spec opt_semi)* @punctuation ')'
 var_spec = ident_list type_expr @operator '=' expr_list
@@ -96,14 +96,14 @@ var_spec = ident_list type_expr @operator '=' expr_list
 
 const_spec_group = @punctuation '(' (const_spec opt_semi)* @punctuation ')'
 # Trailing `(= expr)?` absorbed by outer recovery.
-~const_spec = const_ident_list type_expr? (@operator '=' expr_list)?
+const_spec: partial = const_ident_list type_expr? (@operator '=' expr_list)?
 
 type_spec_group = @punctuation '(' (type_spec opt_semi)* @punctuation ')'
 type_spec = @type ident type_params? @operator '='? type_expr
 
 # Trailing `block?` absorbed by `*^` / `^block_close`.
-~func_decl = kw_func @function ident type_params? fn_signature block?
-~method_decl = kw_func method_receiver @function ident fn_signature block?
+func_decl: partial = kw_func @function ident type_params? fn_signature block?
+method_decl: partial = kw_func method_receiver @function ident fn_signature block?
 method_receiver = @punctuation '(' (@variable ident)? type_expr @punctuation ')'
 
 # Generics type parameters: `[T any, U comparable]`.
@@ -116,7 +116,7 @@ type_term = @operator '~' type_expr
           / type_expr
 
 # Trailing `fn_result?` absorbed by outer recovery.
-~fn_signature = fn_params fn_result?
+fn_signature: partial = fn_params fn_result?
 fn_params = @punctuation '(' fn_param_list? @punctuation ')'
 fn_param_list = fn_param (@punctuation ',' fn_param)* (@punctuation ',')?
 fn_param = ident_list @operator '...'? type_expr
@@ -153,13 +153,13 @@ interface_member = @function ident fn_signature
                  / type_term
 type_paren = @punctuation '(' type_expr @punctuation ')'
 # Trailing `type_args?` leniency absorbed by outer recovery.
-~type_name = @type qualified_ident type_args?
+type_name: partial = @type qualified_ident type_args?
 type_args = @punctuation '[' type_arg_list @punctuation ']'
 type_arg_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
 
 # `pkg.Name` or `Name`.
 # Trailing `(.ident)?` leniency absorbed by outer recovery.
-~qualified_ident = ident (@punctuation '.' ident)?
+qualified_ident: partial = ident (@punctuation '.' ident)?
 
 # --- Statements ------------------------------------------------------
 
@@ -204,8 +204,8 @@ assign_op = @operator '+=' / @operator '-=' / @operator '*=' / @operator '/='
 labeled_stmt = @variable ident @punctuation ':' stmt
 
 # Trailing `(else (if | block))?` leniency absorbed by outer recovery.
-~if_stmt = kw_if (simple_stmt @punctuation ';')? expr_no_compound block
-           (kw_else (if_stmt / block))?
+if_stmt: partial = kw_if (simple_stmt @punctuation ';')? expr_no_compound block
+                   (kw_else (if_stmt / block))?
 for_stmt = kw_for for_header? block
 for_header = for_range
            / for_c_style
@@ -235,9 +235,9 @@ recv_stmt = (ident_list (@operator '=' / @operator ':='))? expr_no_compound
 go_stmt = kw_go expr
 defer_stmt = kw_defer expr
 # Trailing-optional leniency absorbed by outer recovery.
-~return_stmt = kw_return expr_list?
-~break_stmt = kw_break (@variable ident)?
-~continue_stmt = kw_continue (@variable ident)?
+return_stmt: partial = kw_return expr_list?
+break_stmt: partial = kw_break (@variable ident)?
+continue_stmt: partial = kw_continue (@variable ident)?
 goto_stmt = kw_goto @variable ident
 fallthrough_stmt = kw_fallthrough
 
@@ -365,28 +365,28 @@ literal = string_lit / number_lit / rune_lit / lit_const
 
 # Predeclared constants as a `%?` preferred-word alternation so the `wb`
 # boundary keeps `trueish` / `nilish` from matching the prefix.
-%?lit_const = @constant 'true' / @constant 'false'
-            / @constant 'nil' / @constant 'iota'
+lit_const: preferred = @constant 'true' / @constant 'false'
+                     / @constant 'nil' / @constant 'iota'
 
 string_lit = @string (raw_string / interp_string)
-*raw_string = '`' ..= '`'
-*interp_string = '"' ('\\' . / !'"' !'\n' .)* '"'
+raw_string: atomic = '`' ..= '`'
+interp_string: atomic = '"' ('\\' . / !'"' !'\n' .)* '"'
 
-*rune_lit = @string ("'" ('\\' . / !"'" .)* "'")
+rune_lit: atomic = @string ("'" ('\\' . / !"'" .)* "'")
 
 number_lit = @number num_body
-*num_body = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
-          / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
-          / '0o' oct_digits 'i'?
-          / '0b' bin_digits 'i'?
-          / digit_seq '.' digit_seq? exp_part? 'i'?
-          / '.' digit_seq exp_part? 'i'?
-          / digit_seq exp_part? 'i'?
-*digit_seq = \d ([\d_])*
-*hex_digits = [\da-fA-F] [\da-fA-F_]*
-*oct_digits = [0-7] [0-7_]*
-*bin_digits = [01] [01_]*
-*exp_part = [eE] [+\-]? \d+
+num_body: atomic = '0x' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+                 / '0X' hex_digits ('.' hex_digits?)? ([pP] [+\-]? \d+)? 'i'?
+                 / '0o' oct_digits 'i'?
+                 / '0b' bin_digits 'i'?
+                 / digit_seq '.' digit_seq? exp_part? 'i'?
+                 / '.' digit_seq exp_part? 'i'?
+                 / digit_seq exp_part? 'i'?
+digit_seq: atomic = \d ([\d_])*
+hex_digits: atomic = [\da-fA-F] [\da-fA-F_]*
+oct_digits: atomic = [0-7] [0-7_]*
+bin_digits: atomic = [01] [01_]*
+exp_part: atomic = [eE] [+\-]? \d+
 
 # --- Identifiers / predeclared names ---------------------------------
 
@@ -399,29 +399,29 @@ number_lit = @number num_body
 # (exported names start uppercase). Admitting non-ASCII letters into
 # both ranges would collapse the distinction; refine with `\p{Lu}` /
 # `\p{Ll}` in a follow-on if needed.
-*ident = !reserved [\p{L}_] ident_body*
-*upper_ident = !reserved [A-Z] ident_body*
-*lower_ident = !reserved [a-z_] ident_body*
+ident: atomic = !reserved [\p{L}_] ident_body*
+upper_ident: atomic = !reserved [A-Z] ident_body*
+lower_ident: atomic = !reserved [a-z_] ident_body*
 ident_body = [\p{L}\p{Nd}_]
 
 # Predeclared constants / types / builtin funcs — matched as whole
 # identifiers so colouring is consistent without contextual
 # resolution.
-%?predeclared_const = 'true' / 'false' / 'nil' / 'iota'
-%?predeclared_type = 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
-                  / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
-                  / 'float32' / 'float64' / 'complex64' / 'complex128'
-                  / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
-                  / 'error' / 'any' / 'comparable'
-%?predeclared_fn = 'append' / 'cap' / 'close' / 'complex' / 'copy'
-                / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
-                / 'print' / 'println' / 'real' / 'recover'
+predeclared_const: preferred = 'true' / 'false' / 'nil' / 'iota'
+predeclared_type: preferred = 'uint8' / 'uint16' / 'uint32' / 'uint64' / 'uint'
+                           / 'int8' / 'int16' / 'int32' / 'int64' / 'int'
+                           / 'float32' / 'float64' / 'complex64' / 'complex128'
+                           / 'uintptr' / 'byte' / 'rune' / 'string' / 'bool'
+                           / 'error' / 'any' / 'comparable'
+predeclared_fn: preferred = 'append' / 'cap' / 'close' / 'complex' / 'copy'
+                         / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
+                         / 'print' / 'println' / 'real' / 'recover'
 
 # --- Whitespace / comments / semicolon handling ----------------------
 
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
 # we accept optional explicit `;` and let `trivia` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
-~opt_semi = @punctuation ';'?
+opt_semi: partial = @punctuation ';'?
 
-*comment = @comment ('//' .. '\n' / '/*' ..= '*/')
+comment: atomic = @comment ('//' .. '\n' / '/*' ..= '*/')

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -45,47 +45,47 @@ wb = !ident_body
 # `from`, `get`, `set`, `static`, `yield`) deliberately kept out of
 # `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
 # must stay one method name.
-%kw_import = @keyword 'import'
-%?kw_from = @keyword 'from'
-%?kw_as = @keyword 'as'
-%kw_export = @keyword 'export'
-%kw_default = @keyword 'default'
-%?kw_async = @keyword 'async'
-%kw_function = @keyword 'function'
-%kw_class = @keyword 'class'
-%kw_extends = @keyword 'extends'
-%?kw_static = @keyword 'static'
-%?kw_get = @keyword 'get'
-%?kw_set = @keyword 'set'
-%kw_var = @keyword 'var'
-%?kw_let = @keyword 'let'
-%kw_const = @keyword 'const'
-%kw_if = @keyword 'if'
-%kw_else = @keyword 'else'
-%kw_for = @keyword 'for'
-%?kw_await = @keyword 'await'
-%kw_in = @keyword 'in'
-%?kw_of = @keyword 'of'
-%kw_while = @keyword 'while'
-%kw_do = @keyword 'do'
-%kw_switch = @keyword 'switch'
-%kw_case = @keyword 'case'
-%kw_try = @keyword 'try'
-%kw_catch = @keyword 'catch'
-%kw_finally = @keyword 'finally'
-%kw_throw = @keyword 'throw'
-%kw_return = @keyword 'return'
-%kw_break = @keyword 'break'
-%kw_continue = @keyword 'continue'
-%kw_debugger = @keyword 'debugger'
-%kw_yield = @keyword 'yield'
-%kw_instanceof = @keyword 'instanceof'
-%kw_typeof = @keyword 'typeof'
-%kw_void = @keyword 'void'
-%kw_delete = @keyword 'delete'
-%kw_new = @keyword 'new'
-%kw_this = @keyword 'this'
-%kw_super = @keyword 'super'
+kw_import: reserved = @keyword 'import'
+kw_from: preferred = @keyword 'from'
+kw_as: preferred = @keyword 'as'
+kw_export: reserved = @keyword 'export'
+kw_default: reserved = @keyword 'default'
+kw_async: preferred = @keyword 'async'
+kw_function: reserved = @keyword 'function'
+kw_class: reserved = @keyword 'class'
+kw_extends: reserved = @keyword 'extends'
+kw_static: preferred = @keyword 'static'
+kw_get: preferred = @keyword 'get'
+kw_set: preferred = @keyword 'set'
+kw_var: reserved = @keyword 'var'
+kw_let: preferred = @keyword 'let'
+kw_const: reserved = @keyword 'const'
+kw_if: reserved = @keyword 'if'
+kw_else: reserved = @keyword 'else'
+kw_for: reserved = @keyword 'for'
+kw_await: preferred = @keyword 'await'
+kw_in: reserved = @keyword 'in'
+kw_of: preferred = @keyword 'of'
+kw_while: reserved = @keyword 'while'
+kw_do: reserved = @keyword 'do'
+kw_switch: reserved = @keyword 'switch'
+kw_case: reserved = @keyword 'case'
+kw_try: reserved = @keyword 'try'
+kw_catch: reserved = @keyword 'catch'
+kw_finally: reserved = @keyword 'finally'
+kw_throw: reserved = @keyword 'throw'
+kw_return: reserved = @keyword 'return'
+kw_break: reserved = @keyword 'break'
+kw_continue: reserved = @keyword 'continue'
+kw_debugger: reserved = @keyword 'debugger'
+kw_yield: reserved = @keyword 'yield'
+kw_instanceof: reserved = @keyword 'instanceof'
+kw_typeof: reserved = @keyword 'typeof'
+kw_void: reserved = @keyword 'void'
+kw_delete: reserved = @keyword 'delete'
+kw_new: reserved = @keyword 'new'
+kw_this: reserved = @keyword 'this'
+kw_super: reserved = @keyword 'super'
 
 # --- Statements -------------------------------------------------------
 #
@@ -118,7 +118,7 @@ stmt = import_decl
 # missing-else / missing-catch / missing-finally leniency on the other
 # `~`-marked stmts below is absorbed by stmt-level `*^` and
 # `block`'s `^block_close` recovery.
-~opt_semi = @punctuation ';'?
+opt_semi: partial = @punctuation ';'?
 empty_stmt = @punctuation ';'
 
 # --- Imports / exports ------------------------------------------------
@@ -147,7 +147,7 @@ export_default_body = fn_decl
                     / class_decl
                     / expr opt_semi
 # Trailing `opt_semi` on `~export_named` is absorbed by stmt-level recovery.
-~export_named = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi
+export_named: partial = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi
 export_specifier_list = export_specifier (@punctuation ',' export_specifier)* (@punctuation ',')?
 export_specifier = @variable ident_name kw_as @variable ident_name
                  / @variable ident
@@ -177,13 +177,13 @@ class_field = (computed_prop / @property ident_name) (@operator '=' expr_no_comm
 var_decl = (kw_var / kw_let / kw_const) var_declarator_list
 var_declarator_list = var_declarator (@punctuation ',' var_declarator)*
 # Trailing `(= expr)?` absorbed by enclosing stmt recovery.
-~var_declarator = pattern (@operator '=' expr_no_comma)?
+var_declarator: partial = pattern (@operator '=' expr_no_comma)?
 
 # --- Control flow -----------------------------------------------------
 
 # Trailing `(else stmt)?` leniency absorbed by stmt-level recovery.
-~if_stmt = kw_if @punctuation '(' expr @punctuation ')' stmt
-           (kw_else stmt)?
+if_stmt: partial = kw_if @punctuation '(' expr @punctuation ')' stmt
+                   (kw_else stmt)?
 for_stmt = kw_for kw_await? @punctuation '(' for_head @punctuation ')' stmt
 for_head = for_c_style
          / for_in_of
@@ -202,14 +202,14 @@ switch_case = kw_case expr @punctuation ':' (!switch_case_term stmt)*
             / kw_default @punctuation ':' (!switch_case_term stmt)*
 switch_case_term = kw_case / kw_default / @punctuation '}'
 # Trailing `(catch)? (finally)?` absorbed by stmt-level recovery.
-~try_stmt = kw_try block catch_clause? finally_clause?
+try_stmt: partial = kw_try block catch_clause? finally_clause?
 catch_clause = kw_catch (@punctuation '(' pattern @punctuation ')')? block
 finally_clause = kw_finally block
 throw_stmt = kw_throw expr opt_semi
 # Trailing `expr?` leniency on `~return_stmt` absorbed by stmt recovery.
-~return_stmt = kw_return expr? opt_semi
-~break_stmt = kw_break (@variable ident)? opt_semi
-~continue_stmt = kw_continue (@variable ident)? opt_semi
+return_stmt: partial = kw_return expr? opt_semi
+break_stmt: partial = kw_break (@variable ident)? opt_semi
+continue_stmt: partial = kw_continue (@variable ident)? opt_semi
 debugger_stmt = kw_debugger opt_semi
 labeled_stmt = @variable ident @punctuation ':' stmt
 block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
@@ -264,7 +264,7 @@ arrow_body = block
            / expr_no_comma
 
 # Trailing `(*)? (expr_assign)?` absorbed by stmt-level recovery.
-~expr_yield = kw_yield @operator '*'? expr_assign?
+expr_yield: partial = kw_yield @operator '*'? expr_assign?
 
 # Ternary. Below the ternary, precedence is encoded by direct left
 # recursion — `level_n =  level_n OP level_{n+1} / level_{n+1}` per
@@ -273,7 +273,7 @@ arrow_body = block
 # alternation; cross-level ambiguities (`<` vs `<<`, `&` vs `&&`,
 # operator vs compound-assign, …) need explicit `!`-lookaheads.
 # Trailing ternary leniency absorbed by stmt-level recovery.
-~expr_conditional = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)?
+expr_conditional: partial = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)?
 
 expr_nullish = expr_nullish @operator '??' !'=' expr_lor / expr_lor
 expr_lor = expr_lor @operator '||' !'=' expr_land / expr_land
@@ -368,34 +368,34 @@ literal = template_lit
 
 # Boolean / null / undefined constants; the `wb` boundary keeps
 # `trueish` / `nullish` from matching the prefix.
-%lit_const = @constant 'true' / @constant 'false' / @constant 'null'
-%?lit_undefined = @constant 'undefined'
+lit_const: reserved = @constant 'true' / @constant 'false' / @constant 'null'
+lit_undefined: preferred = @constant 'undefined'
 
 string_lit = @string (sq_string / dq_string)
-*sq_string = "'" ('\\' . / !"'" !'\n' .)* "'"
-*dq_string = '"' ('\\' . / !'"' !'\n' .)* '"'
+sq_string: atomic = "'" ('\\' . / !"'" !'\n' .)* "'"
+dq_string: atomic = '"' ('\\' . / !'"' !'\n' .)* '"'
 
 # Template literals with ${...} interpolation. Chunks outside the
 # interpolations get @string; the interpolation braces stay
 # @punctuation and the inner expression is parsed as normal.
-*template_lit = @string '`' template_body @string '`'
-*template_body = (template_chunk / template_interp)*
-*template_chunk = @string (('\\' . / !'`' !'${' .)+)
+template_lit: atomic = @string '`' template_body @string '`'
+template_body: atomic = (template_chunk / template_interp)*
+template_chunk: atomic = @string (('\\' . / !'`' !'${' .)+)
 template_interp = @punctuation '${' expr @punctuation '}'
 
 number_lit = @number num_body
-*num_body = '0x' hex_digits 'n'?
-          / '0o' oct_digits 'n'?
-          / '0b' bin_digits 'n'?
-          / decimal_num 'n'?
-*decimal_num = digit_seq '.' digit_seq? exp_part?
-             / '.' digit_seq exp_part?
-             / digit_seq exp_part?
-*digit_seq = \d ([\d_])*
-*hex_digits = [\da-fA-F] [\da-fA-F_]*
-*oct_digits = [0-7] [0-7_]*
-*bin_digits = [01] [01_]*
-*exp_part = [eE] [+\-]? \d+
+num_body: atomic = '0x' hex_digits 'n'?
+                 / '0o' oct_digits 'n'?
+                 / '0b' bin_digits 'n'?
+                 / decimal_num 'n'?
+decimal_num: atomic = digit_seq '.' digit_seq? exp_part?
+                    / '.' digit_seq exp_part?
+                    / digit_seq exp_part?
+digit_seq: atomic = \d ([\d_])*
+hex_digits: atomic = [\da-fA-F] [\da-fA-F_]*
+oct_digits: atomic = [0-7] [0-7_]*
+bin_digits: atomic = [01] [01_]*
+exp_part: atomic = [eE] [+\-]? \d+
 
 # --- Identifiers / reserved words ------------------------------------
 
@@ -405,26 +405,26 @@ number_lit = @number num_body
 # Unicode's identifier properties); same for the ZWNJ/ZWJ continuation
 # extras. Escape forms `\uHHHH` and `\u{H..}` are admitted in both
 # positions.
-*ident = !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+ident: atomic = !reserved ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # `ident_name` mirrors ECMA's `IdentifierName`: like `ident`, but the
 # `!reserved` guard is dropped so reserved words are accepted. Use at
 # positions where ES allows IdentifierName but not BindingIdentifier
 # (member access after `.` / `?.`, property keys, imported/exported
 # names that aren't local bindings).
-*ident_name = ([\p{ID_Start}_$] / js_uesc) ident_body_part*
+ident_name: atomic = ([\p{ID_Start}_$] / js_uesc) ident_body_part*
 # Per §12.7.1 UnicodeEscapeSequence: 4 fixed hex digits or `{H..}` for
 # 1-6 hex digits inside braces. Atomic so the prefix-then-fail shape
 # stays internal.
-*js_uesc = '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
+js_uesc: atomic = '\\u{' [0-9A-Fa-f]+ '}' / '\\u' [0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]
 # `upper_ident` / `lower_ident` keep their ASCII-only start so the
 # case-based shape gate (PascalCase → @type, etc.) doesn't dissolve
 # into "any ID_Start letter". Future refinement via `\p{Lu}` /
 # `\p{Ll}` if a non-ASCII-aware variant is needed.
-*upper_ident = !reserved [A-Z] ident_body_part*
-*lower_ident = !reserved [a-z_$] ident_body_part*
+upper_ident: atomic = !reserved [A-Z] ident_body_part*
+lower_ident: atomic = !reserved [a-z_$] ident_body_part*
 ident_body_part = ident_body / js_uesc
 ident_body = [\p{ID_Continue}$\u{200C}\u{200D}]
 
 # --- Whitespace / comments --------------------------------------------
 
-*comment = @comment ('//' .. '\n' / '/*' ..= '*/')
+comment: atomic = @comment ('//' .. '\n' / '/*' ..= '*/')

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -22,12 +22,12 @@ array = @punctuation '['
         (value (@punctuation ',' value)*)?
         @punctuation ']'
 
-*string = '"' string_char* '"'
-*string_char = '\\' ["\\/bfnrt]
-             / '\\' 'u' [\da-fA-F]{4}
-             / [^"\\]
+string: atomic = '"' string_char* '"'
+string_char: atomic = '\\' ["\\/bfnrt]
+                    / '\\' 'u' [\da-fA-F]{4}
+                    / [^"\\]
 
-*number = '-'? int frac? exp?
-*int = '0' / [1-9] \d*
-*frac = '.' \d+
-*exp = [eE] [+\-]? \d+
+number: atomic = '-'? int frac? exp?
+int: atomic = '0' / [1-9] \d*
+frac: atomic = '.' \d+
+exp: atomic = [eE] [+\-]? \d+

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -37,43 +37,43 @@ wb = !ident_body
 # One `%` reserved-word rule per keyword, referenced wherever the
 # keyword appears so the `wb` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`fnfoo`).
-%kw_use = @keyword 'use'
-%kw_as = @keyword 'as'
-%kw_self = @keyword 'self'
-%kw_self_ty = @keyword 'Self'
-%kw_super = @keyword 'super'
-%kw_crate = @keyword 'crate'
-%kw_fn = @keyword 'fn'
-%kw_const = @keyword 'const'
-%kw_static = @keyword 'static'
-%kw_type = @keyword 'type'
-%kw_async = @keyword 'async'
-%kw_unsafe = @keyword 'unsafe'
-%kw_extern = @keyword 'extern'
-%kw_mut = @keyword 'mut'
-%kw_struct = @keyword 'struct'
-%kw_enum = @keyword 'enum'
-%kw_impl = @keyword 'impl'
-%kw_for = @keyword 'for'
-%kw_trait = @keyword 'trait'
-%kw_mod = @keyword 'mod'
-%kw_pub = @keyword 'pub'
-%kw_in = @keyword 'in'
-%kw_where = @keyword 'where'
-%kw_dyn = @keyword 'dyn'
-%kw_box = @keyword 'box'
-%kw_ref = @keyword 'ref'
-%kw_if = @keyword 'if'
-%kw_let = @keyword 'let'
-%kw_else = @keyword 'else'
-%kw_match = @keyword 'match'
-%kw_while = @keyword 'while'
-%kw_loop = @keyword 'loop'
-%kw_return = @keyword 'return'
-%kw_break = @keyword 'break'
-%kw_continue = @keyword 'continue'
-%kw_move = @keyword 'move'
-%kw_await = @keyword 'await'
+kw_use: reserved = @keyword 'use'
+kw_as: reserved = @keyword 'as'
+kw_self: reserved = @keyword 'self'
+kw_self_ty: reserved = @keyword 'Self'
+kw_super: reserved = @keyword 'super'
+kw_crate: reserved = @keyword 'crate'
+kw_fn: reserved = @keyword 'fn'
+kw_const: reserved = @keyword 'const'
+kw_static: reserved = @keyword 'static'
+kw_type: reserved = @keyword 'type'
+kw_async: reserved = @keyword 'async'
+kw_unsafe: reserved = @keyword 'unsafe'
+kw_extern: reserved = @keyword 'extern'
+kw_mut: reserved = @keyword 'mut'
+kw_struct: reserved = @keyword 'struct'
+kw_enum: reserved = @keyword 'enum'
+kw_impl: reserved = @keyword 'impl'
+kw_for: reserved = @keyword 'for'
+kw_trait: reserved = @keyword 'trait'
+kw_mod: reserved = @keyword 'mod'
+kw_pub: reserved = @keyword 'pub'
+kw_in: reserved = @keyword 'in'
+kw_where: reserved = @keyword 'where'
+kw_dyn: reserved = @keyword 'dyn'
+kw_box: reserved = @keyword 'box'
+kw_ref: reserved = @keyword 'ref'
+kw_if: reserved = @keyword 'if'
+kw_let: reserved = @keyword 'let'
+kw_else: reserved = @keyword 'else'
+kw_match: reserved = @keyword 'match'
+kw_while: reserved = @keyword 'while'
+kw_loop: reserved = @keyword 'loop'
+kw_return: reserved = @keyword 'return'
+kw_break: reserved = @keyword 'break'
+kw_continue: reserved = @keyword 'continue'
+kw_move: reserved = @keyword 'move'
+kw_await: reserved = @keyword 'await'
 
 # --- Items -------------------------------------------------------------
 #
@@ -98,9 +98,9 @@ item = attr_outer
      / stmt
 
 # Attributes and doc-comments at item position.
-*attr_outer = @punctuation '#' @punctuation '[' attr_body @punctuation ']'
-*attr_inner = @punctuation '#' @punctuation '!' @punctuation '[' attr_body @punctuation ']'
-*attr_body = .. ']'
+attr_outer: atomic = @punctuation '#' @punctuation '[' attr_body @punctuation ']'
+attr_inner: atomic = @punctuation '#' @punctuation '!' @punctuation '[' attr_body @punctuation ']'
+attr_body: atomic = .. ']'
 
 # `use foo::bar::{baz, qux as q};`
 use_item = kw_use use_tree @punctuation ';'
@@ -185,7 +185,7 @@ macro_rules_item = @function 'macro_rules' @punctuation '!' @function ident brac
 
 # Item-position macro invocation: `foo!(...)` / `foo!{...}` / `foo![...]`.
 # Trailing `;?` absorbed by `root`'s `*^`.
-~macro_invocation_stmt = @function ident @punctuation '!' macro_args (@punctuation ';')?
+macro_invocation_stmt: partial = @function ident @punctuation '!' macro_args (@punctuation ';')?
 macro_args = paren_group
            / brace_block
            / bracket_group
@@ -231,8 +231,8 @@ type_expr = type_fn
           / type_path
 
 # Trailing `(-> type)?` absorbed by enclosing recovery.
-~type_fn = type_fn_qualifier* kw_fn @punctuation '(' type_list? @punctuation ')'
-           (@punctuation '->' type_expr)?
+type_fn: partial = type_fn_qualifier* kw_fn @punctuation '(' type_list? @punctuation ')'
+                   (@punctuation '->' type_expr)?
 type_fn_qualifier = kw_unsafe
                   / kw_extern string_lit?
 type_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
@@ -265,7 +265,7 @@ path_tail = generic_args
 generic_args = @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>'
              / @punctuation '<' generic_arg_list? @punctuation '>'
 # Trailing `(-> type)?` absorbed by `*^` / `^block_close`.
-~paren_generic_args = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)?
+paren_generic_args: partial = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)?
 generic_arg_list = generic_arg (@punctuation ',' generic_arg)* (@punctuation ',')?
 generic_arg = lifetime
             / type_expr
@@ -298,8 +298,8 @@ pattern_box = kw_box pattern_atom
 pattern_tuple = @punctuation '(' pattern_list? @punctuation ')'
 pattern_list = pattern (@punctuation ',' pattern)* (@punctuation ',')?
 # Trailing `::` chain leniency absorbed by outer recovery.
-~pattern_struct_or_enum = @type upper_ident (@punctuation '::' @type upper_ident)*
-                         (pattern_struct_body / pattern_tuple)?
+pattern_struct_or_enum: partial = @type upper_ident (@punctuation '::' @type upper_ident)*
+                                 (pattern_struct_body / pattern_tuple)?
 pattern_struct_body = @punctuation '{' pattern_struct_fields? @punctuation '}'
 pattern_struct_fields = pattern_struct_field (@punctuation ',' pattern_struct_field)* (@punctuation ',')?
 pattern_struct_field = @property ident @punctuation ':' pattern
@@ -311,8 +311,8 @@ pattern_literal = string_lit / char_lit / number_lit / lit_const
 pattern_wild = @punctuation '_'
 pattern_rest = @punctuation '..'
 # `(ref)? (mut)?` prefix leniency absorbed by outer recovery.
-~pattern_binding = kw_ref? kw_mut? @variable ident
-                  (@punctuation '@' pattern_atom)?
+pattern_binding: partial = kw_ref? kw_mut? @variable ident
+                          (@punctuation '@' pattern_atom)?
 
 # --- Expressions -------------------------------------------------------
 #
@@ -373,7 +373,7 @@ postfix_member = turbofish_method
                / @function ident (@punctuation '(' expr_list? @punctuation ')')?
                / @number digit_seq
 # Trailing `(args)?` absorbed by outer recovery.
-~turbofish_method = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')?
+turbofish_method: partial = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')?
 
 expr_primary = literal
              / expr_if
@@ -394,8 +394,8 @@ expr_primary = literal
              / expr_keyword
 
 # Trailing `(else (if | block))?` leniency absorbed by `root`'s `*^` and `block`'s `^block_close`.
-~expr_if = kw_if (kw_let pattern @operator '=')? expr block
-           (kw_else (expr_if / block))?
+expr_if: partial = kw_if (kw_let pattern @operator '=')? expr block
+                   (kw_else (expr_if / block))?
 expr_match = kw_match expr @punctuation '{' match_arms? @punctuation '}'
 match_arms = match_arm (@punctuation ',' match_arm)* (@punctuation ',')?
 match_arm = attr_outer* pattern (kw_if expr)? @punctuation '=>' expr
@@ -403,9 +403,9 @@ expr_while = kw_while (kw_let pattern @operator '=')? expr block
 expr_loop = loop_label? kw_loop block
 expr_for = kw_for pattern kw_in expr block
 # Trailing-optional leniency on these stmt-shaped exprs is absorbed by outer recovery.
-~expr_return = kw_return expr?
-~expr_break = kw_break loop_label? expr?
-~expr_continue = kw_continue loop_label?
+expr_return: partial = kw_return expr?
+expr_break: partial = kw_break loop_label? expr?
+expr_continue: partial = kw_continue loop_label?
 expr_unsafe = kw_unsafe block
 expr_closure = kw_move? @punctuation '|' closure_params? @punctuation '|'
                (@punctuation '->' type_expr)? expr
@@ -420,12 +420,12 @@ expr_array_body = expr @punctuation ';' expr
 expr_list = expr (@punctuation ',' expr)* (@punctuation ',')?
 expr_keyword = kw_self / kw_self_ty / kw_super / kw_crate
 
-*loop_label = @punctuation '\'' @variable ident @punctuation ':'
+loop_label: atomic = @punctuation '\'' @variable ident @punctuation ':'
 
 # `path::to::thing`, `path::to::thing::<T>(...)`, `Struct { ... }`,
 # or `macro!(...)` / `macro!{...}` / `macro![...]`.
 # Trailing `(struct_init | macro_args)?` leniency absorbed by outer recovery.
-~expr_macro_or_path = path_expr (struct_init / @punctuation '!' macro_args)?
+expr_macro_or_path: partial = path_expr (struct_init / @punctuation '!' macro_args)?
 path_expr = path_seg (@punctuation '::' path_seg)*
 path_seg = @type upper_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?
          / @function lower_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?
@@ -476,39 +476,39 @@ literal = string_lit / char_lit / number_lit / lit_const
 
 # Boolean constants as a `%` reserved-word alternation so the `wb`
 # boundary keeps `trueish` from matching the `true` prefix.
-%lit_const = @constant 'true' / @constant 'false'
+lit_const: reserved = @constant 'true' / @constant 'false'
 
 # Raw strings first (longer prefix), then regular.
 string_lit = @string (raw_string / byte_string / regular_string)
-*regular_string = '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*byte_string = 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
-*raw_string = 'r' raw_hashes '"' (.. '"') '"' raw_hashes
-            / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
+regular_string: atomic = '"' ('\\' (!'\n' .) / !'"' .)* '"'
+byte_string: atomic = 'b' '"' ('\\' (!'\n' .) / !'"' .)* '"'
+raw_string: atomic = 'r' raw_hashes '"' (.. '"') '"' raw_hashes
+                   / 'br' raw_hashes '"' (.. '"') '"' raw_hashes
 # Consume matching hash fences; the body is "up to the closing delim".
 # Keeping this simple: require the closing `"#*` to match the opening.
 # We approximate by supporting 0..=8 hashes explicitly.
-*raw_hashes = '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
+raw_hashes: atomic = '########' / '#######' / '######' / '#####' / '####' / '###' / '##' / '#' / ''
 
-*char_lit = @string ("'" ('\\' (!'\n' .) / !"'" .) "'")
+char_lit: atomic = @string ("'" ('\\' (!'\n' .) / !"'" .) "'")
 
 number_lit = @number num_body
-*num_body = float_num / int_num
-*float_num = digit_seq '.' digit_seq (exp_part)? num_suffix?
-           / digit_seq exp_part num_suffix?
-*int_num = '0x' hex_digits num_suffix?
-         / '0o' oct_digits num_suffix?
-         / '0b' bin_digits num_suffix?
-         / digit_seq num_suffix?
-*digit_seq = \d ([\d_])*
-*hex_digits = [\da-fA-F] [\da-fA-F_]*
-*oct_digits = [0-7] [0-7_]*
-*bin_digits = [01] [01_]*
-*exp_part = [eE] [+\-]? digit_seq
-*num_suffix = [a-zA-Z_] [a-zA-Z\d_]*
+num_body: atomic = float_num / int_num
+float_num: atomic = digit_seq '.' digit_seq (exp_part)? num_suffix?
+                  / digit_seq exp_part num_suffix?
+int_num: atomic = '0x' hex_digits num_suffix?
+                / '0o' oct_digits num_suffix?
+                / '0b' bin_digits num_suffix?
+                / digit_seq num_suffix?
+digit_seq: atomic = \d ([\d_])*
+hex_digits: atomic = [\da-fA-F] [\da-fA-F_]*
+oct_digits: atomic = [0-7] [0-7_]*
+bin_digits: atomic = [01] [01_]*
+exp_part: atomic = [eE] [+\-]? digit_seq
+num_suffix: atomic = [a-zA-Z_] [a-zA-Z\d_]*
 
 # --- Lifetimes and identifiers -----------------------------------------
 
-*lifetime = @type ("'" ident_body+)
+lifetime: atomic = @type ("'" ident_body+)
 
 # `r#keyword` raw identifier is accepted; the `r#` prefix is stripped
 # of special meaning for highlighting.
@@ -525,13 +525,13 @@ ident_any = @type upper_ident
 # non-ASCII letters into both ranges would collapse that distinction.
 # Stage 2 widens the body but leaves the shape gate ASCII; future work
 # can refine the upper/lower split using `\p{Lu}` / `\p{Ll}` if needed.
-*upper_ident = 'r#'? [A-Z] ident_body*
-*lower_ident = 'r#'? [a-z_] ident_body*
-*ident = 'r#'? [\p{XID_Start}_] ident_body*
+upper_ident: atomic = 'r#'? [A-Z] ident_body*
+lower_ident: atomic = 'r#'? [a-z_] ident_body*
+ident: atomic = 'r#'? [\p{XID_Start}_] ident_body*
 ident_body = [\p{XID_Continue}]
 
 # --- Whitespace and comments ------------------------------------------
 
 # Non-nested block comment. Real Rust allows nesting; for highlighting
 # the occasional mismatch is acceptable and keeps the grammar simpler.
-*comment = @comment ('//' .. '\n' / '/*' ..= '*/')
+comment: atomic = @comment ('//' .. '\n' / '/*' ..= '*/')

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -91,7 +91,7 @@ statement_body = select_stmt
 # --- SELECT statement -------------------------------------------------
 
 # Trailing `limit_clause?` absorbed by `sql_file`'s top-level `*^[;]`.
-~select_stmt = with_clause? select_core compound_tail* order_clause? limit_clause?
+select_stmt: partial = with_clause? select_core compound_tail* order_clause? limit_clause?
 
 with_clause = kw_with (kw_recursive)? cte_defn (@punctuation ',' cte_defn)*
 cte_defn = @type bare_ident
@@ -99,9 +99,9 @@ cte_defn = @type bare_ident
            kw_as @punctuation '(' select_stmt @punctuation ')'
 
 # Trailing `(window_clause)?` absorbed by `*^[;]`.
-~select_core = kw_select ((kw_distinct / kw_all))? result_list
-               (from_clause)? (where_clause)? (group_clause)? (having_clause)?
-               (window_clause)?
+select_core: partial = kw_select ((kw_distinct / kw_all))? result_list
+                       (from_clause)? (where_clause)? (group_clause)? (having_clause)?
+                       (window_clause)?
 
 result_list = result_column (@punctuation ',' result_column)*
 # A column expression that didn't reach a known boundary is treated
@@ -127,12 +127,12 @@ from_clause = kw_from table_or_subquery (join_clause)*
 table_or_subquery = @punctuation '(' select_stmt @punctuation ')' (table_alias)?
                   / qualified_table_name (table_alias)?
 # Trailing `(.ident)?` leniency absorbed by `sql_file`'s `*^[;]`.
-~qualified_table_name = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)?
+qualified_table_name: partial = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)?
 table_alias = kw_as @variable bare_ident_nonkw
             / @variable bare_ident_nonkw
 
 # Trailing `(join_constraint)?` absorbed by `*^[;]`.
-~join_clause = join_op table_or_subquery (join_constraint)?
+join_clause: partial = join_op table_or_subquery (join_constraint)?
 join_op = @punctuation ','
         / kw_natural (join_type)? kw_join
         / join_type kw_join
@@ -163,11 +163,11 @@ having_clause = kw_having expr
 
 order_clause = kw_order kw_by order_item (@punctuation ',' order_item)*
 # Trailing `(asc/desc)?` absorbed by `*^[;]`.
-~order_item = expr ((kw_asc / kw_desc))?
+order_item: partial = expr ((kw_asc / kw_desc))?
 
 # Trailing `(offset)?` absorbed by `*^[;]`.
-~limit_clause = kw_limit expr (kw_offset expr
-                                    / @punctuation ',' expr)?
+limit_clause: partial = kw_limit expr (kw_offset expr
+                                            / @punctuation ',' expr)?
 
 # --- Window functions & WINDOW clause --------------------------------
 # Not counted as reserved keywords in SQLite aside from WINDOW and
@@ -211,12 +211,12 @@ frame_exclude = kw_no kw_others
 # `update_set_list`, which is defined here.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~insert_stmt = with_clause? insert_prefix kw_into qualified_table_name
-               (kw_as @variable bare_ident_nonkw)?
-               (@punctuation '(' ident_list @punctuation ')')?
-               insert_source
-               (upsert_clause)*
-               (returning_clause)?
+insert_stmt: partial = with_clause? insert_prefix kw_into qualified_table_name
+                       (kw_as @variable bare_ident_nonkw)?
+                       (@punctuation '(' ident_list @punctuation ')')?
+                       insert_source
+                       (upsert_clause)*
+                       (returning_clause)?
 
 insert_prefix = kw_insert (kw_or conflict_action)?
               / kw_replace
@@ -255,20 +255,20 @@ returning_clause = kw_returning result_list
 # should not pretend the syntax doesn't exist.
 
 # Trailing `(returning_clause)?` absorbed by `*^[;]`.
-~update_stmt = with_clause? kw_update (kw_or conflict_action)?
-              qualified_table_name (table_alias)?
-              kw_set update_set_list
-              (from_clause)?
-              (where_clause)?
-              order_clause?
-              limit_clause?
-              (returning_clause)?
+update_stmt: partial = with_clause? kw_update (kw_or conflict_action)?
+                      qualified_table_name (table_alias)?
+                      kw_set update_set_list
+                      (from_clause)?
+                      (where_clause)?
+                      order_clause?
+                      limit_clause?
+                      (returning_clause)?
 
-~delete_stmt = with_clause? kw_delete kw_from qualified_table_name (table_alias)?
-              (where_clause)?
-              order_clause?
-              limit_clause?
-              (returning_clause)?
+delete_stmt: partial = with_clause? kw_delete kw_from qualified_table_name (table_alias)?
+                      (where_clause)?
+                      order_clause?
+                      limit_clause?
+                      (returning_clause)?
 
 # --- DDL: CREATE / DROP / ALTER TABLE --------------------------------
 # Interleaves column_def with table_constraint because SQLite does
@@ -288,16 +288,16 @@ create_table_stmt = kw_create ((kw_temporary / kw_temp))? kw_table
                       / kw_as select_stmt)
 
 # Trailing `(column_constraint)*` leniency absorbed by `*^[;]`.
-~column_def = @variable bare_ident_nonkw
-              (type_name)?
-              (column_constraint)*
+column_def: partial = @variable bare_ident_nonkw
+                      (type_name)?
+                      (column_constraint)*
 
 # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
 # `UNSIGNED BIG INT`. Consume consecutive non-keyword identifiers.
 # Trailing `(...)?` leniency absorbed by `*^[;]`.
-~type_name = @type bare_ident_nonkw (@type bare_ident_nonkw)*
-             (@punctuation '(' signed_number
-                  (@punctuation ',' signed_number)? @punctuation ')')?
+type_name: partial = @type bare_ident_nonkw (@type bare_ident_nonkw)*
+                     (@punctuation '(' signed_number
+                          (@punctuation ',' signed_number)? @punctuation ')')?
 
 signed_number = (@operator '-' / @operator '+')? @number number_body
 
@@ -323,10 +323,10 @@ table_constraint_body =
           foreign_key_clause
 
 # Trailing `(fk_deferrable)?` absorbed by `*^[;]`.
-~foreign_key_clause = kw_references @type bare_ident_nonkw
-                     (@punctuation '(' ident_list @punctuation ')')?
-                     (fk_action)*
-                     (fk_deferrable)?
+foreign_key_clause: partial = kw_references @type bare_ident_nonkw
+                             (@punctuation '(' ident_list @punctuation ')')?
+                             (fk_action)*
+                             (fk_deferrable)?
 fk_action = kw_on (kw_delete / kw_update) fk_action_body
           / kw_match @variable bare_ident_nonkw
 fk_action_body = kw_set (kw_null / kw_default)
@@ -334,7 +334,7 @@ fk_action_body = kw_set (kw_null / kw_default)
                / kw_restrict
                / kw_no kw_action
 # Trailing `(initially)?` absorbed by `*^[;]`.
-~fk_deferrable = (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
+fk_deferrable: partial = (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
 
 conflict_clause = kw_on kw_conflict conflict_action
 
@@ -353,12 +353,12 @@ alter_table_stmt = kw_alter kw_table qualified_table_name (
 # --- DDL: CREATE / DROP INDEX and VIEW -------------------------------
 
 # Trailing `(where_clause)?` absorbed by `*^[;]`.
-~create_index_stmt = kw_create (kw_unique)? kw_index
-                    (kw_if kw_not kw_exists)?
-                    qualified_table_name
-                    kw_on @type bare_ident_nonkw
-                    @punctuation '(' indexed_col_list @punctuation ')'
-                    (where_clause)?
+create_index_stmt: partial = kw_create (kw_unique)? kw_index
+                            (kw_if kw_not kw_exists)?
+                            qualified_table_name
+                            kw_on @type bare_ident_nonkw
+                            @punctuation '(' indexed_col_list @punctuation ')'
+                            (where_clause)?
 
 drop_index_stmt = kw_drop kw_index (kw_if kw_exists)? qualified_table_name
 
@@ -396,12 +396,12 @@ drop_trigger_stmt = kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
 # --- Transactions & savepoints ---------------------------------------
 
 # Trailing `(transaction-mode)?` absorbed by `*^[;]`.
-~begin_stmt = kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
-              (kw_transaction)?
+begin_stmt: partial = kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
+                      (kw_transaction)?
 # Trailing `(transaction)?` absorbed by `*^[;]`.
-~commit_stmt = (kw_commit / kw_end) (kw_transaction)?
-~rollback_stmt = kw_rollback (kw_transaction)?
-                 (kw_to (kw_savepoint)? @variable bare_ident_nonkw)?
+commit_stmt: partial = (kw_commit / kw_end) (kw_transaction)?
+rollback_stmt: partial = kw_rollback (kw_transaction)?
+                         (kw_to (kw_savepoint)? @variable bare_ident_nonkw)?
 savepoint_stmt = kw_savepoint @variable bare_ident_nonkw
 release_stmt = kw_release (kw_savepoint)? @variable bare_ident_nonkw
 
@@ -413,26 +413,26 @@ release_stmt = kw_release (kw_savepoint)? @variable bare_ident_nonkw
 # the module is invoked, not merely referenced.
 
 # Trailing `(value)?` absorbed by `*^[;]`.
-~pragma_stmt = kw_pragma qualified_table_name
-               (@operator '=' pragma_value
-                / @punctuation '(' pragma_value @punctuation ')')?
+pragma_stmt: partial = kw_pragma qualified_table_name
+                       (@operator '=' pragma_value
+                        / @punctuation '(' pragma_value @punctuation ')')?
 pragma_value = signed_number / string_lit / @variable bare_ident
 
 # Trailing `(into)?` absorbed by `*^[;]`.
-~vacuum_stmt = kw_vacuum (@type bare_ident_nonkw)? (kw_into string_lit)?
+vacuum_stmt: partial = kw_vacuum (@type bare_ident_nonkw)? (kw_into string_lit)?
 
 attach_stmt = kw_attach (kw_database)? expr kw_as
               @type bare_ident_nonkw
 detach_stmt = kw_detach (kw_database)? @type bare_ident_nonkw
 
 # Trailing `(target)?` absorbed by `*^[;]`.
-~reindex_stmt = kw_reindex (qualified_table_name)?
-~analyze_stmt = kw_analyze (qualified_table_name)?
+reindex_stmt: partial = kw_reindex (qualified_table_name)?
+analyze_stmt: partial = kw_analyze (qualified_table_name)?
 
 explain_stmt = kw_explain (kw_query kw_plan)? statement_body
 
 # Trailing `(args)?` absorbed by `*^[;]`.
-~create_virtual_table_stmt =
+create_virtual_table_stmt: partial =
     kw_create kw_virtual kw_table
     (kw_if kw_not kw_exists)?
     qualified_table_name
@@ -491,9 +491,9 @@ primary = literal
 paren_primary = @punctuation '(' (select_stmt / expr) @punctuation ')'
 
 # Trailing `(filter)? (over window)?` absorbed by `*^[;]`.
-~function_call = @function bare_ident_nonkw @punctuation '(' func_args? @punctuation ')'
-                (filter_clause)?
-                (kw_over window_ref)?
+function_call: partial = @function bare_ident_nonkw @punctuation '(' func_args? @punctuation ')'
+                        (filter_clause)?
+                        (kw_over window_ref)?
 func_args = @operator '*'
           / (kw_distinct)? expr (@punctuation ',' expr)*
 
@@ -513,31 +513,31 @@ exists_expr = kw_exists @punctuation '(' select_stmt @punctuation ')'
 
 literal = blob_lit / string_lit / @number number_body / null_lit / bool_lit
 
-%null_lit = @constant null_body
-%bool_lit = @constant bool_body
-*null_body = i"null"
-*bool_body = i"true" / i"false"
+null_lit: reserved = @constant null_body
+bool_lit: reserved = @constant bool_body
+null_body: atomic = i"null"
+bool_body: atomic = i"true" / i"false"
 
-*blob_lit = @string blob_body
-*blob_body = [xX] "'" [\da-fA-F]* "'"
-*string_lit = @string string_body
-*string_body = "'" ("''" / !"'" .)* "'"
+blob_lit: atomic = @string blob_body
+blob_body: atomic = [xX] "'" [\da-fA-F]* "'"
+string_lit: atomic = @string string_body
+string_body: atomic = "'" ("''" / !"'" .)* "'"
 
 # Hex is a `%` rule so the compiler appends the `wb` boundary: hex
 # digits include a-f, so a hex run can butt against identifier chars
 # (`0x1Fg` must fall back to `0` + `x1Fg`, not lex `0x1F`). float/int
 # use `\d`, which can't, so they carry no boundary.
 number_body = hex_body / float_body / int_body
-%hex_body = '0x' [\da-fA-F]+
-*float_body = \d+ '.' \d+ ([eE] [+\-]? \d+)?
-           / \d+ [eE] [+\-]? \d+
-*int_body = \d+
+hex_body: reserved = '0x' [\da-fA-F]+
+float_body: atomic = \d+ '.' \d+ ([eE] [+\-]? \d+)?
+                  / \d+ [eE] [+\-]? \d+
+int_body: atomic = \d+
 
 # Bind parameters are placeholders bound at execute time — lexically
 # variables, not named constants.
-*bind_param = @variable bind_body
-*bind_body = '?' \d*
-          / [:@$] ident_start ident_cont*
+bind_param: atomic = @variable bind_body
+bind_body: atomic = '?' \d*
+                 / [:@$] ident_start ident_cont*
 
 # --- Identifiers ------------------------------------------------------
 # Four syntactic forms — bare, double-quoted, backtick, bracketed.
@@ -547,20 +547,20 @@ number_body = hex_body / float_body / int_body
 # names and CTE heads where a keyword like INTEGER is actually the
 # content we want to capture as @type).
 
-*bare_ident_nonkw = quoted_ident / !reserved bare_raw
-*bare_ident = quoted_ident / bare_raw
-*quoted_ident = double_quoted_id / backtick_id / bracket_id
+bare_ident_nonkw: atomic = quoted_ident / !reserved bare_raw
+bare_ident: atomic = quoted_ident / bare_raw
+quoted_ident: atomic = double_quoted_id / backtick_id / bracket_id
 
-*bare_raw = ident_start ident_cont*
+bare_raw: atomic = ident_start ident_cont*
 # Per sqlite.org/draft/tokenreq.html ALPHABETIC + ALPHANUMERIC: the
 # ASCII letter/underscore range, the ASCII digits (continuation only),
 # `$` (continuation only), plus any code point above U+007F.
-*ident_start = [a-zA-Z_\u{80}-\u{10FFFF}]
-*ident_cont = [a-zA-Z\d_$\u{80}-\u{10FFFF}]
+ident_start: atomic = [a-zA-Z_\u{80}-\u{10FFFF}]
+ident_cont: atomic = [a-zA-Z\d_$\u{80}-\u{10FFFF}]
 
-*double_quoted_id = '"' ('""' / !'"' !\R .)* '"'
-*backtick_id = '`' ('``' / !'`' !\R .)* '`'
-*bracket_id = '[' .. (']' / \R) ']'
+double_quoted_id: atomic = '"' ('""' / !'"' !\R .)* '"'
+backtick_id: atomic = '`' ('``' / !'`' !\R .)* '`'
+bracket_id: atomic = '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
 # Each kw_* is a `%` reserved-word rule: the compiler appends a `wb`
@@ -568,155 +568,155 @@ number_body = hex_body / float_body / int_body
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.
 
-%kw_select = @keyword i"select"
-%kw_from = @keyword i"from"
-%kw_where = @keyword i"where"
-%kw_group = @keyword i"group"
-%kw_by = @keyword i"by"
-%kw_having = @keyword i"having"
-%kw_order = @keyword i"order"
-%kw_asc = @keyword i"asc"
-%kw_desc = @keyword i"desc"
-%kw_limit = @keyword i"limit"
-%kw_offset = @keyword i"offset"
-%kw_join = @keyword i"join"
-%kw_inner = @keyword i"inner"
-%kw_left = @keyword i"left"
-%kw_right = @keyword i"right"
-%kw_full = @keyword i"full"
-%kw_outer = @keyword i"outer"
-%kw_cross = @keyword i"cross"
-%kw_natural = @keyword i"natural"
-%kw_on = @keyword i"on"
-%kw_using = @keyword i"using"
-%kw_as = @keyword i"as"
-%kw_distinct = @keyword i"distinct"
-%kw_all = @keyword i"all"
-%kw_union = @keyword i"union"
-%kw_intersect = @keyword i"intersect"
-%kw_except = @keyword i"except"
-%kw_with = @keyword i"with"
-%kw_and = @keyword i"and"
-%kw_or = @keyword i"or"
-%kw_not = @keyword i"not"
-%kw_is = @keyword i"is"
-%kw_in = @keyword i"in"
-%kw_like = @keyword i"like"
-%kw_glob = @keyword i"glob"
-%kw_match = @keyword i"match"
-%kw_regexp = @keyword i"regexp"
-%kw_between = @keyword i"between"
-%kw_escape = @keyword i"escape"
-%kw_case = @keyword i"case"
-%kw_when = @keyword i"when"
-%kw_then = @keyword i"then"
-%kw_else = @keyword i"else"
-%kw_end = @keyword i"end"
-%kw_cast = @keyword i"cast"
-%kw_exists = @keyword i"exists"
-%kw_collate = @keyword i"collate"
+kw_select: reserved = @keyword i"select"
+kw_from: reserved = @keyword i"from"
+kw_where: reserved = @keyword i"where"
+kw_group: reserved = @keyword i"group"
+kw_by: reserved = @keyword i"by"
+kw_having: reserved = @keyword i"having"
+kw_order: reserved = @keyword i"order"
+kw_asc: reserved = @keyword i"asc"
+kw_desc: reserved = @keyword i"desc"
+kw_limit: reserved = @keyword i"limit"
+kw_offset: reserved = @keyword i"offset"
+kw_join: reserved = @keyword i"join"
+kw_inner: reserved = @keyword i"inner"
+kw_left: reserved = @keyword i"left"
+kw_right: reserved = @keyword i"right"
+kw_full: reserved = @keyword i"full"
+kw_outer: reserved = @keyword i"outer"
+kw_cross: reserved = @keyword i"cross"
+kw_natural: reserved = @keyword i"natural"
+kw_on: reserved = @keyword i"on"
+kw_using: reserved = @keyword i"using"
+kw_as: reserved = @keyword i"as"
+kw_distinct: reserved = @keyword i"distinct"
+kw_all: reserved = @keyword i"all"
+kw_union: reserved = @keyword i"union"
+kw_intersect: reserved = @keyword i"intersect"
+kw_except: reserved = @keyword i"except"
+kw_with: reserved = @keyword i"with"
+kw_and: reserved = @keyword i"and"
+kw_or: reserved = @keyword i"or"
+kw_not: reserved = @keyword i"not"
+kw_is: reserved = @keyword i"is"
+kw_in: reserved = @keyword i"in"
+kw_like: reserved = @keyword i"like"
+kw_glob: reserved = @keyword i"glob"
+kw_match: reserved = @keyword i"match"
+kw_regexp: reserved = @keyword i"regexp"
+kw_between: reserved = @keyword i"between"
+kw_escape: reserved = @keyword i"escape"
+kw_case: reserved = @keyword i"case"
+kw_when: reserved = @keyword i"when"
+kw_then: reserved = @keyword i"then"
+kw_else: reserved = @keyword i"else"
+kw_end: reserved = @keyword i"end"
+kw_cast: reserved = @keyword i"cast"
+kw_exists: reserved = @keyword i"exists"
+kw_collate: reserved = @keyword i"collate"
 
 # Window-function vocabulary. Only WINDOW and OVER are reserved; the
 # rest are matched positionally inside window_defn / frame_spec and
 # remain usable as identifiers outside those positions.
-%?kw_recursive = @keyword i"recursive"
-%kw_window = @keyword i"window"
-%kw_over = @keyword i"over"
-%?kw_filter = @keyword i"filter"
-%?kw_partition = @keyword i"partition"
-%?kw_range = @keyword i"range"
-%?kw_rows = @keyword i"rows"
-%?kw_groups = @keyword i"groups"
-%?kw_unbounded = @keyword i"unbounded"
-%?kw_preceding = @keyword i"preceding"
-%?kw_following = @keyword i"following"
-%?kw_current = @keyword i"current"
-%?kw_row = @keyword i"row"
-%?kw_exclude = @keyword i"exclude"
-%?kw_ties = @keyword i"ties"
-%?kw_others = @keyword i"others"
-%kw_no = @keyword i"no"
+kw_recursive: preferred = @keyword i"recursive"
+kw_window: reserved = @keyword i"window"
+kw_over: reserved = @keyword i"over"
+kw_filter: preferred = @keyword i"filter"
+kw_partition: preferred = @keyword i"partition"
+kw_range: preferred = @keyword i"range"
+kw_rows: preferred = @keyword i"rows"
+kw_groups: preferred = @keyword i"groups"
+kw_unbounded: preferred = @keyword i"unbounded"
+kw_preceding: preferred = @keyword i"preceding"
+kw_following: preferred = @keyword i"following"
+kw_current: preferred = @keyword i"current"
+kw_row: preferred = @keyword i"row"
+kw_exclude: preferred = @keyword i"exclude"
+kw_ties: preferred = @keyword i"ties"
+kw_others: preferred = @keyword i"others"
+kw_no: reserved = @keyword i"no"
 
 # DML (INSERT family). UPDATE lands in a later commit but its keyword
 # rule goes here so UPSERT's DO UPDATE path can use it now.
-%kw_insert = @keyword i"insert"
-%kw_replace = @keyword i"replace"
-%kw_into = @keyword i"into"
-%kw_values = @keyword i"values"
-%kw_default = @keyword i"default"
-%kw_conflict = @keyword i"conflict"
-%?kw_do = @keyword i"do"
-%kw_nothing = @keyword i"nothing"
-%kw_rollback = @keyword i"rollback"
-%kw_abort = @keyword i"abort"
-%kw_fail = @keyword i"fail"
-%kw_ignore = @keyword i"ignore"
-%kw_set = @keyword i"set"
-%kw_returning = @keyword i"returning"
-%kw_update = @keyword i"update"
-%kw_delete = @keyword i"delete"
+kw_insert: reserved = @keyword i"insert"
+kw_replace: reserved = @keyword i"replace"
+kw_into: reserved = @keyword i"into"
+kw_values: reserved = @keyword i"values"
+kw_default: reserved = @keyword i"default"
+kw_conflict: reserved = @keyword i"conflict"
+kw_do: preferred = @keyword i"do"
+kw_nothing: reserved = @keyword i"nothing"
+kw_rollback: reserved = @keyword i"rollback"
+kw_abort: reserved = @keyword i"abort"
+kw_fail: reserved = @keyword i"fail"
+kw_ignore: reserved = @keyword i"ignore"
+kw_set: reserved = @keyword i"set"
+kw_returning: reserved = @keyword i"returning"
+kw_update: reserved = @keyword i"update"
+kw_delete: reserved = @keyword i"delete"
 
 # DDL (CREATE / ALTER / DROP TABLE, constraints, foreign-key actions).
-%kw_create = @keyword i"create"
-%kw_table = @keyword i"table"
-%kw_alter = @keyword i"alter"
-%kw_drop = @keyword i"drop"
-%kw_rename = @keyword i"rename"
-%kw_add = @keyword i"add"
-%kw_column = @keyword i"column"
-%kw_if = @keyword i"if"
-%kw_temp = @keyword i"temp"
-%kw_temporary = @keyword i"temporary"
-%kw_primary = @keyword i"primary"
-%?kw_key = @keyword i"key"
-%kw_unique = @keyword i"unique"
-%kw_check = @keyword i"check"
-%kw_null = @keyword i"null"
-%kw_references = @keyword i"references"
-%kw_generated = @keyword i"generated"
-%kw_always = @keyword i"always"
-%kw_stored = @keyword i"stored"
-%kw_virtual = @keyword i"virtual"
-%kw_constraint = @keyword i"constraint"
-%kw_foreign = @keyword i"foreign"
-%kw_action = @keyword i"action"
-%kw_cascade = @keyword i"cascade"
-%kw_restrict = @keyword i"restrict"
-%kw_deferrable = @keyword i"deferrable"
-%kw_initially = @keyword i"initially"
-%kw_immediate = @keyword i"immediate"
-%kw_deferred = @keyword i"deferred"
-%kw_autoincrement = @keyword i"autoincrement"
-%kw_rowid = @keyword i"rowid"
-%kw_strict = @keyword i"strict"
-%kw_without = @keyword i"without"
-%kw_to = @keyword i"to"
-%kw_index = @keyword i"index"
-%kw_view = @keyword i"view"
-%kw_trigger = @keyword i"trigger"
-%kw_before = @keyword i"before"
-%kw_after = @keyword i"after"
-%kw_instead = @keyword i"instead"
-%kw_of = @keyword i"of"
-%kw_for = @keyword i"for"
-%kw_each = @keyword i"each"
-%kw_begin = @keyword i"begin"
-%kw_commit = @keyword i"commit"
-%kw_transaction = @keyword i"transaction"
-%kw_savepoint = @keyword i"savepoint"
-%kw_release = @keyword i"release"
-%kw_exclusive = @keyword i"exclusive"
-%kw_pragma = @keyword i"pragma"
-%kw_vacuum = @keyword i"vacuum"
-%kw_attach = @keyword i"attach"
-%kw_detach = @keyword i"detach"
-%kw_database = @keyword i"database"
-%kw_reindex = @keyword i"reindex"
-%kw_analyze = @keyword i"analyze"
-%kw_explain = @keyword i"explain"
-%kw_query = @keyword i"query"
-%kw_plan = @keyword i"plan"
+kw_create: reserved = @keyword i"create"
+kw_table: reserved = @keyword i"table"
+kw_alter: reserved = @keyword i"alter"
+kw_drop: reserved = @keyword i"drop"
+kw_rename: reserved = @keyword i"rename"
+kw_add: reserved = @keyword i"add"
+kw_column: reserved = @keyword i"column"
+kw_if: reserved = @keyword i"if"
+kw_temp: reserved = @keyword i"temp"
+kw_temporary: reserved = @keyword i"temporary"
+kw_primary: reserved = @keyword i"primary"
+kw_key: preferred = @keyword i"key"
+kw_unique: reserved = @keyword i"unique"
+kw_check: reserved = @keyword i"check"
+kw_null: reserved = @keyword i"null"
+kw_references: reserved = @keyword i"references"
+kw_generated: reserved = @keyword i"generated"
+kw_always: reserved = @keyword i"always"
+kw_stored: reserved = @keyword i"stored"
+kw_virtual: reserved = @keyword i"virtual"
+kw_constraint: reserved = @keyword i"constraint"
+kw_foreign: reserved = @keyword i"foreign"
+kw_action: reserved = @keyword i"action"
+kw_cascade: reserved = @keyword i"cascade"
+kw_restrict: reserved = @keyword i"restrict"
+kw_deferrable: reserved = @keyword i"deferrable"
+kw_initially: reserved = @keyword i"initially"
+kw_immediate: reserved = @keyword i"immediate"
+kw_deferred: reserved = @keyword i"deferred"
+kw_autoincrement: reserved = @keyword i"autoincrement"
+kw_rowid: reserved = @keyword i"rowid"
+kw_strict: reserved = @keyword i"strict"
+kw_without: reserved = @keyword i"without"
+kw_to: reserved = @keyword i"to"
+kw_index: reserved = @keyword i"index"
+kw_view: reserved = @keyword i"view"
+kw_trigger: reserved = @keyword i"trigger"
+kw_before: reserved = @keyword i"before"
+kw_after: reserved = @keyword i"after"
+kw_instead: reserved = @keyword i"instead"
+kw_of: reserved = @keyword i"of"
+kw_for: reserved = @keyword i"for"
+kw_each: reserved = @keyword i"each"
+kw_begin: reserved = @keyword i"begin"
+kw_commit: reserved = @keyword i"commit"
+kw_transaction: reserved = @keyword i"transaction"
+kw_savepoint: reserved = @keyword i"savepoint"
+kw_release: reserved = @keyword i"release"
+kw_exclusive: reserved = @keyword i"exclusive"
+kw_pragma: reserved = @keyword i"pragma"
+kw_vacuum: reserved = @keyword i"vacuum"
+kw_attach: reserved = @keyword i"attach"
+kw_detach: reserved = @keyword i"detach"
+kw_database: reserved = @keyword i"database"
+kw_reindex: reserved = @keyword i"reindex"
+kw_analyze: reserved = @keyword i"analyze"
+kw_explain: reserved = @keyword i"explain"
+kw_query: reserved = @keyword i"query"
+kw_plan: reserved = @keyword i"plan"
 
 # --- Whitespace & comments -------------------------------------------
 
-*comment = @comment ('--' .. \R / '/*' ..= '*/')
+comment: atomic = @comment ('--' .. \R / '/*' ..= '*/')

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -34,22 +34,26 @@ name2 =  body2
   between iterations of `*` / `+`. Without a `trivia` rule, no
   auto-insertion happens.
 - An optional **`wb` rule** is the word-boundary target consumed by
-  `%` rules (see below); it is typically `wb = !ident_body`. Defining
-  it is only required when the grammar has at least one `%` rule.
-- Rules may carry **prefix sigils**: `~name =` for the intentional
-  leniency marker, `*name =` for the atomic marker (no `trivia`
-  injected inside this rule's body), `%name =` for the reserved-word
-  marker (atomic *and* appends a trailing `wb` call inside the rule's
-  terminal captures), and `%?name =` for the preferred-word marker (a
-  sibling of `%` for identifier-eligible distinguished tokens). `~`
-  composes with `*` / `%` / `%?` (`~*name`, `%~name`, …); `*` and
-  `%` / `%?` are mutually exclusive — both make a rule atomic. The
-  three special rules `root`, `trivia`, and `wb` carry no qualifiers at
-  all (any sigil on them is a parse error); whitespace auto-insertion is
-  disabled by omitting `trivia`, not by marking it.
+  `reserved` rules (see below); it is typically `wb = !ident_body`.
+  Defining it is only required when the grammar has at least one
+  `reserved` rule.
+- Rules may carry postfix **ascriptions** between the name and `=`,
+  `name: kw [kw ...] =`: `partial` (the intentional-leniency marker),
+  `atomic` (no `trivia` injected inside this rule's body), `reserved`
+  (atomic *and* appends a trailing `wb` call inside the rule's terminal
+  captures), and `preferred` (a sibling of `reserved` for
+  identifier-eligible distinguished tokens). The keywords are
+  *contextual* — special only in this slot, usable as ordinary rule
+  names elsewhere. `atomic` / `reserved` / `preferred` are mutually
+  exclusive (each makes a rule atomic); `partial` composes with any and,
+  when present, must be written first (`name: partial atomic =`). The
+  three special rules `root`, `trivia`, and `wb` carry no ascriptions at
+  all (any ascription on them is a parse error); whitespace
+  auto-insertion is disabled by omitting `trivia`, not by ascribing it.
 - Two special rules, **`reserved`** and **`preferred`**, are
-  *synthesized* by the compiler from the `%` / `%?` rules (see below) —
-  a grammar references them (`!reserved`) but never defines them.
+  *synthesized* by the compiler from the `reserved` / `preferred` rules
+  (see below) — a grammar references them (`!reserved`) but never
+  defines them.
 - **Position constraint:** `root` is always the first rule. The
   optional special rules `trivia` and `wb` occupy the contiguous slots
   immediately after `root` (positions 1..2, in either order). Other
@@ -77,9 +81,9 @@ catch      p1 ^label p2      p1 ^^label B      p1 ^^label
 choice     p1 / p2 / p3
 ```
 
-Rule definitions may carry a top-level `~name =` decorator to mark
+Rule definitions may carry a `name: partial =` ascription to mark
 the whole rule as intentionally lenient — see
-[`~name =`](#name----intentional-leniency-marker) below.
+[`name: partial`](#name-partial--intentional-leniency-ascription) below.
 
 ### Atoms
 
@@ -508,35 +512,34 @@ only `..=`, not `..` — the catch necessarily consumes its boundary,
 and `^^lbl .. B` would diverge from the standalone `..` non-consuming
 meaning. The parser rejects it with a hint pointing at `..=`.
 
-### `~name =` — intentional-leniency marker
+### `name: partial` — intentional-leniency ascription
 
 The static `lint_partial_match` check flags trailing-nullable rules
 called unanchored — but on shipped grammars almost every flag is a
 "partial-match leniency intentionally absorbed by outer `*^`-style
 recovery" that the static analysis can't statically prove safe. The
-`~name =` marker is the author's intent signal: "yes, this rule's
+`partial` ascription is the author's intent signal: "yes, this rule's
 leniency is known, don't flag any call to it." Wraps the rule's body
 in `Pattern::Lenient`, which the lint walker treats as an opaque
 barrier and the compiler treats as transparent (emits the inner's
 bytecode unchanged).
 
 ```peg
-~opt_semi = (@punctuation ';' ws)?
+opt_semi: partial = (@punctuation ';' ws)?
 ```
 
-The marker must touch the name (no whitespace between `~` and the
-identifier). Whether the runtime invariant the marker assumes —
-typically an outer `*^` / `*^[;]` / `^block_close` recovery scope
-absorbing the leniency — actually holds is currently a convention
-recorded in adjacent comments and unenforced by the lint; see
-`#113` for the planned tightening.
+Whether the runtime invariant the ascription assumes — typically an
+outer `*^` / `*^[;]` / `^block_close` recovery scope absorbing the
+leniency — actually holds is currently a convention recorded in
+adjacent comments and unenforced by the lint; see `#113` for the
+planned tightening.
 
 ### Reserved rule names
 
 Three rule names get compile-time treatment. All three are structural
 slots the compiler wraps or injects, not lexable tokens, so none of
-them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
-`trivia`, or `wb` is a parse error.
+them accepts an ascription — `partial` / `atomic` / `reserved` /
+`preferred` on `root`, `trivia`, or `wb` is a parse error.
 
 - **`root`** — the start rule (mandatory). The compiler wraps its
   body as `trivia? root_body trivia? !.` so end-of-input is always
@@ -593,11 +596,12 @@ them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
   pair`, and each iteration begins by consuming whatever
   inter-iteration whitespace is sitting in front of it.
 
-- **`wb`** — the optional word-boundary target for `%` / `%?` rules.
-  Its body is a bare boundary predicate (typically `wb = !ident_body`,
-  or `!ident_cont` for a Unicode-aware continuation class). The
-  compiler appends a `wb` call inside the terminal captures of every
-  `%` / `%?` rule (see [`%name =`](#name----reserved-word-marker)); it
+- **`wb`** — the optional word-boundary target for `reserved` /
+  `preferred` rules. Its body is a bare boundary predicate (typically
+  `wb = !ident_body`, or `!ident_cont` for a Unicode-aware continuation
+  class). The compiler appends a `wb` call inside the terminal captures
+  of every `reserved` / `preferred` rule (see
+  [`name: reserved`](#name-reserved--reserved-word-ascription)); it
   is required only when the grammar has at least one such rule. Like
   `trivia`, `wb` is exempt from trivia auto-insertion and must sit in
   the reserved slots immediately after `root`. It is **not** part of
@@ -607,17 +611,16 @@ them accepts a prefix sigil — `*` / `~` / `%` / `%?` on `root`,
   wb            = !ident_body
   ```
 
-### `*name =` — atomic-rule marker
+### `name: atomic` — atomic-rule ascription
 
-A `*` prefix on the rule name opts the rule out of `trivia`
+The `atomic` ascription opts the rule out of `trivia`
 auto-insertion: the rewriter walks the body but does not splice
 `trivia` between `Sequence` items or prepend one to `Repeat`
-iterations. The two prefix sigils compose: `~*name` and `*~name`
-are both valid.
+iterations. `partial` composes with it (`name: partial atomic =`).
 
 ```peg
-*string_lit   = '"' (str_escape / !'"' .)* '"'
-*ident        = [A-Za-z_] [A-Za-z0-9_]*
+string_lit: atomic = '"' (str_escape / !'"' .)* '"'
+ident: atomic      = [A-Za-z_] [A-Za-z0-9_]*
 ```
 
 Used on token-shape rules — string / number / char literals,
@@ -628,21 +631,22 @@ non-atomic rule called from inside an atomic body still gets
 auto-insertion in its own body.
 
 For a keyword rule that also needs a trailing word boundary, prefer
-the [`%name =`](#name----reserved-word-marker) sibling below — it is
-atomic *and* supplies the boundary, so you don't hand-write `!ident_body`.
+the [`reserved`](#name-reserved--reserved-word-ascription) sibling
+below — it is atomic *and* supplies the boundary, so you don't
+hand-write `!ident_body`.
 
-### `%name =` — reserved-word marker
+### `name: reserved` — reserved-word ascription
 
-A `%` prefix marks a rule as a **reserved word**: it is compiled
-atomic (like `*`) *and* the compiler appends a call to the `wb` rule
+The `reserved` ascription marks a rule as a **reserved word**: it is
+compiled atomic *and* the compiler appends a call to the `wb` rule
 inside the rule's terminal captures, so the match must be followed by
 a word boundary. This keeps a keyword from firing on the prefix of a
 longer identifier — `if` must not match the start of `ifx`.
 
 ```peg
-wb            = !ident_body
-%kw_if        = @keyword 'if'
-%storage_spec = @keyword 'typedef' / @keyword 'extern' / @keyword 'static'
+wb                  = !ident_body
+kw_if: reserved     = @keyword 'if'
+storage_spec: reserved = @keyword 'typedef' / @keyword 'extern' / @keyword 'static'
 ```
 
 The `wb` call is pushed inside each leaf capture (and distributed
@@ -652,65 +656,68 @@ the boundary holds, so a rejected keyword leaves no stray capture for
 top-level `*^` recovery to surface. Because the rule is atomic, no
 `trivia` is spliced between the literal and the appended `wb` call.
 
-When a `%` / `%?` rule's body is a **capture-less alternation of plain
-literals**, the compiler prefix-factors it into a longest-match **trie**
-(with `wb` at each accepting leaf) instead of a flat alternation. The
-trie is order-independent, so a shorter keyword can't shadow a longer
-one that extends it — `do` / `double`, `go` / `goto`, `int` / `int8`
-all match maximally regardless of source order. (Case-insensitive
-`i"…"` keyword sets lower to char-class sequences, not plain literals,
-so they keep the flat form — the synthesizer below emits those
-longest-first so maximal munch still holds.)
+When a `reserved` / `preferred` rule's body is a **capture-less
+alternation of plain literals**, the compiler prefix-factors it into a
+longest-match **trie** (with `wb` at each accepting leaf) instead of a
+flat alternation. The trie is order-independent, so a shorter keyword
+can't shadow a longer one that extends it — `do` / `double`, `go` /
+`goto`, `int` / `int8` all match maximally regardless of source order.
+(Case-insensitive `i"…"` keyword sets lower to char-class sequences,
+not plain literals, so they keep the flat form — the synthesizer below
+emits those longest-first so maximal munch still holds.)
 
 - Requires a `wb` rule; with none defined, the synthesized
   `NonTerminal("wb")` surfaces as `CompileError::UndefinedRule("wb")`.
-- Composes with `~` (`%~name` / `~%name`); mutually exclusive with `*`
-  (combining them is a parse error).
+- Composes with `partial` (written first); mutually exclusive with
+  `atomic` / `preferred`.
 - Rejected on the reserved rules `root` / `trivia` / `wb`.
 
-### `%?name =` — preferred-word marker
+### `name: preferred` — preferred-word ascription
 
-A `%?` prefix (the `?` touches the `%`) is the sibling of `%` for
+The `preferred` ascription is the sibling of `reserved` for
 **preferred words**: identifier-eligible distinguished tokens such as
 Go's predeclared `int` / `len` / `true` or JavaScript's contextual
-`async` / `let`. It behaves exactly like `%` — atomic, with the same
-`wb` boundary and the same trie treatment — and differs only in *which
-synthesized set the rule's literals feed*: a `%?` rule's words go into
-`preferred` and are **excluded** from `reserved`, so they stay usable as
-identifiers.
+`async` / `let`. It behaves exactly like `reserved` — atomic, with the
+same `wb` boundary and the same trie treatment — and differs only in
+*which synthesized set the rule's literals feed*: a `preferred` rule's
+words go into `preferred` and are **excluded** from `reserved`, so they
+stay usable as identifiers.
 
 ```peg
-%?predeclared_type = 'int8' / 'int16' / 'int'   # Go: shadowable
-%?kw_async         = @keyword 'async'          # JS: contextual
+predeclared_type: preferred = 'int8' / 'int16' / 'int'  # Go: shadowable
+kw_async: preferred         = @keyword 'async'          # JS: contextual
 ```
 
-- Same requirements / composition / rejections as `%`.
-- A word reachable from both a `%` and a `%?` rule is a contradiction
-  (it can't be both barred from and allowed in identifier position) and
-  raises `CompileError::ReservedPreferredConflict`.
+- Same requirements / composition / rejections as `reserved`.
+- A word reachable from both a `reserved` and a `preferred` rule is a
+  contradiction (it can't be both barred from and allowed in identifier
+  position) and raises `CompileError::ReservedPreferredConflict`.
 
 ### `reserved` / `preferred` — synthesized word sets
 
-The compiler synthesizes two rules from the `%` / `%?` rules above:
+The compiler synthesizes two rules from the `reserved` / `preferred`
+rules above:
 
-- **`reserved`** — every literal of a `%` rule that is **not** `%?`.
+- **`reserved`** — every literal of a `reserved` rule (excluding
+  `preferred`).
   Reference it as `!reserved` in an identifier rule to bar keywords from
   identifier position without hand-maintaining a list:
 
   ```peg
-  *ident = !reserved [A-Za-z_] [A-Za-z0-9_]*
+  ident: atomic = !reserved [A-Za-z_] [A-Za-z0-9_]*
   ```
 
-- **`preferred`** — every literal of a `%?` rule. Materialized for
-  symmetry / inspection (e.g. `pegdb`); a grammar usually doesn't
+- **`preferred`** — every literal of a `preferred` rule. Materialized
+  for symmetry / inspection (e.g. `pegdb`); a grammar usually doesn't
   reference it.
 
-Both are emitted as `%` rules (trie + `wb`), so `!reserved` does correct
-maximal-munch: `int` is reserved, but `integer` — a longer word that
-merely starts with it — is not. A rule whose body isn't a fixed keyword
-shape (it has a quantifier / wildcard / predicate, e.g. a number body
-like `'0x' [\da-fA-F]+`) contributes nothing; keep such boundary-only
-helpers as `*name = … wb` rather than `%`. Authors **reference** these
+Both are emitted as `reserved` rules (trie + `wb`), so `!reserved` does
+correct maximal-munch: `int` is reserved, but `integer` — a longer word
+that merely starts with it — is not. A rule whose body isn't a fixed
+keyword shape (it has a quantifier / wildcard / predicate, e.g. a number
+body like `'0x' [\da-fA-F]+`) contributes nothing; keep such
+boundary-only helpers as `name: atomic = … wb` rather than `reserved`.
+Authors **reference** these
 two names but never **define** them (a definition is a parse error).
 
 ### Reserved syntax
@@ -770,7 +777,7 @@ concrete use case.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
   that doesn't exist, partial-match leniency on a call site that's
   neither anchored (`^^lbl B`) nor explicitly marked intentional
-  (`~name =`), an `^^lbl` whose call-site FOLLOW set is empty
+  (`name: partial`), an `^^lbl` whose call-site FOLLOW set is empty
   so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -636,7 +636,7 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         Pattern::Catch { inner, .. } => {
             out.extend(trailing_first(inner, nullable));
         }
-        // Definition-level `~name =` opts the rule out of being a flag
+        // Definition-level `name: partial` opts the rule out of being a flag
         // target: its `trailing_first` is empty regardless of body shape.
         Pattern::Lenient { .. } => {}
         _ => {}
@@ -1526,7 +1526,7 @@ pub fn inject_auto_trivia(grammar: &mut Grammar) {
         // The trivia rule itself is exempt: every `trivia_call` from
         // the rewriter calls back into it, so injecting trivia inside
         // its body would recurse the runtime indefinitely. Atomic
-        // rules opt out explicitly via the `*name =` sigil.
+        // rules opt out explicitly via the `name: atomic` ascription.
         if atomic.contains(&name) || name == TRIVIA_ROOT_RULE {
             continue;
         }
@@ -1634,14 +1634,14 @@ fn trivia_call() -> Pattern {
 }
 
 /// Append a `wb` word-boundary call inside the terminal captures of
-/// every `%`-marked rule (see [`Grammar::percent_rules`]).
+/// every `reserved` rule (see [`Grammar::percent_rules`]).
 ///
 /// The boundary is pushed to the tail of the matched region, *inside*
 /// the capture that ends the match, so the capture commits only when
 /// the boundary holds. Placing `wb` after the capture instead would let
 /// the keyword capture commit before the boundary check fails, leaking a
 /// stray keyword token through top-level `*^` recovery on inputs like
-/// `typedefx`. The rule is already atomic (the `%` sigil inserts it into
+/// `typedefx`. The rule is already atomic (the `reserved` ascription inserts it into
 /// `atomic_rules`), so no `trivia` is spliced between the literal and
 /// the appended call.
 ///
@@ -1803,20 +1803,23 @@ fn build_trie(entries: Vec<Vec<u8>>) -> Pattern {
 }
 
 /// Synthesize the compiler-generated `reserved` and `preferred` rules
-/// from the literals reachable through the grammar's `%` / `%?` rules.
+/// from the literals reachable through the grammar's `reserved` /
+/// `preferred` rules.
 ///
-/// `reserved` collects every literal of a `%` rule that is *not* `%?`;
-/// `preferred` collects every literal of a `%?` rule. A rule whose body
-/// isn't a fixed keyword shape (it has a quantifier, wildcard, predicate,
-/// or an unresolvable reference — e.g. a number body like
-/// `'0x' [\da-fA-F]+`) contributes nothing. Both rules are emitted as a
-/// flat alternation ordered longest-first and registered as `%` rules, so
-/// the following [`append_wb_check`] gives them the same trie + `wb`
-/// treatment as any author-written keyword set.
+/// `reserved` collects every literal of a `reserved` rule (excluding
+/// `preferred`); `preferred` collects every literal of a `preferred`
+/// rule. A rule whose body isn't a fixed keyword shape (it has a
+/// quantifier, wildcard, predicate, or an unresolvable reference — e.g.
+/// a number body like `'0x' [\da-fA-F]+`) contributes nothing. Both
+/// rules are emitted as a flat alternation ordered longest-first and
+/// registered as `reserved` rules, so the following [`append_wb_check`]
+/// gives them the same trie + `wb` treatment as any author-written
+/// keyword set.
 ///
-/// A literal reachable from both a `%` and a `%?` rule is a contradiction
-/// (it can't be both barred from and allowed in identifier position) and
-/// raises [`CompileError::ReservedPreferredConflict`].
+/// A literal reachable from both a `reserved` and a `preferred` rule is
+/// a contradiction (it can't be both barred from and allowed in
+/// identifier position) and raises
+/// [`CompileError::ReservedPreferredConflict`].
 pub fn synthesize_reserved_preferred(grammar: &mut Grammar) -> Result<(), CompileError> {
     let mut reserved: BTreeSet<Vec<CharSet>> = BTreeSet::new();
     let mut preferred: BTreeSet<Vec<CharSet>> = BTreeSet::new();
@@ -1880,7 +1883,7 @@ pub fn synthesize_reserved_preferred(grammar: &mut Grammar) -> Result<(), Compil
 /// shape: a quantifier, wildcard, predicate, catch, or a reference that
 /// cycles or escapes the keyword shape. `NonTerminal`s are resolved
 /// through `rules` (with a `visiting` cycle guard) so wrappers like
-/// `%bool_lit = @constant bool_body` reach their literals.
+/// `bool_lit: reserved = @constant bool_body` reach their literals.
 fn keyword_entries(
     pat: &Pattern,
     rules: &HashMap<String, Pattern>,
@@ -2066,7 +2069,7 @@ mod tests {
         }
     }
 
-    /// Mark a single rule `t` as a `%` rule, run `append_wb_check`, and
+    /// Mark a single rule `t` as a `reserved` rule, run `append_wb_check`, and
     /// return the rewritten body.
     fn append_to(body: Pattern) -> Pattern {
         let mut rules = HashMap::new();
@@ -2079,7 +2082,7 @@ mod tests {
 
     #[test]
     fn capture_less_charclass_choice_gets_one_trailing_wb() {
-        // `%t = [ab] / [cd]` — capture-less but not all-literal, so the
+        // `t: reserved = [ab] / [cd]` — capture-less but not all-literal, so the
         // trie path is skipped and a single trailing `wb` follows the
         // whole choice, not one per branch.
         let body = Pattern::choice(vec![
@@ -2091,7 +2094,7 @@ mod tests {
 
     #[test]
     fn capture_less_literal_choice_factors_into_trie() {
-        // `%t = 'do' / 'double'` — all-literal, so it folds into a
+        // `t: reserved = 'do' / 'double'` — all-literal, so it folds into a
         // longest-match trie: `do` shared, then `uble` accept vs the bare
         // `do` accept. Two accepts → two `wb`s.
         let body = Pattern::choice(vec![Pattern::literal("do"), Pattern::literal("double")]);
@@ -2108,7 +2111,7 @@ mod tests {
 
     #[test]
     fn capture_choice_distributes_wb_per_branch() {
-        // `%t = @k 'a' / @k 'b'` — each capture must keep `wb` inside
+        // `t: reserved = @k 'a' / @k 'b'` — each capture must keep `wb` inside
         // so a committed keyword can't leak through recovery.
         let body = Pattern::choice(vec![
             Pattern::capture("k", Pattern::literal("a")),

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -33,15 +33,15 @@ pub enum CompileError {
     /// `lint_partial_match` returned a non-empty result. Each finding
     /// names a `(rule, caller)` pair where a trailing-nullable rule's
     /// partial-match leniency reaches an unguarded scope. Anchor with
-    /// `^^lbl B` (or `^^lbl`) when the leniency is a bug, or wrap the
-    /// call site with `~p` when the leniency is intentional. Each
+    /// `^^lbl B` (or `^^lbl`) when the leniency is a bug, or mark the
+    /// rule `name: partial` when the leniency is intentional. Each
     /// [`LintFinding`] carries the call-site's span so the rendered
     /// message points directly at the unanchored call.
     PartialMatchLeniency(Vec<LintFinding>),
-    /// One or more literals are reachable from both a `%` rule and a
-    /// `%?` rule, so the synthesized `reserved` and `preferred` sets
-    /// would overlap — a word can't be both barred from and allowed in
-    /// identifier position. Emitted by `synthesize_reserved_preferred`.
+    /// One or more literals are reachable from both a `reserved` rule and
+    /// a `preferred` rule, so the synthesized `reserved` and `preferred`
+    /// sets would overlap — a word can't be both barred from and allowed
+    /// in identifier position. Emitted by `synthesize_reserved_preferred`.
     /// The payload is the offending literals (UTF-8 lossy), sorted.
     ReservedPreferredConflict(Vec<String>),
 }
@@ -77,7 +77,7 @@ impl std::fmt::Display for CompileError {
             }
             CompileError::ReservedPreferredConflict(words) => write!(
                 f,
-                "the following word(s) are marked both `%` (reserved) and `%?` (preferred), \
+                "the following word(s) are marked both `reserved` and `preferred`, \
                  so the synthesized `reserved` / `preferred` sets would overlap: {}",
                 words.join(", ")
             ),

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -45,24 +45,25 @@ pub const ROOT_RULE: &str = "root";
 pub const TRIVIA_RULE: &str = "trivia";
 
 /// Reserved rule name for the (optional) word-boundary target. A rule
-/// marked with the `%name = …` sigil is compiled atomic and has a
-/// trailing call to [`WB_RULE`] appended inside its terminal captures by
+/// ascribed `reserved` is compiled atomic and has a trailing call to
+/// [`WB_RULE`] appended inside its terminal captures by
 /// [`append_wb_check`](super::analysis::append_wb_check), so a keyword
 /// can't fire on the prefix of a longer identifier. Defining `wb` is
-/// only required when at least one `%` rule exists; like [`TRIVIA_RULE`]
-/// it must sit in the reserved slots immediately after [`ROOT_RULE`].
+/// only required when at least one `reserved` rule exists; like
+/// [`TRIVIA_RULE`] it must sit in the reserved slots immediately after
+/// [`ROOT_RULE`].
 pub const WB_RULE: &str = "wb";
 
 /// Compiler-generated rule name for the reserved-word set. Synthesized
 /// by [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred)
-/// from the literals of every `%` rule minus every `%?` rule, so a
-/// grammar can write `!reserved` to bar keywords from identifier
-/// position without hand-maintaining the list. Authors may *reference*
-/// it but not *define* it — the parser rejects a definition.
+/// from the literals of every `reserved` rule minus every `preferred`
+/// rule, so a grammar can write `!reserved` to bar keywords from
+/// identifier position without hand-maintaining the list. Authors may
+/// *reference* it but not *define* it — the parser rejects a definition.
 pub const RESERVED_RULE: &str = "reserved";
 
 /// Compiler-generated rule name for the preferred-word set: the union
-/// of every `%?` rule's literals (identifier-eligible distinguished
+/// of every `preferred` rule's literals (identifier-eligible distinguished
 /// tokens, e.g. Go predeclared `int` / `len`). Synthesized alongside
 /// [`RESERVED_RULE`]; like it, authors may reference but not define it.
 pub const PREFERRED_RULE: &str = "preferred";
@@ -76,25 +77,24 @@ const MAX_REPEAT_COUNT: usize = 1024;
 #[derive(Debug, Clone)]
 pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
-    /// Names of rules marked atomic with the `*name = body` sigil. The
-    /// auto-insertion rewriter skips these rules: `Sequence` items inside
-    /// an atomic body don't get a synthesized `trivia` call spliced
-    /// between them. The `trivia` rule itself never appears here — it
-    /// carries no qualifiers; auto-insertion is disabled by omitting
-    /// the rule, not by marking it.
+    /// Names of rules ascribed `atomic`. The auto-insertion rewriter
+    /// skips these rules: `Sequence` items inside an atomic body don't
+    /// get a synthesized `trivia` call spliced between them. The `trivia`
+    /// rule itself never appears here — it carries no ascriptions;
+    /// auto-insertion is disabled by omitting the rule, not by ascribing
+    /// it.
     pub atomic_rules: HashSet<String>,
-    /// Names of rules marked with the `%name = body` reserved-word
-    /// sigil (and the `%?name = body` preferred-word sigil, which is a
-    /// subset — every `%?` rule is also here so it still gets a
+    /// Names of rules ascribed `reserved` (and `preferred`, which is a
+    /// subset — every `preferred` rule is also here so it still gets a
     /// boundary). Each such rule is also in `atomic_rules` (so trivia is
     /// not auto-inserted inside it); membership here additionally drives
     /// [`append_wb_check`](super::analysis::append_wb_check), which
     /// appends a [`WB_RULE`] call inside the rule's terminal captures.
     pub percent_rules: HashSet<String>,
-    /// Names of rules marked with the `%?name = body` preferred-word
-    /// sigil — identifier-eligible distinguished tokens (Go predeclared
-    /// `int` / `len`, JS contextual `async` / `let`). A strict subset of
-    /// `percent_rules`: a `%?` rule still gets the [`WB_RULE`] boundary,
+    /// Names of rules ascribed `preferred` — identifier-eligible
+    /// distinguished tokens (Go predeclared `int` / `len`, JS contextual
+    /// `async` / `let`). A strict subset of `percent_rules`: a
+    /// `preferred` rule still gets the [`WB_RULE`] boundary,
     /// but its literals are *excluded* from the synthesized
     /// [`RESERVED_RULE`] and instead collected into [`PREFERRED_RULE`] by
     /// [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred).
@@ -141,7 +141,7 @@ impl Grammar {
     }
 
     /// Construct a grammar with a pre-built atomic-rule set. Test-only
-    /// shortcut for exercising the `*name` sigil's behavior without
+    /// shortcut for exercising the `atomic` ascription's behavior without
     /// routing through grammar source.
     pub fn with_atomic(rules: HashMap<String, Pattern>, atomic_rules: HashSet<String>) -> Self {
         Grammar {
@@ -164,8 +164,8 @@ impl Grammar {
     ///    boundary from FOLLOW.
     /// 2. Run [`lint_partial_match`]; any finding is a fatal
     ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
-    ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with `~`
-    ///    at the call site or `~name = body` at the rule definition.
+    ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with the
+    ///    `name: partial` ascription at the rule definition.
     /// 3. Inject auto-trivia calls into every non-atomic rule's body
     ///    (no-op when the grammar has no `trivia` rule).
     /// 4. Wrap `root`'s body with `trivia? body trivia? !.` (the
@@ -211,15 +211,15 @@ impl Grammar {
         }
         inject_auto_trivia(&mut resolved);
         // Synthesize the `reserved` / `preferred` rules from the literals
-        // of the `%` / `%?` rules. Runs after trivia injection (so the
+        // of the `reserved` / `preferred` rules. Runs after trivia injection (so the
         // synthesized atomic rules aren't walked) and before
         // `append_wb_check` (so the synthesized rules pick up the trie +
-        // `wb` like any other `%` rule, and exist before `compile_rules`'
-        // reference check).
+        // `wb` like any other `reserved` rule, and exist before
+        // `compile_rules`' reference check).
         synthesize_reserved_preferred(&mut resolved)?;
-        // After trivia injection (which skips the atomic `%` rules) and
-        // before the root wrap: append the `wb` boundary call inside each
-        // `%` rule's terminal captures. An undefined `wb` surfaces as
+        // After trivia injection (which skips the atomic `reserved` rules)
+        // and before the root wrap: append the `wb` boundary call inside
+        // each `reserved` rule's terminal captures. An undefined `wb` surfaces as
         // `CompileError::UndefinedRule("wb")` from `compile_rules`.
         append_wb_check(&mut resolved);
         wrap_root(&mut resolved);
@@ -308,70 +308,88 @@ impl<'a> Parser<'a> {
         let mut preferred_rules: HashSet<String> = HashSet::new();
         let mut rule_headers: Vec<RuleHeader> = Vec::new();
         while self.pos < self.src.len() {
-            // Definition-level lenient marker: `~name = body` declares
-            // that every call to `name` is intentionally lenient and
-            // suppresses `lint_partial_match` findings at every call site
-            // of `name`. The marker touches the name (no whitespace);
-            // the rule's body is wrapped with `Pattern::Lenient` so the
-            // lint walker sees the same shape as a per-call-site `~p`.
+            // Rule definitions may carry postfix **ascriptions** between
+            // the name and `=`: `name: kw [kw ...] = body`. The keywords
+            // are contextual — recognized only in this slot, and usable as
+            // ordinary rule names / references everywhere else.
             //
-            // The atomic marker `*name = body` (sibling of `~`) opts
-            // the rule out of trivia auto-insertion: the rewriter walks
-            // the body but does not splice `trivia` between `Sequence`
-            // items. The `trivia` rule carries no qualifiers; omitting it
-            // (not marking it) is what disables auto-insertion.
+            // - `partial` declares every call to the rule intentionally
+            //   lenient, suppressing `lint_partial_match` findings at its
+            //   call sites; the body is wrapped in `Pattern::Lenient` so
+            //   the lint walker sees the same shape as a per-call-site
+            //   leniency.
+            // - `atomic` opts the rule out of `trivia` auto-insertion (no
+            //   `trivia` spliced between `Sequence` items).
+            // - `reserved` implies `atomic` and additionally appends a
+            //   `wb` boundary call inside the rule's terminal captures
+            //   (see `append_wb_check`); its literals seed the synthesized
+            //   `reserved` set.
+            // - `preferred` is the sibling of `reserved` (same atomic +
+            //   `wb` behavior) whose literals feed `preferred` instead and
+            //   stay identifier-eligible.
             //
-            // The reserved-word marker `%name = body` implies atomic and
-            // additionally appends a `wb` boundary call inside the rule's
-            // terminal captures (see `append_wb_check`). `%` composes with
-            // `~` but is mutually exclusive with `*` — both make a rule
-            // atomic, so combining them is always a mistake.
-            //
-            // The preferred-word marker `%?name = body` (the `?` touches
-            // the `%`) is a sibling of `%`: same atomic + `wb` behavior,
-            // but the rule's literals are *excluded* from the synthesized
-            // `reserved` set and collected into `preferred` instead, so a
-            // predeclared / contextual name (`int`, `async`) stays usable
-            // as an identifier. `%?` is also mutually exclusive with `*`.
+            // `atomic` / `reserved` / `preferred` are mutually exclusive
+            // (each makes the rule atomic); `partial` composes with any
+            // and, when present, must be written first.
+            let name_byte = self.pos;
+            let name = self.parse_ident()?;
+            self.skip_ws();
             let mut lenient_span: Option<Span> = None;
             let mut definition_atomic = false;
             let mut definition_percent = false;
             let mut definition_preferred = false;
-            loop {
-                match self.peek() {
-                    Some(b'~') if lenient_span.is_none() => {
-                        lenient_span = Some(self.span());
-                        self.pos += 1;
+            if self.peek() == Some(b':') {
+                self.pos += 1;
+                let mut count = 0usize;
+                loop {
+                    self.skip_ws();
+                    if !matches!(self.peek(), Some(c) if is_ident_start(c)) {
+                        break;
                     }
-                    Some(b'*') if !definition_atomic && !definition_percent => {
-                        self.pos += 1;
-                        definition_atomic = true;
-                    }
-                    Some(b'%') if !definition_percent && !definition_atomic => {
-                        self.pos += 1;
-                        definition_percent = true;
-                        // `%?` — the optional preferred-word discriminator.
-                        // The `?` must touch the `%` (no whitespace).
-                        if self.peek() == Some(b'?') {
-                            self.pos += 1;
-                            definition_preferred = true;
+                    let kw_span = self.span();
+                    let kw = self.parse_ident()?;
+                    match kw.as_str() {
+                        "partial" => {
+                            if lenient_span.is_some() {
+                                return Err(self.err("duplicate `partial` ascription".into()));
+                            }
+                            if definition_atomic || definition_percent {
+                                return Err(self.err(
+                                    "`partial` must come before `atomic` / `reserved` / `preferred`"
+                                        .into(),
+                                ));
+                            }
+                            lenient_span = Some(kw_span);
+                        }
+                        "atomic" | "reserved" | "preferred" => {
+                            if definition_atomic || definition_percent {
+                                return Err(self.err(
+                                    "`atomic`, `reserved`, and `preferred` are mutually exclusive"
+                                        .into(),
+                                ));
+                            }
+                            definition_atomic = kw == "atomic";
+                            definition_percent = kw != "atomic";
+                            definition_preferred = kw == "preferred";
+                        }
+                        other => {
+                            return Err(self.err(format!(
+                                "unknown ascription `{other}`; expected `partial`, `atomic`, \
+                                 `reserved`, or `preferred`"
+                            )));
                         }
                     }
-                    _ => break,
+                    count += 1;
+                }
+                if count == 0 {
+                    return Err(self.err(
+                        "`:` must be followed by at least one ascription (`partial`, \
+                         `atomic`, `reserved`, `preferred`)"
+                            .into(),
+                    ));
                 }
             }
-            // A leftover `*`/`%` here means the two were combined
-            // (`*%name`, `%*name`) or doubled — reject with a clear error
-            // instead of a confusing "expected rule name".
-            if matches!(self.peek(), Some(b'*') | Some(b'%')) {
-                return Err(self.err(
-                    "the `*` (atomic) and `%` (reserved-word) rule qualifiers cannot be combined"
-                        .into(),
-                ));
-            }
             let definition_lenient = lenient_span.is_some();
-            let name_byte = self.pos;
-            let name = self.parse_ident()?;
             self.skip_ws();
             self.expect_str("=")?;
             self.skip_ws();
@@ -390,17 +408,18 @@ impl<'a> Parser<'a> {
             // still *reference* them (`!reserved`).
             if name == RESERVED_RULE || name == PREFERRED_RULE {
                 return Err(self.err(format!(
-                    "`{name}` is a compiler-generated rule (synthesized from the `%` / `%?` rules) \
-                     and cannot be defined explicitly; reference it (e.g. `!{name}`) instead"
+                    "`{name}` is a compiler-generated rule (synthesized from the `reserved` / \
+                     `preferred` ascriptions) and cannot be defined explicitly; reference it \
+                     (e.g. `!{name}`) instead"
                 )));
             }
             // The three special rules — the start rule `root` and the two
             // auto-insertion targets `trivia` (whitespace) and `wb` (word
             // boundary) — are structural slots wrapped or injected by the
-            // compiler, not lexable tokens, so every qualifier (`*`, `~`,
-            // `%`, `%?`) is meaningless on them and rejected. Disabling
-            // whitespace auto-insertion is done by omitting `trivia`, not
-            // by qualifying it.
+            // compiler, not lexable tokens, so every ascription
+            // (`partial`, `atomic`, `reserved`, `preferred`) is meaningless
+            // on them and rejected. Disabling whitespace auto-insertion is
+            // done by omitting `trivia`, not by ascribing it.
             if (definition_atomic
                 || definition_percent
                 || definition_preferred
@@ -414,7 +433,8 @@ impl<'a> Parser<'a> {
                     ""
                 };
                 return Err(self.err(format!(
-                    "the `{name}` rule cannot carry a qualifier (`*`, `~`, `%`, `%?`){disable_hint}"
+                    "the `{name}` rule cannot carry an ascription (`partial`, `atomic`, \
+                     `reserved`, `preferred`){disable_hint}"
                 )));
             }
             if definition_percent {
@@ -626,26 +646,22 @@ impl<'a> Parser<'a> {
         match self.peek() {
             None => false,
             Some(b'/') | Some(b')') | Some(b'}') => false,
-            Some(b'=') => false, // start of next rule's "="
+            // Start of the next rule's `=` or its `: ascription` slot.
+            Some(b'=') | Some(b':') => false,
             // `^` is the catch operator at infix position — leave it
             // for `parse_catch`. Future overlays (e.g. `^!lbl` throw
             // atom, `^_` anonymous catch) live in the reserved
             // `^<non-ident-byte>` slot; when added, this function
             // grows a one-byte lookahead.
             Some(b'^') => false,
-            // `~` is a definition-level marker on the NEXT rule. There
-            // is no call-site form, so `~` is never a valid in-body
-            // atom-start: fall through and let the sequence terminate
-            // here, letting `parse_grammar` consume `~name = ...`.
-            Some(b'~') => false,
             Some(c) if is_ident_start(c) => !self.looks_like_rule_def(),
             Some(c) => is_atom_start(c),
         }
     }
 
     /// Look ahead from the current position to determine whether what follows is
-    /// `ident = ...` (a new rule definition) rather than a non-terminal reference
-    /// in an expression. Does not consume input.
+    /// `ident = ...` or `ident: ascription ... = ...` (a new rule definition)
+    /// rather than a non-terminal reference in an expression. Does not consume input.
     fn looks_like_rule_def(&self) -> bool {
         let mut p = self.pos;
         // Skip identifier
@@ -669,7 +685,7 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        p < self.src.len() && self.src[p] == b'='
+        p < self.src.len() && (self.src[p] == b'=' || self.src[p] == b':')
     }
 
     fn parse_prefix(&mut self) -> Result<Pattern, ParseError> {

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -114,7 +114,7 @@ pub enum Pattern {
     /// `lint_partial_match` walker treats this as an opaque barrier and
     /// does not descend into it for call-site detection. At runtime the
     /// wrapper is transparent: the compiler emits exactly the inner
-    /// pattern's bytecode. Surface syntax: postfix `~p`.
+    /// pattern's bytecode. Surface syntax: the `name: partial` ascription.
     Lenient {
         inner: Box<Pattern>,
         span: Span,

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1723,14 +1723,13 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
     );
 }
 
-// ---- Definition-level lenient marker (~rule_name = body) -----
+// ---- Partial ascription (name: partial = body) ---------------
 
 #[test]
-fn definition_lenient_marker_wraps_rule_body() {
-    // `~rule = body` parses the body with a top-level `Pattern::Lenient`
-    // wrap, exposing the intent to the lint via the same AST node the
-    // call-site `~p` form produces.
-    let g = parse("~r = 'a'?").expect("parse");
+fn partial_ascription_wraps_rule_body() {
+    // `name: partial = body` parses the body with a top-level
+    // `Pattern::Lenient` wrap, exposing the intent to the lint.
+    let g = parse("r: partial = 'a'?").expect("parse");
     assert_eq!(
         g.rules["r"].strip_spans(),
         Pattern::lenient(Pattern::optional(Pattern::literal("a"))),
@@ -1738,10 +1737,13 @@ fn definition_lenient_marker_wraps_rule_body() {
 }
 
 #[test]
-fn definition_lenient_marker_requires_touching_name() {
-    let err = parse("~ r = 'a'?").expect_err("space between `~` and name must error");
+fn partial_must_precede_main_ascription() {
+    // `partial` composes with `atomic` / `reserved` / `preferred` but
+    // must be written first; the reversed order is a parse error.
+    parse("r: partial atomic = 'a'").expect("partial-first order parses");
+    let err = parse("r: atomic partial = 'a'").expect_err("partial after main must error");
     assert!(
-        err.message.contains("expected identifier"),
+        err.message.contains("`partial` must come before"),
         "unexpected error: {}",
         err.message
     );
@@ -1759,24 +1761,24 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
         "baseline: unmarked grammar should flag r"
     );
 
-    let marked = parse("root = (r)*^[;]\n~r = 'x' 'y'?").expect("parse marked");
+    let marked = parse("root = (r)*^[;]\nr: partial = 'x' 'y'?").expect("parse marked");
     let findings = lint_partial_match(&marked);
     assert!(
         !findings.iter().any(|f| f.rule == "r"),
-        "definition-level `~r` should suppress all r-related findings, got: {findings:?}"
+        "definition-level `r: partial` should suppress all r-related findings, got: {findings:?}"
     );
 }
 
 #[test]
 fn definition_lenient_marker_is_runtime_transparent() {
-    // The `~name =` wrap compiles to the same bytecode as the bare
-    // form. The marker rides a non-special helper rule — `root` (like
-    // `trivia` / `wb`) rejects every qualifier.
+    // The `name: partial =` wrap compiles to the same bytecode as the
+    // bare form. The marker rides a non-special helper rule — `root`
+    // (like `trivia` / `wb`) rejects every ascription.
     let plain = parse("root = r\nr = 'x'+")
         .expect("parse plain")
         .compile()
         .expect("compile plain");
-    let marked = parse("root = r\n~r = 'x'+")
+    let marked = parse("root = r\nr: partial = 'x'+")
         .expect("parse marked")
         .compile()
         .expect("compile marked");
@@ -1803,9 +1805,9 @@ fn compile_errors_on_partial_match_leniency() {
 
 #[test]
 fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
-    let g = parse("root = (r)*^[;]\n~r = 'x' 'y'?").expect("parse");
+    let g = parse("root = (r)*^[;]\nr: partial = 'x' 'y'?").expect("parse");
     g.compile()
-        .expect("compile should succeed with definition-level `~r`");
+        .expect("compile should succeed with definition-level `r: partial`");
 }
 
 #[test]
@@ -2096,7 +2098,7 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     assert_eq!(*lit_span, Span { line: 1, col: 12 });
 }
 
-// ---- `%` reserved-word sigil + `wb` special rule -------------------
+// ---- `reserved` ascription + `wb` special rule --------------------
 
 /// Compile a grammar from source and run it, returning the captures
 /// paired with their resolved kind name and matched text.
@@ -2118,32 +2120,33 @@ fn run_grammar<'a>(src: &str, input: &'a str) -> Vec<(String, &'a str)> {
 }
 
 #[test]
-fn percent_sigil_populates_percent_and_atomic_sets() {
-    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\n%r = @keyword 'if'").expect("parse");
+fn reserved_ascription_populates_percent_and_atomic_sets() {
+    let g =
+        parse("root = r\ntrivia = (\\s)*\nwb = !'x'\nr: reserved = @keyword 'if'").expect("parse");
     assert!(
         g.percent_rules.contains("r"),
-        "`%r` should be a percent rule"
+        "`r: reserved` should be a percent rule"
     );
     assert!(
         g.atomic_rules.contains("r"),
-        "a `%` rule is also atomic (trivia is not auto-inserted inside it)"
+        "a `reserved` rule is also atomic (trivia is not auto-inserted inside it)"
     );
 }
 
 #[test]
-fn qualifier_on_special_rule_is_rejected() {
+fn ascription_on_special_rule_is_rejected() {
     // The three special rules — the start rule `root` and the two
     // auto-insertion targets `trivia` (whitespace) and `wb` (word
     // boundary) — are structural slots, not lexable tokens: every
-    // qualifier (`*`, `~`, `%`, `%?`) is rejected on all of them.
-    // Disabling whitespace auto-insertion is done by omitting `trivia`,
-    // not by qualifying it.
+    // ascription (`partial`, `atomic`, `reserved`, `preferred`) is
+    // rejected on all of them. Disabling whitespace auto-insertion is
+    // done by omitting `trivia`, not by ascribing it.
     for name in ["root", "trivia", "wb"] {
-        for qual in ["*", "~", "%", "%?"] {
-            let src = format!("{qual}{name} = 'a'");
-            let err = parse(&src).expect_err("a qualifier on a special rule must error");
+        for asc in ["partial", "atomic", "reserved", "preferred"] {
+            let src = format!("{name}: {asc} = 'a'");
+            let err = parse(&src).expect_err("an ascription on a special rule must error");
             assert!(
-                err.message.contains("cannot carry a qualifier"),
+                err.message.contains("cannot carry an ascription"),
                 "{src:?}: unexpected error {:?}",
                 err.message
             );
@@ -2158,31 +2161,32 @@ fn qualifier_on_special_rule_is_rejected() {
 }
 
 #[test]
-fn percent_composes_with_lenient() {
-    // `~%name` and `%~name` both parse: `~` (lenient) and `%`
-    // (reserved-word) are independent markers.
-    for src in [
-        "root = r\ntrivia = (\\s)*\nwb = !'x'\n~%r = @keyword 'if'",
-        "root = r\ntrivia = (\\s)*\nwb = !'x'\n%~r = @keyword 'if'",
-    ] {
-        let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
-        assert!(
-            g.percent_rules.contains("r"),
-            "{src:?} should mark r percent"
-        );
-    }
+fn partial_composes_with_reserved() {
+    // `partial reserved` combines the leniency marker with the
+    // reserved-word ascription (partial written first).
+    let src = "root = r\ntrivia = (\\s)*\nwb = !'x'\nr: partial reserved = @keyword 'if'";
+    let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
+    assert!(
+        g.percent_rules.contains("r"),
+        "{src:?} should mark r percent"
+    );
+    assert!(
+        matches!(g.rules["r"], Pattern::Lenient { .. }),
+        "{src:?} should wrap r in Lenient"
+    );
 }
 
 #[test]
 fn percent_rule_appends_wb_inside_capture() {
-    // `%kw_if` must match the keyword `if` but not fire on `ifx`, and
-    // (the leak guard) must leave no stray `if` capture behind on `ifx`.
+    // `kw_if: reserved` must match the keyword `if` but not fire on
+    // `ifx`, and (the leak guard) must leave no stray `if` capture
+    // behind on `ifx`.
     let src = "root = (token)*^\n\
                trivia = (\\s)*\n\
                wb = !ident_body\n\
                token = kw_if / @variable ident\n\
-               %kw_if = @keyword 'if'\n\
-               *ident = [a-z] ident_body*\n\
+               kw_if: reserved = @keyword 'if'\n\
+               ident: atomic = [a-z] ident_body*\n\
                ident_body = [a-z0-9_]";
     assert_eq!(
         run_grammar(src, "if ifx if"),
@@ -2196,9 +2200,9 @@ fn percent_rule_appends_wb_inside_capture() {
 
 #[test]
 fn percent_without_wb_errors_undefined_rule() {
-    // A `%` rule emits a `NonTerminal("wb")`; with no `wb` defined the
-    // reference surfaces as `UndefinedRule("wb")`.
-    let g = parse("root = r\ntrivia = (\\s)*\n%r = @keyword 'if'").expect("parse");
+    // A `reserved` rule emits a `NonTerminal("wb")`; with no `wb`
+    // defined the reference surfaces as `UndefinedRule("wb")`.
+    let g = parse("root = r\ntrivia = (\\s)*\nr: reserved = @keyword 'if'").expect("parse");
     match g.compile().expect_err("compile should fail without wb") {
         syntax_highlighter::pegc::CompileError::UndefinedRule(name) => assert_eq!(name, "wb"),
         other => panic!("expected UndefinedRule(\"wb\"), got: {other:?}"),
@@ -2206,11 +2210,11 @@ fn percent_without_wb_errors_undefined_rule() {
 }
 
 #[test]
-fn percent_and_atomic_combined_is_parse_error() {
-    for src in ["%*r = 'a'", "*%r = 'a'"] {
-        let err = parse(src).expect_err("combining `%` and `*` must error");
+fn reserved_and_atomic_combined_is_parse_error() {
+    for src in ["r: reserved atomic = 'a'", "r: atomic reserved = 'a'"] {
+        let err = parse(src).expect_err("combining `reserved` and `atomic` must error");
         assert!(
-            err.message.contains("cannot be combined"),
+            err.message.contains("mutually exclusive"),
             "{src:?} unexpected error: {}",
             err.message
         );
@@ -2238,35 +2242,42 @@ fn wb_and_trivia_compose_in_either_order() {
 #[test]
 fn wb_without_trivia_is_valid() {
     // `wb` does not require `trivia`; a grammar may define only `wb`.
-    parse("root = r\nwb = !'x'\n%r = @keyword 'if'")
+    parse("root = r\nwb = !'x'\nr: reserved = @keyword 'if'")
         .expect("parse")
         .compile()
         .expect("compile");
 }
 
-// ---- `%?` preferred-word sigil + synthesized reserved / preferred ---
+// ---- `preferred` ascription + synthesized reserved / preferred -----
 
 #[test]
-fn preferred_sigil_populates_preferred_and_percent_sets() {
-    // `%?r` is a preferred-word rule: it lands in `preferred_rules`, and
-    // also in `percent_rules` + `atomic_rules` (it still gets the `wb`
-    // boundary; it differs from `%` only in which synthesized set it
-    // feeds).
-    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\n%?r = @keyword 'async'").expect("parse");
-    assert!(g.preferred_rules.contains("r"), "`%?r` should be preferred");
+fn preferred_ascription_populates_preferred_and_percent_sets() {
+    // `r: preferred` is a preferred-word rule: it lands in
+    // `preferred_rules`, and also in `percent_rules` + `atomic_rules`
+    // (it still gets the `wb` boundary; it differs from `reserved` only
+    // in which synthesized set it feeds).
+    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\nr: preferred = @keyword 'async'")
+        .expect("parse");
+    assert!(
+        g.preferred_rules.contains("r"),
+        "`r: preferred` should be preferred"
+    );
     assert!(
         g.percent_rules.contains("r"),
-        "`%?r` is still a percent rule (gets `wb`)"
+        "`r: preferred` is still a percent rule (gets `wb`)"
     );
-    assert!(g.atomic_rules.contains("r"), "`%?r` is also atomic");
+    assert!(
+        g.atomic_rules.contains("r"),
+        "`r: preferred` is also atomic"
+    );
 }
 
 #[test]
 fn preferred_and_atomic_combined_is_parse_error() {
-    for src in ["%?*r = 'a'", "*%?r = 'a'"] {
-        let err = parse(src).expect_err("combining `%?` and `*` must error");
+    for src in ["r: preferred atomic = 'a'", "r: atomic preferred = 'a'"] {
+        let err = parse(src).expect_err("combining `preferred` and `atomic` must error");
         assert!(
-            err.message.contains("cannot be combined"),
+            err.message.contains("mutually exclusive"),
             "{src:?} unexpected error: {}",
             err.message
         );
@@ -2276,12 +2287,12 @@ fn preferred_and_atomic_combined_is_parse_error() {
 #[test]
 fn defining_synthesized_rule_is_parse_error() {
     // `reserved` / `preferred` are compiler-generated; an explicit
-    // definition (with or without a sigil) is rejected.
+    // definition (with or without an ascription) is rejected.
     for src in [
         "reserved = 'a'",
-        "%reserved = 'a'",
+        "reserved: reserved = 'a'",
         "preferred = 'a'",
-        "%?preferred = 'a'",
+        "preferred: preferred = 'a'",
     ] {
         let err = parse(src).expect_err("defining a synthesized rule must error");
         assert!(
@@ -2294,9 +2305,9 @@ fn defining_synthesized_rule_is_parse_error() {
 
 #[test]
 fn reserved_preferred_conflict_errors() {
-    // The same literal marked `%` (reserved) in one rule and `%?`
-    // (preferred) in another is a contradiction — compile rejects it.
-    let err = parse("root = 'x'\nwb = !'y'\n%a = 'int'\n%?b = 'int'")
+    // The same literal marked `reserved` in one rule and `preferred`
+    // in another is a contradiction — compile rejects it.
+    let err = parse("root = 'x'\nwb = !'y'\na: reserved = 'int'\nb: preferred = 'int'")
         .expect("parse")
         .compile()
         .expect_err("conflicting reserved/preferred must error");
@@ -2310,18 +2321,18 @@ fn reserved_preferred_conflict_errors() {
 
 #[test]
 fn synthesized_reserved_trie_and_preferred_membership() {
-    // `%kw_word` is reserved with a deliberately wrong source order
-    // (`int` before `int8`); the synthesized `reserved` / keyword trie
-    // still matches `int8` maximally (#13 fixed structurally). `%?pre`
-    // (`len`) is preferred, so it is excluded from `reserved` and stays
-    // usable as an identifier.
+    // `kw_word: reserved` has a deliberately wrong source order (`int`
+    // before `int8`); the synthesized `reserved` / keyword trie still
+    // matches `int8` maximally (#13 fixed structurally). `pre: preferred`
+    // (`len`) is excluded from `reserved` and stays usable as an
+    // identifier.
     let src = "root = (token)*^\n\
                trivia = (\\s)*\n\
                wb = !ident_body\n\
                token = @keyword kw_word / @variable ident\n\
-               %kw_word = 'int' / 'int8'\n\
-               %?pre = 'len'\n\
-               *ident = !reserved [a-z] ident_body*\n\
+               kw_word: reserved = 'int' / 'int8'\n\
+               pre: preferred = 'len'\n\
+               ident: atomic = !reserved [a-z] ident_body*\n\
                ident_body = [a-z0-9]";
     assert_eq!(
         run_grammar(src, "int8 len int"),

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -815,13 +815,13 @@ fn inferred_vs_explicit_no_ambiguity() {
     );
 }
 
-// ---- Lenient marker (definition-level only) -------------------
+// ---- Partial ascription (definition-level only) ---------------
 //
-// Definition-level `~name = body` parsing is verified end-to-end by
-// the `definition_lenient_marker_*` tests in `tests/compiler_tests.rs`.
-// The call-site `~p` form was considered during design and dropped
-// before landing: empirically zero shipped grammars used it after the
-// pivot to definition-level marking.
+// Definition-level `name: partial = body` parsing is verified
+// end-to-end by the `partial_ascription_*` tests in
+// `tests/compiler_tests.rs`. A call-site leniency form was considered
+// during design and dropped before landing: empirically zero shipped
+// grammars used it after the pivot to definition-level marking.
 
 #[test]
 fn catch_accepts_underscore_prefixed_labels() {
@@ -1179,10 +1179,10 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
 fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
     // The marker rides a non-special helper rule — `root` (like
-    // `trivia` / `wb`) rejects every qualifier.
+    // `trivia` / `wb`) rejects every ascription.
     let plain = parse("root = r\nr = 'x'+").compile().unwrap();
-    let lenient = parse("root = r\n~r = 'x'+").compile().unwrap();
-    assert_eq!(plain.code, lenient.code, "`~` is runtime-transparent");
+    let lenient = parse("root = r\nr: partial = 'x'+").compile().unwrap();
+    assert_eq!(plain.code, lenient.code, "`partial` is runtime-transparent");
     let r = VM::new(&lenient.code, b"xxx").run();
     assert!(r.complete);
     assert_eq!(r.matched, 3);


### PR DESCRIPTION
Next step of the staged `.peg` surface-syntax redesign: the symbolic rule-qualifier sigils become readable postfix **ascriptions** written between the name and `=`. `~name =` → `name: partial =`, `*name =` → `name: atomic =`, `%name =` → `name: reserved =`, `%?name =` → `name: preferred =`.

The keywords are *contextual* — special only in the `name: … =` slot, usable as ordinary rule names and references everywhere else. `atomic` / `reserved` / `preferred` stay mutually exclusive (each makes a rule atomic); `partial` composes with any one of them and, when present, must be written first (`name: partial atomic =`). The three special rules `root` / `trivia` / `wb` reject every ascription, exactly as they rejected every sigil.

The parser swaps the prefix-sigil scan for a postfix ascription parse after the name (and teaches the two rule-boundary lookaheads about the `:`); the rest is the mechanical port of every grammar, fixture, inline test grammar, and doc. Continuation lines in multi-line rules are re-indented to track the body, which now starts further right.
