### PR TITLE
pegc: rename special rules trivia->ignore, wb->boundary

### DIFF
--- a/.claude/skills/grammar-refactor/SKILL.md
+++ b/.claude/skills/grammar-refactor/SKILL.md
@@ -56,13 +56,13 @@ for f in /tmp/grammar-refactor/*.ndjson; do
   g=$(basename "$f" .ndjson)
   echo "=== $g ==="
   echo "-- single-use, excluding reserved --"
-  tail -n +2 "$f" | jq -r 'select(.references==1 and .rule!="trivia" and .rule!="root" and .rule!="wb") | "\(.rule) (\(.body_chars) chars)"'
+  tail -n +2 "$f" | jq -r 'select(.references==1 and .rule!="ignore" and .rule!="root" and .rule!="boundary") | "\(.rule) (\(.body_chars) chars)"'
   echo "-- name length >= body chars, excluding reserved --"
-  tail -n +2 "$f" | jq -r 'select((.rule|length) >= .body_chars and .rule!="trivia" and .rule!="root" and .rule!="wb") | "\(.rule) (name=\(.rule|length), body=\(.body_chars), refs=\(.references))"'
+  tail -n +2 "$f" | jq -r 'select((.rule|length) >= .body_chars and .rule!="ignore" and .rule!="root" and .rule!="boundary") | "\(.rule) (name=\(.rule|length), body=\(.body_chars), refs=\(.references))"'
 done
 ```
 
-`root`, `trivia`, and `wb` are reserved (`src/pegc/parser.rs` enforces) — never candidates. `reserved` and `preferred` are compiler-*synthesized* (from the `reserved` / `preferred` rules) and can't be defined at all. A `reserved`- or `preferred`-ascribed rule is also off-limits to inlining: see the *Atomicity check* below.
+`root`, `ignore`, and `boundary` are reserved (`src/pegc/parser.rs` enforces) — never candidates. `reserved` and `preferred` are compiler-*synthesized* (from the `reserved` / `preferred` rules) and can't be defined at all. A `reserved`- or `preferred`-ascribed rule is also off-limits to inlining: see the *Atomicity check* below.
 
 ### 3. For each candidate, evaluate
 
@@ -75,18 +75,18 @@ Open the grammar, read the rule, read its callers, and read any comments above t
 
 ### 4. Atomicity check (correctness-critical)
 
-Inlining changes which rule the auto-trivia rewriter is walking. From `src/pegc/analysis.rs::inject_auto_trivia`:
+Inlining changes which rule the auto-ignore rewriter is walking. From `src/pegc/analysis.rs::inject_auto_ignore`:
 
-- Trivia is auto-inserted between consecutive Sequence elements *of non-atomic rules*. NonTerminal calls are leaves from the rewriter's POV.
-- Inlining an **atomic** rule body into a **non-atomic** caller exposes the body to auto-injection — trivia will now appear between its elements where it didn't before.
+- Ignore is auto-inserted between consecutive Sequence elements *of non-atomic rules*. NonTerminal calls are leaves from the rewriter's POV.
+- Inlining an **atomic** rule body into a **non-atomic** caller exposes the body to auto-injection — ignore will now appear between its elements where it didn't before.
 - Inlining a **non-atomic** rule body into an **atomic** caller suppresses auto-injection where it used to fire.
 
 Safe shapes regardless of atomicity:
-- Body is a single char class, single literal, single NonTerminal, or single Repeat-of-NonTerminal — no internal Sequence, so no internal trivia injection to gain or lose.
+- Body is a single char class, single literal, single NonTerminal, or single Repeat-of-NonTerminal — no internal Sequence, so no internal ignore injection to gain or lose.
 
 When the body has internal Sequence elements (e.g. `'foo' bar baz`), inlining is **only safe when source and target rule atomicity match**. Verify by reading the `atomic` (or `reserved` / `preferred`) ascription on both rule headers before changing anything.
 
-**`reserved` / `preferred` rules are never inline candidates.** A `name: reserved =` (or `name: preferred =`) rule carries an *implicit* trailing `wb` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `reserved` / `preferred` rules (and the `wb` rule itself) alone.
+**`reserved` / `preferred` rules are never inline candidates.** A `name: reserved =` (or `name: preferred =`) rule carries an *implicit* trailing `boundary` boundary that the compiler appends inside the rule's captures; the boundary is invisible in the rule body, so inlining the body silently drops it — the same class of hazard as the atomic case above, but worse because there's no `!ident_body` in the source to tip you off. The rule's literals are also collected into the synthesized `reserved` / `preferred` sets, so renaming or splitting it shifts what `!reserved` blocks. Leave `reserved` / `preferred` rules (and the `boundary` rule itself) alone.
 
 ### 5. Report
 
@@ -109,10 +109,10 @@ The applied edit is mechanical at this point — the judgment was the previous s
 - **Bulk-inlining all refs=1 rules.** Most refs=1 rules are spec-significant cascade entries (every binary-precedence level, every statement form, every type-position-specific entry). Inlining them produces an unreadable wall of alternation.
 - **Inlining across atomicity boundaries without checking.** Will silently change parsing behavior — usually in a way that's not caught by the unit tests but shows up in the highlighter fixtures or recovery baselines.
 - **Forgetting to update the grammar header comment** when removing a rule that's named there.
-- **Touching `root`, `trivia`, `wb`, `reserved`, `preferred`, or any `reserved` / `preferred` rule.** `root` / `trivia` / `wb` are reserved (the parser rejects grammars that mangle their position); `reserved` / `preferred` are compiler-synthesized (defining them is a parse error); `reserved` / `preferred` rules carry an invisible trailing `wb` boundary that inlining would drop *and* feed the synthesized sets. Filter all of these out before evaluating.
+- **Touching `root`, `ignore`, `boundary`, `reserved`, `preferred`, or any `reserved` / `preferred` rule.** `root` / `ignore` / `boundary` are reserved (the parser rejects grammars that mangle their position); `reserved` / `preferred` are compiler-synthesized (defining them is a parse error); `reserved` / `preferred` rules carry an invisible trailing `boundary` boundary that inlining would drop *and* feed the synthesized sets. Filter all of these out before evaluating.
 - **Touching the `sqlite.peg` `kw_*` / `*_body` cluster.** Each `kw_*` rule has refs=1 by construction (one keyword, one statement-rule use), but the two-tier `kw_*` → `*_body` design is a deliberate convention. The `kw_*: reserved` literals are also the source of the synthesized `reserved` set (the no-keyword-as-identifier lookahead, `!reserved`); window-vocabulary keywords are `kw_*: preferred` so they stay usable as identifiers. Don't sweep these.
 
 ## Reference PRs
 
-- #123 — the big sweep across all eight grammars (post-#86 / #87 cleanup; collapsed `trivia = ws`, inlined thin aliases, folded block-comment patterns into `..=`).
-- #136 — the small follow-up (four trivial single-use aliases left after #123 and the implicit-`root`/`trivia` PR #132).
+- #123 — the big sweep across all eight grammars (post-#86 / #87 cleanup; collapsed `ignore = ws`, inlined thin aliases, folded block-comment patterns into `..=`).
+- #136 — the small follow-up (four trivial single-use aliases left after #123 and the implicit-`root`/`ignore` PR #132).

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -101,7 +101,7 @@ every rule appears, including unreferenced ones):
 | `references` | Total occurrences of `<rule>` as a `NonTerminal` across every rule's body.   |
 | `body_chars` | Source character count of the rule's body (after `=`), trimmed.             |
 
-`references` counts **author-written** `NonTerminal` calls in rule bodies. The auto-injected `trivia` calls produced by `src/pegc/analysis.rs::inject_auto_trivia` are not counted, so the reserved `trivia` rule typically reports `references: 0` even though it is the most-invoked rule at runtime. Use the count to find dead or single-use rules in *authored* grammar source; do not read it as runtime call frequency.
+`references` counts **author-written** `NonTerminal` calls in rule bodies. The auto-injected `ignore` calls produced by `src/pegc/analysis.rs::inject_auto_ignore` are not counted, so the reserved `ignore` rule typically reports `references: 0` even though it is the most-invoked rule at runtime. Use the count to find dead or single-use rules in *authored* grammar source; do not read it as runtime call frequency.
 
 **Stdin:** not accepted — `stats` always takes a `<grammar.peg>` path.
 
@@ -250,7 +250,7 @@ for "what did the parser actually recover from, and where?"
 | `kind`       | Capture-kind name — always `"recovery"`. Emitted for symmetry with `captures dump`. |
 | `label`      | The catch's label name — author-supplied for `^label`, or `recovery_kind`'s intern for bare `*^`. |
 | `pos`        | Deepest byte offset reached by the failed iterations that contributed to this span. May sit anywhere relative to `end` — it's where the deepest dive happened, not where resync succeeded. |
-| `rule_stack` | The full trivia-trimmed call stack at the moment `pos` was set, root-to-leaf. Trailing frames reached from the reserved `trivia` rule are popped; the leaf is the deepest semantically interesting rule. |
+| `rule_stack` | The full ignore-trimmed call stack at the moment `pos` was set, root-to-leaf. Trailing frames reached from the reserved `ignore` rule are popped; the leaf is the deepest semantically interesting rule. |
 | `literal`    | The span's bytes as a JSON string (subject to `--max-literal=N`).                   |
 
 A *recovery span* is a maximal contiguous run of `kind == "recovery"`
@@ -308,7 +308,7 @@ thousands of recovery rows into a handful of bug-class lines.
 
 **Output:** one cluster per line on stdout in the form
 `<count> recoveries — farthest reach ends at <rule> (label: <name>)`,
-where `<rule>` is the leaf of the trivia-trimmed rule stack the failed
+where `<rule>` is the leaf of the ignore-trimmed rule stack the failed
 iterations reached deepest, and `<name>` is the catch label.
 Clusters are sorted by `<count>` descending. When the parse produces
 no recoveries and no orphan rows, the single line `no recoveries` is
@@ -339,7 +339,7 @@ $ pegdb recoveries explain -g grammars/rust.peg /tmp/broken.rs
 $ pegdb recoveries explain -g grammars/go.peg benches/fixtures/xlarge.go | head -1
 ```
 
-The cluster key is the full trivia-trimmed rule stack plus the catch
+The cluster key is the full ignore-trimmed rule stack plus the catch
 label — two recoveries are in the same cluster iff they reached the
 same leaf via the same intermediate frames under the same label.
 

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -31,11 +31,11 @@
 
 root = (external_decl)*^
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Per C11 §6.4.2.1 identifier-continue.
-wb = !ident_body
+boundary = !ident_body
 
 # --- Preprocessor directives (absorbed as @comment) ------------------
 
@@ -64,7 +64,7 @@ decl_spec = storage_spec
           / type_spec
           / fn_spec
 
-# `%` reserved-word rules: compiled atomic, with a `wb` boundary call
+# `%` reserved-word rules: compiled atomic, with a `boundary` boundary call
 # appended inside each keyword capture. A keyword can't fire on a longer
 # identifier that merely starts with it (`static MyType`, `typedefx`),
 # and a rejected keyword leaves no stray capture for recovery to surface.
@@ -82,7 +82,7 @@ fn_spec: reserved = @keyword 'inline'
                   / @keyword '_Noreturn'
 
 # Embedded keyword tokens: one `%` rule per keyword, referenced wherever
-# the keyword appears so the `wb` boundary is applied uniformly.
+# the keyword appears so the `boundary` boundary is applied uniformly.
 kw_struct: reserved = @keyword 'struct'
 kw_union: reserved = @keyword 'union'
 kw_enum: reserved = @keyword 'enum'
@@ -118,7 +118,7 @@ predef_type_name: reserved = 'void' / 'char' / 'short' / 'long long' / 'long'
 # greedy `ident_body*` would swallow the trailing `_t`.
 typedef_name: atomic = [A-Z] ident_body*
                      / [a-z_] (!typedef_t_end ident_body)* typedef_t_end
-typedef_t_end: atomic = '_t' wb
+typedef_t_end: atomic = '_t' boundary
 
 struct_or_union_spec = (kw_struct / kw_union)
                       (@type ident)? (@punctuation '{' struct_decl* @punctuation '}')?
@@ -280,7 +280,7 @@ expr_primary = string_lit
              / @variable ident
 
 # Boolean / null constants as a `%?` preferred-word alternation so the
-# `wb` boundary keeps `trueish` / `NULLify` from matching the prefix.
+# `boundary` boundary keeps `trueish` / `NULLify` from matching the prefix.
 lit_const: preferred = @constant 'true'
                      / @constant 'false'
                      / @constant 'NULL'

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -25,7 +25,7 @@
 
 root = (statement)*^
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 
 statement = at_rule
            / rule

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -26,16 +26,16 @@
 
 root = package_clause import_decl* (top_decl)*^
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Go spec identifier-continue).
-wb = !ident_body
+boundary = !ident_body
 
 # --- Keyword tokens --------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
-# keyword appears so the `wb` boundary is applied uniformly: a keyword
+# keyword appears so the `boundary` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`funcx`).
 kw_package: reserved = @keyword 'package'
 kw_import: reserved = @keyword 'import'
@@ -363,7 +363,7 @@ expr_no_compound_list = expr_no_compound (@punctuation ',' expr_no_compound)*
 
 literal = string_lit / number_lit / rune_lit / lit_const
 
-# Predeclared constants as a `%?` preferred-word alternation so the `wb`
+# Predeclared constants as a `%?` preferred-word alternation so the `boundary`
 # boundary keeps `trueish` / `nilish` from matching the prefix.
 lit_const: preferred = @constant 'true' / @constant 'false'
                      / @constant 'nil' / @constant 'iota'
@@ -420,7 +420,7 @@ predeclared_fn: preferred = 'append' / 'cap' / 'close' / 'complex' / 'copy'
 # --- Whitespace / comments / semicolon handling ----------------------
 
 # Go uses newlines as statement terminators (lexer-inserted `;`); here
-# we accept optional explicit `;` and let `trivia` eat whitespace.
+# we accept optional explicit `;` and let `ignore` eat whitespace.
 # `~`-marked: ASI absorption is intentional everywhere this is called.
 opt_semi: partial = @punctuation ';'?
 

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -31,16 +31,16 @@
 
 root = (stmt)*^
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (ECMAScript IdentifierPartChar).
-wb = !ident_body
+boundary = !ident_body
 
 # --- Keyword tokens ---------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
-# keyword appears so the `wb` boundary is applied uniformly. This
+# keyword appears so the `boundary` boundary is applied uniformly. This
 # matters most for the contextual keywords (`async`, `as`, `of`,
 # `from`, `get`, `set`, `static`, `yield`) deliberately kept out of
 # `reserved` so they remain usable as identifiers: `{ asyncFoo() {} }`
@@ -366,7 +366,7 @@ literal = template_lit
         / lit_const
         / lit_undefined
 
-# Boolean / null / undefined constants; the `wb` boundary keeps
+# Boolean / null / undefined constants; the `boundary` boundary keeps
 # `trueish` / `nullish` from matching the prefix.
 lit_const: reserved = @constant 'true' / @constant 'false' / @constant 'null'
 lit_undefined: preferred = @constant 'undefined'

--- a/grammars/json.peg
+++ b/grammars/json.peg
@@ -2,7 +2,7 @@
 
 root = value
 
-trivia = \s*
+ignore = \s*
 
 value = @string string
       / @number number

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -26,16 +26,16 @@
 
 root = (item)*^
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier (Rust Reference XID_Continue).
-wb = !ident_body
+boundary = !ident_body
 
 # --- Keyword tokens ----------------------------------------------------
 #
 # One `%` reserved-word rule per keyword, referenced wherever the
-# keyword appears so the `wb` boundary is applied uniformly: a keyword
+# keyword appears so the `boundary` boundary is applied uniformly: a keyword
 # can't fire on a longer identifier that starts with it (`fnfoo`).
 kw_use: reserved = @keyword 'use'
 kw_as: reserved = @keyword 'as'
@@ -454,7 +454,7 @@ let_stmt = kw_let pattern (@punctuation ':' type_expr)?
 # and Rust string / char / comment literals so we don't mis-balance
 # a `}` inside a string. This is the pragmatic alternative to a real
 # token-tree grammar. These rules stay non-atomic so the call-site
-# `trivia` auto-insertion still consumes leading whitespace inside
+# `ignore` auto-insertion still consumes leading whitespace inside
 # the brackets — necessary for multi-line macro argument lists like
 # `vec![\n  1,\n]`.
 
@@ -474,7 +474,7 @@ balanced_atom = brace_block
 
 literal = string_lit / char_lit / number_lit / lit_const
 
-# Boolean constants as a `%` reserved-word alternation so the `wb`
+# Boolean constants as a `%` reserved-word alternation so the `boundary`
 # boundary keeps `trueish` from matching the `true` prefix.
 lit_const: reserved = @constant 'true' / @constant 'false'
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -55,11 +55,11 @@
 
 root = (statement stmt_sep?)*^[;]
 
-trivia = (comment / \s)*
+ignore = (comment / \s)*
 # Word boundary for `%` reserved-word rules: a keyword can't be the
 # prefix of a longer identifier. Matches the full identifier-continue
 # class (`ident_cont`, Unicode included).
-wb = !ident_cont
+boundary = !ident_cont
 stmt_sep = @punctuation ';'
 statement = explain_stmt / statement_body
 statement_body = select_stmt
@@ -523,7 +523,7 @@ blob_body: atomic = [xX] "'" [\da-fA-F]* "'"
 string_lit: atomic = @string string_body
 string_body: atomic = "'" ("''" / !"'" .)* "'"
 
-# Hex is a `%` rule so the compiler appends the `wb` boundary: hex
+# Hex is a `%` rule so the compiler appends the `boundary` boundary: hex
 # digits include a-f, so a hex run can butt against identifier chars
 # (`0x1Fg` must fall back to `0` + `x1Fg`, not lex `0x1F`). float/int
 # use `\d`, which can't, so they carry no boundary.
@@ -563,7 +563,7 @@ backtick_id: atomic = '`' ('``' / !'`' !\R .)* '`'
 bracket_id: atomic = '[' .. (']' / \R) ']'
 
 # --- Keywords (case-insensitive) --------------------------------------
-# Each kw_* is a `%` reserved-word rule: the compiler appends a `wb`
+# Each kw_* is a `%` reserved-word rule: the compiler appends a `boundary`
 # boundary call inside the @keyword capture so `SELECT` doesn't match
 # the prefix of `SELECTED`. The `i"…"` literal sugar gives
 # case-insensitive matching at the parser level — see src/pegc/README.md.

--- a/grammars/toml.peg
+++ b/grammars/toml.peg
@@ -1,6 +1,6 @@
 # TOML v1.0 grammar with highlight annotations.
 #
-# TOML defines no `trivia` rule, so trivia auto-insertion stays off
+# TOML defines no `ignore` rule, so ignore auto-insertion stays off
 # grammar-wide. TOML is line-oriented — entries are newline-separated
 # via `entry_sep`, key-value pairs can't span lines, and arrays /
 # inline tables have their own whitespace disciplines. An
@@ -24,7 +24,7 @@
 #   - inf / nan are @constant (like true/false), not @number.
 
 # `blank`: whitespace (incl. newlines) and comments, threaded by hand
-# — never auto-injected (TOML has no `trivia` rule). Each atom
+# — never auto-injected (TOML has no `ignore` rule). Each atom
 # consumes at least one byte, so the enclosing '*' cannot infinite-loop.
 root = blank (entry (entry_sep entry)*)? blank
 

--- a/src/bin/pegdb.rs
+++ b/src/bin/pegdb.rs
@@ -71,7 +71,7 @@ Usage: pegdb recoveries dump -g <grammar.peg> [--max-literal=N] [<path>]
 Print one JSON object per surviving recovery span (keys: start, end,
 kind, label, pos, rule_stack, literal). One row per span — adjacent
 single-byte recovery captures from the same `*^` loop collapse into
-a single object. `rule_stack` is the full trivia-trimmed call stack
+a single object. `rule_stack` is the full ignore-trimmed call stack
 root-to-leaf at the deepest dive that contributed to the span.
 
 When capture/diagnostic accounting mismatches (a known bug class —
@@ -268,7 +268,7 @@ fn run_recoveries_dump(args: &[String]) -> ExitCode {
     p.set_input(input.into_bytes());
     let kinds = p.capture_kinds();
     let rule_names = p.rule_names();
-    let rule_is_trivia = p.rule_is_trivia();
+    let rule_is_ignore = p.rule_is_ignore();
     let label_names = p.label_kinds();
     let complete = p.is_complete();
     let (matched, captures) = p.captures();
@@ -314,7 +314,7 @@ fn run_recoveries_dump(args: &[String]) -> ExitCode {
         let span_start = captures[span_start_idx].start;
         let span_end = captures[span_end_idx - 1].end;
 
-        let trimmed = trim_trivia_tail(reach.rule_stack(), rule_is_trivia);
+        let trimmed = trim_ignore_tail(reach.rule_stack(), rule_is_ignore);
         let stack_names: Vec<&str> = trimmed
             .iter()
             .filter_map(|id| rule_names.get(id.0 as usize).map(String::as_str))
@@ -374,7 +374,7 @@ fn run_recoveries_dump(args: &[String]) -> ExitCode {
     }
     for idx in &orphan_diagnostics {
         let diag = &diagnostics[*idx];
-        let trimmed = trim_trivia_tail(diag.rule_stack(), rule_is_trivia);
+        let trimmed = trim_ignore_tail(diag.rule_stack(), rule_is_ignore);
         let stack_names: Vec<&str> = trimmed
             .iter()
             .filter_map(|id| rule_names.get(id.0 as usize).map(String::as_str))
@@ -434,7 +434,7 @@ fn run_recoveries_explain(args: &[String]) -> ExitCode {
     p.set_input(input.into_bytes());
     let kinds = p.capture_kinds();
     let rule_names = p.rule_names();
-    let rule_is_trivia = p.rule_is_trivia();
+    let rule_is_ignore = p.rule_is_ignore();
     let complete = p.is_complete();
     let (matched, captures) = p.captures();
     let diagnostics = p.recovery_diagnostics();
@@ -447,9 +447,9 @@ fn run_recoveries_explain(args: &[String]) -> ExitCode {
     // Cluster by `(rule_stack, label_name)`. Every recovery firing
     // carries a label — labeled catches (`^label`) use the author's
     // identifier; `*^` uses the intern of its `recovery_kind` string.
-    // Trailing rule_stack frames marked trivia (reached from a
-    // `trivia = …` reserved-name root) are popped before the key is
-    // built, so two diagnostics that bottom out in different trivia
+    // Trailing rule_stack frames marked ignore (reached from a
+    // `ignore = …` reserved-name root) are popped before the key is
+    // built, so two diagnostics that bottom out in different ignore
     // merge into one cluster on the deepest semantic rule. BTreeMap
     // preserves a stable key order for deterministic output.
     type ClusterKey = (Vec<String>, String);
@@ -459,7 +459,7 @@ fn run_recoveries_explain(args: &[String]) -> ExitCode {
         let Some(reach) = slot else {
             continue;
         };
-        let trimmed_stack = trim_trivia_tail(reach.rule_stack(), rule_is_trivia);
+        let trimmed_stack = trim_ignore_tail(reach.rule_stack(), rule_is_ignore);
         let stack: Vec<String> = trimmed_stack
             .iter()
             .filter_map(|id| rule_names.get(id.0 as usize).cloned())
@@ -510,7 +510,7 @@ fn run_recoveries_explain(args: &[String]) -> ExitCode {
     if !orphan_diagnostics.is_empty() {
         for &idx in &orphan_diagnostics {
             let diag = &diagnostics[idx];
-            let trimmed = trim_trivia_tail(diag.rule_stack(), rule_is_trivia);
+            let trimmed = trim_ignore_tail(diag.rule_stack(), rule_is_ignore);
             let leaf = trimmed
                 .last()
                 .and_then(|id| rule_names.get(id.0 as usize))
@@ -630,16 +630,16 @@ fn compute_recovery_span_aggregates(
     out
 }
 
-/// Pop trailing trivia frames from `stack`. A frame is trivia when its
-/// `MemoId.0` indexes a `true` slot in `rule_is_trivia` (cascaded from
-/// the reserved `trivia = …` rule at compile time). Both
+/// Pop trailing ignore frames from `stack`. A frame is ignore when its
+/// `MemoId.0` indexes a `true` slot in `rule_is_ignore` (cascaded from
+/// the reserved `ignore = …` rule at compile time). Both
 /// `recoveries explain` and `recoveries dump` use this to keep the
 /// displayed leaf on a semantically interesting rule rather than `ws`
 /// or `line_comment`.
-fn trim_trivia_tail(stack: &[MemoId], rule_is_trivia: &[bool]) -> Vec<MemoId> {
+fn trim_ignore_tail(stack: &[MemoId], rule_is_ignore: &[bool]) -> Vec<MemoId> {
     let mut out = stack.to_vec();
     while let Some(last) = out.last() {
-        if rule_is_trivia
+        if rule_is_ignore
             .get(last.0 as usize)
             .copied()
             .unwrap_or(false)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -185,12 +185,12 @@ impl Parser {
         &self.program.label_kinds
     }
 
-    /// Per-rule trivia flags indexed by `MemoId.0` — see
-    /// [`crate::pegvm::Program::rule_is_trivia`]. `pegdb recoveries explain`
-    /// uses this to drop trailing trivia frames from the rule_stack
+    /// Per-rule ignore flags indexed by `MemoId.0` — see
+    /// [`crate::pegvm::Program::rule_is_ignore`]. `pegdb recoveries explain`
+    /// uses this to drop trailing ignore frames from the rule_stack
     /// when picking the displayed leaf of a recovery cluster.
-    pub fn rule_is_trivia(&self) -> &[bool] {
-        &self.program.rule_is_trivia
+    pub fn rule_is_ignore(&self) -> &[bool] {
+        &self.program.rule_is_ignore
     }
 
     /// Per-recovery diagnostic records from the most recent parse.

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -30,7 +30,7 @@
 //!   for each name: NUL-terminated UTF-8 bytes
 //!
 //! rule-attribute bits:
-//!   ceil(rule_names.len() / 8) bytes, bit-packed `rule_is_trivia`
+//!   ceil(rule_names.len() / 8) bytes, bit-packed `rule_is_ignore`
 //!   (rule `i`'s bit is bit `i % 8` of byte `i / 8`, LSB-first).
 //!
 //! label-name table:
@@ -189,7 +189,7 @@ pub fn encode(program: &Program) -> Vec<u8> {
     let mut out = Vec::new();
     write_name_table(&mut out, &program.capture_kinds, "capture");
     write_name_table(&mut out, &program.rule_names, "rule");
-    write_bit_vec(&mut out, &program.rule_is_trivia);
+    write_bit_vec(&mut out, &program.rule_is_ignore);
     write_name_table(&mut out, &program.label_kinds, "label");
     write_char_sets(&mut out, &program.char_sets);
     write_instructions(&mut out, &program.code);
@@ -354,7 +354,7 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
     let mut cur = Cursor::new(bytes);
     let capture_kinds = read_name_table(&mut cur, Error::InvalidCaptureName)?;
     let rule_names = read_name_table(&mut cur, Error::InvalidRuleName)?;
-    let rule_is_trivia = read_bit_vec(&mut cur, rule_names.len())?;
+    let rule_is_ignore = read_bit_vec(&mut cur, rule_names.len())?;
     let label_kinds = read_name_table(&mut cur, Error::InvalidLabelName)?;
     let char_sets = read_char_sets(&mut cur)?;
     let code = read_instructions(&mut cur)?;
@@ -370,7 +370,7 @@ pub fn decode(bytes: &[u8]) -> Result<Program, Error> {
         rule_count,
         rule_names,
         label_kinds,
-        rule_is_trivia,
+        rule_is_ignore,
         char_sets,
     })
 }
@@ -751,7 +751,7 @@ mod tests {
             rule_count: 2,
             rule_names: vec!["start".to_string(), "other".to_string()],
             label_kinds: vec!["missing_then".to_string()],
-            rule_is_trivia: vec![false, true],
+            rule_is_ignore: vec![false, true],
             char_sets: vec![class_a, class_b],
         };
         assert_roundtrip(&p);
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn bit_vec_round_trips_across_byte_boundary() {
-        // 10 rules so the trivia bitmap spans 2 bytes; alternating
+        // 10 rules so the ignore bitmap spans 2 bytes; alternating
         // pattern catches any off-by-one in the bit ordering.
         let bits: Vec<bool> = (0..10).map(|i| i % 2 == 0).collect();
         let rule_names: Vec<String> = (0..10).map(|i| format!("r{i}")).collect();
@@ -769,14 +769,14 @@ mod tests {
             rule_count: 10,
             rule_names,
             label_kinds: vec![],
-            rule_is_trivia: bits,
+            rule_is_ignore: bits,
             char_sets: vec![],
         };
         let bytes = encode(&p);
         let decoded = decode(&bytes).expect("decode succeeds");
         assert_eq!(
-            decoded.rule_is_trivia, p.rule_is_trivia,
-            "trivia bit-vec mismatch after round-trip"
+            decoded.rule_is_ignore, p.rule_is_ignore,
+            "ignore bit-vec mismatch after round-trip"
         );
     }
 
@@ -918,7 +918,7 @@ mod tests {
             rule_count: 0,
             rule_names: vec![],
             label_kinds: vec![],
-            rule_is_trivia: vec![],
+            rule_is_ignore: vec![],
             char_sets: vec![],
         };
         assert_roundtrip(&p);
@@ -941,7 +941,7 @@ mod tests {
             rule_count: 99, // intentionally inconsistent with the code
             rule_names: vec![],
             label_kinds: vec![],
-            rule_is_trivia: vec![],
+            rule_is_ignore: vec![],
             char_sets: vec![],
         };
         let bytes = encode(&p);

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -26,36 +26,36 @@ name2 =  body2
 ```
 
 - Every grammar must define a **`root` rule** — that's the entry
-  point. The compiler wraps its body as `trivia? root_body trivia? !.`
+  point. The compiler wraps its body as `ignore? root_body ignore? !.`
   so end-of-input is implicit (any trailing junk fails the parse).
-- An optional **`trivia` rule** acts as the auto-insertion target:
-  when present, the compiler splices a `trivia` call between every
+- An optional **`ignore` rule** acts as the auto-insertion target:
+  when present, the compiler splices a `ignore` call between every
   pair of consecutive items in non-atomic rule bodies, including
-  between iterations of `*` / `+`. Without a `trivia` rule, no
+  between iterations of `*` / `+`. Without a `ignore` rule, no
   auto-insertion happens.
-- An optional **`wb` rule** is the word-boundary target consumed by
-  `reserved` rules (see below); it is typically `wb = !ident_body`.
+- An optional **`boundary` rule** is the word-boundary target consumed by
+  `reserved` rules (see below); it is typically `boundary = !ident_body`.
   Defining it is only required when the grammar has at least one
   `reserved` rule.
 - Rules may carry postfix **ascriptions** between the name and `=`,
   `name: kw [kw ...] =`: `partial` (the intentional-leniency marker),
-  `atomic` (no `trivia` injected inside this rule's body), `reserved`
-  (atomic *and* appends a trailing `wb` call inside the rule's terminal
+  `atomic` (no `ignore` injected inside this rule's body), `reserved`
+  (atomic *and* appends a trailing `boundary` call inside the rule's terminal
   captures), and `preferred` (a sibling of `reserved` for
   identifier-eligible distinguished tokens). The keywords are
   *contextual* — special only in this slot, usable as ordinary rule
   names elsewhere. `atomic` / `reserved` / `preferred` are mutually
   exclusive (each makes a rule atomic); `partial` composes with any and,
   when present, must be written first (`name: partial atomic =`). The
-  three special rules `root`, `trivia`, and `wb` carry no ascriptions at
+  three special rules `root`, `ignore`, and `boundary` carry no ascriptions at
   all (any ascription on them is a parse error); whitespace
-  auto-insertion is disabled by omitting `trivia`, not by ascribing it.
+  auto-insertion is disabled by omitting `ignore`, not by ascribing it.
 - Two special rules, **`reserved`** and **`preferred`**, are
   *synthesized* by the compiler from the `reserved` / `preferred` rules
   (see below) — a grammar references them (`!reserved`) but never
   defines them.
 - **Position constraint:** `root` is always the first rule. The
-  optional special rules `trivia` and `wb` occupy the contiguous slots
+  optional special rules `ignore` and `boundary` occupy the contiguous slots
   immediately after `root` (positions 1..2, in either order). Other
   rules follow in any order.
 - **Identifiers** are ASCII `[A-Za-z_][A-Za-z0-9_]*`.
@@ -539,83 +539,83 @@ planned tightening.
 Three rule names get compile-time treatment. All three are structural
 slots the compiler wraps or injects, not lexable tokens, so none of
 them accepts an ascription — `partial` / `atomic` / `reserved` /
-`preferred` on `root`, `trivia`, or `wb` is a parse error.
+`preferred` on `root`, `ignore`, or `boundary` is a parse error.
 
 - **`root`** — the start rule (mandatory). The compiler wraps its
-  body as `trivia? root_body trivia? !.` so end-of-input is always
-  asserted, and a `trivia` rule (when present) pads the leading and
+  body as `ignore? root_body ignore? !.` so end-of-input is always
+  asserted, and a `ignore` rule (when present) pads the leading and
   trailing whitespace. The wrap means a grammar
   source like `root = value` parses whole inputs, not just longest
   prefixes — the implicit `!.` rejects trailing junk.
 
-- **`trivia`** — the optional auto-insertion target. When defined,
-  the compiler injects a call to `trivia` between
+- **`ignore`** — the optional auto-insertion target. When defined,
+  the compiler injects a call to `ignore` between
   every pair of consecutive items in every non-atomic rule's
   `Sequence`, plus prepends one to each iteration of `*` / `+`.
   This replaces the explicit `ws` / `spacing` calls that used to
   appear between tokens.
 
-  The rule also seeds the diagnostic *trivia cascade*: every rule
-  transitively reachable from `trivia` through the call graph gets
-  `Program::rule_is_trivia = true`, and `pegdb recoveries explain`
-  pops trailing trivia frames from the rule_stack when picking the
+  The rule also seeds the diagnostic *ignore cascade*: every rule
+  transitively reachable from `ignore` through the call graph gets
+  `Program::rule_is_ignore = true`, and `pegdb recoveries explain`
+  pops trailing ignore frames from the rule_stack when picking the
   displayed leaf of each cluster. Rules whose body contains a
   recovery catch (`^lbl`, `^^lbl`, `*^`) are pinned out of the
   cascade so the catch's diagnostic frame stays visible.
 
   Indentation-sensitive grammars (`#43`) keep significant-whitespace
-  rules outside the `trivia` subgraph; only ignorable bytes go in.
+  rules outside the `ignore` subgraph; only ignorable bytes go in.
 
   ```peg
-  trivia        = (comment / \s)*
+  ignore        = (comment / \s)*
   comment       = @comment ('//' .. '\n' / '/*' ..= '*/')
   ```
 
-  Grammars without a `trivia` rule (e.g. indent-sensitive shapes)
-  get no auto-insertion and no trivia-padding wrap on `root`; the
+  Grammars without a `ignore` rule (e.g. indent-sensitive shapes)
+  get no auto-insertion and no ignore-padding wrap on `root`; the
   EOF assertion is still applied. To keep a callable whitespace rule
   while leaving auto-insertion off, name it anything other than
-  `trivia` and thread it by hand — the `trivia` rule carries no
+  `ignore` and thread it by hand — the `ignore` rule carries no
   qualifiers, so its mere presence turns auto-insertion on. Such a
   hand-threaded rule sits outside the diagnostic cascade, which is
-  keyed on the name `trivia`.
+  keyed on the name `ignore`.
 
   *Why the per-iteration prepend matters.* The auto-insertion
-  splices `trivia` at every inter-item boundary of a `Sequence`, but
+  splices `ignore` at every inter-item boundary of a `Sequence`, but
   `Repeat` iterations have no parent `Sequence` to splice into —
   inserting between items of the body covers one iteration's
   interior, not the boundary between iteration N and iteration
-  N+1. So the rewriter also prepends a `trivia` call to the body of
+  N+1. So the rewriter also prepends a `ignore` call to the body of
   every `Repeat` / `RepeatOne`. Consider `pair (',' pair)*` parsing
   `pair, pair, pair` with spaces between every token. Without the
-  prepend, the Repeat body is `',' trivia pair`: the first
+  prepend, the Repeat body is `',' ignore pair`: the first
   iteration's `,` matches at the position just after the outer
-  Sequence's `pair trivia` — but the second iteration starts on a
+  Sequence's `pair ignore` — but the second iteration starts on a
   space, so its `,` rejects and the loop ends with one pair
-  missing. With the prepend the body becomes `trivia ',' trivia
+  missing. With the prepend the body becomes `ignore ',' ignore
   pair`, and each iteration begins by consuming whatever
   inter-iteration whitespace is sitting in front of it.
 
