### PR TITLE
Add indentation support via `%root` / `%align` / `%indent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,22 @@ override).
 
 ## Status
 
-Early MVP; expect breaking changes. Eight grammars ship today, plus
-an ANSI-coloring CLI. The "kilobyte range per grammar" design goal
-holds across the shipped set: as a representative data point, the
-largest grammar (SQLite) compiles to roughly 5,600 instructions
-across 426 rules — comfortably within the kilobyte-per-grammar target.
+Early MVP; expect breaking changes. Ten grammars ship today — eight
+free-form, plus deliberately-pruned Starlark and YAML subsets that
+validate the implicit indentation operators (issue #43; see
+[`src/pegc/README.md`](src/pegc/README.md)) — plus an ANSI-coloring CLI.
+The "kilobyte range per grammar" design goal holds across the shipped
+set: as a representative data point, the largest grammar (SQLite)
+compiles to roughly 5,600 instructions across 426 rules — comfortably
+within the kilobyte-per-grammar target.
 
 For current per-grammar numbers, run `cargo run --bin pegc -- stats grammars/<lang>.peg`; see [`TOOLS.md`](TOOLS.md) for the developer tools' full contract.
 
 The CLI picks a grammar by file extension (`.json`, `.toml`, `.sql`,
-`.rs`, `.js`/`.mjs`/`.cjs`, `.go`, `.c`/`.h`, `.css`) or an explicit
-`-l json|toml|sql|rust|js|go|c|css` flag; stdin without a flag
-defaults to JSON.
+`.rs`, `.js`/`.mjs`/`.cjs`, `.go`, `.c`/`.h`, `.css`, `.star`/`.bzl`,
+`.yaml`/`.yml`) or an explicit
+`-l json|toml|sql|rust|js|go|c|css|starlark|yaml` flag; stdin without a
+flag defaults to JSON.
 
 Malformed or incomplete inputs render the longest valid prefix styled and
 the rest plain (see `src/pegvm/vm.rs` for the farthest-failure tracking).

--- a/benches/fixtures/large.star
+++ b/benches/fixtures/large.star
@@ -1,0 +1,728 @@
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+

--- a/benches/fixtures/large.yaml
+++ b/benches/fixtures/large.yaml
@@ -1,0 +1,728 @@
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+

--- a/benches/fixtures/medium.star
+++ b/benches/fixtures/medium.star
@@ -1,0 +1,112 @@
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+

--- a/benches/fixtures/medium.yaml
+++ b/benches/fixtures/medium.yaml
@@ -1,0 +1,112 @@
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+

--- a/benches/fixtures/small.star
+++ b/benches/fixtures/small.star
@@ -1,0 +1,27 @@
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config

--- a/benches/fixtures/small.yaml
+++ b/benches/fixtures/small.yaml
@@ -1,0 +1,29 @@
+--- # sample document
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+...

--- a/benches/fixtures/xlarge.star
+++ b/benches/fixtures/xlarge.star
@@ -1,0 +1,1792 @@
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+
+# sample starlark module
+load("//tools:defs.bzl", "helper")
+
+CONST = 42
+NAMES = ["alpha", "beta", "gamma"]
+
+def fib(n):
+    if n < 2:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+def classify(values):
+    total = 0
+    for x in values:
+        if x > 0:
+            total += x
+        elif x < 0:
+            total -= x
+        else:
+            total = total
+    config = {
+        "sum": total,
+        "items": [1, 2, 3],
+        "nested": {"a": 1, "b": 2},
+    }
+    return config
+

--- a/benches/fixtures/xlarge.yaml
+++ b/benches/fixtures/xlarge.yaml
@@ -1,0 +1,1792 @@
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+
+name: example-service
+version: 1.4.2
+enabled: true
+metadata:
+  owner: platform
+  labels:
+    tier: backend
+    region: us-east-1
+  annotations:
+    note: "a quoted value"
+replicas: 3
+ports:
+  - 8080
+  - 8443
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+args: [serve, --verbose, --port=8080]
+labels: {app: web, env: prod}
+nested:
+  - first
+  - second
+  - third
+

--- a/benches/follow_set.rs
+++ b/benches/follow_set.rs
@@ -30,6 +30,8 @@ const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
 const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
+const STARLARK_GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+const YAML_GRAMMAR: &str = include_str!("../grammars/yaml.peg");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -90,6 +92,14 @@ fn main() {
         GrammarCase {
             name: "css",
             grammar: parse_case("css", CSS_GRAMMAR),
+        },
+        GrammarCase {
+            name: "starlark",
+            grammar: parse_case("starlark", STARLARK_GRAMMAR),
+        },
+        GrammarCase {
+            name: "yaml",
+            grammar: parse_case("yaml", YAML_GRAMMAR),
         },
     ];
 

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -31,6 +31,8 @@ const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
 const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
+const STARLARK_GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+const YAML_GRAMMAR: &str = include_str!("../grammars/yaml.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -71,6 +73,16 @@ const CSS_SMALL: &str = include_str!("fixtures/small.css");
 const CSS_MEDIUM: &str = include_str!("fixtures/medium.css");
 const CSS_LARGE: &str = include_str!("fixtures/large.css");
 const CSS_XLARGE: &str = include_str!("fixtures/xlarge.css");
+
+const STAR_SMALL: &str = include_str!("fixtures/small.star");
+const STAR_MEDIUM: &str = include_str!("fixtures/medium.star");
+const STAR_LARGE: &str = include_str!("fixtures/large.star");
+const STAR_XLARGE: &str = include_str!("fixtures/xlarge.star");
+
+const YAML_SMALL: &str = include_str!("fixtures/small.yaml");
+const YAML_MEDIUM: &str = include_str!("fixtures/medium.yaml");
+const YAML_LARGE: &str = include_str!("fixtures/large.yaml");
+const YAML_XLARGE: &str = include_str!("fixtures/xlarge.yaml");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -350,6 +362,26 @@ fn main() {
                 ("medium", CSS_MEDIUM),
                 ("large", CSS_LARGE),
                 ("xlarge", CSS_XLARGE),
+            ],
+        },
+        GrammarCase {
+            label: "starlark",
+            source: STARLARK_GRAMMAR,
+            fixtures: &[
+                ("small", STAR_SMALL),
+                ("medium", STAR_MEDIUM),
+                ("large", STAR_LARGE),
+                ("xlarge", STAR_XLARGE),
+            ],
+        },
+        GrammarCase {
+            label: "yaml",
+            source: YAML_GRAMMAR,
+            fixtures: &[
+                ("small", YAML_SMALL),
+                ("medium", YAML_MEDIUM),
+                ("large", YAML_LARGE),
+                ("xlarge", YAML_XLARGE),
             ],
         },
     ];

--- a/benches/lint.rs
+++ b/benches/lint.rs
@@ -31,6 +31,8 @@ const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
 const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
+const STARLARK_GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+const YAML_GRAMMAR: &str = include_str!("../grammars/yaml.peg");
 
 const RUNS_PER_CELL: usize = 11;
 
@@ -89,6 +91,14 @@ fn main() {
         GrammarCase {
             name: "css",
             grammar: parse_case("css", CSS_GRAMMAR),
+        },
+        GrammarCase {
+            name: "starlark",
+            grammar: parse_case("starlark", STARLARK_GRAMMAR),
+        },
+        GrammarCase {
+            name: "yaml",
+            grammar: parse_case("yaml", YAML_GRAMMAR),
         },
     ];
 

--- a/benches/memo.rs
+++ b/benches/memo.rs
@@ -31,6 +31,8 @@ const JS_GRAMMAR: &str = include_str!("../grammars/javascript.peg");
 const GO_GRAMMAR: &str = include_str!("../grammars/go.peg");
 const C_GRAMMAR: &str = include_str!("../grammars/c.peg");
 const CSS_GRAMMAR: &str = include_str!("../grammars/css.peg");
+const STARLARK_GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+const YAML_GRAMMAR: &str = include_str!("../grammars/yaml.peg");
 
 const JSON_SMALL: &str = include_str!("fixtures/small.json");
 const JSON_MEDIUM: &str = include_str!("fixtures/medium.json");
@@ -71,6 +73,16 @@ const CSS_SMALL: &str = include_str!("fixtures/small.css");
 const CSS_MEDIUM: &str = include_str!("fixtures/medium.css");
 const CSS_LARGE: &str = include_str!("fixtures/large.css");
 const CSS_XLARGE: &str = include_str!("fixtures/xlarge.css");
+
+const STAR_SMALL: &str = include_str!("fixtures/small.star");
+const STAR_MEDIUM: &str = include_str!("fixtures/medium.star");
+const STAR_LARGE: &str = include_str!("fixtures/large.star");
+const STAR_XLARGE: &str = include_str!("fixtures/xlarge.star");
+
+const YAML_SMALL: &str = include_str!("fixtures/small.yaml");
+const YAML_MEDIUM: &str = include_str!("fixtures/medium.yaml");
+const YAML_LARGE: &str = include_str!("fixtures/large.yaml");
+const YAML_XLARGE: &str = include_str!("fixtures/xlarge.yaml");
 
 const THRESHOLDS: &[usize] = &[0, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 const RUNS_PER_CELL: usize = 11;
@@ -261,6 +273,26 @@ fn main() {
                 ("medium", CSS_MEDIUM.as_bytes()),
                 ("large", CSS_LARGE.as_bytes()),
                 ("xlarge", CSS_XLARGE.as_bytes()),
+            ],
+        },
+        GrammarCase {
+            name: "starlark",
+            program: compile_case("starlark", STARLARK_GRAMMAR),
+            inputs: vec![
+                ("small", STAR_SMALL.as_bytes()),
+                ("medium", STAR_MEDIUM.as_bytes()),
+                ("large", STAR_LARGE.as_bytes()),
+                ("xlarge", STAR_XLARGE.as_bytes()),
+            ],
+        },
+        GrammarCase {
+            name: "yaml",
+            program: compile_case("yaml", YAML_GRAMMAR),
+            inputs: vec![
+                ("small", YAML_SMALL.as_bytes()),
+                ("medium", YAML_MEDIUM.as_bytes()),
+                ("large", YAML_LARGE.as_bytes()),
+                ("xlarge", YAML_XLARGE.as_bytes()),
             ],
         },
     ];

--- a/grammars/starlark.peg
+++ b/grammars/starlark.peg
@@ -1,0 +1,120 @@
+# Starlark, a deliberately-pruned subset; out-of-subset gaps tracked in #164.
+# Line-structure rules are `atomic` so the horizontal-only auto-`ignore`
+# can't eat a line's indentation before a `%align` / `%indent` operator
+# measures it.
+
+starlark = module {
+
+    ignore = \h*
+
+    blanks: atomic = (\h* comment? \R)*
+    line_break: atomic = \h* comment? \R blanks
+    comment: atomic = @comment ('#' .. \R)
+
+    wsnl: atomic = (\s / comment)*
+
+    module: atomic =
+        blanks
+        (%root (stmt (line_break %align stmt)*))?
+        blanks
+
+    stmt = compound / simple
+
+    compound = if_stmt / for_stmt / while_stmt / def_stmt
+
+    clause_sep: atomic = line_break %align
+
+    if_stmt =
+        @keyword 'if' expr @punctuation ':' suite
+        (clause_sep @keyword 'elif' expr @punctuation ':' suite)*
+        (clause_sep @keyword 'else' @punctuation ':' suite)?
+
+    for_stmt =
+        @keyword 'for' targets @keyword 'in' expr @punctuation ':' suite
+
+    while_stmt =
+        @keyword 'while' expr @punctuation ':' suite
+
+    def_stmt =
+        @keyword 'def' @function name @punctuation '(' wsnl params? wsnl @punctuation ')'
+        @punctuation ':' suite
+
+    suite: atomic =
+        line_break
+        %indent (stmt (line_break %align stmt)*)
+
+    simple = small (@punctuation ';' small)* @punctuation ';'?
+
+    small = @keyword 'pass'
+          / @keyword 'break'
+          / @keyword 'continue'
+          / @keyword 'return' expr?
+          / load_stmt
+          / assign_or_expr
+
+    load_stmt = @keyword 'load' @punctuation '(' wsnl arglist? wsnl @punctuation ')'
+
+    assign_or_expr =
+        expr (@operator ('=' / '+=' / '-=' / '*=' / '//=' / '/=' / '%=') expr)?
+
+    targets = target (@punctuation ',' target)* @punctuation ','?
+    target = @variable name
+
+    params = param (@punctuation ',' param)*
+    param = @operator ('**' / '*')? @variable name (@punctuation '=' expr)?
+
+    expr = ternary
+    ternary = or_test (@keyword 'if' or_test @keyword 'else' expr)?
+    or_test = and_test (@keyword 'or' and_test)*
+    and_test = not_test (@keyword 'and' not_test)*
+    not_test = @keyword 'not' not_test / comparison
+    comparison = bit_or (comp_op bit_or)*
+    comp_op = @operator ('==' / '!=' / '<=' / '>=' / '<' / '>') / @keyword 'in'
+    bit_or = sum (@operator ('|' / '&' / '^') sum)*
+    sum = term (@operator ('+' / '-') term)*
+    term = factor (@operator ('*' / '//' / '/' / '%') factor)*
+    factor = @operator ('+' / '-' / '~') factor / power
+    power = postfix (@operator '**' factor)?
+
+    postfix = atom trailer*
+    trailer = @punctuation '.' @property name
+            / call
+            / index
+    call: atomic = @punctuation '(' wsnl arglist? wsnl @punctuation ')'
+    index: atomic = @punctuation '[' wsnl expr wsnl @punctuation ']'
+
+    arglist = arg (wsnl @punctuation ',' wsnl arg)* (wsnl @punctuation ',')?
+    arg = named_arg / @operator ('**' / '*') expr / expr
+    named_arg = @property name @punctuation '=' expr
+
+    atom = @string string
+         / @number number
+         / @constant ('True' / 'False' / 'None')
+         / list
+         / dict
+         / paren
+         / @variable name
+
+    list: atomic =
+        @punctuation '[' wsnl (expr (wsnl @punctuation ',' wsnl expr)* (wsnl @punctuation ',')?)? wsnl @punctuation ']'
+
+    dict: atomic =
+        @punctuation '{' wsnl (pair (wsnl @punctuation ',' wsnl pair)* (wsnl @punctuation ',')?)? wsnl @punctuation '}'
+    pair = expr wsnl @punctuation ':' wsnl expr
+
+    paren: atomic = @punctuation '(' wsnl expr wsnl @punctuation ')'
+
+    name: atomic = [A-Za-z_] [A-Za-z_0-9]*
+
+    string = triple_double / triple_single / double / single
+    triple_double: atomic = '"""' ..= '"""'
+    triple_single: atomic = "'''" ..= "'''"
+    double: atomic = '"' ('\\' . / [^"\\\n])* '"'
+    single: atomic = "'" ('\\' . / [^'\\\n])* "'"
+
+    number: atomic = '0' [xX] [\da-fA-F]+
+                   / '0' [oO] [0-7]+
+                   / '0' [bB] [01]+
+                   / \d+ ('.' \d*)? ([eE] [+\-]? \d+)?
+                   / '.' \d+
+}

--- a/grammars/yaml.peg
+++ b/grammars/yaml.peg
@@ -1,0 +1,73 @@
+# YAML, a deliberately-pruned subset; out-of-subset gaps tracked in #165.
+# Line-structure rules are `atomic` so the horizontal-only auto-`ignore`
+# can't eat a line's indentation before a `%align` / `%indent` operator
+# measures it.
+
+yaml = stream {
+
+    ignore = \h*
+
+    blanks: atomic = (\h* comment? \R)*
+    line_break: atomic = \h* comment? \R blanks
+    comment: atomic = @comment ('#' .. \R)
+    wsnl: atomic = (\s / comment)*
+
+    stream: atomic =
+        blanks
+        document?
+        blanks
+
+    document: atomic =
+        (doc_start blanks)?
+        (%root node)?
+        blanks
+        doc_end?
+
+    doc_start: atomic = @punctuation '---'
+    doc_end: atomic = @punctuation '...'
+
+    node = mapping / sequence / scalar
+
+    mapping: atomic =
+        entry
+        (align entry)*
+
+    align: atomic = line_break %align
+
+    entry = @property key @punctuation ':' value?
+
+    sequence: atomic =
+        seq_item
+        (align seq_item)*
+
+    seq_item = @punctuation '-' value?
+
+    value = flow_seq / flow_map / quoted / plain / block
+
+    block: atomic =
+        line_break
+        %indent (mapping / sequence)
+
+    scalar = flow_seq / flow_map / quoted / plain
+    quoted = @string (double / single)
+    double: atomic = '"' ('\\' . / [^"\\\n])* '"'
+    single: atomic = "'" ([^'\n] / "''")* "'"
+
+    plain: atomic = @string (!indicator (!\R !comment_start .)+)
+    indicator: atomic = [\-?:,\[\]{}#&*!|>'"%@`] / \R
+    comment_start: atomic = \h '#'
+
+    key: atomic = [A-Za-z0-9_/.\-]+
+
+    flow_seq: atomic =
+        @punctuation '[' wsnl (flow_node (wsnl @punctuation ',' wsnl flow_node)* (wsnl @punctuation ',')?)? wsnl @punctuation ']'
+
+    flow_map: atomic =
+        @punctuation '{' wsnl (flow_pair (wsnl @punctuation ',' wsnl flow_pair)* (wsnl @punctuation ',')?)? wsnl @punctuation '}'
+
+    flow_pair = @property flow_key wsnl @punctuation ':' wsnl flow_node
+    flow_key: atomic = [A-Za-z0-9_/.\-]+
+
+    flow_node = flow_seq / flow_map / quoted / @string flow_plain
+    flow_plain: atomic = (![,\[\]{}:] !\s .)+
+}

--- a/src/bin/demo/main.rs
+++ b/src/bin/demo/main.rs
@@ -15,18 +15,21 @@ const JS_GRAMMAR: &str = include_str!("../../../grammars/javascript.peg");
 const GO_GRAMMAR: &str = include_str!("../../../grammars/go.peg");
 const C_GRAMMAR: &str = include_str!("../../../grammars/c.peg");
 const CSS_GRAMMAR: &str = include_str!("../../../grammars/css.peg");
+const STARLARK_GRAMMAR: &str = include_str!("../../../grammars/starlark.peg");
+const YAML_GRAMMAR: &str = include_str!("../../../grammars/yaml.peg");
 
 /// Default grammar source used when neither `-l` nor a path-extension
 /// hint is available (e.g. stdin without flags).
 const DEFAULT: &str = JSON_GRAMMAR;
 
 /// Pipe-separated list of canonical language names, suitable for
-/// embedding in usage strings: `-l json|toml|sql|rust|js|go|c|css`.
-const LANG_NAMES: &str = "json|toml|sql|rust|js|go|c|css";
+/// embedding in usage strings.
+const LANG_NAMES: &str = "json|toml|sql|rust|js|go|c|css|starlark|yaml";
 
 /// Resolve a language name (canonical or common alias) to the embedded
 /// grammar source. Aliases: `sql|sqlite`, `rs|rust`, `js|javascript|mjs|cjs`,
-/// `c|h`.
+/// `c|h`, `starlark|star|bzl`, `yaml|yml`. Starlark and YAML are
+/// deliberately-pruned subsets (issue #43); see `grammars/{starlark,yaml}.peg`.
 fn by_name(name: &str) -> Option<&'static str> {
     match name {
         "json" => Some(JSON_GRAMMAR),
@@ -37,6 +40,8 @@ fn by_name(name: &str) -> Option<&'static str> {
         "go" => Some(GO_GRAMMAR),
         "c" | "h" => Some(C_GRAMMAR),
         "css" => Some(CSS_GRAMMAR),
+        "starlark" | "star" | "bzl" => Some(STARLARK_GRAMMAR),
+        "yaml" | "yml" => Some(YAML_GRAMMAR),
         _ => None,
     }
 }