-- **`wb`** — the optional word-boundary target for `reserved` /
+- **`boundary`** — the optional word-boundary target for `reserved` /
   `preferred` rules. Its body is a bare boundary predicate (typically
-  `wb = !ident_body`, or `!ident_cont` for a Unicode-aware continuation
-  class). The compiler appends a `wb` call inside the terminal captures
+  `boundary = !ident_body`, or `!ident_cont` for a Unicode-aware continuation
+  class). The compiler appends a `boundary` call inside the terminal captures
   of every `reserved` / `preferred` rule (see
   [`name: reserved`](#name-reserved--reserved-word-ascription)); it
   is required only when the grammar has at least one such rule. Like
-  `trivia`, `wb` is exempt from trivia auto-insertion and must sit in
+  `ignore`, `boundary` is exempt from ignore auto-insertion and must sit in
   the reserved slots immediately after `root`. It is **not** part of
-  the trivia diagnostic cascade.
+  the ignore diagnostic cascade.
 
   ```peg
-  wb            = !ident_body
+  boundary            = !ident_body
   ```
 
 ### `name: atomic` — atomic-rule ascription
 
-The `atomic` ascription opts the rule out of `trivia`
+The `atomic` ascription opts the rule out of `ignore`
 auto-insertion: the rewriter walks the body but does not splice
-`trivia` between `Sequence` items or prepend one to `Repeat`
+`ignore` between `Sequence` items or prepend one to `Repeat`
 iterations. `partial` composes with it (`name: partial atomic =`).
 
 ```peg
@@ -624,7 +624,7 @@ ident: atomic      = [A-Za-z_] [A-Za-z0-9_]*
 ```
 
 Used on token-shape rules — string / number / char literals,
-identifiers, multi-byte keyword spellings — where injecting trivia
+identifiers, multi-byte keyword spellings — where injecting ignore
 between adjacent bytes would let whitespace appear inside the
 token. The atomic boundary stops at `NonTerminal` calls: a
 non-atomic rule called from inside an atomic body still gets
@@ -638,27 +638,27 @@ hand-write `!ident_body`.
 ### `name: reserved` — reserved-word ascription
 
 The `reserved` ascription marks a rule as a **reserved word**: it is
-compiled atomic *and* the compiler appends a call to the `wb` rule
+compiled atomic *and* the compiler appends a call to the `boundary` rule
 inside the rule's terminal captures, so the match must be followed by
 a word boundary. This keeps a keyword from firing on the prefix of a
 longer identifier — `if` must not match the start of `ifx`.
 
 ```peg
-wb                  = !ident_body
+boundary                  = !ident_body
 kw_if: reserved     = @keyword 'if'
 storage_spec: reserved = @keyword 'typedef' / @keyword 'extern' / @keyword 'static'
 ```
 
-The `wb` call is pushed inside each leaf capture (and distributed
+The `boundary` call is pushed inside each leaf capture (and distributed
 across choice branches), not appended after the rule body. That
 placement matters: it means the `@keyword` capture only commits when
 the boundary holds, so a rejected keyword leaves no stray capture for
 top-level `*^` recovery to surface. Because the rule is atomic, no
-`trivia` is spliced between the literal and the appended `wb` call.
+`ignore` is spliced between the literal and the appended `boundary` call.
 
 When a `reserved` / `preferred` rule's body is a **capture-less
 alternation of plain literals**, the compiler prefix-factors it into a
-longest-match **trie** (with `wb` at each accepting leaf) instead of a
+longest-match **trie** (with `boundary` at each accepting leaf) instead of a
 flat alternation. The trie is order-independent, so a shorter keyword
 can't shadow a longer one that extends it — `do` / `double`, `go` /
 `goto`, `int` / `int8` all match maximally regardless of source order.
@@ -666,11 +666,11 @@ can't shadow a longer one that extends it — `do` / `double`, `go` /
 not plain literals, so they keep the flat form — the synthesizer below
 emits those longest-first so maximal munch still holds.)
 
-- Requires a `wb` rule; with none defined, the synthesized
-  `NonTerminal("wb")` surfaces as `CompileError::UndefinedRule("wb")`.
+- Requires a `boundary` rule; with none defined, the synthesized
+  `NonTerminal("boundary")` surfaces as `CompileError::UndefinedRule("boundary")`.
 - Composes with `partial` (written first); mutually exclusive with
   `atomic` / `preferred`.
-- Rejected on the reserved rules `root` / `trivia` / `wb`.
+- Rejected on the reserved rules `root` / `ignore` / `boundary`.
 
 ### `name: preferred` — preferred-word ascription
 
@@ -678,7 +678,7 @@ The `preferred` ascription is the sibling of `reserved` for
 **preferred words**: identifier-eligible distinguished tokens such as
 Go's predeclared `int` / `len` / `true` or JavaScript's contextual
 `async` / `let`. It behaves exactly like `reserved` — atomic, with the
-same `wb` boundary and the same trie treatment — and differs only in
+same `boundary` boundary and the same trie treatment — and differs only in
 *which synthesized set the rule's literals feed*: a `preferred` rule's
 words go into `preferred` and are **excluded** from `reserved`, so they
 stay usable as identifiers.
@@ -711,12 +711,12 @@ rules above:
   for symmetry / inspection (e.g. `pegdb`); a grammar usually doesn't
   reference it.
 
-Both are emitted as `reserved` rules (trie + `wb`), so `!reserved` does
+Both are emitted as `reserved` rules (trie + `boundary`), so `!reserved` does
 correct maximal-munch: `int` is reserved, but `integer` — a longer word
 that merely starts with it — is not. A rule whose body isn't a fixed
 keyword shape (it has a quantifier / wildcard / predicate, e.g. a number
 body like `'0x' [\da-fA-F]+`) contributes nothing; keep such
-boundary-only helpers as `name: atomic = … wb` rather than `reserved`.
+boundary-only helpers as `name: atomic = … boundary` rather than `reserved`.
 Authors **reference** these
 two names but never **define** them (a definition is a parse error).
 

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -1351,15 +1351,15 @@ fn lower_inferred_boundary_catch(
     }
 }
 
-/// The reserved rule name that marks the trivia subgraph's root.
+/// The reserved rule name that marks the ignore subgraph's root.
 /// If a grammar defines a rule with this name, the compiler cascades
-/// the trivia bit through every rule transitively reachable from it
+/// the ignore bit through every rule transitively reachable from it
 /// (subject to the catch-exclusion below).
-pub(crate) const TRIVIA_ROOT_RULE: &str = "trivia";
+pub(crate) const IGNORE_ROOT_RULE: &str = "ignore";
 
-/// Compute the per-rule trivia bit. A rule is trivia iff it's
+/// Compute the per-rule ignore bit. A rule is ignore iff it's
 /// transitively reachable through the call graph from a rule named
-/// [`TRIVIA_ROOT_RULE`], excluding rules whose body contains a recovery
+/// [`IGNORE_ROOT_RULE`], excluding rules whose body contains a recovery
 /// catch (`Pattern::Catch` or `Pattern::InferBoundaryCatch`). The
 /// catch-exclusion preserves diagnostic visibility for catch-bearing
 /// frames in `pegdb recoveries explain`: the catch is the author's
@@ -1367,11 +1367,11 @@ pub(crate) const TRIVIA_ROOT_RULE: &str = "trivia";
 /// it would hide exactly the rule the catch lives in.
 ///
 /// Returns an entry for every rule in `rules`; rules in a grammar with
-/// no `trivia` root all get `false`.
-pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<String, bool> {
-    let mut trivia: HashMap<String, bool> = rules.keys().map(|n| (n.clone(), false)).collect();
-    if !rules.contains_key(TRIVIA_ROOT_RULE) {
-        return trivia;
+/// no `ignore` root all get `false`.
+pub(crate) fn compute_ignore_rules(rules: &HashMap<String, Pattern>) -> HashMap<String, bool> {
+    let mut ignore: HashMap<String, bool> = rules.keys().map(|n| (n.clone(), false)).collect();
+    if !rules.contains_key(IGNORE_ROOT_RULE) {
+        return ignore;
     }
     let pinned: HashSet<String> = rules
         .iter()
@@ -1379,13 +1379,13 @@ pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<
         .map(|(name, _)| name.clone())
         .collect();
     let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: Vec<String> = vec![TRIVIA_ROOT_RULE.to_string()];
+    let mut queue: Vec<String> = vec![IGNORE_ROOT_RULE.to_string()];
     while let Some(rule) = queue.pop() {
         if !visited.insert(rule.clone()) {
             continue;
         }
         if !pinned.contains(&rule) {
-            trivia.insert(rule.clone(), true);
+            ignore.insert(rule.clone(), true);
         }
         if let Some(body) = rules.get(&rule) {
             let mut callees = HashSet::new();
@@ -1397,7 +1397,7 @@ pub(crate) fn compute_trivia_rules(rules: &HashMap<String, Pattern>) -> HashMap<
             }
         }
     }
-    trivia
+    ignore
 }
 
 /// Walk `pat` and bump `out[name]` for every `Pattern::NonTerminal { name }`
@@ -1490,60 +1490,60 @@ fn body_contains_catch(pat: &Pattern) -> bool {
 }
 
 /// True iff the grammar has an active auto-insertion target: a rule
-/// named `trivia`. Both [`inject_auto_trivia`] and [`wrap_root`]
+/// named `ignore`. Both [`inject_auto_ignore`] and [`wrap_root`]
 /// consult this; on `false` they no-op (no inter-Sequence splicing, no
-/// `trivia?` siblings in the root wrap). The `trivia` rule carries no
+/// `ignore?` siblings in the root wrap). The `ignore` rule carries no
 /// qualifiers, so omitting it is the only way to disable auto-insertion.
 fn auto_insertion_active(grammar: &Grammar) -> bool {
-    grammar.rules.contains_key(TRIVIA_ROOT_RULE)
+    grammar.rules.contains_key(IGNORE_ROOT_RULE)
 }
 
 /// AST-level rewrite: in every non-atomic rule's body, splice a
-/// `NonTerminal("trivia")` call between consecutive items of every
+/// `NonTerminal("ignore")` call between consecutive items of every
 /// `Sequence`, and prepend one to every `Repeat` / `RepeatOne`
 /// iteration so inter-iteration whitespace gets consumed. Runs after
 /// `lint_partial_match` and the FOLLOW-driven `^^lbl` resolver so both
 /// still see the author's original body.
 ///
-/// No-op when the grammar has no `trivia` rule (the grammar-wide
-/// opt-out — `trivia` carries no qualifiers). The `trivia` rule itself
-/// is exempt from injection: splicing trivia inside its own body would
+/// No-op when the grammar has no `ignore` rule (the grammar-wide
+/// opt-out — `ignore` carries no qualifiers). The `ignore` rule itself
+/// is exempt from injection: splicing ignore inside its own body would
 /// recurse the runtime indefinitely.
 ///
 /// The walker descends transparently through `Choice`, `Optional`,
 /// `Capture`, `Catch`, `Lenient`, `AndPredicate`, `NotPredicate`, and
 /// stops at `NonTerminal` and the atom leaves (`Literal`, `CharClass`,
-/// `AnyChar`). Crossing a `NonTerminal` would pull trivia into the
+/// `AnyChar`). Crossing a `NonTerminal` would pull ignore into the
 /// callee's body — which the callee handles by its own auto-insertion
 /// if non-atomic, or explicitly if atomic.
-pub fn inject_auto_trivia(grammar: &mut Grammar) {
+pub fn inject_auto_ignore(grammar: &mut Grammar) {
     if !auto_insertion_active(grammar) {
         return;
     }
     let atomic = grammar.atomic_rules.clone();
     let rule_names: Vec<String> = grammar.rules.keys().cloned().collect();
     for name in rule_names {
-        // The trivia rule itself is exempt: every `trivia_call` from
-        // the rewriter calls back into it, so injecting trivia inside
+        // The ignore rule itself is exempt: every `ignore_call` from
+        // the rewriter calls back into it, so injecting ignore inside
         // its body would recurse the runtime indefinitely. Atomic
         // rules opt out explicitly via the `name: atomic` ascription.
-        if atomic.contains(&name) || name == TRIVIA_ROOT_RULE {
+        if atomic.contains(&name) || name == IGNORE_ROOT_RULE {
             continue;
         }
         if let Some(body) = grammar.rules.get_mut(&name) {
-            inject_trivia_in(body);
+            inject_ignore_in(body);
         }
     }
 }
 
-/// Walk one rule body, splicing `NonTerminal("trivia")` between every
+/// Walk one rule body, splicing `NonTerminal("ignore")` between every
 /// pair of consecutive `Sequence` items at every depth and prepending
 /// one to every `Repeat` / `RepeatOne` iteration.
-fn inject_trivia_in(pat: &mut Pattern) {
+fn inject_ignore_in(pat: &mut Pattern) {
     match pat {
         Pattern::Sequence { items, .. } => {
             for it in items.iter_mut() {
-                inject_trivia_in(it);
+                inject_ignore_in(it);
             }
             if items.len() >= 2 {
                 let mut spliced = Vec::with_capacity(items.len() * 2 - 1);
@@ -1552,7 +1552,7 @@ fn inject_trivia_in(pat: &mut Pattern) {
                 for (i, it) in drained.into_iter().enumerate() {
                     spliced.push(it);
                     if i != last {
-                        spliced.push(trivia_call());
+                        spliced.push(ignore_call());
                     }
                 }
                 *items = spliced;
@@ -1560,25 +1560,25 @@ fn inject_trivia_in(pat: &mut Pattern) {
         }
         Pattern::OrderedChoice { alts, .. } => {
             for it in alts {
-                inject_trivia_in(it);
+                inject_ignore_in(it);
             }
         }
         Pattern::Repeat { inner, .. } | Pattern::RepeatOne { inner, .. } => {
-            inject_trivia_in(inner);
-            // Prepend a trivia call so each iteration consumes
+            inject_ignore_in(inner);
+            // Prepend a ignore call so each iteration consumes
             // ambient whitespace before its body runs. Without this,
             // `(',' pair)*` would fail on the second iteration's
             // leading whitespace — the inter-iteration boundary has
-            // no parent `Sequence` to splice trivia into. Flatten
+            // no parent `Sequence` to splice ignore into. Flatten
             // when `inner` is already a `Sequence` so the result
             // stays at one level of nesting.
             let original = std::mem::replace(inner.as_mut(), Pattern::any_char());
             let wrapped = match original {
                 Pattern::Sequence { mut items, span } => {
-                    items.insert(0, trivia_call());
+                    items.insert(0, ignore_call());
                     Pattern::Sequence { items, span }
                 }
-                other => Pattern::seq(vec![trivia_call(), other]),
+                other => Pattern::seq(vec![ignore_call(), other]),
             };
             **inner = wrapped;
         }
@@ -1586,14 +1586,14 @@ fn inject_trivia_in(pat: &mut Pattern) {
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
         | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => inject_trivia_in(inner),
+        | Pattern::Lenient { inner, .. } => inject_ignore_in(inner),
         Pattern::Catch {
             inner, recovery, ..
         } => {
-            inject_trivia_in(inner);
-            inject_trivia_in(recovery);
+            inject_ignore_in(inner);
+            inject_ignore_in(recovery);
         }
-        Pattern::InferBoundaryCatch { inner, .. } => inject_trivia_in(inner),
+        Pattern::InferBoundaryCatch { inner, .. } => inject_ignore_in(inner),
         Pattern::Literal { .. }
         | Pattern::CharClass { .. }
         | Pattern::AnyChar { .. }
@@ -1601,13 +1601,13 @@ fn inject_trivia_in(pat: &mut Pattern) {
     }
 }
 
-/// Wrap the start rule's body so it reads `trivia? body trivia? !.` —
-/// implicit leading/trailing trivia and end-of-input assertion. Built
-/// manually as a `Sequence` *after* [`inject_auto_trivia`] has run on
+/// Wrap the start rule's body so it reads `ignore? body ignore? !.` —
+/// implicit leading/trailing ignore and end-of-input assertion. Built
+/// manually as a `Sequence` *after* [`inject_auto_ignore`] has run on
 /// `root`'s body, so the synthesized siblings here don't themselves
-/// pick up trivia injection.
+/// pick up ignore injection.
 ///
-/// `trivia?` is included iff auto-insertion is active. With no `trivia`
+/// `ignore?` is included iff auto-insertion is active. With no `ignore`
 /// rule the wrap collapses to `body !.` — still supplying the EOF
 /// assertion uniformly.
 pub fn wrap_root(grammar: &mut Grammar) {
@@ -1617,11 +1617,11 @@ pub fn wrap_root(grammar: &mut Grammar) {
     };
     let mut items: Vec<Pattern> = Vec::with_capacity(4);
     if active {
-        items.push(Pattern::optional(trivia_call()));
+        items.push(Pattern::optional(ignore_call()));
     }
     items.push(body);
     if active {
-        items.push(Pattern::optional(trivia_call()));
+        items.push(Pattern::optional(ignore_call()));
     }
     items.push(Pattern::not_predicate(Pattern::any_char()));
     grammar
@@ -1629,53 +1629,53 @@ pub fn wrap_root(grammar: &mut Grammar) {
         .insert(super::parser::ROOT_RULE.to_string(), Pattern::seq(items));
 }
 
-fn trivia_call() -> Pattern {
-    Pattern::nt(TRIVIA_ROOT_RULE)
+fn ignore_call() -> Pattern {
+    Pattern::nt(IGNORE_ROOT_RULE)
 }
 
-/// Append a `wb` word-boundary call inside the terminal captures of
+/// Append a `boundary` word-boundary call inside the terminal captures of
 /// every `reserved` rule (see [`Grammar::percent_rules`]).
 ///
 /// The boundary is pushed to the tail of the matched region, *inside*
 /// the capture that ends the match, so the capture commits only when
-/// the boundary holds. Placing `wb` after the capture instead would let
+/// the boundary holds. Placing `boundary` after the capture instead would let
 /// the keyword capture commit before the boundary check fails, leaking a
 /// stray keyword token through top-level `*^` recovery on inputs like
 /// `typedefx`. The rule is already atomic (the `reserved` ascription inserts it into
-/// `atomic_rules`), so no `trivia` is spliced between the literal and
+/// `atomic_rules`), so no `ignore` is spliced between the literal and
 /// the appended call.
 ///
-/// A `wb` call into a rule with no `wb` definition surfaces downstream
-/// as `CompileError::UndefinedRule("wb")` from `compile_rules`.
-pub fn append_wb_check(grammar: &mut Grammar) {
+/// A `boundary` call into a rule with no `boundary` definition surfaces downstream
+/// as `CompileError::UndefinedRule("boundary")` from `compile_rules`.
+pub fn append_boundary_check(grammar: &mut Grammar) {
     let names: Vec<String> = grammar.percent_rules.iter().cloned().collect();
     for name in names {
         if let Some(mut body) = grammar.rules.remove(&name) {
-            append_wb_in(&mut body);
+            append_boundary_in(&mut body);
             grammar.rules.insert(name, body);
         }
     }
 }
 
-/// Recursively append a `wb` call at the tail of `pat`'s match, pushing
+/// Recursively append a `boundary` call at the tail of `pat`'s match, pushing
 /// it inside the final capture and distributing across choice branches
 /// so each alternative ends in its own boundary check.
-fn append_wb_in(pat: &mut Pattern) {
+fn append_boundary_in(pat: &mut Pattern) {
     // A choice whose branches hold no capture can't leak a committed
-    // capture through recovery, so one trailing `wb` after the whole
+    // capture through recovery, so one trailing `boundary` after the whole
     // choice is equivalent to — and leaner than — one per branch. Only
     // distribute when there is a capture to keep the boundary inside of.
     if matches!(pat, Pattern::OrderedChoice { .. }) && !contains_capture(pat) {
         // When every branch is a plain literal, prefix-factor the set
-        // into a longest-match trie (with `wb` at each accept) instead of
-        // a flat alternation under one trailing `wb`. The trie makes
+        // into a longest-match trie (with `boundary` at each accept) instead of
+        // a flat alternation under one trailing `boundary`. The trie makes
         // source ordering irrelevant — a shorter keyword can no longer
         // shadow a longer one that shares its prefix (#13: `do`/`double`,
         // `go`/`goto`, `int`/`int8`) — and turns the hot
         // identifier-exclusion scan into a prefix walk. Non-literal
         // capture-less choices (e.g. the case-insensitive `i"…"` keyword
         // sets, which lower to char-class sequences) keep the flat
-        // single-trailing-`wb` form; `synthesize_reserved_preferred`
+        // single-trailing-`boundary` form; `synthesize_reserved_preferred`
         // emits those longest-first so the flat form is still correct.
         if let Pattern::OrderedChoice { alts, .. } = pat {
             if let Some(literals) = all_plain_literals(alts) {
@@ -1684,32 +1684,32 @@ fn append_wb_in(pat: &mut Pattern) {
             }
         }
         let taken = std::mem::replace(pat, Pattern::any_char());
-        *pat = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
+        *pat = Pattern::seq(vec![taken, Pattern::nt(super::parser::BOUNDARY_RULE)]);
         return;
     }
     match pat {
         Pattern::OrderedChoice { alts, .. } => {
             for alt in alts.iter_mut() {
-                append_wb_in(alt);
+                append_boundary_in(alt);
             }
         }
         Pattern::Sequence { items, .. } => {
             if let Some(last) = items.last_mut() {
-                append_wb_in(last);
+                append_boundary_in(last);
             }
         }
-        Pattern::Capture { inner, .. } => append_wb_in(inner),
+        Pattern::Capture { inner, .. } => append_boundary_in(inner),
         other => {
             let taken = std::mem::replace(other, Pattern::any_char());
-            *other = Pattern::seq(vec![taken, Pattern::nt(super::parser::WB_RULE)]);
+            *other = Pattern::seq(vec![taken, Pattern::nt(super::parser::BOUNDARY_RULE)]);
         }
     }
 }
 
 /// Whether `pat` contains a [`Pattern::Capture`] anywhere in its tree.
 /// `NonTerminal`s are opaque (a referenced rule's captures aren't
-/// visible here) — consistent with the rest of `append_wb_in`, which
-/// appends `wb` after a `NonTerminal` call rather than inside it.
+/// visible here) — consistent with the rest of `append_boundary_in`, which
+/// appends `boundary` after a `NonTerminal` call rather than inside it.
 fn contains_capture(pat: &Pattern) -> bool {
     match pat {
         Pattern::Capture { .. } => true,
@@ -1734,7 +1734,7 @@ fn contains_capture(pat: &Pattern) -> bool {
 
 /// If every alternative of a choice is a plain [`Pattern::Literal`],
 /// return their raw byte-strings; otherwise `None`. The all-or-nothing
-/// gate keeps [`append_wb_in`] on the flat single-`wb` path for choices
+/// gate keeps [`append_boundary_in`] on the flat single-`boundary` path for choices
 /// that mix literals with char classes / sub-rules (e.g. the
 /// case-insensitive `i"…"` keyword sets).
 fn all_plain_literals(alts: &[Pattern]) -> Option<Vec<Vec<u8>>> {
@@ -1749,7 +1749,7 @@ fn all_plain_literals(alts: &[Pattern]) -> Option<Vec<Vec<u8>>> {
 }
 
 /// Prefix-factor a set of literal byte-strings into a longest-match trie
-/// with a [`WB_RULE`](super::parser::WB_RULE) call at every accepting
+/// with a [`BOUNDARY_RULE`](super::parser::BOUNDARY_RULE) call at every accepting
 /// node. Replaces a flat capture-less literal alternation: the trie is
 /// order-independent (a shorter keyword can't shadow a longer one that
 /// extends it) and walks the input once instead of re-scanning every
@@ -1761,13 +1761,13 @@ fn factor_literal_trie(mut literals: Vec<Vec<u8>>) -> Pattern {
 }
 
 /// Build one trie node from the suffixes that reach it. An empty suffix
-/// means "a keyword ends here" → emit `wb`. Distinct continuation bytes
+/// means "a keyword ends here" → emit `boundary`. Distinct continuation bytes
 /// become sibling branches; a single-child, no-accept chain is coalesced
-/// into one multi-byte literal. The accept (`wb`) branch is emitted
+/// into one multi-byte literal. The accept (`boundary`) branch is emitted
 /// *last* so maximal munch wins: with `long` and `long long` in the set,
 /// trying ` long` before accepting `long` is what stops `long long` from
 /// matching only its `long` prefix (the space is a valid boundary, so a
-/// `wb`-first order would accept the short form).
+/// `boundary`-first order would accept the short form).
 fn build_trie(entries: Vec<Vec<u8>>) -> Pattern {
     let mut accept = false;
     let mut groups: BTreeMap<u8, Vec<Vec<u8>>> = BTreeMap::new();
@@ -1797,7 +1797,7 @@ fn build_trie(entries: Vec<Vec<u8>>) -> Pattern {
         branches.push(Pattern::seq(vec![Pattern::literal_bytes(prefix), sub]));
     }
     if accept {
-        branches.push(Pattern::nt(super::parser::WB_RULE));
+        branches.push(Pattern::nt(super::parser::BOUNDARY_RULE));
     }
     Pattern::choice(branches)
 }
@@ -1812,8 +1812,8 @@ fn build_trie(entries: Vec<Vec<u8>>) -> Pattern {
 /// quantifier, wildcard, predicate, or an unresolvable reference — e.g.
 /// a number body like `'0x' [\da-fA-F]+`) contributes nothing. Both
 /// rules are emitted as a flat alternation ordered longest-first and
-/// registered as `reserved` rules, so the following [`append_wb_check`]
-/// gives them the same trie + `wb` treatment as any author-written
+/// registered as `reserved` rules, so the following [`append_boundary_check`]
+/// gives them the same trie + `boundary` treatment as any author-written
 /// keyword set.
 ///
 /// A literal reachable from both a `reserved` and a `preferred` rule is
@@ -1936,7 +1936,7 @@ fn keyword_entries(
 
 /// Build a `reserved` / `preferred` rule body from its keyword set: a
 /// flat alternation ordered longest-first. All-singleton-ASCII entries
-/// become byte literals (so [`append_wb_in`] folds them into a trie);
+/// become byte literals (so [`append_boundary_in`] folds them into a trie);
 /// case-folded entries stay sequences of char classes.
 fn build_word_set_rule(set: BTreeSet<Vec<CharSet>>) -> Pattern {
     let mut entries: Vec<Vec<CharSet>> = set.into_iter().collect();
@@ -1988,118 +1988,120 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    // ---- trivia cascade (compute_trivia_rules) -----------------------
+    // ---- ignore cascade (compute_ignore_rules) -----------------------
     //
     // Exercised directly on the parsed (pre-injection) rule map: the
-    // cascade is forward reachability from `trivia`, independent of
-    // auto-insertion, so a plain `trivia` rule is the faithful fixture.
+    // cascade is forward reachability from `ignore`, independent of
+    // auto-insertion, so a plain `ignore` rule is the faithful fixture.
 
-    fn trivia_bits(src: &str) -> HashMap<String, bool> {
-        compute_trivia_rules(&super::super::parser::parse(src).expect("parse").rules)
+    fn ignore_bits(src: &str) -> HashMap<String, bool> {
+        compute_ignore_rules(&super::super::parser::parse(src).expect("parse").rules)
     }
 
     #[test]
-    fn no_trivia_rule_leaves_all_bits_false() {
-        let bits = trivia_bits("root = 'x'");
+    fn no_ignore_rule_leaves_all_bits_false() {
+        let bits = ignore_bits("root = 'x'");
         assert!(bits.values().all(|&b| !b));
     }
 
     #[test]
-    fn trivia_rule_marks_itself_not_root() {
-        let bits = trivia_bits("root = trivia 'x'\ntrivia = ' '*");
-        assert!(bits["trivia"]);
+    fn ignore_rule_marks_itself_not_root() {
+        let bits = ignore_bits("root = ignore 'x'\nignore = ' '*");
+        assert!(bits["ignore"]);
         assert!(!bits["root"]);
     }
 
     #[test]
-    fn trivia_cascade_reaches_transitive_callees() {
-        let bits = trivia_bits(
-            "root = trivia 'x'\n\
-             trivia = ws\n\
+    fn ignore_cascade_reaches_transitive_callees() {
+        let bits = ignore_bits(
+            "root = ignore 'x'\n\
+             ignore = ws\n\
              ws = (comment / ' ')*\n\
              comment = '#' (!'\\n' .)*",
         );
-        assert!(bits["trivia"] && bits["ws"] && bits["comment"]);
+        assert!(bits["ignore"] && bits["ws"] && bits["comment"]);
         assert!(!bits["root"]);
     }
 
     #[test]
-    fn trivia_cascade_skips_catch_bearing_rules() {
-        // `victim` is reachable from trivia but carries a catch, so it
+    fn ignore_cascade_skips_catch_bearing_rules() {
+        // `victim` is reachable from ignore but carries a catch, so it
         // is pinned out of the cascade — keeping its frame visible in
         // `pegdb recoveries explain`.
-        let bits = trivia_bits(
-            "root = trivia 'x'\n\
-             trivia = (victim / ' ')*\n\
+        let bits = ignore_bits(
+            "root = ignore 'x'\n\
+             ignore = (victim / ' ')*\n\
              victim = 'a' ^bad 'b'",
         );
-        assert!(bits["trivia"]);
+        assert!(bits["ignore"]);
         assert!(!bits["victim"], "catch-bearing rule must not cascade");
     }
 
     #[test]
-    fn trivia_cascade_terminates_on_recursion() {
-        let bits = trivia_bits(
-            "root = trivia 'x'\n\
-             trivia = ws\n\
+    fn ignore_cascade_terminates_on_recursion() {
+        let bits = ignore_bits(
+            "root = ignore 'x'\n\
+             ignore = ws\n\
              ws = (ws / ' ')*",
         );
-        assert!(bits["trivia"] && bits["ws"]);
+        assert!(bits["ignore"] && bits["ws"]);
     }
 
-    fn count_wb(pat: &Pattern) -> usize {
+    fn count_boundary(pat: &Pattern) -> usize {
         match pat {
-            Pattern::NonTerminal { name, .. } if name.as_str() == super::super::parser::WB_RULE => {
+            Pattern::NonTerminal { name, .. }
+                if name.as_str() == super::super::parser::BOUNDARY_RULE =>
+            {
                 1
             }
-            Pattern::Sequence { items, .. } => items.iter().map(count_wb).sum(),
-            Pattern::OrderedChoice { alts, .. } => alts.iter().map(count_wb).sum(),
+            Pattern::Sequence { items, .. } => items.iter().map(count_boundary).sum(),
+            Pattern::OrderedChoice { alts, .. } => alts.iter().map(count_boundary).sum(),
             Pattern::Repeat { inner, .. }
             | Pattern::RepeatOne { inner, .. }
             | Pattern::Optional { inner, .. }
             | Pattern::NotPredicate { inner, .. }
             | Pattern::AndPredicate { inner, .. }
             | Pattern::Capture { inner, .. }
-            | Pattern::Lenient { inner, .. } => count_wb(inner),
+            | Pattern::Lenient { inner, .. } => count_boundary(inner),
             Pattern::Catch {
                 inner, recovery, ..
-            } => count_wb(inner) + count_wb(recovery),
-            Pattern::InferBoundaryCatch { inner, .. } => count_wb(inner),
+            } => count_boundary(inner) + count_boundary(recovery),
+            Pattern::InferBoundaryCatch { inner, .. } => count_boundary(inner),
             _ => 0,
         }
     }
 
-    /// Mark a single rule `t` as a `reserved` rule, run `append_wb_check`, and
+    /// Mark a single rule `t` as a `reserved` rule, run `append_boundary_check`, and
     /// return the rewritten body.
     fn append_to(body: Pattern) -> Pattern {
         let mut rules = HashMap::new();
         rules.insert("t".to_string(), body);
         let mut g = Grammar::new(rules);
         g.percent_rules.insert("t".to_string());
-        append_wb_check(&mut g);
+        append_boundary_check(&mut g);
         g.rules.remove("t").unwrap()
     }
 
     #[test]
-    fn capture_less_charclass_choice_gets_one_trailing_wb() {
+    fn capture_less_charclass_choice_gets_one_trailing_boundary() {
         // `t: reserved = [ab] / [cd]` — capture-less but not all-literal, so the
-        // trie path is skipped and a single trailing `wb` follows the
+        // trie path is skipped and a single trailing `boundary` follows the
         // whole choice, not one per branch.
         let body = Pattern::choice(vec![
             Pattern::char_class(CharSet::from_chars(&['a', 'b'])),
             Pattern::char_class(CharSet::from_chars(&['c', 'd'])),
         ]);
-        assert_eq!(count_wb(&append_to(body)), 1);
+        assert_eq!(count_boundary(&append_to(body)), 1);
     }
 
     #[test]
     fn capture_less_literal_choice_factors_into_trie() {
         // `t: reserved = 'do' / 'double'` — all-literal, so it folds into a
         // longest-match trie: `do` shared, then `uble` accept vs the bare
-        // `do` accept. Two accepts → two `wb`s.
+        // `do` accept. Two accepts → two `boundary`s.
         let body = Pattern::choice(vec![Pattern::literal("do"), Pattern::literal("double")]);
         let trie = append_to(body);
-        assert_eq!(count_wb(&trie), 2);
+        assert_eq!(count_boundary(&trie), 2);
         // Source order must not matter: the scrambled set factors to the
         // identical trie (this is the structural #13 fix).
         let scrambled = append_to(Pattern::choice(vec![
@@ -2110,13 +2112,13 @@ mod tests {
     }
 
     #[test]
-    fn capture_choice_distributes_wb_per_branch() {
-        // `t: reserved = @k 'a' / @k 'b'` — each capture must keep `wb` inside
+    fn capture_choice_distributes_boundary_per_branch() {
+        // `t: reserved = @k 'a' / @k 'b'` — each capture must keep `boundary` inside
         // so a committed keyword can't leak through recovery.
         let body = Pattern::choice(vec![
             Pattern::capture("k", Pattern::literal("a")),
             Pattern::capture("k", Pattern::literal("b")),
         ]);
-        assert_eq!(count_wb(&append_to(body)), 2);
+        assert_eq!(count_boundary(&append_to(body)), 2);
     }
 }

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -14,12 +14,12 @@ pub enum CompileError {
     MissingRootRule,
     /// Grammar defines `root` but not at the expected source position.
     /// `root` must always be the first rule (parse-time enforcement
-    /// also requires `trivia`, when present, to sit immediately
+    /// also requires `ignore`, when present, to sit immediately
     /// after). Only raised for parsed grammars (hand-built ones have
     /// no recorded source order).
     RootRulePosition {
         expected_pos: usize,
-        has_trivia: bool,
+        has_ignore: bool,
     },
     /// One or more `^^lbl` catches have no following context to infer
     /// their boundary from. Emitted by `resolve_inferred_boundaries`.
@@ -56,7 +56,7 @@ impl std::fmt::Display for CompileError {
             ),
             CompileError::RootRulePosition {
                 expected_pos: _,
-                has_trivia: _,
+                has_ignore: _,
             } => write!(f, "`root` must be the first rule"),
             CompileError::CannotInferBoundary { rule, label, span } => write!(
                 f,
@@ -377,7 +377,7 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
         rule_count: 0,
         rule_names: Vec::new(),
         label_kinds: c.label_names,
-        rule_is_trivia: Vec::new(),
+        rule_is_ignore: Vec::new(),
         char_sets: c.char_sets,
     }
 }
@@ -410,11 +410,11 @@ pub(crate) fn compile_rules(rules: &HashMap<String, Pattern>) -> Result<Program,
     // Identify left-recursive rules (direct and indirect).
     let lr_rules = analyze_left_recursion(rules)?;
 
-    // Compute the per-rule trivia bit by cascading from any `trivia = …`
+    // Compute the per-rule ignore bit by cascading from any `ignore = …`
     // reserved-name root the grammar defines. Catch-bearing rules are
     // pinned out of the cascade so their frames stay visible in
     // `pegdb recoveries explain`.
-    let trivia_bits = super::analysis::compute_trivia_rules(rules);
+    let ignore_bits = super::analysis::compute_ignore_rules(rules);
 
     let mut c = Compiler::new();
     c.emit(Instruction::Call(Label(0))); // patched below
@@ -432,13 +432,13 @@ pub(crate) fn compile_rules(rules: &HashMap<String, Pattern>) -> Result<Program,
 
     let mut rule_addrs: HashMap<String, usize> = HashMap::new();
     let mut rule_names: Vec<String> = Vec::new();
-    let mut rule_is_trivia: Vec<bool> = Vec::new();
+    let mut rule_is_ignore: Vec<bool> = Vec::new();
     let mut rule_count: u32 = 0;
     for name in ordered {
         rule_addrs.insert(name.clone(), c.pos());
         let memo_id = MemoId(rule_count);
         rule_names.push(name.clone());
-        rule_is_trivia.push(trivia_bits.get(name).copied().unwrap_or(false));
+        rule_is_ignore.push(ignore_bits.get(name).copied().unwrap_or(false));
         rule_count += 1;
         let kind = if lr_rules.contains(name.as_str()) {
             RuleKind::Lr
@@ -484,7 +484,7 @@ pub(crate) fn compile_rules(rules: &HashMap<String, Pattern>) -> Result<Program,
         rule_count: rule_count as usize,
         rule_names,
         label_kinds: c.label_names,
-        rule_is_trivia,
+        rule_is_ignore,
         char_sets: c.char_sets,
     })
 }

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::analysis::{
-    append_wb_check, inject_auto_trivia, lint_partial_match, resolve_inferred_boundaries,
+    append_boundary_check, inject_auto_ignore, lint_partial_match, resolve_inferred_boundaries,
     synthesize_reserved_preferred, wrap_root,
 };
 use super::compiler::{compile_rules, CompileError};
@@ -34,25 +34,25 @@ fn case_fold_codepoint(c: char) -> CharSet {
 /// Reserved rule name for the grammar's start rule. Every grammar must
 /// define exactly one rule named [`ROOT_RULE`]; the compiler wraps its
 /// body to assert end-of-input and to splice optional leading / trailing
-/// `trivia` calls when an auto-insertion target exists.
+/// `ignore` calls when an auto-insertion target exists.
 pub const ROOT_RULE: &str = "root";
 
 /// Reserved rule name for the (optional) auto-insertion target. When a
-/// grammar defines a rule named [`TRIVIA_RULE`], the compiler injects a
+/// grammar defines a rule named [`IGNORE_RULE`], the compiler injects a
 /// call to it between consecutive `Sequence` items in every non-atomic
 /// rule's body. The rule carries no qualifiers; auto-insertion is
-/// disabled grammar-wide by omitting `trivia`, not by marking it.
-pub const TRIVIA_RULE: &str = "trivia";
+/// disabled grammar-wide by omitting `ignore`, not by marking it.
+pub const IGNORE_RULE: &str = "ignore";
 
 /// Reserved rule name for the (optional) word-boundary target. A rule
 /// ascribed `reserved` is compiled atomic and has a trailing call to
-/// [`WB_RULE`] appended inside its terminal captures by
-/// [`append_wb_check`](super::analysis::append_wb_check), so a keyword
-/// can't fire on the prefix of a longer identifier. Defining `wb` is
+/// [`BOUNDARY_RULE`] appended inside its terminal captures by
+/// [`append_boundary_check`](super::analysis::append_boundary_check), so a keyword
+/// can't fire on the prefix of a longer identifier. Defining `boundary` is
 /// only required when at least one `reserved` rule exists; like
-/// [`TRIVIA_RULE`] it must sit in the reserved slots immediately after
+/// [`IGNORE_RULE`] it must sit in the reserved slots immediately after
 /// [`ROOT_RULE`].
-pub const WB_RULE: &str = "wb";
+pub const BOUNDARY_RULE: &str = "boundary";
 
 /// Compiler-generated rule name for the reserved-word set. Synthesized
 /// by [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred)
@@ -79,22 +79,22 @@ pub struct Grammar {
     pub rules: HashMap<String, Pattern>,
     /// Names of rules ascribed `atomic`. The auto-insertion rewriter
     /// skips these rules: `Sequence` items inside an atomic body don't
-    /// get a synthesized `trivia` call spliced between them. The `trivia`
+    /// get a synthesized `ignore` call spliced between them. The `ignore`
     /// rule itself never appears here — it carries no ascriptions;
     /// auto-insertion is disabled by omitting the rule, not by ascribing
     /// it.
     pub atomic_rules: HashSet<String>,
     /// Names of rules ascribed `reserved` (and `preferred`, which is a
     /// subset — every `preferred` rule is also here so it still gets a
-    /// boundary). Each such rule is also in `atomic_rules` (so trivia is
+    /// boundary). Each such rule is also in `atomic_rules` (so ignore is
     /// not auto-inserted inside it); membership here additionally drives
-    /// [`append_wb_check`](super::analysis::append_wb_check), which
-    /// appends a [`WB_RULE`] call inside the rule's terminal captures.
+    /// [`append_boundary_check`](super::analysis::append_boundary_check), which
+    /// appends a [`BOUNDARY_RULE`] call inside the rule's terminal captures.
     pub percent_rules: HashSet<String>,
     /// Names of rules ascribed `preferred` — identifier-eligible
     /// distinguished tokens (Go predeclared `int` / `len`, JS contextual
     /// `async` / `let`). A strict subset of `percent_rules`: a
-    /// `preferred` rule still gets the [`WB_RULE`] boundary,
+    /// `preferred` rule still gets the [`BOUNDARY_RULE`] boundary,
     /// but its literals are *excluded* from the synthesized
     /// [`RESERVED_RULE`] and instead collected into [`PREFERRED_RULE`] by
     /// [`synthesize_reserved_preferred`](super::analysis::synthesize_reserved_preferred).
@@ -166,22 +166,22 @@ impl Grammar {
     ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
     ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with the
     ///    `name: partial` ascription at the rule definition.
-    /// 3. Inject auto-trivia calls into every non-atomic rule's body
-    ///    (no-op when the grammar has no `trivia` rule).
-    /// 4. Wrap `root`'s body with `trivia? body trivia? !.` (the
-    ///    `trivia?` calls are present iff auto-insertion is active).
+    /// 3. Inject auto-ignore calls into every non-atomic rule's body
+    ///    (no-op when the grammar has no `ignore` rule).
+    /// 4. Wrap `root`'s body with `ignore? body ignore? !.` (the
+    ///    `ignore?` calls are present iff auto-insertion is active).
     /// 5. Emit bytecode via `compile_rules`.
     ///
     /// The lint and FOLLOW-driven boundary resolver see the author's
     /// original body — auto-insertion and the `root` wrap run after
-    /// both, so synthesized `trivia` calls and the EOF assertion can't
+    /// both, so synthesized `ignore` calls and the EOF assertion can't
     /// confuse the lint walker or the FOLLOW set.
     pub fn compile(&self) -> Result<Program, CompileError> {
         if !self.rules.contains_key(ROOT_RULE) {
             return Err(CompileError::MissingRootRule);
         }
         // When the grammar was parsed from source, enforce that `root`
-        // is the first rule and `trivia` — when present — is the
+        // is the first rule and `ignore` — when present — is the
         // second. Hand-built grammars from `Grammar::new` skip this —
         // `rule_headers` is empty for them.
         if !self.rule_headers.is_empty() {
@@ -193,7 +193,7 @@ impl Grammar {
             if root_pos != 0 {
                 return Err(CompileError::RootRulePosition {
                     expected_pos: 0,
-                    has_trivia: self.rules.contains_key(TRIVIA_RULE),
+                    has_ignore: self.rules.contains_key(IGNORE_RULE),
                 });
             }
         }
@@ -209,19 +209,19 @@ impl Grammar {
         if !findings.is_empty() {
             return Err(CompileError::PartialMatchLeniency(findings));
         }
-        inject_auto_trivia(&mut resolved);
+        inject_auto_ignore(&mut resolved);
         // Synthesize the `reserved` / `preferred` rules from the literals
-        // of the `reserved` / `preferred` rules. Runs after trivia injection (so the
+        // of the `reserved` / `preferred` rules. Runs after ignore injection (so the
         // synthesized atomic rules aren't walked) and before
-        // `append_wb_check` (so the synthesized rules pick up the trie +
-        // `wb` like any other `reserved` rule, and exist before
+        // `append_boundary_check` (so the synthesized rules pick up the trie +
+        // `boundary` like any other `reserved` rule, and exist before
         // `compile_rules`' reference check).
         synthesize_reserved_preferred(&mut resolved)?;
-        // After trivia injection (which skips the atomic `reserved` rules)
-        // and before the root wrap: append the `wb` boundary call inside
-        // each `reserved` rule's terminal captures. An undefined `wb` surfaces as
-        // `CompileError::UndefinedRule("wb")` from `compile_rules`.
-        append_wb_check(&mut resolved);
+        // After ignore injection (which skips the atomic `reserved` rules)
+        // and before the root wrap: append the `boundary` boundary call inside
+        // each `reserved` rule's terminal captures. An undefined `boundary` surfaces as
+        // `CompileError::UndefinedRule("boundary")` from `compile_rules`.
+        append_boundary_check(&mut resolved);
         wrap_root(&mut resolved);
         compile_rules(&resolved.rules)
     }
@@ -318,14 +318,14 @@ impl<'a> Parser<'a> {
             //   call sites; the body is wrapped in `Pattern::Lenient` so
             //   the lint walker sees the same shape as a per-call-site
             //   leniency.
-            // - `atomic` opts the rule out of `trivia` auto-insertion (no
-            //   `trivia` spliced between `Sequence` items).
+            // - `atomic` opts the rule out of `ignore` auto-insertion (no
+            //   `ignore` spliced between `Sequence` items).
             // - `reserved` implies `atomic` and additionally appends a
-            //   `wb` boundary call inside the rule's terminal captures
-            //   (see `append_wb_check`); its literals seed the synthesized
+            //   `boundary` boundary call inside the rule's terminal captures
+            //   (see `append_boundary_check`); its literals seed the synthesized
             //   `reserved` set.
             // - `preferred` is the sibling of `reserved` (same atomic +
-            //   `wb` behavior) whose literals feed `preferred` instead and
+            //   `boundary` behavior) whose literals feed `preferred` instead and
             //   stay identifier-eligible.
             //
             // `atomic` / `reserved` / `preferred` are mutually exclusive
@@ -414,20 +414,20 @@ impl<'a> Parser<'a> {
                 )));
             }
             // The three special rules — the start rule `root` and the two
-            // auto-insertion targets `trivia` (whitespace) and `wb` (word
+            // auto-insertion targets `ignore` (whitespace) and `boundary` (word
             // boundary) — are structural slots wrapped or injected by the
             // compiler, not lexable tokens, so every ascription
             // (`partial`, `atomic`, `reserved`, `preferred`) is meaningless
             // on them and rejected. Disabling whitespace auto-insertion is
-            // done by omitting `trivia`, not by ascribing it.
+            // done by omitting `ignore`, not by ascribing it.
             if (definition_atomic
                 || definition_percent
                 || definition_preferred
                 || definition_lenient)
-                && (name == ROOT_RULE || name == TRIVIA_RULE || name == WB_RULE)
+                && (name == ROOT_RULE || name == IGNORE_RULE || name == BOUNDARY_RULE)
             {
-                let disable_hint = if name == TRIVIA_RULE {
-                    "; to disable auto-insertion, omit `trivia` and thread \
+                let disable_hint = if name == IGNORE_RULE {
+                    "; to disable auto-insertion, omit `ignore` and thread \
                      whitespace through a plainly-named rule"
                 } else {
                     ""
@@ -467,10 +467,10 @@ impl<'a> Parser<'a> {
         // that lets AST-only parser tests build fixtures with arbitrary
         // rule names without inventing a `root` placeholder.
         //
-        // `trivia` and `wb`, when present, occupy the contiguous slots
+        // `ignore` and `boundary`, when present, occupy the contiguous slots
         // immediately after `root` (positions 1..=n in either order),
         // where n is how many of them the grammar defines.
-        let specials = [TRIVIA_RULE, WB_RULE];
+        let specials = [IGNORE_RULE, BOUNDARY_RULE];
         let n_special = rule_headers
             .iter()
             .filter(|h| specials.contains(&h.name.as_str()))
@@ -483,11 +483,11 @@ impl<'a> Parser<'a> {
                 )));
             }
         }
-        // `wb`, like `trivia`, is exempt from trivia auto-insertion: its
+        // `boundary`, like `ignore`, is exempt from ignore auto-insertion: its
         // body is a bare boundary predicate that must stay adjacent to
         // the keyword it follows.
-        if rules.contains_key(WB_RULE) {
-            atomic_rules.insert(WB_RULE.to_string());
+        if rules.contains_key(BOUNDARY_RULE) {
+            atomic_rules.insert(BOUNDARY_RULE.to_string());
         }
         Ok(Grammar {
             rules,

--- a/src/pegvm/program.rs
+++ b/src/pegvm/program.rs
@@ -33,14 +33,14 @@ pub struct Program {
     /// recovery firing back to its source name. Empty for grammars
     /// that don't use labeled failures.
     pub label_kinds: Vec<String>,
-    /// Per-rule trivia flags, indexed by `MemoId.0`. `true` when the
-    /// rule is reachable from a `trivia = …` reserved-name root in
+    /// Per-rule ignore flags, indexed by `MemoId.0`. `true` when the
+    /// rule is reachable from a `ignore = …` reserved-name root in
     /// the grammar; a rule containing a recovery catch is pinned out
     /// of inference so the catch's frame stays visible. The
-    /// `recoveries` subcommands consult this to drop trailing trivia
+    /// `recoveries` subcommands consult this to drop trailing ignore
     /// frames from the rule_stack when picking the displayed leaf of
     /// a recovery cluster or span. Length is exactly `rule_count`.
-    pub rule_is_trivia: Vec<bool>,
+    pub rule_is_ignore: Vec<bool>,
     /// Character sets interned by the compiler. Indexed by
     /// [`crate::pegvm::SetId`]; each
     /// [`crate::pegvm::Instruction::CharSet`] payload is the index of

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1773,7 +1773,7 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
 fn definition_lenient_marker_is_runtime_transparent() {
     // The `name: partial =` wrap compiles to the same bytecode as the
     // bare form. The marker rides a non-special helper rule — `root`
-    // (like `trivia` / `wb`) rejects every ascription.
+    // (like `ignore` / `boundary`) rejects every ascription.
     let plain = parse("root = r\nr = 'x'+")
         .expect("parse plain")
         .compile()
@@ -1885,15 +1885,15 @@ fn compile_errors_on_uninferable_boundary() {
 }
 
 #[test]
-fn auto_trivia_handles_inter_repeat_whitespace() {
-    // The rewriter prepends a trivia call to each Repeat iteration so
+fn auto_ignore_handles_inter_repeat_whitespace() {
+    // The rewriter prepends a ignore call to each Repeat iteration so
     // `(',' x)*` accepts whitespace between iterations, not only on
-    // the first comma (which the outer Sequence's inter-item trivia
+    // the first comma (which the outer Sequence's inter-item ignore
     // already covers). Without the prepend, ` , 2 , 3` would fail on
     // the second iteration's leading space.
     let prog = parse(
         "root   = 'x' (',' 'x')*\n\
-         trivia = ' '*",
+         ignore = ' '*",
     )
     .expect("parse")
     .compile()
@@ -2098,7 +2098,7 @@ fn pattern_nodes_carry_parser_set_spans_for_each_variant_family() {
     assert_eq!(*lit_span, Span { line: 1, col: 12 });
 }
 
-// ---- `reserved` ascription + `wb` special rule --------------------
+// ---- `reserved` ascription + `boundary` special rule --------------------
 
 /// Compile a grammar from source and run it, returning the captures
 /// paired with their resolved kind name and matched text.
@@ -2121,27 +2121,27 @@ fn run_grammar<'a>(src: &str, input: &'a str) -> Vec<(String, &'a str)> {
 
 #[test]
 fn reserved_ascription_populates_percent_and_atomic_sets() {
-    let g =
-        parse("root = r\ntrivia = (\\s)*\nwb = !'x'\nr: reserved = @keyword 'if'").expect("parse");
+    let g = parse("root = r\nignore = (\\s)*\nboundary = !'x'\nr: reserved = @keyword 'if'")
+        .expect("parse");
     assert!(
         g.percent_rules.contains("r"),
         "`r: reserved` should be a percent rule"
     );
     assert!(
         g.atomic_rules.contains("r"),
-        "a `reserved` rule is also atomic (trivia is not auto-inserted inside it)"
+        "a `reserved` rule is also atomic (ignore is not auto-inserted inside it)"
     );
 }
 
 #[test]
 fn ascription_on_special_rule_is_rejected() {
     // The three special rules — the start rule `root` and the two
-    // auto-insertion targets `trivia` (whitespace) and `wb` (word
+    // auto-insertion targets `ignore` (whitespace) and `boundary` (word
     // boundary) — are structural slots, not lexable tokens: every
     // ascription (`partial`, `atomic`, `reserved`, `preferred`) is
     // rejected on all of them. Disabling whitespace auto-insertion is
-    // done by omitting `trivia`, not by ascribing it.
-    for name in ["root", "trivia", "wb"] {
+    // done by omitting `ignore`, not by ascribing it.
+    for name in ["root", "ignore", "boundary"] {
         for asc in ["partial", "atomic", "reserved", "preferred"] {
             let src = format!("{name}: {asc} = 'a'");
             let err = parse(&src).expect_err("an ascription on a special rule must error");
@@ -2150,11 +2150,11 @@ fn ascription_on_special_rule_is_rejected() {
                 "{src:?}: unexpected error {:?}",
                 err.message
             );
-            // Only `trivia` carries the auto-insertion-disable hint.
+            // Only `ignore` carries the auto-insertion-disable hint.
             assert_eq!(
-                err.message.contains("omit `trivia`"),
-                name == "trivia",
-                "{src:?}: hint presence should track the `trivia` name"
+                err.message.contains("omit `ignore`"),
+                name == "ignore",
+                "{src:?}: hint presence should track the `ignore` name"
             );
         }
     }
@@ -2164,7 +2164,7 @@ fn ascription_on_special_rule_is_rejected() {
 fn partial_composes_with_reserved() {
     // `partial reserved` combines the leniency marker with the
     // reserved-word ascription (partial written first).
-    let src = "root = r\ntrivia = (\\s)*\nwb = !'x'\nr: partial reserved = @keyword 'if'";
+    let src = "root = r\nignore = (\\s)*\nboundary = !'x'\nr: partial reserved = @keyword 'if'";
     let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
     assert!(
         g.percent_rules.contains("r"),
@@ -2177,13 +2177,13 @@ fn partial_composes_with_reserved() {
 }
 
 #[test]
-fn percent_rule_appends_wb_inside_capture() {
+fn percent_rule_appends_boundary_inside_capture() {
     // `kw_if: reserved` must match the keyword `if` but not fire on
     // `ifx`, and (the leak guard) must leave no stray `if` capture
     // behind on `ifx`.
     let src = "root = (token)*^\n\
-               trivia = (\\s)*\n\
-               wb = !ident_body\n\
+               ignore = (\\s)*\n\
+               boundary = !ident_body\n\
                token = kw_if / @variable ident\n\
                kw_if: reserved = @keyword 'if'\n\
                ident: atomic = [a-z] ident_body*\n\
@@ -2199,13 +2199,16 @@ fn percent_rule_appends_wb_inside_capture() {
 }
 
 #[test]
-fn percent_without_wb_errors_undefined_rule() {
-    // A `reserved` rule emits a `NonTerminal("wb")`; with no `wb`
-    // defined the reference surfaces as `UndefinedRule("wb")`.
-    let g = parse("root = r\ntrivia = (\\s)*\nr: reserved = @keyword 'if'").expect("parse");
-    match g.compile().expect_err("compile should fail without wb") {
-        syntax_highlighter::pegc::CompileError::UndefinedRule(name) => assert_eq!(name, "wb"),
-        other => panic!("expected UndefinedRule(\"wb\"), got: {other:?}"),
+fn percent_without_boundary_errors_undefined_rule() {
+    // A `reserved` rule emits a `NonTerminal("boundary")`; with no `boundary`
+    // defined the reference surfaces as `UndefinedRule("boundary")`.
+    let g = parse("root = r\nignore = (\\s)*\nr: reserved = @keyword 'if'").expect("parse");
+    match g
+        .compile()
+        .expect_err("compile should fail without boundary")
+    {
+        syntax_highlighter::pegc::CompileError::UndefinedRule(name) => assert_eq!(name, "boundary"),
+        other => panic!("expected UndefinedRule(\"boundary\"), got: {other:?}"),
     }
 }
 
@@ -2222,9 +2225,10 @@ fn reserved_and_atomic_combined_is_parse_error() {
 }
 
 #[test]
-fn wb_must_sit_in_the_reserved_slots() {
-    // `wb` after a non-reserved rule (not contiguous with `root`) errors.
-    let err = parse("root = r\nr = 'a'\nwb = !'x'").expect_err("misplaced wb must error");
+fn boundary_must_sit_in_the_reserved_slots() {
+    // `boundary` after a non-reserved rule (not contiguous with `root`) errors.
+    let err =
+        parse("root = r\nr = 'a'\nboundary = !'x'").expect_err("misplaced boundary must error");
     assert!(
         err.message.contains("reserved slots"),
         "unexpected error: {}",
@@ -2233,16 +2237,16 @@ fn wb_must_sit_in_the_reserved_slots() {
 }
 
 #[test]
-fn wb_and_trivia_compose_in_either_order() {
+fn boundary_and_ignore_compose_in_either_order() {
     // Both orderings of the two reserved slots after `root` are accepted.
-    parse("root = 'a'\ntrivia = (\\s)*\nwb = !'x'").expect("trivia then wb");
-    parse("root = 'a'\nwb = !'x'\ntrivia = (\\s)*").expect("wb then trivia");
+    parse("root = 'a'\nignore = (\\s)*\nboundary = !'x'").expect("ignore then boundary");
+    parse("root = 'a'\nboundary = !'x'\nignore = (\\s)*").expect("boundary then ignore");
 }
 
 #[test]
-fn wb_without_trivia_is_valid() {
-    // `wb` does not require `trivia`; a grammar may define only `wb`.
-    parse("root = r\nwb = !'x'\nr: reserved = @keyword 'if'")
+fn boundary_without_ignore_is_valid() {
+    // `boundary` does not require `ignore`; a grammar may define only `boundary`.
+    parse("root = r\nboundary = !'x'\nr: reserved = @keyword 'if'")
         .expect("parse")
         .compile()
         .expect("compile");
@@ -2254,9 +2258,9 @@ fn wb_without_trivia_is_valid() {
 fn preferred_ascription_populates_preferred_and_percent_sets() {
     // `r: preferred` is a preferred-word rule: it lands in
     // `preferred_rules`, and also in `percent_rules` + `atomic_rules`
-    // (it still gets the `wb` boundary; it differs from `reserved` only
+    // (it still gets the `boundary` boundary; it differs from `reserved` only
     // in which synthesized set it feeds).
-    let g = parse("root = r\ntrivia = (\\s)*\nwb = !'x'\nr: preferred = @keyword 'async'")
+    let g = parse("root = r\nignore = (\\s)*\nboundary = !'x'\nr: preferred = @keyword 'async'")
         .expect("parse");
     assert!(
         g.preferred_rules.contains("r"),
@@ -2264,7 +2268,7 @@ fn preferred_ascription_populates_preferred_and_percent_sets() {
     );
     assert!(
         g.percent_rules.contains("r"),
-        "`r: preferred` is still a percent rule (gets `wb`)"
+        "`r: preferred` is still a percent rule (gets `boundary`)"
     );
     assert!(
         g.atomic_rules.contains("r"),
@@ -2307,7 +2311,7 @@ fn defining_synthesized_rule_is_parse_error() {
 fn reserved_preferred_conflict_errors() {
     // The same literal marked `reserved` in one rule and `preferred`
     // in another is a contradiction — compile rejects it.
-    let err = parse("root = 'x'\nwb = !'y'\na: reserved = 'int'\nb: preferred = 'int'")
+    let err = parse("root = 'x'\nboundary = !'y'\na: reserved = 'int'\nb: preferred = 'int'")
         .expect("parse")
         .compile()
         .expect_err("conflicting reserved/preferred must error");
@@ -2327,8 +2331,8 @@ fn synthesized_reserved_trie_and_preferred_membership() {
     // (`len`) is excluded from `reserved` and stays usable as an
     // identifier.
     let src = "root = (token)*^\n\
-               trivia = (\\s)*\n\
-               wb = !ident_body\n\
+               ignore = (\\s)*\n\
+               boundary = !ident_body\n\
                token = @keyword kw_word / @variable ident\n\
                kw_word: reserved = 'int' / 'int8'\n\
                pre: preferred = 'len'\n\

--- a/tests/grammar_sql_tests.rs
+++ b/tests/grammar_sql_tests.rs
@@ -359,7 +359,7 @@ fn float_variants() {
 #[test]
 fn number_literal_does_not_span_whitespace() {
     // Numeric forms are atomic: `1 . 5` must not lex as a single number
-    // (no trivia injected inside a numeric literal).
+    // (no ignore injected inside a numeric literal).
     let input = "SELECT 1 . 5";
     let (_, caps, kinds, _) = run(input);
     let nums = spans_for(&caps, &kinds, "number", input);

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1179,7 +1179,7 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
 fn end_to_end_lenient_marker_is_runtime_transparent() {
     use syntax_highlighter::pegvm::VM;
     // The marker rides a non-special helper rule — `root` (like
-    // `trivia` / `wb`) rejects every ascription.
+    // `ignore` / `boundary`) rejects every ascription.
     let plain = parse("root = r\nr = 'x'+").compile().unwrap();
     let lenient = parse("root = r\nr: partial = 'x'+").compile().unwrap();
     assert_eq!(plain.code, lenient.code, "`partial` is runtime-transparent");

--- a/tests/pegdb_tests.rs
+++ b/tests/pegdb_tests.rs
@@ -348,16 +348,16 @@ fn recoveries_dump_carries_label_pos_rule_stack_literal() {
 }
 
 #[test]
-fn recoveries_dump_skips_trivia_in_leaf() {
-    // Same `trivia = ws` cascade story as `recoveries explain`: the
+fn recoveries_dump_skips_ignore_in_leaf() {
+    // Same `ignore = ws` cascade story as `recoveries explain`: the
     // displayed leaf (last element of `rule_stack`) must not be a
-    // trivia rule.
+    // ignore rule.
     let (code, stdout, _) = run_stdin(
         &["recoveries", "dump", "-g", "grammars/rust.peg"],
         b"fn ok() {}\n@@@ garbage @@@\nfn ok2() {}\n",
     );
     assert_eq!(code, 0);
-    let trivia_names = [
+    let ignore_names = [
         "\"ws\"",
         "\"spacing\"",
         "\"comment\"",
@@ -380,8 +380,8 @@ fn recoveries_dump_skips_trivia_in_leaf() {
             .map(str::trim)
             .unwrap_or("");
         assert!(
-            !trivia_names.contains(&leaf_token),
-            "displayed leaf must not be a trivia rule, got {leaf_token:?} in: {line}"
+            !ignore_names.contains(&leaf_token),
+            "displayed leaf must not be a ignore rule, got {leaf_token:?} in: {line}"
         );
         row_count += 1;
     }
@@ -510,13 +510,13 @@ fn recoveries_dump_clean_run_emits_no_sanity_rows() {
 // ---------- recoveries explain ----------
 
 #[test]
-fn recoveries_explain_skips_trivia_when_picking_leaf() {
+fn recoveries_explain_skips_ignore_when_picking_leaf() {
     let (code, stdout, _) = run_stdin(
         &["recoveries", "explain", "-g", "grammars/rust.peg"],
         b"fn ok() {}\n@@@ garbage @@@\nfn ok2() {}\n",
     );
     assert_eq!(code, 0);
-    let trivia_names = ["ws", "spacing", "comment", "line_comment", "block_comment"];
+    let ignore_names = ["ws", "spacing", "comment", "line_comment", "block_comment"];
     for line in stdout.lines() {
         if line.starts_with("[sanity]") || line == "no recoveries" {
             continue;
@@ -528,8 +528,8 @@ fn recoveries_explain_skips_trivia_when_picking_leaf() {
             .map(str::trim)
             .unwrap_or_else(|| panic!("could not parse leaf from: {line}"));
         assert!(
-            !trivia_names.contains(&leaf),
-            "displayed leaf must not be a trivia rule, got `{leaf}` in: {line}"
+            !ignore_names.contains(&leaf),
+            "displayed leaf must not be a ignore rule, got `{leaf}` in: {line}"
         );
     }
 }


### PR DESCRIPTION
Renames the two compiler-recognized special rules to clearer, self-explanatory names: the whitespace auto-insertion target `trivia` becomes `ignore`, and the word-boundary target `wb` becomes `boundary`. This is an intermezzo ahead of the single-root-item step of the surface-syntax redesign, where these rules get scoped under the root declaration.

A full rename: the surface keyword in every grammar, fixture, inline test grammar, and doc, plus the internal identifiers that carry the names — `TRIVIA_RULE`/`WB_RULE` → `IGNORE_RULE`/`BOUNDARY_RULE`, `compute_trivia_rules` → `compute_ignore_rules`, `rule_is_trivia` → `rule_is_ignore`, `append_wb_check` → `append_boundary_check`, and the cascade/test names. No behavior changes — the rules play exactly the same compile-time roles under their new names.