@@ -163,6 +168,9 @@ mod tests {
         assert_eq!(by_name("mjs"), by_name("js"));
         assert_eq!(by_name("cjs"), by_name("js"));
         assert_eq!(by_name("h"), by_name("c"));
+        assert_eq!(by_name("star"), by_name("starlark"));
+        assert_eq!(by_name("bzl"), by_name("starlark"));
+        assert_eq!(by_name("yml"), by_name("yaml"));
     }
 
     #[test]
@@ -175,6 +183,8 @@ mod tests {
     fn by_extension_uses_name_table() {
         assert!(by_extension(Path::new("foo.rs")).is_some());
         assert!(by_extension(Path::new("foo.json")).is_some());
+        assert!(by_extension(Path::new("foo.star")).is_some());
+        assert!(by_extension(Path::new("foo.yaml")).is_some());
         assert!(by_extension(Path::new("foo.unknown")).is_none());
         assert!(by_extension(Path::new("Makefile")).is_none());
     }

--- a/src/pegb.rs
+++ b/src/pegb.rs
@@ -60,7 +60,8 @@
 //! instructions decodes in sub-millisecond time.
 
 use crate::pegvm::{
-    CaptureKind, CharSet, Instruction, Label, LabelId, MemoId, Program, RuleKind, SetId,
+    ArgSrc, CaptureKind, CharSet, CmpOp, Instruction, Label, LabelId, MemoId, Program, RuleKind,
+    SetId,
 };
 
 /// Failure modes for [`decode`]. [`encode`] is infallible for any
@@ -75,6 +76,12 @@ pub enum Error {
     /// `RuleEnter`'s `RuleKind` discriminator was neither `0` (`Memo`)
     /// nor `1` (`Lr`).
     InvalidRuleKind { tag: u8, position: usize },
+    /// `IndentCmp`'s `CmpOp` discriminator was outside `0..=2`
+    /// (`Gt` / `Ge` / `Eq`).
+    InvalidCmpOp { tag: u8, position: usize },
+    /// An `ArgSrc` discriminator (in `ArgPush` / `IndentCmp`) was neither
+    /// `0` (`Lit`) nor `1` (`Local`).
+    InvalidArgSrc { tag: u8, position: usize },
     /// Varint read either ran past the 5-byte upper bound for a `u32`
     /// value, or the 5th byte had bits set that overflow `u32`.
     MalformedVarint { position: usize },
@@ -115,6 +122,16 @@ impl std::fmt::Display for Error {
             Error::InvalidRuleKind { tag, position } => write!(
                 f,
                 "invalid RuleKind discriminant {} at position {}",
+                tag, position
+            ),
+            Error::InvalidCmpOp { tag, position } => write!(
+                f,
+                "invalid CmpOp discriminant {} at position {}",
+                tag, position
+            ),
+            Error::InvalidArgSrc { tag, position } => write!(
+                f,
+                "invalid ArgSrc discriminant {} at position {}",
                 tag, position
             ),
             Error::MalformedVarint { position } => {
@@ -163,6 +180,9 @@ const TAG_CAPTURE_END: u8 = 0x11;
 const TAG_RECOVER_SCOPE_BEGIN: u8 = 0x12;
 const TAG_RECOVER_TO_SCOPED_MAX: u8 = 0x13;
 const TAG_RECOVER_SCOPE_END: u8 = 0x14;
+const TAG_INDENT_MEASURE: u8 = 0x15;
+const TAG_INDENT_CMP: u8 = 0x16;
+const TAG_ARG_PUSH: u8 = 0x17;
 
 // `End` is the program-termination sentinel; placed at the top of the
 // `u8` range to keep it visually distinct from the matching /
@@ -171,6 +191,19 @@ const TAG_END: u8 = 0xFF;
 
 const RULE_KIND_MEMO: u8 = 0;
 const RULE_KIND_LR: u8 = 1;
+
+// `CmpOp` discriminants for the `IndentCmp` payload.
+const CMP_GT: u8 = 0;
+const CMP_GE: u8 = 1;
+const CMP_EQ: u8 = 2;
+
+// `ArgSrc` discriminants for the `ArgPush` / `IndentCmp` payloads. A
+// `Lit` carries its `i32` as a varint over the value's `u32` bit pattern
+// (round-trips any value, including the negatives the type permits even
+// though the compiler only emits non-negative columns); a `Local`
+// carries its one-byte slot index.
+const ARG_SRC_LIT: u8 = 0;
+const ARG_SRC_LOCAL: u8 = 1;
 
 /// Sanity cap on the declared instruction count read from the wire,
 /// enforced by [`decode`]. Without it, the decoder would happily
@@ -304,7 +337,7 @@ fn write_instruction(out: &mut Vec<u8>, ins: &Instruction) {
             write_varint_u32(out, label.0);
         }
         Instruction::Return => out.push(TAG_RETURN),
-        Instruction::RuleEnter(memo_id, kind, label) => {
+        Instruction::RuleEnter(memo_id, kind, label, argc) => {
             out.push(TAG_RULE_ENTER);
             write_varint_u32(out, memo_id.0);
             out.push(match kind {
@@ -312,6 +345,7 @@ fn write_instruction(out: &mut Vec<u8>, ins: &Instruction) {
                 RuleKind::Lr => RULE_KIND_LR,
             });
             write_varint_u32(out, label.0);
+            out.push(*argc);
         }
         Instruction::MemoClose(memo_id) => {
             out.push(TAG_MEMO_CLOSE);
@@ -333,7 +367,38 @@ fn write_instruction(out: &mut Vec<u8>, ins: &Instruction) {
         }
         Instruction::RecoverToScopedMax => out.push(TAG_RECOVER_TO_SCOPED_MAX),
         Instruction::RecoverScopeEnd => out.push(TAG_RECOVER_SCOPE_END),
+        Instruction::IndentMeasure(slot) => {
+            out.push(TAG_INDENT_MEASURE);
+            out.push(*slot);
+        }
+        Instruction::IndentCmp(op, slot, src) => {
+            out.push(TAG_INDENT_CMP);
+            out.push(match op {
+                CmpOp::Gt => CMP_GT,
+                CmpOp::Ge => CMP_GE,
+                CmpOp::Eq => CMP_EQ,
+            });
+            out.push(*slot);
+            write_arg_src(out, *src);
+        }
+        Instruction::ArgPush(src) => {
+            out.push(TAG_ARG_PUSH);
+            write_arg_src(out, *src);
+        }
         Instruction::End => out.push(TAG_END),
+    }
+}
+
+fn write_arg_src(out: &mut Vec<u8>, src: ArgSrc) {
+    match src {
+        ArgSrc::Lit(v) => {
+            out.push(ARG_SRC_LIT);
+            write_varint_u32(out, v as u32);
+        }
+        ArgSrc::Local(slot) => {
+            out.push(ARG_SRC_LOCAL);
+            out.push(slot);
+        }
     }
 }
 
@@ -479,7 +544,8 @@ fn read_instruction(cur: &mut Cursor<'_>) -> Result<Instruction, Error> {
                 }
             };
             let label = Label(cur.read_varint_u32()?);
-            Instruction::RuleEnter(memo_id, kind, label)
+            let argc = cur.read_u8()?;
+            Instruction::RuleEnter(memo_id, kind, label, argc)
         }
         TAG_MEMO_CLOSE => Instruction::MemoClose(MemoId(cur.read_varint_u32()?)),
         TAG_LR_TAIL => {
@@ -498,6 +564,25 @@ fn read_instruction(cur: &mut Cursor<'_>) -> Result<Instruction, Error> {
         }
         TAG_RECOVER_TO_SCOPED_MAX => Instruction::RecoverToScopedMax,
         TAG_RECOVER_SCOPE_END => Instruction::RecoverScopeEnd,
+        TAG_INDENT_MEASURE => Instruction::IndentMeasure(cur.read_u8()?),
+        TAG_INDENT_CMP => {
+            let op_pos = cur.pos;
+            let op = match cur.read_u8()? {
+                CMP_GT => CmpOp::Gt,
+                CMP_GE => CmpOp::Ge,
+                CMP_EQ => CmpOp::Eq,
+                other => {
+                    return Err(Error::InvalidCmpOp {
+                        tag: other,
+                        position: op_pos,
+                    })
+                }
+            };
+            let slot = cur.read_u8()?;
+            let src = read_arg_src(cur)?;
+            Instruction::IndentCmp(op, slot, src)
+        }
+        TAG_ARG_PUSH => Instruction::ArgPush(read_arg_src(cur)?),
         TAG_END => Instruction::End,
         _ => {
             return Err(Error::InvalidOpcode {
@@ -508,10 +593,24 @@ fn read_instruction(cur: &mut Cursor<'_>) -> Result<Instruction, Error> {
     })
 }
 
+fn read_arg_src(cur: &mut Cursor<'_>) -> Result<ArgSrc, Error> {
+    let kind_pos = cur.pos;
+    Ok(match cur.read_u8()? {
+        ARG_SRC_LIT => ArgSrc::Lit(cur.read_varint_u32()? as i32),
+        ARG_SRC_LOCAL => ArgSrc::Local(cur.read_u8()?),
+        other => {
+            return Err(Error::InvalidArgSrc {
+                tag: other,
+                position: kind_pos,
+            })
+        }
+    })
+}
+
 fn derive_rule_count(code: &[Instruction]) -> usize {
     code.iter()
         .filter_map(|ins| match ins {
-            Instruction::RuleEnter(id, _, _)
+            Instruction::RuleEnter(id, _, _, _)
             | Instruction::MemoClose(id)
             | Instruction::LRTail(id, _) => Some(id.0),
             _ => None,
@@ -735,8 +834,8 @@ mod tests {
                 Instruction::Fail,
                 Instruction::Call(Label(31)),
                 Instruction::Return,
-                Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(37)),
-                Instruction::RuleEnter(MemoId(1), RuleKind::Lr, Label(41)),
+                Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(37), 0),
+                Instruction::RuleEnter(MemoId(1), RuleKind::Lr, Label(41), 2),
                 Instruction::MemoClose(MemoId(0)),
                 Instruction::LRTail(MemoId(1), Label(43)),
                 Instruction::CaptureBegin(CaptureKind(0)),
@@ -744,6 +843,12 @@ mod tests {
                 Instruction::RecoverScopeBegin(LabelId(0)),
                 Instruction::RecoverToScopedMax,
                 Instruction::RecoverScopeEnd,
+                Instruction::IndentMeasure(0),
+                Instruction::IndentCmp(CmpOp::Gt, 1, ArgSrc::Local(0)),
+                Instruction::IndentCmp(CmpOp::Ge, 2, ArgSrc::Lit(4)),
+                Instruction::IndentCmp(CmpOp::Eq, 0, ArgSrc::Local(3)),
+                Instruction::ArgPush(ArgSrc::Lit(0)),
+                Instruction::ArgPush(ArgSrc::Local(7)),
                 Instruction::CharSet(SetId(1)),
                 Instruction::End,
             ],
@@ -933,7 +1038,7 @@ mod tests {
     fn decode_recomputes_rule_count_from_code_stream() {
         let p = Program {
             code: vec![
-                Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(2)),
+                Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(2), 0),
                 Instruction::MemoClose(MemoId(0)),
                 Instruction::Return,
             ],

--- a/src/pegc/README.md
+++ b/src/pegc/README.md
@@ -755,6 +755,72 @@ boundary-only helpers as `name: atomic = … boundary` rather than `reserved`.
 Authors **reference** these
 two names but never **define** them (a definition is a parse error).
 
+### Indentation: the `%root` / `%align` / `%indent` operators
+
+For indentation-sensitive languages (Python/YAML class, issue #43), three
+prefix operators express block structure against the indentation of the
+current line. The shipped `grammars/starlark.peg` and `grammars/yaml.peg`
+are the worked examples.
+
+A single *ambient anchor* — the indentation column of the construct being
+parsed — threads through the grammar implicitly; the author never names it:
+
+| Operator | Meaning |
+| --- | --- |
+| `%root X` | seed a fresh anchor at the current line's column, then parse `X` under it |
+| `%indent X` | open a level strictly deeper than the ambient anchor, rebind the anchor to it, then parse `X` |
+| `%align` | assert the current line starts exactly at the ambient anchor (standalone — no operand) |
+
+`%root` and `%indent` bind a single following atom, the same rule as a
+`@kind` capture: `%indent a?` is `(%indent a)?`, and a multi-element block
+is parenthesized — `%indent ( stmt (line_break %align stmt)* )`. A typical
+block rule opens a level with `%indent (…)` and separates siblings inside
+it with `%align`; a dedent is simply an operator failure that ends the
+enclosing repetition, so there is no INDENT/DEDENT token stream.
+
+A rule that uses these operators must be `atomic`, so the horizontal-only
+auto-`ignore` can't swallow a line's indentation before it is measured. The
+operators consume the indentation they measure, so `%align stmt` lands
+`stmt` at the first non-space byte.
+
+**The machinery is hidden.** `%root` / `%align` / `%indent` are the whole
+surface. A compiler pass (`src/pegc/desugar_indent.rs`, run first in
+`Grammar::compile`) rewrites them into the lower-level IR the VM runs:
+rules implicitly parameterized by their anchor column, the
+`deeper` / `same` / `at_least` combinators that assert `>` / `==` / `>=`
+against it, and an arg-keyed packrat memo so a rule cached at one
+indentation context isn't reused at another. Only a rule that actually
+reads an inherited anchor gets the implicit parameter (a call-graph
+fixpoint), so every rule in every non-indentation grammar keeps the
+allocation-free `ArgKey::None` memo key. A `%align` / `%indent` or anchored
+call reachable from the root with no enclosing `%root` / `%indent` to
+establish the column is a compile error
+(`CompileError::IndentAnchorOutOfScope`).
+
+**Incremental soundness.** Indentation is measured *forward* (the operator
+consumes the whitespace run), so the enclosing rule's `examined_max` covers
+it and a warm reparse correctly invalidates any entry whose measured
+indentation an edit changed — see `tests/incremental_indent_tests.rs`.
+
+**Integer-only, by design.** The desugared anchor is an `i32` column; the
+memo key's argument component (`pegvm::vm::ArgKey`) is `None` / `One(i32)` /
+`Many(Box<[i32]>)`, where `None` keeps every zero-argument rule (i.e. every
+rule in every non-indentation grammar) allocation-free and byte-identical
+to the unparameterized key. The single ambient anchor uses only the
+`One(i32)` arm; the `Many` arm and the underlying multiple-column IR are the
+seam for a future **typed-argument** extension (e.g. a heredoc terminator
+string, or a Ruby-style backreference). That extension is **documented, not
+built** — no shipped grammar needs it, and no surface exposes the richer IR.
+
+**Pruned-language gaps.** Both shipped indentation grammars are
+deliberately reduced subsets; each file's header comment lists the exact
+out-of-subset constructs. The common theme is that anything needing
+*column arithmetic* (`n + 1`, YAML's `seq-spaces(n,c) = n - 1`, compact
+block-in-block nesting) or *typed arguments* (block-scalar indicators,
+anchors/aliases) is out of scope — the single ambient anchor expresses only
+relative `>` / `>=` / `==`. Tabs count as one column (no tab-stop
+expansion).
+
 ### Reserved syntax
 
 `^<non-ident-byte>` is a parse error today and reserved for future

--- a/src/pegc/analysis.rs
+++ b/src/pegc/analysis.rs
@@ -76,7 +76,15 @@ pub(crate) fn compute_nullable(rules: &HashMap<String, Pattern>) -> HashSet<Stri
 pub(crate) fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> bool {
     match pat {
         Pattern::Literal { bytes, .. } => bytes.is_empty(),
-        Pattern::CharClass { .. } | Pattern::AnyChar { .. } => false,
+        // An indent combinator consumes the leading `[ \t]*` and then
+        // asserts a relation — treated as non-nullable (see its Pattern
+        // doc), like any other consuming atom.
+        Pattern::CharClass { .. } | Pattern::AnyChar { .. } | Pattern::IndentCombinator { .. } => {
+            false
+        }
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, .. } => items.iter().all(|p| pattern_nullable(p, nullable)),
         Pattern::OrderedChoice { alts, .. } => alts.iter().any(|p| pattern_nullable(p, nullable)),
         Pattern::Repeat { .. } | Pattern::Optional { .. } => true,
@@ -122,7 +130,15 @@ fn compute_first_calls(
 
 fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut HashSet<String>) {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        // An indent combinator references no rule (its arg is a column,
+        // not a non-terminal), so it routes no first-call edge.
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, .. } => {
             for it in items {
                 collect_first_calls(it, nullable, out);
@@ -335,6 +351,12 @@ fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
             out.extend(pattern_first(inner, nullable));
         }
         Pattern::NotPredicate { .. } => {}
+        // No FIRST non-terminal: the combinator's only observable prefix
+        // is `[ \t]*`, deliberately not surfaced (see its Pattern doc).
+        Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::AndPredicate { inner, .. } => {
             out.extend(pattern_first(inner, nullable));
         }
@@ -411,7 +433,13 @@ fn collect_follow(
     changed: &mut bool,
 ) {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::NonTerminal { name, .. } => {
             extend_follow(follow, name, trailing, changed);
         }
@@ -673,8 +701,14 @@ fn walk_for_call_sites<'a>(
     findings: &mut Vec<LintFinding>,
 ) {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
-        Pattern::NonTerminal { name, span } => {
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
+        Pattern::NonTerminal { name, span, .. } => {
             let Some(t) = ctx.trailing.get(name) else {
                 return;
             };
@@ -868,7 +902,13 @@ fn find_callsite_unguarded<'a>(
     found_callsite: &mut bool,
 ) -> bool {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => false,
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => false,
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::NonTerminal { name, .. } => {
             if name != probe.target_caller {
                 return false;
@@ -1161,7 +1201,11 @@ fn resolve_in_pattern(
         Pattern::Literal { .. }
         | Pattern::CharClass { .. }
         | Pattern::AnyChar { .. }
-        | Pattern::NonTerminal { .. } => Ok(pat.clone()),
+        | Pattern::NonTerminal { .. }
+        | Pattern::IndentCombinator { .. } => Ok(pat.clone()),
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, span } => {
             let mut out = Vec::with_capacity(items.len());
             for i in 0..items.len() {
@@ -1406,7 +1450,13 @@ pub(crate) fn compute_ignore_rules(rules: &HashMap<String, Pattern>) -> HashMap<
 /// rule bodies.
 pub fn tally_non_terminal_refs(pat: &Pattern, out: &mut HashMap<String, usize>) {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, .. } => {
             for it in items {
                 tally_non_terminal_refs(it, out);
@@ -1439,7 +1489,13 @@ pub fn tally_non_terminal_refs(pat: &Pattern, out: &mut HashMap<String, usize>) 
 
 fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, .. } => {
             for it in items {
                 collect_non_terminal_refs(it, out);
@@ -1476,7 +1532,11 @@ fn body_contains_catch(pat: &Pattern) -> bool {
         Pattern::Literal { .. }
         | Pattern::CharClass { .. }
         | Pattern::AnyChar { .. }
-        | Pattern::NonTerminal { .. } => false,
+        | Pattern::NonTerminal { .. }
+        | Pattern::IndentCombinator { .. } => false,
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
         Pattern::Sequence { items, .. } => items.iter().any(body_contains_catch),
         Pattern::OrderedChoice { alts, .. } => alts.iter().any(body_contains_catch),
         Pattern::Repeat { inner, .. }
@@ -1597,7 +1657,11 @@ fn inject_ignore_in(pat: &mut Pattern) {
         Pattern::Literal { .. }
         | Pattern::CharClass { .. }
         | Pattern::AnyChar { .. }
-        | Pattern::NonTerminal { .. } => {}
+        | Pattern::NonTerminal { .. }
+        | Pattern::IndentCombinator { .. } => {}
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
     }
 }
 
@@ -1727,7 +1791,11 @@ fn contains_capture(pat: &Pattern) -> bool {
         Pattern::Literal { .. }
         | Pattern::CharClass { .. }
         | Pattern::AnyChar { .. }
-        | Pattern::NonTerminal { .. } => false,
+        | Pattern::NonTerminal { .. }
+        | Pattern::IndentCombinator { .. } => false,
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp is desugared by desugar_indent before analysis")
+        }
     }
 }
 

--- a/src/pegc/compiler.rs
+++ b/src/pegc/compiler.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
 use super::analysis::{analyze_left_recursion, LintFinding};
-use super::pattern::{Pattern, Span};
-use crate::pegvm::{CaptureKind, Instruction, Label, LabelId, MemoId, Program, RuleKind};
+use super::pattern::{IndentArg, IndentOp, Pattern, Span};
+use crate::pegvm::{
+    ArgSrc, CaptureKind, CmpOp, Instruction, Label, LabelId, MemoId, Program, RuleKind,
+};
 
 #[derive(Debug)]
 pub enum CompileError {
@@ -36,6 +38,34 @@ pub enum CompileError {
     /// in identifier position. Emitted by `synthesize_reserved_preferred`.
     /// The payload is the offending literals (UTF-8 lossy), sorted.
     ReservedPreferredConflict(Vec<String>),
+    /// A parameterized call passes the wrong number of indentation
+    /// arguments for the callee's declared parameter list — e.g.
+    /// `suite()` or `suite(a, b)` for a `suite(outer)`. Detected in
+    /// `check_refs` against [`Grammar::rule_params`](super::Grammar::rule_params).
+    ArgCountMismatch {
+        callee: String,
+        expected: usize,
+        found: usize,
+    },
+    /// An indent combinator or call argument references a local name
+    /// (`same(i)`, `block(n)`) that is not in scope — no enclosing rule
+    /// parameter or earlier `as`-binding introduced it. Carries the
+    /// offending name and the rule it appeared in.
+    UnboundIndentLocal {
+        rule: String,
+        name: String,
+    },
+    /// A `%align` / `%indent` operator, or a call to an
+    /// indentation-anchored rule, is reachable from the grammar root with
+    /// no enclosing `%root` / `%indent` to establish the anchor column, so
+    /// the column would have no provider at runtime. Emitted by
+    /// `desugar_indent`. `rule` is where the unanchored demand surfaced
+    /// (the grammar root); `demand` describes the construct that needed
+    /// the anchor.
+    IndentAnchorOutOfScope {
+        rule: String,
+        demand: String,
+    },
 }
 
 impl std::fmt::Display for CompileError {
@@ -69,6 +99,25 @@ impl std::fmt::Display for CompileError {
                  so the synthesized `reserved` / `preferred` sets would overlap: {}",
                 words.join(", ")
             ),
+            CompileError::ArgCountMismatch {
+                callee,
+                expected,
+                found,
+            } => write!(
+                f,
+                "rule `{callee}` takes {expected} indentation argument(s) but is called with {found}"
+            ),
+            CompileError::UnboundIndentLocal { rule, name } => write!(
+                f,
+                "indentation local `{name}` referenced in rule `{rule}` is not in scope \
+                 (no enclosing parameter or `as` binding introduces it)"
+            ),
+            CompileError::IndentAnchorOutOfScope { rule, demand } => write!(
+                f,
+                "{demand} in rule `{rule}` has no indentation anchor in scope: it is reachable \
+                 from the grammar root with no enclosing `%root` or `%indent` to establish the \
+                 column"
+            ),
         }
     }
 }
@@ -92,6 +141,24 @@ struct Compiler {
     label_names: Vec<String>,
     char_sets: Vec<crate::pegvm::CharSet>,
     char_set_dedup: HashMap<crate::pegvm::CharSet, crate::pegvm::SetId>,
+    /// Activation-slot environment for the rule currently being
+    /// compiled, in slot order: `Some(name)` for a parameter or an
+    /// `as`-bound indent width, `None` for an anonymous measure (e.g.
+    /// the throwaway width a `same(i)` measures). The slot index of a
+    /// name is its position here, so `IndentArg::Local` resolves by
+    /// reverse lookup. Reset per rule by [`begin_rule_locals`].
+    ///
+    /// [`begin_rule_locals`]: Compiler::begin_rule_locals
+    locals: Vec<Option<String>>,
+    /// The rule name owning `locals`, for error messages.
+    current_rule: String,
+    /// First unresolved-local error seen while lowering, surfaced by
+    /// `compile_rules` after the whole grammar is walked. Kept as
+    /// accumulated state (rather than threading `Result` through the
+    /// infallible `compile_pat`) so the bare-pattern path stays simple;
+    /// the validation in `check_refs` catches the same class of error
+    /// for the grammar path up front.
+    local_error: Option<CompileError>,
 }
 
 impl Compiler {
@@ -105,6 +172,50 @@ impl Compiler {
             label_names: Vec::new(),
             char_sets: Vec::new(),
             char_set_dedup: HashMap::new(),
+            locals: Vec::new(),
+            current_rule: String::new(),
+            local_error: None,
+        }
+    }
+
+    /// Reset the activation-slot environment for a new rule: parameters
+    /// occupy the first slots in declaration order, anonymous /
+    /// `as`-bound slots accrue after them as the body is lowered.
+    fn begin_rule_locals(&mut self, rule: &str, params: &[String]) {
+        self.current_rule = rule.to_string();
+        self.locals = params.iter().map(|p| Some(p.clone())).collect();
+    }
+
+    /// Resolve an [`IndentArg`] to a runtime [`ArgSrc`]: a literal
+    /// verbatim, a local by reverse-lookup of its slot. An unresolved
+    /// local records a [`CompileError::UnboundIndentLocal`] (first one
+    /// wins) and falls back to slot 0 so lowering can continue to a
+    /// clean error return rather than panicking.
+    fn indent_arg_src(&mut self, arg: &IndentArg) -> ArgSrc {
+        match arg {
+            IndentArg::Lit(v) => ArgSrc::Lit(*v),
+            IndentArg::Local(name) => ArgSrc::Local(self.resolve_local(name)),
+        }
+    }
+
+    /// Slot index of local `name` in the current rule's environment
+    /// (most-recent binding wins). Records an error and returns 0 if
+    /// absent.
+    fn resolve_local(&mut self, name: &str) -> u8 {
+        if let Some(pos) = self
+            .locals
+            .iter()
+            .rposition(|slot| slot.as_deref() == Some(name))
+        {
+            u8::try_from(pos).unwrap_or(u8::MAX)
+        } else {
+            if self.local_error.is_none() {
+                self.local_error = Some(CompileError::UnboundIndentLocal {
+                    rule: self.current_rule.clone(),
+                    name: name.to_string(),
+                });
+            }
+            0
         }
     }
 
@@ -156,7 +267,9 @@ impl Compiler {
             Instruction::PartialCommit(_) => Instruction::PartialCommit(target),
             Instruction::BackCommit(_) => Instruction::BackCommit(target),
             Instruction::Call(_) => Instruction::Call(target),
-            Instruction::RuleEnter(id, kind, _) => Instruction::RuleEnter(*id, *kind, target),
+            Instruction::RuleEnter(id, kind, _, argc) => {
+                Instruction::RuleEnter(*id, *kind, target, *argc)
+            }
             Instruction::LRTail(id, _) => Instruction::LRTail(*id, target),
             other => panic!("patch_jump: not a jump instruction: {:?}", other),
         };
@@ -277,9 +390,36 @@ impl Compiler {
                 self.patch_jump(choice, l1);
                 self.patch_jump(back, l2);
             }
-            Pattern::NonTerminal { name, .. } => {
+            Pattern::NonTerminal { name, args, .. } => {
+                // Push the indentation arguments (if any) left-to-right so
+                // the callee's `RuleEnter` seeds parameter slot 0 with the
+                // first argument. A plain reference (empty `args`) emits
+                // just the `Call`, exactly as before.
+                for arg in args {
+                    let src = self.indent_arg_src(arg);
+                    self.emit(Instruction::ArgPush(src));
+                }
                 let idx = self.emit(Instruction::Call(Label(0)));
                 self.pending_calls.push((idx, name.clone()));
+            }
+            Pattern::IndentCombinator { op, arg, bind, .. } => {
+                // Resolve the reference column against the environment
+                // *before* introducing this combinator's own slot, so
+                // `same(i)` binds to the earlier `i` and a degenerate
+                // `deeper(i) as i` resolves `i` as unbound rather than to
+                // its own not-yet-measured slot.
+                let src = self.indent_arg_src(arg);
+                let measure_slot = u8::try_from(self.locals.len()).unwrap_or(u8::MAX);
+                // The measured width takes the next slot — named by the
+                // `as` binder, or anonymous for a bare assertion.
+                self.locals.push(bind.clone());
+                self.emit(Instruction::IndentMeasure(measure_slot));
+                let cmp = match op {
+                    IndentOp::Deeper => CmpOp::Gt,
+                    IndentOp::Same => CmpOp::Eq,
+                    IndentOp::AtLeast => CmpOp::Ge,
+                };
+                self.emit(Instruction::IndentCmp(cmp, measure_slot, src));
             }
             Pattern::Capture { kind, inner, .. } => {
                 let kind_id = self.intern_capture(kind);
@@ -344,6 +484,14 @@ impl Compiler {
                      analysis::resolve_inferred_boundaries before compilation"
                 )
             }
+            // `desugar_indent` runs first in `Grammar::compile`, rewriting
+            // every `%`-operator into the combinator IR; none survives to
+            // lowering.
+            Pattern::IndentOp { .. } => {
+                unreachable!(
+                    "Pattern::IndentOp must be desugared by desugar_indent before compilation"
+                )
+            }
         }
     }
 }
@@ -358,6 +506,9 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
             "compile_pattern: unresolved NonTerminal({}) — use Grammar::compile",
             name
         );
+    }
+    if let Some(err) = &c.local_error {
+        panic!("compile_pattern: {err} — use Grammar::compile");
     }
     Program {
         code: c.code,
@@ -387,6 +538,7 @@ pub fn compile_pattern(pat: &Pattern) -> Program {
 pub(crate) fn compile_rules(
     rules: &HashMap<String, Pattern>,
     root: &str,
+    rule_params: &HashMap<String, Vec<String>>,
 ) -> Result<Program, CompileError> {
     let start = root;
     debug_assert!(
@@ -394,10 +546,11 @@ pub(crate) fn compile_rules(
         "compile_rules: entry rule must be present (Grammar::compile enforces this)"
     );
 
-    // Detect undefined NonTerminal references up front so the LR analysis
-    // doesn't have to defend against missing rules in the call graph.
+    // Detect undefined NonTerminal references and argument-arity
+    // mismatches up front so the LR analysis doesn't have to defend
+    // against missing rules in the call graph.
     for (rule_name, body) in rules {
-        check_refs(rule_name, body, rules)?;
+        check_refs(rule_name, body, rules, rule_params)?;
     }
 
     // Identify left-recursive rules (direct and indirect).
@@ -441,9 +594,18 @@ pub(crate) fn compile_rules(
         // RuleEnter's Label is patched to the Return address below so a cache
         // hit can skip straight past the body. LR rules close the body with
         // LRTail (the seed-and-grow controller); non-LR rules close with
-        // MemoClose (the success-entry committer).
-        let enter = c.emit(Instruction::RuleEnter(memo_id, kind, Label(0)));
+        // MemoClose (the success-entry committer). `argc` is the rule's
+        // declared parameter count, looked up from the grammar's
+        // `rule_params`; 0 for every non-parameterized rule.
+        let argc =
+            u8::try_from(rule_params.get(name.as_str()).map_or(0, Vec::len)).unwrap_or(u8::MAX);
+        let enter = c.emit(Instruction::RuleEnter(memo_id, kind, Label(0), argc));
         let body_start = c.pos();
+        // Seed the activation-slot environment with this rule's params
+        // before lowering its body, so `IndentArg::Local` references and
+        // `as`-bindings resolve to stable slot indices.
+        let params: &[String] = rule_params.get(name).map_or(&[], Vec::as_slice);
+        c.begin_rule_locals(name, params);
         c.compile_pat(&rules[name]);
         match kind {
             RuleKind::Lr => {
@@ -456,6 +618,13 @@ pub(crate) fn compile_rules(
         let return_addr = c.pos();
         c.emit(Instruction::Return);
         c.patch_jump(enter, return_addr);
+    }
+
+    // Surface any unresolved indentation-local reference encountered
+    // during lowering (the env-tracked counterpart to `check_refs`'s
+    // arity check).
+    if let Some(err) = c.local_error.take() {
+        return Err(err);
     }
 
     // Patch the bootstrap Call.
@@ -489,18 +658,25 @@ fn check_refs(
     _rule: &str,
     pat: &Pattern,
     rules: &HashMap<String, Pattern>,
+    rule_params: &HashMap<String, Vec<String>>,
 ) -> Result<(), CompileError> {
     match pat {
-        Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => Ok(()),
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        // An indent combinator references no rule and carries no inner
+        // pattern; its only name is an `IndentArg::Local`, validated
+        // during lowering against the activation environment.
+        | Pattern::IndentCombinator { .. } => Ok(()),
         Pattern::Sequence { items, .. } => {
             for it in items {
-                check_refs(_rule, it, rules)?;
+                check_refs(_rule, it, rules, rule_params)?;
             }
             Ok(())
         }
         Pattern::OrderedChoice { alts, .. } => {
             for it in alts {
-                check_refs(_rule, it, rules)?;
+                check_refs(_rule, it, rules, rule_params)?;
             }
             Ok(())
         }
@@ -510,20 +686,34 @@ fn check_refs(
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
         | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => check_refs(_rule, inner, rules),
+        | Pattern::Lenient { inner, .. } => check_refs(_rule, inner, rules, rule_params),
         Pattern::Catch {
             inner, recovery, ..
         } => {
-            check_refs(_rule, inner, rules)?;
-            check_refs(_rule, recovery, rules)
+            check_refs(_rule, inner, rules, rule_params)?;
+            check_refs(_rule, recovery, rules, rule_params)
         }
-        Pattern::InferBoundaryCatch { inner, .. } => check_refs(_rule, inner, rules),
-        Pattern::NonTerminal { name, .. } => {
-            if rules.contains_key(name) {
-                Ok(())
-            } else {
-                Err(CompileError::UndefinedRule(name.clone()))
+        Pattern::InferBoundaryCatch { inner, .. } => check_refs(_rule, inner, rules, rule_params),
+        // Desugared away before `compile_rules` runs.
+        Pattern::IndentOp { .. } => {
+            unreachable!("Pattern::IndentOp must be desugared by desugar_indent before compilation")
+        }
+        Pattern::NonTerminal { name, args, .. } => {
+            if !rules.contains_key(name) {
+                return Err(CompileError::UndefinedRule(name.clone()));
             }
+            // A parameterized call must pass exactly the callee's
+            // declared parameter count; a plain reference (no args) to a
+            // parameterized rule is itself a mismatch (0 vs N).
+            let expected = rule_params.get(name).map_or(0, Vec::len);
+            if args.len() != expected {
+                return Err(CompileError::ArgCountMismatch {
+                    callee: name.clone(),
+                    expected,
+                    found: args.len(),
+                });
+            }
+            Ok(())
         }
     }
 }

--- a/src/pegc/desugar_indent.rs
+++ b/src/pegc/desugar_indent.rs
@@ -1,0 +1,577 @@
+//! Desugaring of the implicit indentation operators.
+//!
+//! The grammar author writes three prefix operators — `%root X`,
+//! `%align`, and `%indent X` — and never sees the column-threading
+//! machinery underneath. This pass, run first in
+//! [`Grammar::compile`](super::parser::Grammar::compile), rewrites those
+//! operators back into the lower-level IR the rest of the compiler and the
+//! whole VM already understand: rules parameterized by an indentation
+//! column, the `deeper` / `same` / `at_least` combinators
+//! ([`Pattern::IndentCombinator`]), and parameterized calls
+//! ([`Pattern::NonTerminal`] with `args`). After it runs, no
+//! [`Pattern::IndentOp`] remains and `rule_params` is populated, so every
+//! later pass sees exactly the form an author would have written by hand
+//! against the explicit surface.
+//!
+//! # The single ambient anchor
+//!
+//! The operators expose one ambient anchor — the indentation column of
+//! the construct currently being parsed. `%root` seeds a fresh anchor at
+//! the current line's column; `%indent` opens a level strictly deeper than
+//! the ambient anchor and rebinds it for its operand; `%align` asserts the
+//! current line sits exactly at the ambient anchor. The anchor threads
+//! down the call chain as an implicit parameter (`$indent`), so a rule
+//! that reads it never has to name it.
+//!
+//! This single-anchor model covers every brace-replaceable, tree-shaped
+//! indentation language (YAML, Starlark, Scala 3, F#). The underlying IR
+//! keeps the richer capability — literal and multiple named columns, an
+//! assert without reseed — but no surface exposes it.
+//!
+//! # Effect-selective threading
+//!
+//! Only a rule that actually reads an inherited anchor gets the `$indent`
+//! parameter. "Reads an inherited anchor" means: at top level (outside any
+//! `%root` / `%indent` scope, which seed their own) the rule has a
+//! `%align` or `%indent`, or it calls a rule that itself reads one. This
+//! is a monotone call-graph fixpoint ([`compute_needs_anchor`]). Rules
+//! that read nothing — every rule in every non-indentation grammar, plus
+//! the `%root`-only seeding rules — stay parameterless, so the memo
+//! hot-path key (`ArgKey::None`) is untouched for them.
+
+use std::collections::{HashMap, HashSet};
+
+use super::compiler::CompileError;
+use super::parser::Grammar;
+use super::pattern::{IndentArg, IndentOp, IndentOpKind, Pattern, Span};
+
+/// Synthetic name of the implicit anchor parameter. `$`-prefixed so it can
+/// never collide with an author identifier — `is_ident_start` admits only
+/// ASCII letters and `_`, never `$`.
+const ANCHOR_PARAM: &str = "$indent";
+
+/// Rewrite every `%root` / `%align` / `%indent` in `grammar` into the
+/// column-threading IR, and populate `grammar.rule_params` with the
+/// implicit `$indent` parameter for each rule that reads an inherited
+/// anchor. Idempotent in effect on grammars that use no indentation
+/// operators: nothing is rewritten and `rule_params` stays empty.
+///
+/// Errors with [`CompileError::IndentAnchorOutOfScope`] if a `%align` /
+/// `%indent` or an anchored call can be reached from the grammar root
+/// without an enclosing `%root` / `%indent` to establish the column.
+pub(crate) fn desugar_indent(grammar: &mut Grammar) -> Result<(), CompileError> {
+    let needs = compute_needs_anchor(&grammar.rules);
+
+    // The root is invoked by the bootstrap `Call` with no arguments, so it
+    // has nobody to inherit an anchor from. If it reads one, a `%align` /
+    // `%indent` or an anchored call escaped every `%root` / `%indent`
+    // scope — the column would have no provider at runtime.
+    if needs.contains(&grammar.root) {
+        let demand = describe_top_level_demand(&grammar.rules[&grammar.root], &needs)
+            .unwrap_or_else(|| "an indentation operator".to_string());
+        return Err(CompileError::IndentAnchorOutOfScope {
+            rule: grammar.root.clone(),
+            demand,
+        });
+    }
+
+    let mut rewritten: HashMap<String, Pattern> = HashMap::with_capacity(grammar.rules.len());
+    for (name, body) in &grammar.rules {
+        let start = if needs.contains(name) {
+            Some(ANCHOR_PARAM.to_string())
+        } else {
+            None
+        };
+        let mut body = body.clone();
+        let mut fresh = 0usize;
+        rewrite(&mut body, start.as_deref(), &needs, name, &mut fresh)?;
+        rewritten.insert(name.clone(), body);
+    }
+    grammar.rules = rewritten;
+
+    // Give every anchor-reading rule the implicit parameter so the
+    // compiler emits `RuleEnter` with argc=1 and the threaded `ArgPush`
+    // lines resolve against slot 0. The surface has no parameter syntax,
+    // so `rule_params` was empty coming in.
+    for name in &needs {
+        grammar
+            .rule_params
+            .insert(name.clone(), vec![ANCHOR_PARAM.to_string()]);
+    }
+
+    Ok(())
+}
+
+/// Set of rules that read an inherited indentation anchor, by monotone
+/// call-graph fixpoint. Seed: any rule with a top-level `%align` or
+/// `%indent`. Grow: any rule that, at top level, calls a rule already in
+/// the set. `%root` operands are *not* top level — they seed their own
+/// anchor — so a rule whose only anchored work sits under a `%root` reads
+/// nothing inherited and stays out of the set.
+fn compute_needs_anchor(rules: &HashMap<String, Pattern>) -> HashSet<String> {
+    let mut needs: HashSet<String> = HashSet::new();
+    loop {
+        let mut changed = false;
+        for (name, body) in rules {
+            if !needs.contains(name) && top_level_demands_anchor(body, &needs) {
+                needs.insert(name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            return needs;
+        }
+    }
+}
+
+/// Whether `pat`, walked at the enclosing rule's top level, reads the
+/// inherited anchor — via a `%align` / `%indent`, or a call to a rule in
+/// `needs`. Does **not** descend into `%root` / `%indent` operands: those
+/// open a fresh anchor scope, so what they contain says nothing about the
+/// inherited one. (`%indent` itself reads the inherited anchor before
+/// opening the deeper level, hence it counts here without descending.)
+fn top_level_demands_anchor(pat: &Pattern, needs: &HashSet<String>) -> bool {
+    match pat {
+        Pattern::IndentOp {
+            kind: IndentOpKind::Align | IndentOpKind::Indent,
+            ..
+        } => true,
+        Pattern::IndentOp {
+            kind: IndentOpKind::Root,
+            ..
+        } => false,
+        Pattern::NonTerminal { name, .. } => needs.contains(name),
+        Pattern::Sequence { items, .. } => items.iter().any(|p| top_level_demands_anchor(p, needs)),
+        Pattern::OrderedChoice { alts, .. } => {
+            alts.iter().any(|p| top_level_demands_anchor(p, needs))
+        }
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. }
+        | Pattern::InferBoundaryCatch { inner, .. } => top_level_demands_anchor(inner, needs),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => top_level_demands_anchor(inner, needs) || top_level_demands_anchor(recovery, needs),
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => false,
+    }
+}
+
+/// First top-level construct in `pat` that reads the inherited anchor,
+/// rendered for the [`CompileError::IndentAnchorOutOfScope`] message.
+/// Mirrors [`top_level_demands_anchor`]'s descent.
+fn describe_top_level_demand(pat: &Pattern, needs: &HashSet<String>) -> Option<String> {
+    match pat {
+        Pattern::IndentOp {
+            kind: IndentOpKind::Align,
+            ..
+        } => Some("`%align`".to_string()),
+        Pattern::IndentOp {
+            kind: IndentOpKind::Indent,
+            ..
+        } => Some("`%indent`".to_string()),
+        Pattern::IndentOp {
+            kind: IndentOpKind::Root,
+            ..
+        } => None,
+        Pattern::NonTerminal { name, .. } if needs.contains(name) => {
+            Some(format!("a call to indentation-anchored rule `{name}`"))
+        }
+        Pattern::NonTerminal { .. } => None,
+        Pattern::Sequence { items, .. } => items
+            .iter()
+            .find_map(|p| describe_top_level_demand(p, needs)),
+        Pattern::OrderedChoice { alts, .. } => alts
+            .iter()
+            .find_map(|p| describe_top_level_demand(p, needs)),
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. }
+        | Pattern::InferBoundaryCatch { inner, .. } => describe_top_level_demand(inner, needs),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => describe_top_level_demand(inner, needs)
+            .or_else(|| describe_top_level_demand(recovery, needs)),
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => None,
+    }
+}
+
+/// Rewrite `pat` in place, threading `anchor` (the in-scope anchor local's
+/// name, or `None` outside any anchor scope) through the tree:
+///
+/// - `%align` → `same(anchor)`
+/// - `%indent X` → `deeper(anchor) as fresh` then `X` desugared under `fresh`
+/// - `%root X` → `at_least(0) as fresh` then `X` desugared under `fresh`
+/// - a call to a `needs`-anchor rule → that call with `anchor` as its
+///   single argument
+///
+/// `fresh` is a per-rule counter producing collision-proof bind names.
+/// Hitting an anchor-reading construct with `anchor == None` is the
+/// out-of-scope error; for a correctly-propagated grammar this never fires
+/// below the root, since [`compute_needs_anchor`] gives every such rule an
+/// anchor to start from.
+fn rewrite(
+    pat: &mut Pattern,
+    anchor: Option<&str>,
+    needs: &HashSet<String>,
+    rule: &str,
+    fresh: &mut usize,
+) -> Result<(), CompileError> {
+    match pat {
+        Pattern::IndentOp {
+            kind,
+            operand,
+            span,
+        } => {
+            let kind = *kind;
+            let span = *span;
+            let operand = operand.take();
+            *pat = desugar_op(kind, operand, span, anchor, needs, rule, fresh)?;
+            Ok(())
+        }
+        Pattern::NonTerminal { name, args, .. } => {
+            if needs.contains(name) {
+                let a = require_anchor(anchor, rule, || {
+                    format!("a call to indentation-anchored rule `{name}`")
+                })?;
+                debug_assert!(
+                    args.is_empty(),
+                    "the surface has no call-argument syntax, so a parsed call carries none"
+                );
+                *args = vec![IndentArg::Local(a)];
+            }
+            Ok(())
+        }
+        Pattern::Sequence { items, .. } => {
+            for it in items {
+                rewrite(it, anchor, needs, rule, fresh)?;
+            }
+            Ok(())
+        }
+        Pattern::OrderedChoice { alts, .. } => {
+            for a in alts {
+                rewrite(a, anchor, needs, rule, fresh)?;
+            }
+            Ok(())
+        }
+        Pattern::Repeat { inner, .. }
+        | Pattern::RepeatOne { inner, .. }
+        | Pattern::Optional { inner, .. }
+        | Pattern::NotPredicate { inner, .. }
+        | Pattern::AndPredicate { inner, .. }
+        | Pattern::Capture { inner, .. }
+        | Pattern::Lenient { inner, .. }
+        | Pattern::InferBoundaryCatch { inner, .. } => rewrite(inner, anchor, needs, rule, fresh),
+        Pattern::Catch {
+            inner, recovery, ..
+        } => {
+            rewrite(inner, anchor, needs, rule, fresh)?;
+            rewrite(recovery, anchor, needs, rule, fresh)
+        }
+        Pattern::Literal { .. }
+        | Pattern::CharClass { .. }
+        | Pattern::AnyChar { .. }
+        | Pattern::IndentCombinator { .. } => Ok(()),
+    }
+}
+
+/// Build the replacement for one `%`-operator. `%root` / `%indent` desugar
+/// to the seeding/opening combinator followed by their operand desugared
+/// under the freshly-bound anchor; nesting them in a `Sequence` is
+/// transparent to the compiler (it emits the combinator's instructions
+/// then the operand's), so the bytecode matches a hand-written flat
+/// sequence.
+fn desugar_op(
+    kind: IndentOpKind,
+    operand: Option<Box<Pattern>>,
+    span: Span,
+    anchor: Option<&str>,
+    needs: &HashSet<String>,
+    rule: &str,
+    fresh: &mut usize,
+) -> Result<Pattern, CompileError> {
+    match kind {
+        IndentOpKind::Align => {
+            let a = require_anchor(anchor, rule, || "`%align`".to_string())?;
+            Ok(Pattern::IndentCombinator {
+                op: IndentOp::Same,
+                arg: IndentArg::Local(a),
+                bind: None,
+                span,
+            })
+        }
+        IndentOpKind::Indent => {
+            let a = require_anchor(anchor, rule, || "`%indent`".to_string())?;
+            let bind = fresh_anchor(fresh);
+            let inner = desugar_operand(operand, &bind, needs, rule, fresh)?;
+            Ok(opened_block(
+                IndentOp::Deeper,
+                IndentArg::Local(a),
+                bind,
+                inner,
+                span,
+            ))
+        }
+        IndentOpKind::Root => {
+            let bind = fresh_anchor(fresh);
+            let inner = desugar_operand(operand, &bind, needs, rule, fresh)?;
+            Ok(opened_block(
+                IndentOp::AtLeast,
+                IndentArg::Lit(0),
+                bind,
+                inner,
+                span,
+            ))
+        }
+    }
+}
+
+/// Desugar a `%root` / `%indent` operand under the freshly-bound anchor
+/// `bind`.
+fn desugar_operand(
+    operand: Option<Box<Pattern>>,
+    bind: &str,
+    needs: &HashSet<String>,
+    rule: &str,
+    fresh: &mut usize,
+) -> Result<Pattern, CompileError> {
+    let mut inner =
+        *operand.expect("`%root` / `%indent` always carry an operand (parser enforced)");
+    rewrite(&mut inner, Some(bind), needs, rule, fresh)?;
+    Ok(inner)
+}
+
+/// `Sequence[ measure-and-assert, body ]` — the combinator that measures
+/// the line and binds the anchor, then the operand that runs under it.
+fn opened_block(op: IndentOp, arg: IndentArg, bind: String, body: Pattern, span: Span) -> Pattern {
+    Pattern::Sequence {
+        items: vec![
+            Pattern::IndentCombinator {
+                op,
+                arg,
+                bind: Some(bind),
+                span,
+            },
+            body,
+        ],
+        span,
+    }
+}
+
+/// The in-scope anchor name, or the out-of-scope error built from
+/// `demand` (a description of what needed an anchor).
+fn require_anchor(
+    anchor: Option<&str>,
+    rule: &str,
+    demand: impl FnOnce() -> String,
+) -> Result<String, CompileError> {
+    anchor
+        .map(str::to_string)
+        .ok_or_else(|| CompileError::IndentAnchorOutOfScope {
+            rule: rule.to_string(),
+            demand: demand(),
+        })
+}
+
+/// A fresh, collision-proof anchor bind name (`$anchor0`, `$anchor1`, …).
+/// `$`-prefixed like [`ANCHOR_PARAM`], so it can't shadow an author local;
+/// the exact text is irrelevant to bytecode, which addresses activation
+/// slots by index.
+fn fresh_anchor(fresh: &mut usize) -> String {
+    let n = *fresh;
+    *fresh += 1;
+    format!("$anchor{n}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pegc::{compile, parse, Error};
+    use crate::pegvm::CharSet;
+
+    /// The `%`-surface form of a tiny indentation language: a root block of
+    /// column-aligned lines, each of which may own a strictly-deeper
+    /// sub-block. Exercises all three operators plus a threaded recursive
+    /// call (`ln` → `sub` → `ln`).
+    const PCT_SRC: &str = "root = doc {
+    doc: atomic = %root ( ln ( sep %align ln )* )
+    ln: atomic = @text [a-z] sub?
+    sub: atomic = %indent ( ln ( sep %align ln )* )
+    sep: atomic = '\\n'
+}";
+
+    /// The same language written by hand against the lower-level
+    /// column-threading IR — parameterized rules, the
+    /// `deeper` / `same` / `at_least` combinators, parameterized calls.
+    /// This is the form `desugar_indent` must reproduce.
+    fn handwritten_explicit() -> Grammar {
+        let syn = Span::SYNTHETIC;
+        let comb = |op: IndentOp, arg: IndentArg, bind: Option<&str>| Pattern::IndentCombinator {
+            op,
+            arg,
+            bind: bind.map(str::to_string),
+            span: syn,
+        };
+        let call = |name: &str, local: &str| Pattern::NonTerminal {
+            name: name.to_string(),
+            args: vec![IndentArg::Local(local.to_string())],
+            span: syn,
+        };
+        // `<col> as i  ln(i)  ( sep  same(i)  ln(i) )*`
+        let block = |open: Pattern| {
+            Pattern::seq(vec![
+                open,
+                call("ln", "i"),
+                Pattern::repeat(Pattern::seq(vec![
+                    Pattern::nt("sep"),
+                    comb(IndentOp::Same, IndentArg::Local("i".to_string()), None),
+                    call("ln", "i"),
+                ])),
+            ])
+        };
+
+        let mut rules = HashMap::new();
+        rules.insert("root".to_string(), Pattern::nt("doc"));
+        rules.insert(
+            "doc".to_string(),
+            block(comb(IndentOp::AtLeast, IndentArg::Lit(0), Some("i"))),
+        );
+        rules.insert(
+            "ln".to_string(),
+            Pattern::seq(vec![
+                Pattern::capture(
+                    "text",
+                    Pattern::char_class(CharSet::single_range('a', 'z').unwrap()),
+                ),
+                Pattern::optional(call("sub", "cur")),
+            ]),
+        );
+        rules.insert(
+            "sub".to_string(),
+            block(comb(
+                IndentOp::Deeper,
+                IndentArg::Local("outer".to_string()),
+                Some("i"),
+            )),
+        );
+        rules.insert("sep".to_string(), Pattern::literal("\n"));
+
+        let atomic_rules: HashSet<String> = ["doc", "ln", "sub", "sep"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut rule_params = HashMap::new();
+        rule_params.insert("ln".to_string(), vec!["cur".to_string()]);
+        rule_params.insert("sub".to_string(), vec!["outer".to_string()]);
+
+        Grammar {
+            rules,
+            root: "root".to_string(),
+            atomic_rules,
+            percent_rules: HashSet::new(),
+            preferred_rules: HashSet::new(),
+            rule_headers: Vec::new(),
+            rule_params,
+        }
+    }
+
+    /// The decisive test: the desugared `%`-grammar compiles to byte-for-
+    /// byte the same bytecode as the hand-written explicit IR. Proves the
+    /// surface is a pure restatement of the kept internals.
+    #[test]
+    fn desugars_to_byte_identical_bytecode() {
+        let actual = compile(PCT_SRC).expect("%-grammar compiles");
+        let expected = handwritten_explicit()
+            .compile()
+            .expect("explicit IR compiles");
+        assert_eq!(
+            actual.code, expected.code,
+            "desugared bytecode diverged from the hand-written explicit IR"
+        );
+        assert_eq!(actual.capture_kinds, expected.capture_kinds);
+        assert_eq!(actual.rule_names, expected.rule_names);
+        assert_eq!(actual.char_sets, expected.char_sets);
+    }
+
+    /// Effect-selective threading: only rules that read an *inherited*
+    /// anchor get the implicit `$indent` parameter. A `%root`-only seeding
+    /// rule, and a pure-whitespace rule, stay parameterless — so their memo
+    /// key stays the allocation-free zero-argument key.
+    #[test]
+    fn only_anchor_reading_rules_get_the_implicit_param() {
+        let mut g = parse(PCT_SRC).expect("parses");
+        desugar_indent(&mut g).expect("desugars");
+
+        assert!(
+            !g.rule_params.contains_key("doc"),
+            "`doc` only seeds via %root; it reads no inherited anchor"
+        );
+        assert!(
+            !g.rule_params.contains_key("sep"),
+            "`sep` is pure whitespace"
+        );
+        let one_anchor = vec![ANCHOR_PARAM.to_string()];
+        assert_eq!(g.rule_params.get("ln"), Some(&one_anchor));
+        assert_eq!(g.rule_params.get("sub"), Some(&one_anchor));
+
+        for (name, body) in &g.rules {
+            assert!(
+                !contains_indent_op(body),
+                "no `%`-operator may survive desugaring (rule `{name}`)"
+            );
+        }
+    }
+
+    /// A `%align` reachable from the root with no enclosing `%root` /
+    /// `%indent` to seed the column is a compile error, not a silent
+    /// mis-parse.
+    #[test]
+    fn unanchored_operator_is_rejected() {
+        let src = "root = bare {
+    bare: atomic = %align
+}";
+        match compile(src) {
+            Err(Error::Compile(CompileError::IndentAnchorOutOfScope { rule, .. })) => {
+                assert_eq!(rule, "root");
+            }
+            other => panic!("expected IndentAnchorOutOfScope, got {other:?}"),
+        }
+    }
+
+    fn contains_indent_op(pat: &Pattern) -> bool {
+        match pat {
+            Pattern::IndentOp { .. } => true,
+            Pattern::Sequence { items, .. } => items.iter().any(contains_indent_op),
+            Pattern::OrderedChoice { alts, .. } => alts.iter().any(contains_indent_op),
+            Pattern::Repeat { inner, .. }
+            | Pattern::RepeatOne { inner, .. }
+            | Pattern::Optional { inner, .. }
+            | Pattern::NotPredicate { inner, .. }
+            | Pattern::AndPredicate { inner, .. }
+            | Pattern::Capture { inner, .. }
+            | Pattern::Lenient { inner, .. }
+            | Pattern::InferBoundaryCatch { inner, .. } => contains_indent_op(inner),
+            Pattern::Catch {
+                inner, recovery, ..
+            } => contains_indent_op(inner) || contains_indent_op(recovery),
+            Pattern::Literal { .. }
+            | Pattern::CharClass { .. }
+            | Pattern::AnyChar { .. }
+            | Pattern::NonTerminal { .. }
+            | Pattern::IndentCombinator { .. } => false,
+        }
+    }
+}

--- a/src/pegc/mod.rs
+++ b/src/pegc/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod analysis;
 pub mod compiler;
+pub mod desugar_indent;
 pub mod parser;
 pub mod pattern;
 pub mod unicode_properties;
@@ -35,7 +36,7 @@ pub mod unicode_properties;
 pub use analysis::{tally_non_terminal_refs, LintFinding, LintKind};
 pub use compiler::{compile_pattern, CompileError};
 pub use parser::{parse, Grammar, ParseError, RuleHeader};
-pub use pattern::{Pattern, Span};
+pub use pattern::{IndentArg, IndentOp, IndentOpKind, Pattern, Span};
 
 use crate::pegvm::Program;
 

--- a/src/pegc/parser.rs
+++ b/src/pegc/parser.rs
@@ -5,7 +5,8 @@ use super::analysis::{
     synthesize_reserved_preferred, wrap_root,
 };
 use super::compiler::{compile_rules, CompileError};
-use super::pattern::{Pattern, Span};
+use super::desugar_indent::desugar_indent;
+use super::pattern::{IndentOpKind, Pattern, Span};
 use crate::pegvm::{CharSet, Program};
 
 /// Append `c` as UTF-8 to `out`. ASCII chars produce one byte; non-ASCII
@@ -113,6 +114,15 @@ pub struct Grammar {
     /// position check in [`Grammar::compile`] also walks the names in
     /// order to verify `root` is the first rule.
     pub rule_headers: Vec<RuleHeader>,
+    /// Declared parameter names of each parameterized rule, keyed by flat
+    /// rule name (e.g. `suite` → `["outer"]`). The parameters are the
+    /// integer indentation columns a rule is called with; the compiler
+    /// reads `.len()` as the rule's `argc` and
+    /// resolves `ArgSrc::Local` references against this list (params
+    /// occupy the first activation slots). Absent / empty for every
+    /// non-parameterized rule — which is every rule in every grammar that
+    /// predates the indentation surface.
+    pub rule_params: HashMap<String, Vec<String>>,
 }
 
 /// Byte ranges of one rule's pieces in the grammar source. All offsets
@@ -168,6 +178,7 @@ impl Grammar {
             percent_rules: HashSet::new(),
             preferred_rules: HashSet::new(),
             rule_headers: Vec::new(),
+            rule_params: HashMap::new(),
         }
     }
 
@@ -182,6 +193,7 @@ impl Grammar {
             percent_rules: HashSet::new(),
             preferred_rules: HashSet::new(),
             rule_headers: Vec::new(),
+            rule_params: HashMap::new(),
         }
     }
 
@@ -191,6 +203,11 @@ impl Grammar {
     /// [`compile`](super::compile) instead.
     ///
     /// Pipeline:
+    /// 0. Desugar the implicit indentation operators (`%root` / `%align`
+    ///    / `%indent`) via [`desugar_indent`] into the column-threading
+    ///    IR — parameterized rules plus `deeper` / `same` / `at_least`
+    ///    combinators — so every later pass and the whole backend see
+    ///    only that lower-level form. Runs first, before any analysis.
     /// 1. Resolve `Pattern::InferBoundaryCatch` placeholders (`^^lbl`)
     ///    via [`resolve_inferred_boundaries`] — synthesizes each
     ///    boundary from FOLLOW.
@@ -219,7 +236,9 @@ impl Grammar {
             percent_rules: self.percent_rules.clone(),
             preferred_rules: self.preferred_rules.clone(),
             rule_headers: self.rule_headers.clone(),
+            rule_params: self.rule_params.clone(),
         };
+        desugar_indent(&mut resolved)?;
         resolve_inferred_boundaries(&mut resolved)?;
         let findings = lint_partial_match(&resolved);
         if !findings.is_empty() {
@@ -239,7 +258,7 @@ impl Grammar {
         // `CompileError::UndefinedRule("boundary")` from `compile_rules`.
         append_boundary_check(&mut resolved);
         wrap_root(&mut resolved);
-        compile_rules(&resolved.rules, &resolved.root)
+        compile_rules(&resolved.rules, &resolved.root, &resolved.rule_params)
     }
 }
 
@@ -543,6 +562,10 @@ impl<'a> Parser<'a> {
         let mut percent: HashSet<String> = HashSet::new();
         let mut preferred: HashSet<String> = HashSet::new();
         let mut rule_headers: Vec<RuleHeader> = Vec::new();
+        // Indentation parameters are synthesized later by `desugar_indent`
+        // from the `%root` / `%align` / `%indent` operators; the surface
+        // has no parameter syntax, so resolution leaves this empty.
+        let rule_params: HashMap<String, Vec<String>> = HashMap::new();
 
         let root_flat = root.name.clone();
         // Base frame: the root rule itself, visible everywhere (so the
@@ -576,6 +599,7 @@ impl<'a> Parser<'a> {
             percent_rules: percent,
             preferred_rules: preferred,
             rule_headers,
+            rule_params,
         })
     }
 
@@ -704,7 +728,22 @@ impl<'a> Parser<'a> {
                 Self::rewrite_refs(inner, stack);
                 Self::rewrite_refs(recovery, stack);
             }
-            Pattern::Literal { .. } | Pattern::CharClass { .. } | Pattern::AnyChar { .. } => {}
+            // `%root X` / `%indent X` bind a sub-expression that can name
+            // rules (`%root node`); resolve inside the operand. `%align`
+            // carries none.
+            Pattern::IndentOp { operand, .. } => {
+                if let Some(inner) = operand {
+                    Self::rewrite_refs(inner, stack);
+                }
+            }
+            // An indent combinator's `IndentArg::Local` is an activation
+            // local, not a rule reference, so name resolution leaves it
+            // untouched. (It only appears post-desugar, never during the
+            // parse-time resolution this walk performs.)
+            Pattern::Literal { .. }
+            | Pattern::CharClass { .. }
+            | Pattern::AnyChar { .. }
+            | Pattern::IndentCombinator { .. } => {}
         }
     }
 
@@ -1101,11 +1140,16 @@ impl<'a> Parser<'a> {
                 Ok(Pattern::AnyChar { span })
             }
             Some(b'@') => self.parse_capture(),
+            Some(b'%') => self.parse_indent_op(),
             Some(b'\\') => self.parse_backslash_atom(),
             Some(c) if is_ident_start(c) => {
                 // Disambiguation against `name = ...` is handled by at_prefix_start.
                 let name = self.parse_ident()?;
-                Ok(Pattern::NonTerminal { name, span })
+                Ok(Pattern::NonTerminal {
+                    name,
+                    args: Vec::new(),
+                    span,
+                })
             }
             Some(c) => Err(self.err(format!("unexpected '{}'", c as char))),
             None => Err(self.err("unexpected end of input".into())),
@@ -1211,6 +1255,49 @@ impl<'a> Parser<'a> {
         Ok(Pattern::Capture {
             kind: name,
             inner: Box::new(inner),
+            span,
+        })
+    }
+
+    /// Parse a `%`-prefixed indentation operator: `%root X`, `%align`,
+    /// `%indent X`. The keyword touches the `%` (no whitespace), the same
+    /// tight-binding rule as `@kind`. `%root` and `%indent` take a single
+    /// following atom as their operand — `parse_atom`, never a bare
+    /// sequence — so `%indent a?` reads as `(%indent a)?` and a
+    /// multi-element block is parenthesized (`%indent ( a b )`), exactly
+    /// like `@kind`. `%align` is standalone.
+    ///
+    /// The result is a transient [`Pattern::IndentOp`]; the
+    /// [`desugar_indent`](super::desugar_indent::desugar_indent) pass
+    /// rewrites it into the column-threading IR before any other pass
+    /// runs, so no analysis or the backend ever sees this node.
+    fn parse_indent_op(&mut self) -> Result<Pattern, ParseError> {
+        // Span of the operator is the position of the `%` sigil.
+        let span = self.span();
+        self.expect(b'%')?;
+        let kw = self
+            .parse_ident()
+            .map_err(|_| self.err("expected `root`, `align`, or `indent` after `%`".into()))?;
+        let kind = match kw.as_str() {
+            "root" => IndentOpKind::Root,
+            "align" => IndentOpKind::Align,
+            "indent" => IndentOpKind::Indent,
+            other => {
+                return Err(self.err(format!(
+                    "unknown indentation operator `%{other}`; expected `%root`, `%align`, \
+                     or `%indent`"
+                )))
+            }
+        };
+        let operand = if matches!(kind, IndentOpKind::Align) {
+            None
+        } else {
+            self.skip_ws();
+            Some(Box::new(self.parse_atom()?))
+        };
+        Ok(Pattern::IndentOp {
+            kind,
+            operand,
             span,
         })
     }
@@ -1675,7 +1762,7 @@ fn is_ident_cont(c: u8) -> bool {
 fn is_atom_start(c: u8) -> bool {
     matches!(
         c,
-        b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'!' | b'&' | b'\\'
+        b'(' | b'"' | b'\'' | b'[' | b'.' | b'@' | b'%' | b'!' | b'&' | b'\\'
     ) || is_ident_start(c)
 }
 

--- a/src/pegc/pattern.rs
+++ b/src/pegc/pattern.rs
@@ -34,6 +34,51 @@ impl std::fmt::Display for Span {
     }
 }
 
+/// One integer argument to a parameterized rule call or an indent
+/// combinator: either a literal column or a reference to an in-scope
+/// local (a rule parameter or an `as`-bound indent width). Lowered to a
+/// concrete [`crate::pegvm::ArgSrc`] by the compiler, which resolves
+/// `Local` names to activation-slot indices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndentArg {
+    /// A literal column — the `0` in `block(0)`.
+    Lit(i32),
+    /// A reference to an in-scope local by name (`outer`, `i`).
+    Local(String),
+}
+
+/// The relation a declarative indent combinator asserts between the
+/// indentation it measures at the current line and its argument column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndentOp {
+    /// `deeper(n)` — measured strictly greater than `n`.
+    Deeper,
+    /// `same(n)` — measured exactly equal to `n`.
+    Same,
+    /// `at_least(n)` — measured greater than or equal to `n`.
+    AtLeast,
+}
+
+/// Surface-level indentation operator — the `%root` / `%align` / `%indent`
+/// the grammar author writes. A transient kind: the parser produces a
+/// [`Pattern::IndentOp`] carrying one of these, and `desugar_indent`
+/// rewrites the whole thing into the lower-level [`IndentCombinator`] +
+/// parameterized [`Pattern::NonTerminal`] threading before any other pass
+/// runs. It never reaches analysis, lowering, or the VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndentOpKind {
+    /// `%root X` — seed a fresh anchor at the line's own column and run
+    /// `X` under it. Desugars to `at_least(0) as <anchor>` over `X`.
+    Root,
+    /// `%align` — assert the current line starts at the ambient anchor
+    /// column. Standalone (no operand). Desugars to `same(<anchor>)`.
+    Align,
+    /// `%indent X` — open a level strictly deeper than the ambient anchor,
+    /// rebind the anchor to it, and run `X`. Desugars to
+    /// `deeper(<anchor>) as <inner>` over `X`.
+    Indent,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
     Literal {
@@ -79,6 +124,14 @@ pub enum Pattern {
     },
     NonTerminal {
         name: String,
+        /// Indentation arguments for a parameterized call (`suite(i)`,
+        /// `block(0)`). Empty for an ordinary reference — every call in
+        /// every grammar that predates the indentation surface. A
+        /// parameterized call is still fundamentally a rule reference, so
+        /// the analyses treat it like any other `NonTerminal`; only the
+        /// compiler reads `args` (to emit the `ArgPush` run before the
+        /// `Call`).
+        args: Vec<IndentArg>,
         span: Span,
     },
     Capture {
@@ -134,6 +187,37 @@ pub enum Pattern {
         label: String,
         span: Span,
     },
+    /// A declarative indentation combinator — `deeper(outer) as i`,
+    /// `same(i)`, `at_least(n) as i`. Measures the indentation run at the
+    /// current line (which must be a line start; the grammar places these
+    /// right after a newline), asserts [`IndentOp`] against `arg`, and
+    /// optionally binds the measured width to `bind` so later `same(bind)`
+    /// lines in the same suite can re-check alignment.
+    ///
+    /// The compiler lowers it to `IndentMeasure` + `IndentCmp` over the
+    /// current activation's local slots (see `src/pegvm/instruction.rs`).
+    /// It is **non-nullable and consuming** (it eats the leading
+    /// `[ \t]*`) and contributes **no FIRST/FOLLOW non-terminal**, so the
+    /// static analyses treat it as an opaque consuming leaf.
+    IndentCombinator {
+        op: IndentOp,
+        arg: IndentArg,
+        bind: Option<String>,
+        span: Span,
+    },
+    /// Transient surface indentation operator — `%root X`, `%align`,
+    /// `%indent X`. The parser emits this; `desugar_indent` (run first in
+    /// `Grammar::compile`) rewrites it into [`IndentCombinator`] plus the
+    /// implicit anchor parameter threaded through [`Pattern::NonTerminal`]
+    /// `args`. `%align` carries no operand; `%root` / `%indent` carry
+    /// exactly one. Because desugaring happens before every other pass,
+    /// all downstream `Pattern` matches treat this variant as
+    /// `unreachable!`.
+    IndentOp {
+        kind: IndentOpKind,
+        operand: Option<Box<Pattern>>,
+        span: Span,
+    },
 }
 
 impl Pattern {
@@ -155,7 +239,9 @@ impl Pattern {
             | Pattern::Capture { span, .. }
             | Pattern::Catch { span, .. }
             | Pattern::Lenient { span, .. }
-            | Pattern::InferBoundaryCatch { span, .. } => *span,
+            | Pattern::InferBoundaryCatch { span, .. }
+            | Pattern::IndentCombinator { span, .. }
+            | Pattern::IndentOp { span, .. } => *span,
         }
     }
 
@@ -253,6 +339,7 @@ impl Pattern {
     pub fn nt(name: impl Into<String>) -> Pattern {
         Pattern::NonTerminal {
             name: name.into(),
+            args: Vec::new(),
             span: Span::SYNTHETIC,
         }
     }
@@ -330,8 +417,9 @@ impl Pattern {
                 inner: Box::new(inner.strip_spans()),
                 span: Span::SYNTHETIC,
             },
-            Pattern::NonTerminal { name, .. } => Pattern::NonTerminal {
+            Pattern::NonTerminal { name, args, .. } => Pattern::NonTerminal {
                 name: name.clone(),
+                args: args.clone(),
                 span: Span::SYNTHETIC,
             },
             Pattern::Capture { kind, inner, .. } => Pattern::Capture {
@@ -357,6 +445,17 @@ impl Pattern {
             Pattern::InferBoundaryCatch { inner, label, .. } => Pattern::InferBoundaryCatch {
                 inner: Box::new(inner.strip_spans()),
                 label: label.clone(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::IndentCombinator { op, arg, bind, .. } => Pattern::IndentCombinator {
+                op: *op,
+                arg: arg.clone(),
+                bind: bind.clone(),
+                span: Span::SYNTHETIC,
+            },
+            Pattern::IndentOp { kind, operand, .. } => Pattern::IndentOp {
+                kind: *kind,
+                operand: operand.as_ref().map(|p| Box::new(p.strip_spans())),
                 span: Span::SYNTHETIC,
             },
         }

--- a/src/pegvm/incremental.rs
+++ b/src/pegvm/incremental.rs
@@ -51,7 +51,7 @@
 use std::collections::HashMap;
 
 use super::instruction::MemoId;
-use super::vm::MemoEntry;
+use super::vm::{ArgKey, MemoEntry};
 
 /// A description of a single edit to the parser's input. The replacement
 /// content itself is not stored — the cache only needs the byte offsets.
@@ -119,7 +119,7 @@ impl Edit {
 /// next run, and reclaim the post-run table via `VM::into_cache`.
 #[derive(Debug, Default, Clone)]
 pub struct MemoCache {
-    table: HashMap<(MemoId, usize), MemoEntry>,
+    table: HashMap<(MemoId, usize, ArgKey), MemoEntry>,
 }
 
 impl MemoCache {
@@ -145,17 +145,19 @@ impl MemoCache {
         }
         let delta = edit.delta();
         let mut next = HashMap::with_capacity(self.table.len());
-        for ((memo_id, start_sp), mut entry) in self.table.drain() {
+        for ((memo_id, start_sp, arg_key), mut entry) in self.table.drain() {
             if invalidates(edit, start_sp, &entry) {
                 continue;
             }
             if start_sp >= edit.old_end {
                 let new_start_sp = start_sp.wrapping_add_signed(delta);
                 shift_entry(&mut entry, delta);
-                next.insert((memo_id, new_start_sp), entry);
+                next.insert((memo_id, new_start_sp, arg_key), entry);
             } else {
                 // Entry lives entirely before the edit; keep unshifted.
-                next.insert((memo_id, start_sp), entry);
+                // The arg key is an indentation context, not a position,
+                // so it rides along untouched.
+                next.insert((memo_id, start_sp, arg_key), entry);
             }
         }
         self.table = next;
@@ -165,7 +167,7 @@ impl MemoCache {
     /// hook for `VM::new_with_cache` (next commit) to seed its memo
     /// directly without an extra copy.
     #[allow(dead_code)] // consumed by the VM wiring in the next commit
-    pub(crate) fn take(&mut self) -> HashMap<(MemoId, usize), MemoEntry> {
+    pub(crate) fn take(&mut self) -> HashMap<(MemoId, usize, ArgKey), MemoEntry> {
         std::mem::take(&mut self.table)
     }
 
@@ -173,15 +175,18 @@ impl MemoCache {
     /// `VM::into_cache` (next commit) to return a populated cache after
     /// a run.
     #[allow(dead_code)] // consumed by the VM wiring in the next commit
-    pub(crate) fn install(&mut self, table: HashMap<(MemoId, usize), MemoEntry>) {
+    pub(crate) fn install(&mut self, table: HashMap<(MemoId, usize, ArgKey), MemoEntry>) {
         self.table = table;
     }
 
     /// Package-internal read access for tests to assert on per-entry
-    /// structure without leaking `MemoEntry`.
+    /// structure without leaking `MemoEntry`. Probes the zero-arg slot
+    /// ([`ArgKey::None`]) — the only shape the invalidation/shift unit
+    /// tests build; arg-keyed end-to-end invalidation is covered by the
+    /// grammar integration tests.
     #[cfg(test)]
     pub(crate) fn get(&self, memo_id: MemoId, start_sp: usize) -> Option<&MemoEntry> {
-        self.table.get(&(memo_id, start_sp))
+        self.table.get(&(memo_id, start_sp, ArgKey::None))
     }
 }
 
@@ -239,8 +244,10 @@ mod tests {
     fn populate(pairs: Vec<((MemoId, usize), MemoEntry)>) -> MemoCache {
         let mut cache = MemoCache::new();
         let mut table = HashMap::new();
-        for (k, v) in pairs {
-            table.insert(k, v);
+        for ((memo_id, start_sp), v) in pairs {
+            // The invalidation/shift logic is independent of the arg key,
+            // so these fixtures all use the zero-arg slot.
+            table.insert((memo_id, start_sp, ArgKey::None), v);
         }
         cache.install(table);
         cache

--- a/src/pegvm/instruction.rs
+++ b/src/pegvm/instruction.rs
@@ -67,6 +67,35 @@ pub struct SetId(pub u16);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct LabelId(pub u16);
 
+/// Relation tested by [`Instruction::IndentCmp`] between a measured
+/// indentation width (left) and a reference column (right). All three
+/// are the relations the declarative indent combinators desugar to:
+/// `deeper` → [`CmpOp::Gt`], `at_least` → [`CmpOp::Ge`], `same` →
+/// [`CmpOp::Eq`]. A false relation routes through `fail()` like any
+/// other match miss.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CmpOp {
+    /// Strictly deeper: `measured > reference`.
+    Gt,
+    /// At least as deep: `measured >= reference`.
+    Ge,
+    /// Exactly aligned: `measured == reference`.
+    Eq,
+}
+
+/// Source of an integer argument for [`Instruction::ArgPush`],
+/// [`Instruction::IndentCmp`], and the rule-call convention. Either a
+/// compile-time literal column or a read from the current activation's
+/// local slots (params first, then `as`-bound indent widths).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArgSrc {
+    /// A literal column value (e.g. the `0` in `block(0)`).
+    Lit(i32),
+    /// Read activation slot `n` of the current rule frame: index
+    /// `locals_base + n` into the VM's locals arena.
+    Local(u8),
+}
+
 /// Discriminator on a [`Instruction::RuleEnter`] selecting the post-cache-miss
 /// behavior. The cache-hit prologue is identical for both kinds; only the
 /// miss path differs.
@@ -122,6 +151,39 @@ pub enum Instruction {
     Call(Label),
     Return,
 
+    /// Measure the indentation run `[ \t]*` at the current input pointer,
+    /// **consuming it forward** (advancing `sp`, with each byte counted
+    /// against the enclosing rule's `examined_max` watermark), and store
+    /// the column width into activation slot `n` (index `locals_base + n`
+    /// of the VM's locals arena, growing it with zeros if `n` is past the
+    /// current frame's end). One column per space *or* tab — a documented
+    /// simplification (no tab-stop expansion).
+    ///
+    /// Forward-consuming is the incremental-soundness lynchpin: because
+    /// the whitespace is read through the normal `track_read` path, an
+    /// edit anywhere in the measured run is covered by the memo entry's
+    /// `examined_max`, so warm reparses invalidate correctly. A backward
+    /// scan to the previous newline would create a dependency on bytes
+    /// before `start_sp` that the incremental invalidator cannot see.
+    IndentMeasure(u8),
+    /// Compare activation slot `n` (a previously [`IndentMeasure`]d width)
+    /// against a reference column under the [`CmpOp`] relation. The
+    /// reference comes from the [`ArgSrc`] (a literal or another local).
+    /// A false relation routes to `fail()`; a true one falls through. The
+    /// slot is left intact so a single measured width can be both compared
+    /// and (via the same slot) referenced later — e.g. `deeper(outer) as i`
+    /// measures into `i`, compares `i > outer`, and leaves `i` bound for
+    /// the suite's `same(i)` lines.
+    ///
+    /// [`IndentMeasure`]: Instruction::IndentMeasure
+    IndentCmp(CmpOp, u8, ArgSrc),
+    /// Push one integer argument onto the VM's argument stack ahead of a
+    /// `Call`/`RuleEnter` to a parameterized rule. The matching
+    /// `RuleEnter` pops `argc` of these to form its memo key and seed the
+    /// callee's parameter slots. Emitted in left-to-right argument order,
+    /// so the callee's slot `0` is the first argument.
+    ArgPush(ArgSrc),
+
     /// Rule-entry prologue. Probes the packrat cache at `(memo_id, sp)`:
     /// on a hit replays the cached captures, advances `sp` to the cached
     /// end, and jumps to the `Label` (the rule's `Return` address); on a
@@ -134,7 +196,16 @@ pub enum Instruction {
     ///   (`seed: None` ⇒ `fail()`; `seed: Some` ⇒ jump to `Label`); first
     ///   entry pushes a fresh `LFrame { seed: None, return_addr: Label }`
     ///   and falls through. `LRTail` commits the converged seed.
-    RuleEnter(MemoId, RuleKind, Label),
+    ///
+    /// The trailing `u8` is the rule's **arg count** (`argc`). The
+    /// prologue pops that many values off the VM's argument stack (pushed
+    /// by the caller's `ArgPush` run) to form the [`MemoId`]-keyed memo
+    /// probe's argument component, and — on a miss — seeds the callee's
+    /// first `argc` activation slots with them. `argc = 0` is exactly the
+    /// pre-parameterization behavior: no args popped, an empty
+    /// (allocation-free) arg key, and no slot seeding — the hot path every
+    /// non-indentation grammar takes.
+    RuleEnter(MemoId, RuleKind, Label, u8),
     /// Rule-level memoization epilogue. Pops the matching `StackEntry::Memo`
     /// frame and records a success entry for this rule at the frame's
     /// `start_sp` (subject to the memo-threshold filter).

--- a/src/pegvm/mod.rs
+++ b/src/pegvm/mod.rs
@@ -7,6 +7,8 @@ pub mod vm;
 
 pub use charset::{CharSet, CharSetError};
 pub use incremental::{Edit, MemoCache};
-pub use instruction::{CaptureKind, Instruction, Label, LabelId, MemoId, RuleKind, SetId};
+pub use instruction::{
+    ArgSrc, CaptureKind, CmpOp, Instruction, Label, LabelId, MemoId, RuleKind, SetId,
+};
 pub use program::Program;
 pub use vm::{Capture, MatchResult, MemoStats, RecoveryDiagnostic, RecoveryOrigin, VM};

--- a/src/pegvm/vm.rs
+++ b/src/pegvm/vm.rs
@@ -1,6 +1,41 @@
 use std::collections::HashMap;
 
-use super::instruction::{CaptureKind, Instruction, LabelId, MemoId, RuleKind};
+use super::instruction::{ArgSrc, CaptureKind, CmpOp, Instruction, LabelId, MemoId, RuleKind};
+
+/// Argument component of a packrat memo key. A parameterized rule's
+/// cached outcome depends on the integer arguments it was called with
+/// (an indentation column, today), so the memo key carries them
+/// alongside `(MemoId, start_sp)`.
+///
+/// The three shapes keep the common cases cheap:
+/// - [`ArgKey::None`] — zero-arg rules (every rule in every
+///   non-indentation grammar). No allocation; the hot packrat probe
+///   `memo.get(&(id, sp, ArgKey::None))` stays a plain hash of two
+///   integers plus a discriminant.
+/// - [`ArgKey::One`] — the single-column case (`suite(i)`,
+///   `mapping(outer)`): one inline `i32`, still no allocation.
+/// - [`ArgKey::Many`] — two or more args. This is the seam for the
+///   future typed-arg extension (heredoc terminators, etc.); no shipped
+///   grammar reaches it yet, so the boxed slice never allocates in
+///   practice.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum ArgKey {
+    None,
+    One(i32),
+    Many(Box<[i32]>),
+}
+
+impl ArgKey {
+    /// Build the key component from the `argc` argument values a
+    /// `RuleEnter` popped, choosing the cheapest representation.
+    fn from_args(args: &[i32]) -> ArgKey {
+        match args {
+            [] => ArgKey::None,
+            [one] => ArgKey::One(*one),
+            many => ArgKey::Many(many.into()),
+        }
+    }
+}
 
 /// One half-open byte span `start..end` tagged with a [`CaptureKind`].
 ///
@@ -23,6 +58,14 @@ enum StackEntry {
         ip: usize,
         sp: usize,
         capture_len: usize,
+        /// Length of the VM's argument stack at the moment the `Choice`
+        /// fired. Restored on backtrack so a half-pushed argument run
+        /// (between an `ArgPush` and its `Call`) cannot leak across a
+        /// failed alternative. In practice arguments are pushed
+        /// immediately before their `Call`, so this equals the ambient
+        /// arg-stack depth and the truncate is usually a no-op — kept for
+        /// robustness, mirroring the `capture_len` snapshot.
+        args_len: usize,
     },
     Return {
         ip: usize,
@@ -37,6 +80,17 @@ enum StackEntry {
         memo_id: MemoId,
         start_sp: usize,
         capture_start_len: usize,
+        /// Argument component of this invocation's memo key, computed
+        /// once in `RuleEnter`'s miss path so `MemoClose` (success) and
+        /// `fail()`'s `Memo` arm (failure) write the same
+        /// `(memo_id, start_sp, arg_key)` slot without recomputing.
+        /// [`ArgKey::None`] for every zero-arg rule.
+        arg_key: ArgKey,
+        /// The VM's `locals_base` *before* this rule's activation frame
+        /// was pushed. Restored when the frame is popped so nested
+        /// parameterized calls see their own slots. Equal to the new
+        /// base for zero-local rules (the frame reserves nothing).
+        prev_locals_base: usize,
     },
     /// Frame for an in-flight left-recursive rule invocation. Pushed by
     /// `RuleEnter`'s `RuleKind::Lr` miss path on the first entry at a
@@ -52,6 +106,15 @@ enum StackEntry {
         capture_start_len: usize,
         return_addr: usize,
         seed: Option<LSeed>,
+        /// Argument component of this LR invocation's memo key (see the
+        /// `Memo` variant's `arg_key`). Written to the cache when the
+        /// seed-and-grow loop converges at `LRTail`. [`ArgKey::None`] for
+        /// zero-arg rules — i.e. every left-recursive rule shipped today,
+        /// since indentation rules aren't left-recursive.
+        arg_key: ArgKey,
+        /// The VM's `locals_base` before this LR frame was pushed; see
+        /// the `Memo` variant's `prev_locals_base`.
+        prev_locals_base: usize,
     },
     /// Tracking frame for a `^label` catch (and, transitively, for each
     /// iteration of the `*^` / `*^[cs]` desugar `(p ^recovery
@@ -322,9 +385,30 @@ pub struct VM<'p, 'i> {
     /// epoch, and only the suffix being dropped — never the bulk of
     /// the watermark prefix that survives every backtrack.
     saved_above: Vec<OpenCapture>,
-    /// Packrat memo table, keyed by `(memo_id, start_sp)`. Populated by
-    /// `MemoClose` on success and by `fail()` on failure escape (Commit 5).
-    memo: HashMap<(MemoId, usize), MemoEntry>,
+    /// Packrat memo table, keyed by `(memo_id, start_sp, arg_key)`.
+    /// Populated by `MemoClose` on success and by `fail()` on failure
+    /// escape. The [`ArgKey`] component is [`ArgKey::None`] for every
+    /// zero-arg rule, so non-indentation grammars key on the same two
+    /// integers as before.
+    memo: HashMap<(MemoId, usize, ArgKey), MemoEntry>,
+    /// Argument stack for the parameterized-rule call convention.
+    /// `ArgPush` appends; `RuleEnter` drains its rule's `argc` from the
+    /// top to form the memo key and seed the callee's parameter slots.
+    /// Snapshotted in `StackEntry::Backtrack` (`args_len`) and truncated
+    /// on backtrack. Empty whenever no `ArgPush`/`Call` pair is mid-flight
+    /// — i.e. almost always.
+    args: Vec<i32>,
+    /// Activation-locals arena. The current rule frame owns
+    /// `locals[locals_base..]`; `IndentMeasure`/`ArgSrc::Local` index it
+    /// as `locals_base + slot`. `RuleEnter` pushes a frame's parameter
+    /// seeds, the body grows it with measured widths, and the matching
+    /// `MemoClose` / `LRTail` / `fail()` truncates back to the frame's
+    /// base. Stays empty for grammars with no parameterized rules.
+    locals: Vec<i32>,
+    /// Base index into `locals` for the rule activation currently
+    /// executing. Saved into the `Memo` / `LFrame` frame on entry and
+    /// restored on exit so nested calls nest their slot windows.
+    locals_base: usize,
     /// Running count of resolved cache hits, exposed via `MemoStats`.
     memo_hits: usize,
     /// Running count of `RuleEnter` cache misses on `RuleKind::Memo`
@@ -458,6 +542,9 @@ impl<'p, 'i> VM<'p, 'i> {
             saved_lower: 0,
             saved_above: Vec::new(),
             memo: HashMap::new(),
+            args: Vec::new(),
+            locals: Vec::new(),
+            locals_base: 0,
             memo_hits: 0,
             memo_misses: 0,
             memo_threshold: Self::DEFAULT_MEMO_THRESHOLD,
@@ -575,7 +662,13 @@ impl<'p, 'i> VM<'p, 'i> {
     /// per-entry details (notably `examined_max`) and for the public
     /// `run_with_cache` variant that rewraps the table into a
     /// [`MemoCache`](super::incremental::MemoCache).
-    fn run_core(mut self) -> (MatchResult, MemoStats, HashMap<(MemoId, usize), MemoEntry>) {
+    fn run_core(
+        mut self,
+    ) -> (
+        MatchResult,
+        MemoStats,
+        HashMap<(MemoId, usize, ArgKey), MemoEntry>,
+    ) {
         loop {
             let instr = match self.program.get(self.ip) {
                 Some(i) => i,
@@ -655,6 +748,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         ip: label.as_index(),
                         sp: self.sp,
                         capture_len: self.captures.len(),
+                        args_len: self.args.len(),
                     });
                     self.ip += 1;
                 }
@@ -666,10 +760,14 @@ impl<'p, 'i> VM<'p, 'i> {
                     let top = self.stack.last_mut().expect("PartialCommit on empty stack");
                     match top {
                         StackEntry::Backtrack {
-                            sp, capture_len, ..
+                            sp,
+                            capture_len,
+                            args_len,
+                            ..
                         } => {
                             *sp = self.sp;
                             *capture_len = self.captures.len();
+                            *args_len = self.args.len();
                         }
                         _ => panic!("PartialCommit expected Backtrack on stack top"),
                     }
@@ -678,15 +776,19 @@ impl<'p, 'i> VM<'p, 'i> {
                 Instruction::BackCommit(label) => {
                     self.maybe_snapshot();
                     let entry = self.pop_backtrack();
-                    let (sp, capture_len) = match entry {
+                    let (sp, capture_len, args_len) = match entry {
                         StackEntry::Backtrack {
-                            sp, capture_len, ..
-                        } => (sp, capture_len),
+                            sp,
+                            capture_len,
+                            args_len,
+                            ..
+                        } => (sp, capture_len, args_len),
                         _ => unreachable!("pop_backtrack returns only Backtrack frames"),
                     };
                     self.sp = sp;
                     self.protect_max_captures(capture_len);
                     self.captures.truncate(capture_len);
+                    self.args.truncate(args_len);
                     self.ip = label.as_index();
                 }
                 Instruction::FailTwice => {
@@ -714,13 +816,65 @@ impl<'p, 'i> VM<'p, 'i> {
                     };
                     self.ip = ret_ip;
                 }
-                Instruction::RuleEnter(memo_id, kind, return_label) => {
+                Instruction::IndentMeasure(slot) => {
+                    // Consume the indentation run `[ \t]*` forward, one
+                    // column per space or tab. Forward consumption is what
+                    // keeps incremental reparse sound — see the opcode doc.
+                    let start = self.sp;
+                    while matches!(self.input.get(self.sp), Some(b' ') | Some(b'\t')) {
+                        self.sp += 1;
+                    }
+                    // The terminating byte (or EOF) was examined to decide
+                    // the run ended; cover it so an edit there invalidates.
+                    self.track_read(1);
+                    let width = (self.sp - start) as i32;
+                    let idx = self.locals_base + *slot as usize;
+                    if idx >= self.locals.len() {
+                        self.locals.resize(idx + 1, 0);
+                    }
+                    self.locals[idx] = width;
+                    self.ip += 1;
+                }
+                Instruction::IndentCmp(op, slot, src) => {
+                    let measured = self.local(*slot);
+                    let reference = self.arg_value(*src);
+                    let holds = match op {
+                        CmpOp::Gt => measured > reference,
+                        CmpOp::Ge => measured >= reference,
+                        CmpOp::Eq => measured == reference,
+                    };
+                    if holds {
+                        self.ip += 1;
+                    } else if !self.fail() {
+                        return self.finalize_partial();
+                    }
+                }
+                Instruction::ArgPush(src) => {
+                    let value = self.arg_value(*src);
+                    self.args.push(value);
+                    self.ip += 1;
+                }
+                Instruction::RuleEnter(memo_id, kind, return_label, argc) => {
+                    // Drain this call's `argc` arguments off the argument
+                    // stack (the caller's `ArgPush` run left them on top in
+                    // left-to-right order). `param_values` seeds the
+                    // callee's activation slots on a miss; `arg_key` joins
+                    // the packrat key so the same rule at the same position
+                    // but a different indentation context caches separately.
+                    // For `argc == 0` (every non-indentation rule) the slice
+                    // is empty: no allocation, `ArgKey::None`, arg stack
+                    // untouched.
+                    let argc = *argc as usize;
+                    let arg_split = self.args.len() - argc;
+                    let param_values: Vec<i32> = self.args[arg_split..].to_vec();
+                    self.args.truncate(arg_split);
+                    let arg_key = ArgKey::from_args(&param_values);
                     // Shared cache-hit prologue. Both kinds probe the same
                     // packrat slot; only the post-miss frame layout differs.
                     // The `entry` borrow lives across the capture-replay loop
                     // and is released by NLL before the kind branch below,
                     // so the miss path can mutate `self` freely.
-                    if let Some(entry) = self.memo.get(&(*memo_id, self.sp)) {
+                    if let Some(entry) = self.memo.get(&(*memo_id, self.sp, arg_key.clone())) {
                         self.memo_hits += 1;
                         let hit_examined = entry.examined_max;
                         match entry.end_sp {
@@ -759,10 +913,13 @@ impl<'p, 'i> VM<'p, 'i> {
                     match kind {
                         RuleKind::Memo => {
                             self.memo_misses += 1;
+                            let prev_locals_base = self.push_locals_frame(&param_values);
                             self.stack.push(StackEntry::Memo {
                                 memo_id: *memo_id,
                                 start_sp: self.sp,
                                 capture_start_len: self.captures.len(),
+                                arg_key,
+                                prev_locals_base,
                             });
                             // Parallel watermark for this frame. Starts at the
                             // rule's entry sp; read sites bump it as the body
@@ -781,20 +938,24 @@ impl<'p, 'i> VM<'p, 'i> {
                         }
                         RuleKind::Lr => {
                             // Walk the stack top-down for an in-flight LFrame
-                            // at the same (memo_id, sp). The packrat probe
-                            // above has already returned None, so any matching
-                            // LFrame is a current recursive re-entry rather
-                            // than a stale converged seed.
+                            // at the same (memo_id, sp, arg_key). The packrat
+                            // probe above has already returned None, so any
+                            // matching LFrame is a current recursive re-entry
+                            // rather than a stale converged seed.
                             let lookup: Option<Option<LSeed>> =
                                 self.stack.iter().rev().find_map(|e| {
                                     if let StackEntry::LFrame {
                                         memo_id: id,
                                         start_sp,
                                         seed,
+                                        arg_key: frame_key,
                                         ..
                                     } = e
                                     {
-                                        if *id == *memo_id && *start_sp == self.sp {
+                                        if *id == *memo_id
+                                            && *start_sp == self.sp
+                                            && *frame_key == arg_key
+                                        {
                                             return Some(seed.clone());
                                         }
                                     }
@@ -805,7 +966,8 @@ impl<'p, 'i> VM<'p, 'i> {
                                     // Recursive entry with a seed: replay
                                     // captures and jump to the rule's Return
                                     // so the caller's `Call`-pushed Return
-                                    // frame fires normally.
+                                    // frame fires normally. No new activation
+                                    // frame — the live LFrame owns the slots.
                                     for c in &found.captures {
                                         self.captures.push(OpenCapture {
                                             kind: c.kind,
@@ -828,15 +990,19 @@ impl<'p, 'i> VM<'p, 'i> {
                                     }
                                 }
                                 None => {
-                                    // First entry at this sp — push an LFrame
-                                    // and a paired memo_examined watermark,
-                                    // then fall through to the body.
+                                    // First entry at this sp — seed the
+                                    // activation frame, push an LFrame and a
+                                    // paired memo_examined watermark, then
+                                    // fall through to the body.
+                                    let prev_locals_base = self.push_locals_frame(&param_values);
                                     self.stack.push(StackEntry::LFrame {
                                         memo_id: *memo_id,
                                         start_sp: self.sp,
                                         capture_start_len: self.captures.len(),
                                         return_addr: return_label.as_index(),
                                         seed: None,
+                                        arg_key,
+                                        prev_locals_base,
                                     });
                                     self.memo_examined.push(self.sp);
                                     // Mirror push for diagnostics; paired
@@ -852,16 +1018,29 @@ impl<'p, 'i> VM<'p, 'i> {
                     }
                 }
                 Instruction::MemoClose(memo_id) => {
-                    let (top_id, start_sp, capture_start_len) = match self.stack.pop() {
-                        Some(StackEntry::Memo {
-                            memo_id,
-                            start_sp,
-                            capture_start_len,
-                        }) => (memo_id, start_sp, capture_start_len),
-                        other => {
-                            panic!("MemoClose expected Memo on stack top, got {:?}", other)
-                        }
-                    };
+                    let (top_id, start_sp, capture_start_len, arg_key, prev_locals_base) =
+                        match self.stack.pop() {
+                            Some(StackEntry::Memo {
+                                memo_id,
+                                start_sp,
+                                capture_start_len,
+                                arg_key,
+                                prev_locals_base,
+                            }) => (
+                                memo_id,
+                                start_sp,
+                                capture_start_len,
+                                arg_key,
+                                prev_locals_base,
+                            ),
+                            other => {
+                                panic!("MemoClose expected Memo on stack top, got {:?}", other)
+                            }
+                        };
+                    // Restore the caller's activation frame now that the
+                    // body has finished; the cached captures don't depend
+                    // on the locals arena.
+                    self.pop_locals_frame(prev_locals_base);
                     debug_assert_eq!(
                         top_id, *memo_id,
                         "MemoClose id mismatch: expected {:?}, found {:?}",
@@ -929,6 +1108,7 @@ impl<'p, 'i> VM<'p, 'i> {
                         RuleKind::Memo,
                         *memo_id,
                         start_sp,
+                        arg_key,
                         self.sp,
                         examined_max,
                         rule_captures,
@@ -950,6 +1130,8 @@ impl<'p, 'i> VM<'p, 'i> {
                         capture_start_len,
                         return_addr: _,
                         seed,
+                        arg_key,
+                        prev_locals_base,
                     } = &mut self.stack[top_idx]
                     else {
                         unreachable!("rposition matched LFrame")
@@ -961,6 +1143,8 @@ impl<'p, 'i> VM<'p, 'i> {
                     );
                     let start_sp = *start_sp;
                     let capture_start_len = *capture_start_len;
+                    let frame_arg_key = arg_key.clone();
+                    let prev_locals_base = *prev_locals_base;
                     let body_end_sp = self.sp;
                     let grew = match seed {
                         None => body_end_sp > start_sp,
@@ -990,8 +1174,10 @@ impl<'p, 'i> VM<'p, 'i> {
                         // is still None here (body matched empty on first
                         // try), the rule succeeds with an empty match.
                         let final_seed = seed.take();
-                        // Pop the LFrame and the paired memo_examined.
+                        // Pop the LFrame and the paired memo_examined, and
+                        // restore the caller's activation frame.
                         let _frame = self.stack.remove(top_idx);
+                        self.pop_locals_frame(prev_locals_base);
                         let examined = self
                             .memo_examined
                             .pop()
@@ -1036,6 +1222,7 @@ impl<'p, 'i> VM<'p, 'i> {
                             RuleKind::Lr,
                             *memo_id,
                             start_sp,
+                            frame_arg_key,
                             final_sp,
                             examined,
                             seed_captures,
@@ -1317,18 +1504,25 @@ impl<'p, 'i> VM<'p, 'i> {
                     ip,
                     sp,
                     capture_len,
+                    args_len,
                 } => {
                     self.ip = ip;
                     self.sp = sp;
                     self.protect_max_captures(capture_len);
                     self.captures.truncate(capture_len);
+                    self.args.truncate(args_len);
                     return true;
                 }
                 StackEntry::Memo {
                     memo_id,
                     start_sp,
                     capture_start_len: _,
+                    arg_key,
+                    prev_locals_base,
                 } => {
+                    // Restore the caller's activation frame: the failed
+                    // rule's slots die with it.
+                    self.pop_locals_frame(prev_locals_base);
                     // Pop the paired examined watermark. See
                     // `RuleEnter`'s Memo-kind miss path — every
                     // `StackEntry::Memo` push is twinned with a
@@ -1352,7 +1546,7 @@ impl<'p, 'i> VM<'p, 'i> {
                     // this unwind (its `capture_len` was snapshotted *before*
                     // `RuleEnter`'s Memo-kind miss path pushed this frame).
                     self.memo.insert(
-                        (memo_id, start_sp),
+                        (memo_id, start_sp, arg_key),
                         MemoEntry {
                             end_sp: None,
                             examined_max,
@@ -1390,7 +1584,13 @@ impl<'p, 'i> VM<'p, 'i> {
                     capture_start_len,
                     return_addr,
                     seed,
+                    arg_key: _,
+                    prev_locals_base,
                 } => {
+                    // Restore the caller's activation frame before either
+                    // sub-case (seed rescue or continued unwind): the LR
+                    // rule's slots die with the failed body.
+                    self.pop_locals_frame(prev_locals_base);
                     // Pop the paired examined watermark. Successful LR
                     // converged seeds are cached at LRTail; LR-rule
                     // failures (this arm with seed=None) are not cached
@@ -1468,11 +1668,13 @@ impl<'p, 'i> VM<'p, 'i> {
     /// The captures source differs between callers (live buffer at
     /// `MemoClose`; already-closed `LSeed::captures` at `LRTail`);
     /// both pre-process to a closed `Vec<Capture>` before calling.
+    #[allow(clippy::too_many_arguments)]
     fn cache_success(
         &mut self,
         kind: RuleKind,
         memo_id: MemoId,
         start_sp: usize,
+        arg_key: ArgKey,
         end_sp: usize,
         examined_max: usize,
         captures: Vec<Capture>,
@@ -1483,13 +1685,64 @@ impl<'p, 'i> VM<'p, 'i> {
         };
         if should_cache {
             self.memo.insert(
-                (memo_id, start_sp),
+                (memo_id, start_sp, arg_key),
                 MemoEntry {
                     end_sp: Some(end_sp),
                     examined_max,
                     captures,
                 },
             );
+        }
+    }
+
+    /// Push a fresh activation frame: record the current `locals_base`
+    /// as the caller's, re-point the base at the top of the locals
+    /// arena, and seed the callee's parameter slots `0..params.len()`
+    /// with `params`. Returns the previous base for the matching
+    /// [`pop_locals_frame`](Self::pop_locals_frame). A zero-arg rule
+    /// (`params` empty) only snapshots and re-points the base — the arena
+    /// is untouched, so non-parameterized grammars pay nothing beyond the
+    /// saved `usize`.
+    fn push_locals_frame(&mut self, params: &[i32]) -> usize {
+        let prev = self.locals_base;
+        self.locals_base = self.locals.len();
+        self.locals.extend_from_slice(params);
+        prev
+    }
+
+    /// Pop the current activation frame: drop every slot at or above the
+    /// frame's base (params plus any `IndentMeasure`-grown slots) and
+    /// restore the caller's base. Paired with
+    /// [`push_locals_frame`](Self::push_locals_frame) at every rule-exit
+    /// edge — `MemoClose`, `LRTail`'s commit branch, and the `Memo` /
+    /// `LFrame` arms of `fail()`.
+    fn pop_locals_frame(&mut self, prev_locals_base: usize) {
+        self.locals.truncate(self.locals_base);
+        self.locals_base = prev_locals_base;
+    }
+
+    /// Read activation slot `n` of the current frame: index
+    /// `locals_base + n` into the locals arena. The compiler guarantees
+    /// every referenced slot was seeded (a param) or bound (an
+    /// `IndentMeasure`) before use, so the index is always in range.
+    fn local(&self, slot: u8) -> i32 {
+        let idx = self.locals_base + slot as usize;
+        debug_assert!(
+            idx < self.locals.len(),
+            "local slot {} out of range (base {}, len {})",
+            slot,
+            self.locals_base,
+            self.locals.len()
+        );
+        self.locals[idx]
+    }
+
+    /// Resolve an [`ArgSrc`] to its integer value: a literal verbatim, a
+    /// local through [`local`](Self::local).
+    fn arg_value(&self, src: ArgSrc) -> i32 {
+        match src {
+            ArgSrc::Lit(v) => v,
+            ArgSrc::Local(slot) => self.local(slot),
         }
     }
 
@@ -1677,7 +1930,13 @@ impl<'p, 'i> VM<'p, 'i> {
         }
     }
 
-    fn finalize_partial(mut self) -> (MatchResult, MemoStats, HashMap<(MemoId, usize), MemoEntry>) {
+    fn finalize_partial(
+        mut self,
+    ) -> (
+        MatchResult,
+        MemoStats,
+        HashMap<(MemoId, usize, ArgKey), MemoEntry>,
+    ) {
         self.maybe_snapshot();
         let stats = MemoStats {
             entries: self.memo.len(),
@@ -1788,7 +2047,9 @@ mod examined_max_tests {
         // 1 byte unconsumed, so the overall parse fails. The memo
         // entries it built before failing are still observable.
         assert!(!result.complete, "trailing 'y' leaves bytes after !.");
-        let root = memo.get(&(MemoId(0), 0)).expect("root's entry missing");
+        let root = memo
+            .get(&(MemoId(0), 0, ArgKey::None))
+            .expect("root's entry missing");
         assert_eq!(root.end_sp, None);
         assert_eq!(
             root.examined_max, 2,
@@ -1817,7 +2078,7 @@ mod examined_max_tests {
             .run_core();
         assert!(!result.complete, "overall parse must fail");
         let entry = memo
-            .get(&(MemoId(0), 0))
+            .get(&(MemoId(0), 0, ArgKey::None))
             .expect("start's failure entry missing");
         assert_eq!(entry.end_sp, None);
         assert_eq!(
@@ -1850,7 +2111,9 @@ mod examined_max_tests {
         assert!(result.complete);
         assert_eq!(result.matched, 2);
         // root is start → MemoId(0); inner is the other → MemoId(1).
-        let outer = memo.get(&(MemoId(0), 0)).expect("root entry missing");
+        let outer = memo
+            .get(&(MemoId(0), 0, ArgKey::None))
+            .expect("root entry missing");
         assert_eq!(outer.end_sp, Some(2));
         // The wrap's tail-`!.` reads byte 2 once to confirm EOF; the
         // bound is the body's reach plus that one-byte EOF probe.
@@ -1859,7 +2122,9 @@ mod examined_max_tests {
             "inner's examined reach must flow into root: {:?}",
             outer
         );
-        let inner = memo.get(&(MemoId(1), 0)).expect("inner entry missing");
+        let inner = memo
+            .get(&(MemoId(1), 0, ArgKey::None))
+            .expect("inner entry missing");
         assert_eq!(inner.end_sp, Some(1));
         assert_eq!(inner.examined_max, 1);
     }
@@ -1898,7 +2163,9 @@ mod examined_max_tests {
         // start's examined_max must include every byte start's execution
         // ever looked at: position 2 was examined when the first
         // alternative tried "aa" at sp=1 and "bb" at sp=1 needed byte 2.
-        let start = memo.get(&(MemoId(0), 0)).expect("start entry missing");
+        let start = memo
+            .get(&(MemoId(0), 0, ArgKey::None))
+            .expect("start entry missing");
         assert_eq!(start.end_sp, Some(3));
         // The `root` wrap's tail-`!.` reads byte 3 once to confirm
         // EOF; without that probe the watermark would land at 3.
@@ -1940,7 +2207,9 @@ mod examined_max_tests {
             .run_core();
         assert!(result.complete);
         assert_eq!(result.matched, 5);
-        let entry = memo.get(&(MemoId(0), 0)).expect("start entry missing");
+        let entry = memo
+            .get(&(MemoId(0), 0, ArgKey::None))
+            .expect("start entry missing");
         assert_eq!(entry.end_sp, Some(5));
         assert!(
             entry.examined_max >= 5,

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -1028,14 +1028,14 @@ fn grammar_rules_are_wrapped_in_memo_open_close() {
         vec![
             Instruction::Call(Label(2)),
             Instruction::End,
-            Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(8)),
+            Instruction::RuleEnter(MemoId(0), RuleKind::Memo, Label(8), 0),
             Instruction::Byte(b'a'),
             Instruction::Choice(Label(7)),
             Instruction::Any,
             Instruction::FailTwice,
             Instruction::MemoClose(MemoId(0)),
             Instruction::Return,
-            Instruction::RuleEnter(MemoId(1), RuleKind::Memo, Label(12)),
+            Instruction::RuleEnter(MemoId(1), RuleKind::Memo, Label(12), 0),
             Instruction::Byte(b'b'),
             Instruction::MemoClose(MemoId(1)),
             Instruction::Return,
@@ -1077,7 +1077,7 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
     assert!(matches!(prog.code[1], Instruction::End));
     assert!(matches!(
         prog.code[2],
-        Instruction::RuleEnter(MemoId(0), RuleKind::Lr, _)
+        Instruction::RuleEnter(MemoId(0), RuleKind::Lr, _, _)
     ));
     // Last three instructions: LRTail, then the final Return for the rule.
     let n = prog.code.len();
@@ -1092,14 +1092,14 @@ fn direct_lr_rule_emits_lrbody_lrtail_skeleton() {
         assert!(
             !matches!(
                 ins,
-                Instruction::RuleEnter(_, RuleKind::Memo, _) | Instruction::MemoClose(..)
+                Instruction::RuleEnter(_, RuleKind::Memo, _, _) | Instruction::MemoClose(..)
             ),
             "LR rule must not emit Memo-kind RuleEnter/MemoClose: {:?}",
             ins
         );
     }
     // RuleEnter's return label points at the rule's Return (last instruction).
-    if let Instruction::RuleEnter(_, RuleKind::Lr, Label(ret)) = prog.code[2] {
+    if let Instruction::RuleEnter(_, RuleKind::Lr, Label(ret), _) = prog.code[2] {
         assert_eq!(ret as usize, n - 1);
     }
     // LRTail's body-start label points at the instruction after RuleEnter.
@@ -1130,11 +1130,11 @@ fn right_recursive_rule_is_not_marked_lr() {
     let has_memo_open = prog
         .code
         .iter()
-        .any(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Memo, _)));
+        .any(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Memo, _, _)));
     let has_lr = prog.code.iter().any(|i| {
         matches!(
             i,
-            Instruction::RuleEnter(_, RuleKind::Lr, _) | Instruction::LRTail(..)
+            Instruction::RuleEnter(_, RuleKind::Lr, _, _) | Instruction::LRTail(..)
         )
     });
     assert!(
@@ -1169,7 +1169,7 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
     let lr_bodies = prog
         .code
         .iter()
-        .filter(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Lr, _)))
+        .filter(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Lr, _, _)))
         .count();
     let lr_tails = prog
         .code
@@ -1184,7 +1184,7 @@ fn indirect_lr_cycle_of_2_emits_lrbody_lrtail() {
     let a_idx = prog.rule_names.iter().position(|n| n == "a").unwrap();
     let b_idx = prog.rule_names.iter().position(|n| n == "b").unwrap();
     for ins in &prog.code {
-        if let Instruction::RuleEnter(id, RuleKind::Memo, _) = ins {
+        if let Instruction::RuleEnter(id, RuleKind::Memo, _, _) = ins {
             assert!(
                 id.0 as usize != a_idx && id.0 as usize != b_idx,
                 "indirect-LR cycle members must not emit Memo-kind RuleEnter: {:?}",
@@ -1234,7 +1234,7 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
     let lr_bodies = prog
         .code
         .iter()
-        .filter(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Lr, _)))
+        .filter(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Lr, _, _)))
         .count();
     let lr_tails = prog
         .code
@@ -1253,7 +1253,7 @@ fn indirect_lr_cycle_of_3_emits_lrbody_lrtail() {
         .map(|n| prog.rule_names.iter().position(|r| r == *n).unwrap())
         .collect();
     for ins in &prog.code {
-        if let Instruction::RuleEnter(id, RuleKind::Memo, _) = ins {
+        if let Instruction::RuleEnter(id, RuleKind::Memo, _, _) = ins {
             assert!(
                 !cycle.contains(&(id.0 as usize)),
                 "indirect-LR cycle members must not emit Memo-kind RuleEnter: {:?}",
@@ -1297,14 +1297,14 @@ fn right_recursive_two_rule_grammar_is_not_marked_lr() {
     let has_lr = prog.code.iter().any(|i| {
         matches!(
             i,
-            Instruction::RuleEnter(_, RuleKind::Lr, _) | Instruction::LRTail(..)
+            Instruction::RuleEnter(_, RuleKind::Lr, _, _) | Instruction::LRTail(..)
         )
     });
     assert!(!has_lr, "non-first-call mutual recursion must not emit LR");
     let has_memo_open = prog
         .code
         .iter()
-        .any(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Memo, _)));
+        .any(|i| matches!(i, Instruction::RuleEnter(_, RuleKind::Memo, _, _)));
     assert!(has_memo_open, "non-LR rules must use Memo-kind RuleEnter");
 }
 
@@ -1332,7 +1332,7 @@ fn lr_through_nullable_prefix_is_detected() {
     assert!(prog
         .code
         .iter()
-        .any(|i| matches!(i, Instruction::RuleEnter(MemoId(0), RuleKind::Lr, _))));
+        .any(|i| matches!(i, Instruction::RuleEnter(MemoId(0), RuleKind::Lr, _, _))));
 }
 
 // -- FOLLOW analysis ------------------------------------------------------

--- a/tests/grammar_starlark_tests.rs
+++ b/tests/grammar_starlark_tests.rs
@@ -1,0 +1,101 @@
+//! Indentation-structure tests for the Starlark subset: that `deeper` /
+//! `same` actually enforce block shape — nested suites parse, dedents
+//! close blocks, aligned siblings are accepted, and misaligned or
+//! unindented lines make the parse fail. This is the behavioral payoff of
+//! the parameterized indentation rules, distinct from the token-coverage
+//! smoke tests in `tests/parse_starlark_tests.rs`.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{is_complete, kind_at, matched_len};
+
+const GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+
+fn complete(input: &str) -> bool {
+    is_complete(GRAMMAR, input)
+}
+
+#[test]
+fn nested_suite_parses_and_keeps_kinds() {
+    let input = "def f():\n    x = 1\n    return x\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+    // `def` keyword, the function name, and the nested `return` all keep
+    // their kinds across the indentation boundary.
+    assert_eq!(kind_at(GRAMMAR, input, 0).as_deref(), Some("keyword"));
+    assert_eq!(kind_at(GRAMMAR, input, 4).as_deref(), Some("function")); // f
+    let ret = input.find("return").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, ret).as_deref(), Some("keyword"));
+}
+
+#[test]
+fn dedent_closes_block_and_resumes_outer() {
+    // `g` is a column-0 sibling of `f`; it parses only if the dedent after
+    // `f`'s body correctly closes `f`'s suite.
+    let input = "def f():\n    return 1\n\ndef g():\n    return 2\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+    let g = input.find("def g").unwrap() + 4;
+    assert_eq!(kind_at(GRAMMAR, input, g).as_deref(), Some("function"));
+}
+
+#[test]
+fn three_levels_of_nesting() {
+    let input = "def f():\n    if a:\n        for x in y:\n            return x\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}
+
+#[test]
+fn aligned_siblings_in_a_suite_parse() {
+    let input = "def f():\n    a = 1\n    b = 2\n    c = 3\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}
+
+#[test]
+fn misaligned_sibling_makes_parse_incomplete() {
+    // Second body line is indented one column shallower than the first;
+    // it aligns with no open block, so the parse cannot consume it.
+    let input = "if a:\n    x = 1\n   y = 2\n";
+    assert!(
+        !complete(input),
+        "a misaligned sibling must not parse: matched {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn unindented_body_makes_parse_incomplete() {
+    // The body of `if` is not indented past the header, so the suite's
+    // `deeper` assertion fails and the block has no body.
+    let input = "if a:\nx = 1\n";
+    assert!(
+        !complete(input),
+        "an unindented suite body must not parse: matched {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn over_indented_continuation_is_rejected() {
+    // The third line is *deeper* than its siblings but is not a child of
+    // the second (which is a simple statement, not a compound header), so
+    // it cannot attach anywhere.
+    let input = "def f():\n    a = 1\n        b = 2\n";
+    assert!(
+        !complete(input),
+        "an over-indented orphan line must not parse: matched {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn elif_else_chain_at_header_column_parses() {
+    let input = "if a:\n    p = 1\nelif b:\n    q = 2\nelse:\n    r = 3\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+    let elif = input.find("elif").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, elif).as_deref(), Some("keyword"));
+    let els = input.find("else").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, els).as_deref(), Some("keyword"));
+}

--- a/tests/grammar_yaml_tests.rs
+++ b/tests/grammar_yaml_tests.rs
@@ -1,0 +1,87 @@
+//! Indentation-structure tests for the pruned YAML grammar: that
+//! `deeper` (nested value past its key) and `same` (aligned mapping
+//! entries / sequence items) actually enforce block shape, and that
+//! misaligned or wrongly-indented lines make the parse fail. The
+//! behavioral payoff of the parameterized indentation rules for the
+//! relative-indent (YAML) class.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{is_complete, kind_at, matched_len};
+
+const GRAMMAR: &str = include_str!("../grammars/yaml.peg");
+
+fn complete(input: &str) -> bool {
+    is_complete(GRAMMAR, input)
+}
+
+#[test]
+fn nested_value_must_be_deeper_than_its_key() {
+    let input = "outer:\n  inner: 1\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+    let inner = input.find("inner").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, inner).as_deref(), Some("property"));
+}
+
+#[test]
+fn sibling_entries_must_align() {
+    let input = "a: 1\nb: 2\nc: 3\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}
+
+#[test]
+fn deeply_nested_mapping_parses() {
+    let input = "l1:\n  l2:\n    l3:\n      leaf: x\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}
+
+#[test]
+fn dedent_returns_to_outer_mapping() {
+    // `sibling` at column 0 parses only if the nested block under `parent`
+    // is correctly closed by the dedent.
+    let input = "parent:\n  child: 1\nsibling: 2\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+    let sib = input.find("sibling").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, sib).as_deref(), Some("property"));
+}
+
+#[test]
+fn sequence_items_align_under_a_key() {
+    let input = "list:\n  - a\n  - b\n  - c\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}
+
+#[test]
+fn misaligned_mapping_entry_makes_parse_incomplete() {
+    // Three nested entries at three *different* columns: the second and
+    // third align with no open mapping level.
+    let input = "outer:\n  a: 1\n   b: 2\n";
+    assert!(
+        !complete(input),
+        "misaligned nested entries must not parse: matched {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn nested_value_not_deeper_makes_parse_incomplete() {
+    // `child` is at the same column as `parent`, so it cannot be
+    // `parent`'s nested value; `parent:` has a null value and `child`
+    // becomes a sibling — fine — but a value that is *less* indented than
+    // its key has nowhere to attach.
+    let input = "top:\n  a: 1\n b: 2\n";
+    assert!(
+        !complete(input),
+        "a half-dedented entry must not parse: matched {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn flow_sequence_may_span_lines() {
+    let input = "items: [\n  1,\n  2,\n]\nnext: done\n";
+    assert!(complete(input), "matched {}", matched_len(GRAMMAR, input));
+}

--- a/tests/incremental_indent_tests.rs
+++ b/tests/incremental_indent_tests.rs
@@ -1,0 +1,96 @@
+//! Incremental-reparse soundness for the indentation grammars.
+//!
+//! The arg-keyed memo only stays correct if `IndentMeasure` consumes the
+//! indentation run *forward* — so the enclosing rule's `examined_max`
+//! covers it and an edit inside the indentation invalidates the cached
+//! entry. These tests edit whitespace at and around measured line starts
+//! and assert the warm (incremental) capture stream equals a cold parse
+//! of the same post-edit input. A backward indentation scan would leave a
+//! stale entry and diverge here.
+
+use syntax_highlighter::parser::Parser;
+
+const STARLARK: &str = include_str!("../grammars/starlark.peg");
+const YAML: &str = include_str!("../grammars/yaml.peg");
+
+/// Apply `edits` (each `(start, old_end, replacement)`) through one
+/// incremental `Parser`, then assert the result equals a fresh cold parse
+/// of the final input.
+fn assert_warm_matches_cold(grammar: &str, initial: &str, edits: &[(usize, usize, &[u8])]) {
+    let mut inc = Parser::new(grammar).expect("grammar compiles");
+    inc.set_input(initial.as_bytes().to_vec());
+    let _ = inc.captures(); // prime the warm cache
+    for (start, old_end, replacement) in edits {
+        inc.edit(*start, *old_end, replacement);
+    }
+    let (warm_matched, warm_caps) = inc.captures();
+
+    let mut fresh = Parser::new(grammar).expect("grammar compiles");
+    fresh.set_input(inc.input().to_vec());
+    let (cold_matched, cold_caps) = fresh.captures();
+
+    assert_eq!(
+        (warm_matched, warm_caps),
+        (cold_matched, cold_caps),
+        "warm reparse diverged from a cold parse of {:?}",
+        std::str::from_utf8(inc.input()).unwrap()
+    );
+}
+
+#[test]
+fn starlark_deepen_body_line_indent() {
+    // Add four spaces to the body line's indentation. The suite's
+    // `%indent` (a strictly-deeper level) still holds, but the entry that
+    // measured the old indent must be invalidated and recomputed.
+    let src = "def f():\n    return 1\n";
+    let at = src.find("    return").unwrap();
+    assert_warm_matches_cold(STARLARK, src, &[(at, at, b"    ")]);
+}
+
+#[test]
+fn starlark_break_sibling_alignment() {
+    // Push the second statement one column right; it no longer aligns
+    // with the first, so the parse must become incomplete — and warm must
+    // agree with cold about exactly where it stops.
+    let src = "def f():\n    a = 1\n    b = 2\n";
+    let at = src.find("    b").unwrap();
+    assert_warm_matches_cold(STARLARK, src, &[(at, at, b" ")]);
+}
+
+#[test]
+fn starlark_dedent_a_line_into_alignment() {
+    // Start misaligned (incomplete), then delete the offending extra
+    // space so the block becomes well-formed. Exercises invalidation in
+    // the repair direction too.
+    let src = "def f():\n    a = 1\n     b = 2\n";
+    let extra = src.find("     b").unwrap(); // points at the run of 5 spaces
+    assert_warm_matches_cold(STARLARK, src, &[(extra, extra + 1, b"")]);
+}
+
+#[test]
+fn starlark_insert_blank_line_before_measured_line() {
+    let src = "def f():\n    a = 1\n    b = 2\n";
+    let at = src.find("    b").unwrap();
+    assert_warm_matches_cold(STARLARK, src, &[(at, at, b"\n")]);
+}
+
+#[test]
+fn yaml_deepen_nested_entry_indent() {
+    let src = "outer:\n  inner: 1\n";
+    let at = src.find("  inner").unwrap();
+    assert_warm_matches_cold(YAML, src, &[(at, at, b"  ")]);
+}
+
+#[test]
+fn yaml_break_mapping_alignment() {
+    let src = "a: 1\nb: 2\nc: 3\n";
+    let at = src.find("b: 2").unwrap();
+    assert_warm_matches_cold(YAML, src, &[(at, at, b"  ")]);
+}
+
+#[test]
+fn yaml_edit_indent_of_sequence_item() {
+    let src = "list:\n  - a\n  - b\n";
+    let at = src.find("  - b").unwrap();
+    assert_warm_matches_cold(YAML, src, &[(at, at, b" ")]);
+}

--- a/tests/indent_mechanism_tests.rs
+++ b/tests/indent_mechanism_tests.rs
@@ -1,0 +1,96 @@
+//! Low-level end-to-end tests for the implicit indentation operators
+//! (`%root` / `%align` / `%indent`) and the column-threading IR they
+//! desugar into — the `deeper` / `same` / `at_least` combinators,
+//! parameterized rule calls, and the arg-keyed memo — on a deliberately
+//! tiny hand-written grammar, so a failure points at the desugar / VM /
+//! compiler lowering rather than at the much larger Starlark / YAML
+//! grammars that also exercise this path.
+//!
+//! The toy language is "indented words": each line is a lowercase word,
+//! and a more-indented run of lines forms that word's child block.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{is_complete, kind_at, matched_len};
+
+/// `%root` aligns the top block to its first line's column; `%indent`
+/// opens a strictly-deeper child block and `%align` holds siblings at the
+/// ambient column. The block rules are `atomic` so the horizontal-only
+/// auto-`ignore` can't eat a line's indentation before an operator
+/// measures it.
+const GRAMMAR: &str = "\
+root = nl_opt rootblock nl_opt {\n\
+    rootblock: atomic =\n\
+        %root (\n\
+            @word word child?\n\
+            ( hardnl %align @word word child? )*\n\
+        )\n\
+    childblock: atomic =\n\
+        %indent (\n\
+            @word word child?\n\
+            ( hardnl %align @word word child? )*\n\
+        )\n\
+    child = hardnl childblock\n\
+    word: atomic = [a-z]+\n\
+    hardnl: atomic = '\\n'\n\
+    nl_opt: atomic = '\\n'*\n\
+}\n";
+
+#[test]
+fn flat_block_of_aligned_siblings_parses_fully() {
+    let input = "a\nb\nc";
+    assert!(
+        is_complete(GRAMMAR, input),
+        "three column-0 siblings should all parse"
+    );
+    assert_eq!(kind_at(GRAMMAR, input, 0).as_deref(), Some("word"));
+    assert_eq!(kind_at(GRAMMAR, input, 2).as_deref(), Some("word"));
+    assert_eq!(kind_at(GRAMMAR, input, 4).as_deref(), Some("word"));
+}
+
+#[test]
+fn nested_deeper_block_parses_fully() {
+    // `a` owns a child block [b, c] at indent 2; `d` is a column-0 sibling
+    // of `a`.
+    let input = "a\n  b\n  c\nd";
+    assert!(
+        is_complete(GRAMMAR, input),
+        "nested deeper block plus a dedented sibling should fully parse: matched {}",
+        matched_len(GRAMMAR, input)
+    );
+}
+
+#[test]
+fn three_level_nesting_parses_fully() {
+    let input = "a\n  b\n    c\n  d\ne";
+    assert!(
+        is_complete(GRAMMAR, input),
+        "matched only {} of {}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn misaligned_sibling_is_not_consumed() {
+    // `b` sits one column to the right of `a` but is not deep enough to be
+    // a child (it would need its own `deeper` line first) — actually it is
+    // deeper, so it becomes a child. The genuinely broken case is a line
+    // *less* indented than the block but more than its parent with no
+    // matching level: trailing bytes remain unconsumed.
+    let input = "a\n   b\n  c"; // b at 3, c at 2: c aligns with neither a(0) nor b(3)
+    assert!(
+        !is_complete(GRAMMAR, input),
+        "the dangling `c` at an unmatched indent must leave the parse incomplete"
+    );
+}
+
+#[test]
+fn same_indent_is_required_for_siblings() {
+    // Second line is indented one space deeper than the first top-level
+    // line; since the top block aligns on the first line's column (0),
+    // the `  b` is a child of `a`, then `c` at column 0 is a sibling.
+    let input = "a\n b\nc";
+    assert!(is_complete(GRAMMAR, input), "child then dedented sibling");
+}

--- a/tests/parse_starlark_tests.rs
+++ b/tests/parse_starlark_tests.rs
@@ -1,0 +1,82 @@
+//! Smoke tests for the Starlark subset grammar: representative snippets
+//! parse to completion and a few bytes carry the expected capture kind.
+//! Deeper indentation-structure assertions live in
+//! `tests/grammar_starlark_tests.rs`.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{is_complete, kind_at, matched_len};
+
+const GRAMMAR: &str = include_str!("../grammars/starlark.peg");
+
+fn complete(input: &str) {
+    assert!(
+        is_complete(GRAMMAR, input),
+        "expected a full parse; matched {} of {} bytes:\n{input}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn def_with_nested_if_else_parses() {
+    complete(
+        "def greet(name, greeting = \"hi\"):\n\
+        \x20   if name:\n\
+        \x20       return greeting + name\n\
+        \x20   else:\n\
+        \x20       return \"nobody\"\n",
+    );
+}
+
+#[test]
+fn module_level_assignments_and_loop() {
+    complete(
+        "x = [1, 2, 3]\n\
+        y = {\"a\": 1, \"b\": 2}\n\
+        for i in x:\n\
+        \x20   print(i)\n",
+    );
+}
+
+#[test]
+fn multiline_call_spans_lines_inside_brackets() {
+    complete(
+        "result = func(\n\
+        \x20   first,\n\
+        \x20   second = 2,\n\
+        \x20   *rest,\n\
+        )\n",
+    );
+}
+
+#[test]
+fn comments_and_blank_lines_between_statements() {
+    complete(
+        "# leading comment\n\
+        \n\
+        a = 1  # trailing\n\
+        \n\
+        # gap\n\
+        b = 2\n",
+    );
+}
+
+#[test]
+fn keyword_and_string_and_number_capture_kinds() {
+    let input = "def f():\n    return 42\n";
+    assert_eq!(kind_at(GRAMMAR, input, 0).as_deref(), Some("keyword")); // `def`
+    let n = input.find("42").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, n).as_deref(), Some("number"));
+    let r = input.find("return").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, r).as_deref(), Some("keyword"));
+}
+
+#[test]
+fn triple_quoted_string_is_one_string_span() {
+    let input = "doc = \"\"\"line one\nline two\"\"\"\n";
+    complete(input);
+    let q = input.find("\"\"\"").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, q + 4).as_deref(), Some("string"));
+}

--- a/tests/parse_yaml_tests.rs
+++ b/tests/parse_yaml_tests.rs
@@ -1,0 +1,71 @@
+//! Smoke tests for the pruned YAML grammar: representative documents
+//! parse to completion and key bytes carry the expected capture kind.
+//! Indentation-structure assertions live in `tests/grammar_yaml_tests.rs`.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{is_complete, kind_at, matched_len};
+
+const GRAMMAR: &str = include_str!("../grammars/yaml.peg");
+
+fn complete(input: &str) {
+    assert!(
+        is_complete(GRAMMAR, input),
+        "expected a full parse; matched {} of {} bytes:\n{input}",
+        matched_len(GRAMMAR, input),
+        input.len()
+    );
+}
+
+#[test]
+fn flat_mapping_parses() {
+    complete("name: example\nversion: 1.0\nenabled: true\n");
+}
+
+#[test]
+fn nested_mapping_and_sequence_parse() {
+    complete(
+        "metadata:\n\
+        \x20 name: app\n\
+        \x20 labels:\n\
+        \x20   tier: backend\n\
+        items:\n\
+        \x20 - first\n\
+        \x20 - second\n",
+    );
+}
+
+#[test]
+fn flow_collections_parse() {
+    complete("nums: [1, 2, 3]\npoint: {x: 1, y: 2}\nnested: [[a, b], [c, d]]\n");
+}
+
+#[test]
+fn document_markers_and_comments_parse() {
+    complete(
+        "--- # a document\n\
+        # leading comment\n\
+        key: value  # trailing\n\
+        ...\n",
+    );
+}
+
+#[test]
+fn quoted_scalars_parse() {
+    complete("single: 'a quoted value'\ndouble: \"with \\\"escape\\\"\"\n");
+}
+
+#[test]
+fn capture_kinds_on_a_simple_entry() {
+    let input = "name: example\n";
+    assert_eq!(kind_at(GRAMMAR, input, 0).as_deref(), Some("property")); // name
+    assert_eq!(kind_at(GRAMMAR, input, 4).as_deref(), Some("punctuation")); // :
+    let v = input.find("example").unwrap();
+    assert_eq!(kind_at(GRAMMAR, input, v).as_deref(), Some("string"));
+}
+
+#[test]
+fn multiline_flow_sequence_parses() {
+    complete("items: [\n  alpha,\n  beta,\n  gamma,\n]\n");
+}

--- a/tests/pegb_roundtrip_tests.rs
+++ b/tests/pegb_roundtrip_tests.rs
@@ -150,6 +150,28 @@ fn sqlite_roundtrips() {
 }
 
 #[test]
+fn starlark_roundtrips() {
+    // The Starlark program carries the indentation opcodes
+    // (`IndentMeasure`, `IndentCmp`, `ArgPush`, and `RuleEnter` with a
+    // non-zero argc); the sample drives an indented suite so they all
+    // execute on both sides of the round-trip.
+    assert_grammar(
+        "starlark",
+        include_str!("../grammars/starlark.peg"),
+        b"def f(n):\n    if n:\n        return n\n    else:\n        return 0\n",
+    );
+}
+
+#[test]
+fn yaml_roundtrips() {
+    assert_grammar(
+        "yaml",
+        include_str!("../grammars/yaml.peg"),
+        b"root:\n  child: value\n  list:\n    - a\n    - b\n",
+    );
+}
+
+#[test]
 fn labeled_catch_program_round_trips() {
     // Exercises `RecoverScopeBegin(LabelId)` plus the label-name
     // table. Input drives the catch through both success and recovery

--- a/tests/recovery_baseline_tests.rs
+++ b/tests/recovery_baseline_tests.rs
@@ -32,7 +32,9 @@ fn grammar_for(ext: &str) -> Option<&'static str> {
         "json" => Some("json"),
         "rs" => Some("rust"),
         "sql" => Some("sqlite"),
+        "star" => Some("starlark"),
         "toml" => Some("toml"),
+        "yaml" => Some("yaml"),
         _ => None,
     }
 }

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -527,8 +527,8 @@ fn lr_expr_program() -> Vec<Instruction> {
         // 0: bootstrap
         Instruction::Call(Label(2)),
         Instruction::End,
-        // 2: RuleEnter (return_addr = 14)
-        Instruction::RuleEnter(MemoId(0), RuleKind::Lr, Label(14)),
+        // 2: RuleEnter (return_addr = 14, argc = 0)
+        Instruction::RuleEnter(MemoId(0), RuleKind::Lr, Label(14), 0),
         // 3 (body_start): Choice → 11 (second alternative)
         Instruction::Choice(Label(10)),
         // 4: Call(expr)  -- recursive


### PR DESCRIPTION
Highlighting indentation-sensitive languages (Python / YAML class) was impossible — the engine had no notion of indentation (#43). This adds three implicit prefix operators that express block structure against a single ambient anchor, the indentation column of the construct being parsed:

| Operator | Meaning |
| --- | --- |
| `%root X` | seed a fresh anchor at the current line's column, then parse `X` under it |
| `%indent X` | open a level strictly deeper than the ambient anchor, rebind it, then parse `X` |
| `%align` | assert the current line sits at the ambient anchor (standalone) |

A block opens a level with `%indent (…)` and separates siblings inside it with `%align`; a dedent is just an operator failure that ends the enclosing repetition, so there is no INDENT/DEDENT token stream. The author never names the column.

Two deliberately-pruned grammars ship as validators and slot into the existing benchmark and test machinery with no special-casing: `grammars/starlark.peg` (strictly-deeper suites) and `grammars/yaml.peg` (aligned block mappings and sequences), both wired into the demo (`-l starlark` / `-l yaml` and the `.star` / `.bzl` / `.yaml` / `.yml` extensions). Out-of-subset gaps are tracked in #164 (Starlark) and #165 (YAML).

<details>
<summary>How it works, and the zero-argument hot path</summary>

`src/pegc/desugar_indent.rs` (the first pass in `Grammar::compile`) rewrites the operators into column-threaded parameterized rules and the `deeper` / `same` / `at_least` comparison combinators the VM runs; the surface never exposes that IR. The current column threads down the call graph as an implicit argument and the packrat memo key (`pegvm::vm::ArgKey`) carries it, so a rule cached at one indentation context is never reused at another. Only a rule that reads an inherited anchor gets the implicit parameter (a call-graph fixpoint), so zero-argument rules — every rule in every non-indentation grammar — key on `ArgKey::None` with no allocation and stay byte-identical (the memo bench shows no regression). A `%align` / `%indent` reachable with no enclosing `%root` / `%indent` to establish the column is `CompileError::IndentAnchorOutOfScope`.

Indentation is measured *forward* (`IndentMeasure` consumes the run and bumps `examined_max`), which keeps incremental reparse sound: an edit inside a measured indentation invalidates the cached entry rather than leaving it stale. `tests/incremental_indent_tests.rs` proves warm-reparse equals cold-reparse under whitespace edits.

The `ArgKey` argument component is `None` / `One(i32)` / `Many(Box<[i32]>)`; the single ambient anchor uses only `One(i32)`. The `Many` arm and the richer underlying call convention are deliberately not exposed here — generalizing them into a runtime function-application surface (typed arguments, multiple columns) is tracked in #167.

</details>

The added verification beyond CI: a desugar test asserts the operators compile to byte-identical bytecode to the hand-written explicit IR, and `tests/incremental_indent_tests.rs` checks warm-vs-cold reparse equality under whitespace edits.

Closes #43.
