### PR TITLE
Retire the `partial` leniency marker

### DIFF
--- a/crates/compiler/src/pegc/README.md
+++ b/crates/compiler/src/pegc/README.md
@@ -107,14 +107,15 @@ atom       "abc"   [a-z]   .   ident   (...)   @name ...
 postfix    p*      p+      p?      p{n}    p*^     p+^     p*^[cs]   p+^[cs]
 prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
-catch      p1 ^label p2      p1 ^^label B      p1 ^^label      p1 ^&label
+catch      p1 ^label p2      p1 ^^label B      p1 ^^label
+anchor     seq $
 choice     p1 / p2 / p3
 ```
 
-The `^&label` form is the anchor-only member of the boundary family: it
-pins `p1` to its FOLLOW with a bare lookahead and synthesizes no recovery
-branch — see [`INNER ^&lbl`](#inner-lbl--anchor-only-inferred-boundary)
-below.
+The postfix `$` pins the whole preceding sequence to its FOLLOW with a
+bare lookahead and synthesizes no recovery branch. It's a sequence-level
+postfix (binds looser than `*`/`?`), and it takes no label — see
+[Anchor-only inferred boundary](#anchor-only-inferred-boundary) below.
 
 ### Atoms
 
@@ -543,20 +544,23 @@ only `..=`, not `..` — the catch necessarily consumes its boundary,
 and `^^lbl .. B` would diverge from the standalone `..` non-consuming
 meaning. The parser rejects it with a hint pointing at `..=`.
 
-### `INNER ^&lbl` — anchor-only inferred boundary
+### Anchor-only inferred boundary
 
-The anchor-only form is the cheap member of the boundary family. Like
-the FOLLOW-inferred `^^lbl`, it synthesizes the boundary `B` from
-`INNER`'s call-site FOLLOW (terminal-expanded), but it lowers to a bare
-`Sequence([INNER, &B])` with **no** recovery `Catch`:
+The postfix `$` is the cheap member of the boundary family. Like the
+FOLLOW-inferred `^^lbl`, it synthesizes the boundary `B` from the
+sequence's call-site FOLLOW (terminal-expanded), but it lowers to a bare
+`Sequence([SEQ, &B])` with **no** recovery `Catch`:
 
 ```peg
-INNER ^&lbl
+SEQ $
 # lowers to
-INNER &B          # B = terminal-expanded FOLLOW(rule)
+SEQ &B            # B = terminal-expanded FOLLOW(rule)
 ```
 
-A prefix-only match of `INNER` fails the `&B` lookahead and backtracks to
+`$` binds the whole preceding sequence (it parses at the catch level, not
+the atom level, so it's looser than `*`/`?`), and it carries no label.
+
+A prefix-only match of `SEQ` fails the `&B` lookahead and backtracks to
 the caller's next ordered-choice alternative. On a speculative
 expression alternative that is exactly what's wanted — a recovery `Catch`
 there would turn every backtrack into a skip-to-boundary scan, which is
@@ -565,15 +569,14 @@ input always has a legal follower, so `&B` succeeds and the rule is
 unaffected (no recovery capture).
 
 This is the leniency-lint discharge of choice when no recovery branch is
-wanted. It also covers the ASI case (`opt_semi = ';'? ^&semi_tail`): the
-follower set *is* the boundary, so the optional `;` needs nothing to
-anchor *to*. The placeholder `Pattern::InferBoundaryCatch { anchor_only:
-true, .. }` is resolved by `analysis::resolve_inferred_boundaries`; no new
-VM machinery.
+wanted. It also covers the ASI case (`opt_semi = ';'? $`): the follower
+set *is* the boundary, so the optional `;` needs nothing to anchor *to*.
+The placeholder `Pattern::InferBoundaryCatch { anchor_only: true, .. }` is
+resolved by `analysis::resolve_inferred_boundaries`; no new VM machinery.
 
 The partial-match leniency lint (`lint_partial_match`) flags a
 trailing-nullable rule called unanchored; resolve a flag by anchoring the
-rule to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl` when recovery is also
+rule to its FOLLOW (`$`, or `^^lbl B` / `^^lbl` when recovery is also
 wanted) or by restructuring it so the trailing optional can't win on a
 prefix. There is no opt-out ascription.
 
@@ -886,8 +889,8 @@ concrete use case.
 - **`CompileError`** — source is well-formed but semantically invalid.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
   that doesn't exist, partial-match leniency on a call site that is not
-  anchored to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl`), an `^^lbl`
-  whose call-site FOLLOW set is empty so no boundary can be inferred.
+  anchored to its FOLLOW (`$`, or `^^lbl B` / `^^lbl`), an inferred-boundary
+  anchor whose call-site FOLLOW set is empty so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.
 

--- a/crates/compiler/src/pegc/README.md
+++ b/crates/compiler/src/pegc/README.md
@@ -47,19 +47,16 @@ root = body {
   Defining it is only required when the grammar has at least one
   `reserved` rule.
 - Rules may carry postfix **ascriptions** between the name and `=`,
-  `name: kw [kw ...] =`: `partial` (the intentional-leniency marker),
-  `atomic` (no `ignore` injected inside this rule's body), `reserved`
-  (atomic *and* appends a trailing `boundary` call inside the rule's terminal
-  captures), and `preferred` (a sibling of `reserved` for
-  identifier-eligible distinguished tokens). The keywords are
-  *contextual* — special only in this slot, usable as ordinary rule
-  names elsewhere. `atomic` / `reserved` / `preferred` are mutually
-  exclusive (each makes a rule atomic); `partial` composes with any and,
-  when present, must be written first (`name: partial atomic =`). The
-  root rule and the special rules `ignore` and `boundary` carry no
-  ascriptions at all (any ascription on them is a parse error);
-  whitespace auto-insertion is disabled by omitting `ignore`, not by
-  ascribing it.
+  `name: kw [kw ...] =`: `atomic` (no `ignore` injected inside this
+  rule's body), `reserved` (atomic *and* appends a trailing `boundary`
+  call inside the rule's terminal captures), and `preferred` (a sibling
+  of `reserved` for identifier-eligible distinguished tokens). The
+  keywords are *contextual* — special only in this slot, usable as
+  ordinary rule names elsewhere. `atomic` / `reserved` / `preferred` are
+  mutually exclusive (each makes a rule atomic). The root rule and the
+  special rules `ignore` and `boundary` carry no ascriptions at all (any
+  ascription on them is a parse error); whitespace auto-insertion is
+  disabled by omitting `ignore`, not by ascribing it.
 - Two special rules, **`reserved`** and **`preferred`**, are
   *synthesized* by the compiler from the `reserved` / `preferred` rules
   (see below) — a grammar references them (`!reserved`) but never
@@ -110,13 +107,14 @@ atom       "abc"   [a-z]   .   ident   (...)   @name ...
 postfix    p*      p+      p?      p{n}    p*^     p+^     p*^[cs]   p+^[cs]
 prefix     !p      &p
 sequence   p1 p2 p3          (juxtaposition)
-catch      p1 ^label p2      p1 ^^label B      p1 ^^label
+catch      p1 ^label p2      p1 ^^label B      p1 ^^label      p1 ^&label
 choice     p1 / p2 / p3
 ```
 
-Rule definitions may carry a `name: partial =` ascription to mark
-the whole rule as intentionally lenient — see
-[`name: partial`](#name-partial--intentional-leniency-ascription) below.
+The `^&label` form is the anchor-only member of the boundary family: it
+pins `p1` to its FOLLOW with a bare lookahead and synthesizes no recovery
+branch — see [`INNER ^&lbl`](#inner-lbl--anchor-only-inferred-boundary)
+below.
 
 ### Atoms
 
@@ -545,35 +543,46 @@ only `..=`, not `..` — the catch necessarily consumes its boundary,
 and `^^lbl .. B` would diverge from the standalone `..` non-consuming
 meaning. The parser rejects it with a hint pointing at `..=`.
 
-### `name: partial` — intentional-leniency ascription
+### `INNER ^&lbl` — anchor-only inferred boundary
 
-The static `lint_partial_match` check flags trailing-nullable rules
-called unanchored — but on shipped grammars almost every flag is a
-"partial-match leniency intentionally absorbed by outer `*^`-style
-recovery" that the static analysis can't statically prove safe. The
-`partial` ascription is the author's intent signal: "yes, this rule's
-leniency is known, don't flag any call to it." Wraps the rule's body
-in `Pattern::Lenient`, which the lint walker treats as an opaque
-barrier and the compiler treats as transparent (emits the inner's
-bytecode unchanged).
+The anchor-only form is the cheap member of the boundary family. Like
+the FOLLOW-inferred `^^lbl`, it synthesizes the boundary `B` from
+`INNER`'s call-site FOLLOW (terminal-expanded), but it lowers to a bare
+`Sequence([INNER, &B])` with **no** recovery `Catch`:
 
 ```peg
-opt_semi: partial = (@punctuation ';' ws)?
+INNER ^&lbl
+# lowers to
+INNER &B          # B = terminal-expanded FOLLOW(rule)
 ```
 
-Whether the runtime invariant the ascription assumes — typically an
-outer `*^` / `*^[;]` / `^block_close` recovery scope absorbing the
-leniency — actually holds is currently a convention recorded in
-adjacent comments and unenforced by the lint; see `#113` for the
-planned tightening.
+A prefix-only match of `INNER` fails the `&B` lookahead and backtracks to
+the caller's next ordered-choice alternative. On a speculative
+expression alternative that is exactly what's wanted — a recovery `Catch`
+there would turn every backtrack into a skip-to-boundary scan, which is
+ruinous on hot rules; the bare lookahead is backtrack-cheap. Well-formed
+input always has a legal follower, so `&B` succeeds and the rule is
+unaffected (no recovery capture).
+
+This is the leniency-lint discharge of choice when no recovery branch is
+wanted. It also covers the ASI case (`opt_semi = ';'? ^&semi_tail`): the
+follower set *is* the boundary, so the optional `;` needs nothing to
+anchor *to*. The placeholder `Pattern::InferBoundaryCatch { anchor_only:
+true, .. }` is resolved by `analysis::resolve_inferred_boundaries`; no new
+VM machinery.
+
+The partial-match leniency lint (`lint_partial_match`) flags a
+trailing-nullable rule called unanchored; resolve a flag by anchoring the
+rule to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl` when recovery is also
+wanted) or by restructuring it so the trailing optional can't win on a
+prefix. There is no opt-out ascription.
 
 ### Reserved rule names
 
 The grammar's entry rule and two rule *names* get compile-time
 treatment. All are structural slots the compiler wraps or injects, not
-lexable tokens, so none accepts an ascription — `partial` / `atomic` /
-`reserved` / `preferred` on the root rule, `ignore`, or `boundary` is a
-parse error.
+lexable tokens, so none accepts an ascription — `atomic` / `reserved` /
+`preferred` on the root rule, `ignore`, or `boundary` is a parse error.
 
 - **the root** — the single top-level declaration (conventionally
   named `root`); it is the entry by position, not by name. The
@@ -652,7 +661,7 @@ parse error.
 The `atomic` ascription opts the rule out of `ignore`
 auto-insertion: the rewriter walks the body but does not splice
 `ignore` between `Sequence` items or prepend one to `Repeat`
-iterations. `partial` composes with it (`name: partial atomic =`).
+iterations.
 
 ```peg
 string_lit: atomic = '"' (str_escape / !'"' .)* '"'
@@ -704,8 +713,7 @@ emits those longest-first so maximal munch still holds.)
 
 - Requires a `boundary` rule; with none defined, the synthesized
   `NonTerminal("boundary")` surfaces as `CompileError::UndefinedRule("boundary")`.
-- Composes with `partial` (written first); mutually exclusive with
-  `atomic` / `preferred`.
+- Mutually exclusive with `atomic` / `preferred`.
 - Rejected on the reserved rules `root` / `ignore` / `boundary`.
 
 ### `name: preferred` — preferred-word ascription
@@ -877,10 +885,9 @@ concrete use case.
   character-class range out of order, unknown escape.
 - **`CompileError`** — source is well-formed but semantically invalid.
   Examples: `NonTerminal("foo")` with no matching rule, a start rule
-  that doesn't exist, partial-match leniency on a call site that's
-  neither anchored (`^^lbl B`) nor explicitly marked intentional
-  (`name: partial`), an `^^lbl` whose call-site FOLLOW set is empty
-  so no boundary can be inferred.
+  that doesn't exist, partial-match leniency on a call site that is not
+  anchored to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl`), an `^^lbl`
+  whose call-site FOLLOW set is empty so no boundary can be inferred.
 - **`Error`** — unified wrapper returned by `pegc::compile(source)`.
   `From<ParseError>` and `From<CompileError>` are provided.
 

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -593,6 +593,7 @@ pub struct LintFinding {
 /// Findings are returned sorted by `(rule, caller)`.
 pub fn lint_partial_match(grammar: &Grammar) -> Vec<LintFinding> {
     let nullable = compute_nullable(&grammar.rules);
+    let first = compute_first(grammar);
 
     let trailing: HashMap<String, FollowSet> = grammar
         .rules
@@ -606,12 +607,20 @@ pub fn lint_partial_match(grammar: &Grammar) -> Vec<LintFinding> {
     let ctx = LintCtx {
         grammar,
         nullable: &nullable,
+        first: &first,
         trailing: &trailing,
     };
     for caller in rule_names {
         let body = &grammar.rules[caller];
         let mut cont_stack: Vec<&[Pattern]> = Vec::new();
-        walk_for_call_sites(body, caller, &mut cont_stack, false, &ctx, &mut findings);
+        walk_for_call_sites(
+            body,
+            caller,
+            &mut cont_stack,
+            &Absorber::outside(),
+            &ctx,
+            &mut findings,
+        );
     }
 
     findings.sort();
@@ -623,7 +632,172 @@ pub fn lint_partial_match(grammar: &Grammar) -> Vec<LintFinding> {
 struct LintCtx<'a> {
     grammar: &'a Grammar,
     nullable: &'a HashSet<String>,
+    first: &'a HashMap<String, FollowSet>,
     trailing: &'a HashMap<String, FollowSet>,
+}
+
+/// State threaded through the outward leniency walk describing the
+/// recovery scope, if any, that encloses the current call site.
+///
+/// The base lint (PR #101) flags a leniency that is absorbed by *any*
+/// recovery `Catch`. Leg 2 (clean-resync dominator) refines this: a catch
+/// whose recovery body resyncs to a structural boundary (`*^[cs]`,
+/// `^^lbl B`, `^^block_close`) cleanly contains the leniency, provided
+/// nothing but separators sit between the lenient rule and that boundary.
+/// A bare `*^` (byte-by-byte skip) is *not* clean — it absorbs the PR #101
+/// bug itself — so it keeps flagging.
+///
+/// - `in_catch`: the call site is enclosed by some recovery catch.
+/// - `clean_boundary`: when the innermost enclosing catch resyncs cleanly,
+///   the FIRST bytes of its boundary token(s); `None` for a bare-byte catch
+///   (or no catch).
+/// - `crossed`: FIRST bytes of the tail elements walked past on the way
+///   from the call site out to that catch. A clean catch discharges the
+///   call iff every crossed byte is part of the boundary — i.e. only the
+///   construct's own separators lie between it and its terminator.
+#[derive(Clone)]
+struct Absorber {
+    in_catch: bool,
+    clean_boundary: Option<CharSet>,
+    crossed: CharSet,
+}
+
+impl Absorber {
+    /// Not (yet) inside any recovery catch.
+    fn outside() -> Self {
+        Absorber {
+            in_catch: false,
+            clean_boundary: None,
+            crossed: CharSet::empty(),
+        }
+    }
+
+    /// Enter the inner region of a recovery `Catch`. The innermost catch
+    /// is the first absorber, so the boundary is set to the entered catch's
+    /// cleanness. The crossed-tail accumulator is *kept*: when the outward
+    /// walk reaches this catch from a nested rule, those crossings are the
+    /// meaningful structure sitting between the lenient rule and the
+    /// boundary (e.g. `aliased_expr`'s `(',' result_column)*` before the
+    /// `*^[;]`), which a coarse resync would swallow — they must keep the
+    /// call flagged.
+    fn enter_catch(&self, recovery: &Pattern, ctx: &LintCtx<'_>) -> Self {
+        Absorber {
+            in_catch: true,
+            clean_boundary: recovery_boundary_bytes(recovery, ctx.nullable, ctx.first),
+            crossed: self.crossed.clone(),
+        }
+    }
+
+    /// Record FIRST bytes of a tail element walked past before reaching
+    /// the boundary.
+    fn cross(&mut self, bytes: &CharSet) {
+        self.crossed = self.crossed.union(bytes);
+    }
+
+    /// Does the leniency leak (i.e. should the call site flag)? It leaks
+    /// when absorbed by a catch that is either bare-byte (`clean_boundary`
+    /// is `None`) or clean but with meaningful content — a crossed tail
+    /// byte outside the boundary — between the rule and its terminator.
+    fn leaks(&self) -> bool {
+        if !self.in_catch {
+            return false;
+        }
+        match &self.clean_boundary {
+            None => true,
+            Some(boundary) => !charset_subset(&self.crossed, boundary),
+        }
+    }
+}
+
+/// `a ⊆ b` over character sets.
+fn charset_subset(a: &CharSet, b: &CharSet) -> bool {
+    a.union(b) == *b
+}
+
+/// FIRST bytes of the resync boundary embedded in a clean-resync recovery
+/// body — the `X` of the `(!X .)*` guarded-skip loop the desugarers
+/// synthesize for `*^[cs]`, `^^lbl B` and `^^block_close`, plus the
+/// trailing sync token of the `*^[cs]` form. Returns `None` for a
+/// bare-byte recovery (a lone `AnyChar`), which has no boundary.
+fn recovery_boundary_bytes(
+    recovery: &Pattern,
+    nullable: &HashSet<String>,
+    first: &HashMap<String, FollowSet>,
+) -> Option<CharSet> {
+    fn walk(
+        pat: &Pattern,
+        nullable: &HashSet<String>,
+        first: &HashMap<String, FollowSet>,
+        out: &mut CharSet,
+    ) -> bool {
+        match pat {
+            Pattern::Repeat { inner, .. } => {
+                if let Pattern::Sequence { items, .. } = &**inner {
+                    if let Some(Pattern::NotPredicate { inner: b, .. }) = items.first() {
+                        *out = out.union(&first_bytes(&pattern_first(b, nullable), first));
+                        return true;
+                    }
+                }
+                walk(inner, nullable, first, out)
+            }
+            Pattern::Sequence { items, .. } => {
+                let mut found = false;
+                for it in items {
+                    found |= walk(it, nullable, first, out);
+                    // The trailing sync token in `*^[cs]` (a CharClass after
+                    // the guarded-skip loop) is consumed on resync, so it is
+                    // part of the boundary too.
+                    if let Pattern::CharClass { set, .. } = it {
+                        *out = out.union(set);
+                    }
+                }
+                found
+            }
+            Pattern::Capture { inner, .. } => walk(inner, nullable, first, out),
+            _ => false,
+        }
+    }
+    let mut out = CharSet::empty();
+    walk(recovery, nullable, first, &mut out).then_some(out)
+}
+
+/// Lower a FOLLOW/FIRST set to the set of first bytes its elements can
+/// match, expanding rule references through `first` (one level of opaque
+/// `Rule` per visited name, cycle-guarded). Captures are transparent;
+/// `Eof` contributes nothing (it is not a byte).
+fn first_bytes(fs: &FollowSet, first: &HashMap<String, FollowSet>) -> CharSet {
+    fn elem(
+        e: &FollowElement,
+        first: &HashMap<String, FollowSet>,
+        visited: &mut HashSet<String>,
+        out: &mut CharSet,
+    ) {
+        match e {
+            FollowElement::Literal(bytes) => {
+                if let Some(&b) = bytes.first() {
+                    *out = out.union(&CharSet::singleton(b as char));
+                }
+            }
+            FollowElement::CharClass(cs) => *out = out.union(cs),
+            FollowElement::Capture { inner, .. } => elem(inner, first, visited, out),
+            FollowElement::Rule(name) => {
+                if visited.insert(name.clone()) {
+                    if let Some(rf) = first.get(name) {
+                        for e in rf {
+                            elem(e, first, visited, out);
+                        }
+                    }
+                }
+            }
+            FollowElement::Eof => {}
+        }
+    }
+    let mut out = CharSet::empty();
+    let mut visited = HashSet::new();
+    for e in fs {
+        elem(e, first, &mut visited, &mut out);
+    }
+    out
 }
 
 /// FIRST set of any trailing-Optional position in `pat`.
@@ -696,7 +870,7 @@ fn walk_for_call_sites<'a>(
     pat: &'a Pattern,
     caller: &str,
     continuations: &mut Vec<&'a [Pattern]>,
-    inside_catch: bool,
+    absorber: &Absorber,
     ctx: &LintCtx<'a>,
     findings: &mut Vec<LintFinding>,
 ) {
@@ -719,7 +893,7 @@ fn walk_for_call_sites<'a>(
                 t,
                 caller,
                 continuations,
-                inside_catch,
+                absorber.clone(),
                 ctx,
                 &mut HashSet::new(),
             ) {
@@ -735,48 +909,57 @@ fn walk_for_call_sites<'a>(
         Pattern::Sequence { items, .. } => {
             for i in 0..items.len() {
                 continuations.push(&items[i + 1..]);
-                walk_for_call_sites(
-                    &items[i],
-                    caller,
-                    continuations,
-                    inside_catch,
-                    ctx,
-                    findings,
-                );
+                walk_for_call_sites(&items[i], caller, continuations, absorber, ctx, findings);
                 continuations.pop();
             }
         }
         Pattern::OrderedChoice { alts, .. } => {
             for alt in alts {
-                walk_for_call_sites(alt, caller, continuations, inside_catch, ctx, findings);
+                walk_for_call_sites(alt, caller, continuations, absorber, ctx, findings);
             }
         }
         Pattern::Optional { inner, .. }
         | Pattern::Capture { inner, .. }
         | Pattern::Repeat { inner, .. }
         | Pattern::RepeatOne { inner, .. } => {
-            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
+            walk_for_call_sites(inner, caller, continuations, absorber, ctx, findings);
         }
         Pattern::NotPredicate { inner, .. } | Pattern::AndPredicate { inner, .. } => {
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites(inner, caller, &mut isolated, inside_catch, ctx, findings);
+            walk_for_call_sites(inner, caller, &mut isolated, absorber, ctx, findings);
         }
         Pattern::Catch {
             inner, recovery, ..
         } => {
             // Inside the Catch's `inner`: leniency that leaks past `inner`
-            // is absorbed by `recovery` (the recovery body fires whenever
-            // the next outer-context matching step fails on the leftover).
-            walk_for_call_sites(inner, caller, continuations, true, ctx, findings);
+            // is absorbed by `recovery`. Leg 2 records whether that
+            // recovery resyncs cleanly (`enter_catch`); a clean resync to a
+            // structural boundary discharges the leniency, a bare-byte skip
+            // keeps flagging it.
+            walk_for_call_sites(
+                inner,
+                caller,
+                continuations,
+                &absorber.enter_catch(recovery, ctx),
+                ctx,
+                findings,
+            );
             let mut isolated: Vec<&[Pattern]> = Vec::new();
-            walk_for_call_sites(recovery, caller, &mut isolated, false, ctx, findings);
+            walk_for_call_sites(
+                recovery,
+                caller,
+                &mut isolated,
+                &Absorber::outside(),
+                ctx,
+                findings,
+            );
         }
         // `Lenient` at a rule's body root makes the rule's `trailing_first`
         // empty — so the rule never appears as a flag target. The walker
         // still descends transparently to find unrelated unguarded calls
         // the lenient rule's body may itself contain.
         Pattern::Lenient { inner, .. } => {
-            walk_for_call_sites(inner, caller, continuations, inside_catch, ctx, findings);
+            walk_for_call_sites(inner, caller, continuations, absorber, ctx, findings);
         }
         // The resolver runs before the lint, so the lint should
         // never see an unresolved boundary-anchored catch.
@@ -791,25 +974,30 @@ fn walk_for_call_sites<'a>(
 
 /// Returns `true` iff bytes that `target_trailing` could match can reach
 /// an unguarded position from the current continuation stack outward
-/// through call sites of `caller`. "Unguarded" means no `AndPredicate`
-/// anchor and no non-nullable consumer with a FIRST disjoint from
-/// `target_trailing` is encountered along the way.
+/// through call sites of `caller`. "Unguarded" means the leniency is
+/// neither validated (an `AndPredicate` anchor or a non-nullable consumer
+/// with a FIRST disjoint from `target_trailing`) nor cleanly absorbed by
+/// a clean-resync catch — see [`Absorber::leaks`].
 fn leniency_reaches_unguarded(
     target_trailing: &FollowSet,
     caller: &str,
     continuations: &[&[Pattern]],
-    inside_catch: bool,
+    mut absorber: Absorber,
     ctx: &LintCtx<'_>,
     visited_callers: &mut HashSet<String>,
 ) -> bool {
     for frame in continuations.iter().rev() {
-        match scan_frame_for_validator(frame, target_trailing, ctx.nullable) {
+        match scan_frame_for_validator(frame, target_trailing, &mut absorber, ctx) {
             FrameOutcome::Validated => {
-                // A non-Catch validator only saves the call site if we
-                // haven't already passed through a Catch absorber on the
-                // path — a Catch's recovery body would consume the
-                // leniency bytes before a downstream validator fires.
-                if inside_catch {
+                // A bare-byte catch absorber consumes the leniency bytes
+                // before a downstream validator can fire, so the validator
+                // does not save the call site — keep walking out (and it
+                // flags at the bare-`*^` root). A *clean*-resync catch is
+                // different: a validator that rejects the leftover is
+                // exactly what trips the catch's structural resync, so the
+                // leniency is contained. No catch at all: the validator
+                // discharges directly.
+                if absorber.in_catch && absorber.clean_boundary.is_none() {
                     continue;
                 }
                 return false;
@@ -823,13 +1011,13 @@ fn leniency_reaches_unguarded(
         // Caller cycle: returning `true` here would treat a recursive
         // self-call as a confirmed leak, but the same target_trailing
         // is already being evaluated at the outer frame. Defer the
-        // verdict to that frame by returning `inside_catch` (same
-        // sentinel the root-rule short-circuit below uses). If the
+        // verdict to that frame by returning the absorber's leak verdict
+        // (same sentinel the root-rule short-circuit below uses). If the
         // outer frame eventually concludes the leniency is contained,
         // the cycle is too; if it concludes the leniency leaks via
         // some non-cyclic caller, the iteration over other rules in
         // the outer frame will catch that.
-        return inside_catch;
+        return absorber.leaks();
     }
 
     let mut rule_names: Vec<&String> = ctx.grammar.rules.keys().collect();
@@ -837,7 +1025,7 @@ fn leniency_reaches_unguarded(
 
     if caller == ctx.grammar.root && !target_trailing.contains(&FollowElement::Eof) {
         visited_callers.remove(caller);
-        return inside_catch;
+        return absorber.leaks();
     }
 
     let mut found_call_site = false;
@@ -854,7 +1042,7 @@ fn leniency_reaches_unguarded(
             body,
             &probe,
             &mut new_continuations,
-            inside_catch,
+            &absorber,
             ctx,
             visited_callers,
             &mut local_findings,
@@ -867,7 +1055,7 @@ fn leniency_reaches_unguarded(
     visited_callers.remove(caller);
 
     if !found_call_site {
-        return inside_catch;
+        return absorber.leaks();
     }
 
     false
@@ -896,7 +1084,7 @@ fn find_callsite_unguarded<'a>(
     pat: &'a Pattern,
     probe: &CallsiteProbe<'a>,
     continuations: &mut Vec<&'a [Pattern]>,
-    inside_catch: bool,
+    absorber: &Absorber,
     ctx: &LintCtx<'a>,
     visited_callers: &mut HashSet<String>,
     found_callsite: &mut bool,
@@ -918,7 +1106,7 @@ fn find_callsite_unguarded<'a>(
                 probe.target_trailing,
                 probe.in_rule,
                 continuations,
-                inside_catch,
+                absorber.clone(),
                 ctx,
                 visited_callers,
             )
@@ -930,7 +1118,7 @@ fn find_callsite_unguarded<'a>(
                     &items[i],
                     probe,
                     continuations,
-                    inside_catch,
+                    absorber,
                     ctx,
                     visited_callers,
                     found_callsite,
@@ -948,7 +1136,7 @@ fn find_callsite_unguarded<'a>(
                     alt,
                     probe,
                     continuations,
-                    inside_catch,
+                    absorber,
                     ctx,
                     visited_callers,
                     found_callsite,
@@ -965,7 +1153,7 @@ fn find_callsite_unguarded<'a>(
             inner,
             probe,
             continuations,
-            inside_catch,
+            absorber,
             ctx,
             visited_callers,
             found_callsite,
@@ -976,7 +1164,7 @@ fn find_callsite_unguarded<'a>(
                 inner,
                 probe,
                 &mut isolated,
-                inside_catch,
+                absorber,
                 ctx,
                 visited_callers,
                 found_callsite,
@@ -989,7 +1177,7 @@ fn find_callsite_unguarded<'a>(
                 inner,
                 probe,
                 continuations,
-                true,
+                &absorber.enter_catch(recovery, ctx),
                 ctx,
                 visited_callers,
                 found_callsite,
@@ -1001,7 +1189,7 @@ fn find_callsite_unguarded<'a>(
                 recovery,
                 probe,
                 &mut isolated,
-                false,
+                &Absorber::outside(),
                 ctx,
                 visited_callers,
                 found_callsite,
@@ -1015,7 +1203,7 @@ fn find_callsite_unguarded<'a>(
             inner,
             probe,
             continuations,
-            inside_catch,
+            absorber,
             ctx,
             visited_callers,
             found_callsite,
@@ -1041,11 +1229,19 @@ enum FrameOutcome {
 
 /// Scan one continuation frame (a slice of siblings after the current
 /// position in some Sequence) looking for a hard validator.
+///
+/// As a side effect, records into `absorber.crossed` the FIRST bytes of
+/// every consuming tail element walked past — leg 2 compares these against
+/// the enclosing clean catch's boundary to tell genuine separators (which
+/// the boundary subsumes) from meaningful structure that a coarse resync
+/// would silently swallow.
 fn scan_frame_for_validator(
     frame: &[Pattern],
     target_trailing: &FollowSet,
-    nullable: &HashSet<String>,
+    absorber: &mut Absorber,
+    ctx: &LintCtx<'_>,
 ) -> FrameOutcome {
+    let nullable = ctx.nullable;
     for item in frame {
         if matches!(item, Pattern::AndPredicate { .. }) {
             return FrameOutcome::Anchored;
@@ -1071,6 +1267,7 @@ fn scan_frame_for_validator(
         }
         if !pattern_nullable(item, nullable) {
             let item_first = pattern_first(item, nullable);
+            absorber.cross(&first_bytes(&item_first, ctx.first));
             if item_first.is_disjoint(target_trailing) {
                 return FrameOutcome::Validated;
             }
@@ -1080,7 +1277,8 @@ fn scan_frame_for_validator(
             // beyond it; stop walking this frame.
             return FrameOutcome::PassedThrough;
         }
-        // Nullable item: walk past it.
+        // Nullable item: walk past it, recording the structure crossed.
+        absorber.cross(&first_bytes(&pattern_first(item, nullable), ctx.first));
     }
     FrameOutcome::PassedThrough
 }

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -823,6 +823,18 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         }
         Pattern::Sequence { items, .. } => {
             for item in items.iter().rev() {
+                // A trailing `&B` anchor (from `^&lbl`, or written by hand)
+                // pins the rule to its FOLLOW boundary: `B` is guaranteed
+                // to follow the match, so nothing the body leaves can
+                // silently leak past it. When the reverse walk reaches the
+                // anchor with nothing trailing accumulated yet, the rule is
+                // anchored — its `trailing_first` is empty regardless of the
+                // optionals before the anchor. For a non-nullable body the
+                // walk would stop at the body anyway; this also discharges
+                // nullable bodies like `opt_semi = ';'?`.
+                if out.is_empty() && matches!(item, Pattern::AndPredicate { .. }) {
+                    return FollowSet::new();
+                }
                 if pattern_nullable(item, nullable) {
                     if is_trailing_optional_like(item) {
                         out.extend(pattern_first(item, nullable));

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -102,8 +102,6 @@ pub(crate) fn pattern_nullable(pat: &Pattern, nullable: &HashSet<String>) -> boo
         // "matches empty after success" path — nullability follows
         // inner.
         Pattern::Catch { inner, .. } => pattern_nullable(inner, nullable),
-        // `~` is runtime-transparent.
-        Pattern::Lenient { inner, .. } => pattern_nullable(inner, nullable),
         // Pre-resolution placeholder for `^^lbl`. Nullability follows
         // inner just like `Catch` — the eventual recovery body
         // `(!B .)*` is always nullable but only contributes on
@@ -170,7 +168,6 @@ fn collect_first_calls(pat: &Pattern, nullable: &HashSet<String>, out: &mut Hash
             collect_first_calls(inner, nullable, out);
             collect_first_calls(recovery, nullable, out);
         }
-        Pattern::Lenient { inner, .. } => collect_first_calls(inner, nullable, out),
         // Pre-resolution placeholder for `^^lbl`. Only the inner can
         // route a first-call edge — the synthesized recovery
         // `(!B .)*` has no non-terminals other than B, and the
@@ -373,9 +370,6 @@ fn pattern_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
             // in FIRST.
             out.extend(pattern_first(inner, nullable));
         }
-        Pattern::Lenient { inner, .. } => {
-            out.extend(pattern_first(inner, nullable));
-        }
         // Pre-resolution placeholder for `^^lbl`. The eventual recovery
         // body `(!B .)*` fires only on failure (same as Catch) so it
         // doesn't appear in FIRST; only the inner does.
@@ -512,9 +506,6 @@ fn collect_follow(
             // for cross-check).
             collect_follow(inner, nullable, trailing, follow, changed);
             collect_follow(recovery, nullable, trailing, follow, changed);
-        }
-        Pattern::Lenient { inner, .. } => {
-            collect_follow(inner, nullable, trailing, follow, changed);
         }
         // Pre-resolution placeholder for `^^lbl`. Treat like `Catch`'s
         // success arm: inner inherits the catch's trailing. The
@@ -850,9 +841,6 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         Pattern::Catch { inner, .. } => {
             out.extend(trailing_first(inner, nullable));
         }
-        // Definition-level `name: partial` opts the rule out of being a flag
-        // target: its `trailing_first` is empty regardless of body shape.
-        Pattern::Lenient { .. } => {}
         _ => {}
     }
     out
@@ -965,13 +953,6 @@ fn walk_for_call_sites<'a>(
                 ctx,
                 findings,
             );
-        }
-        // `Lenient` at a rule's body root makes the rule's `trailing_first`
-        // empty — so the rule never appears as a flag target. The walker
-        // still descends transparently to find unrelated unguarded calls
-        // the lenient rule's body may itself contain.
-        Pattern::Lenient { inner, .. } => {
-            walk_for_call_sites(inner, caller, continuations, absorber, ctx, findings);
         }
         // The resolver runs before the lint, so the lint should
         // never see an unresolved boundary-anchored catch.
@@ -1207,19 +1188,6 @@ fn find_callsite_unguarded<'a>(
                 found_callsite,
             )
         }
-        // Propagation walks through the lenient marker transparently;
-        // the marker only suppresses the IMMEDIATE call's flag (handled
-        // in `walk_for_call_sites`), not deeper detection or outward
-        // propagation from nested rules' leniency.
-        Pattern::Lenient { inner, .. } => find_callsite_unguarded(
-            inner,
-            probe,
-            continuations,
-            absorber,
-            ctx,
-            visited_callers,
-            found_callsite,
-        ),
         Pattern::InferBoundaryCatch { .. } => {
             unreachable!(
                 "Pattern::InferBoundaryCatch must be resolved by \
@@ -1545,12 +1513,6 @@ fn resolve_in_pattern(
             )?),
             span: *span,
         }),
-        Pattern::Lenient { inner, span } => Ok(Pattern::Lenient {
-            inner: Box::new(resolve_in_pattern(
-                inner, trailing, nullable, first, rule_name,
-            )?),
-            span: *span,
-        }),
         Pattern::Catch {
             inner,
             label,
@@ -1779,8 +1741,7 @@ pub fn tally_non_terminal_refs(pat: &Pattern, out: &mut HashMap<String, usize>) 
         | Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
-        | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => tally_non_terminal_refs(inner, out),
+        | Pattern::Capture { inner, .. } => tally_non_terminal_refs(inner, out),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -1818,8 +1779,7 @@ fn collect_non_terminal_refs(pat: &Pattern, out: &mut HashSet<String>) {
         | Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
-        | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => collect_non_terminal_refs(inner, out),
+        | Pattern::Capture { inner, .. } => collect_non_terminal_refs(inner, out),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -1851,8 +1811,7 @@ fn body_contains_catch(pat: &Pattern) -> bool {
         | Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
-        | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => body_contains_catch(inner),
+        | Pattern::Capture { inner, .. } => body_contains_catch(inner),
     }
 }
 
@@ -1878,7 +1837,7 @@ fn auto_insertion_active(grammar: &Grammar) -> bool {
 /// recurse the runtime indefinitely.
 ///
 /// The walker descends transparently through `Choice`, `Optional`,
-/// `Capture`, `Catch`, `Lenient`, `AndPredicate`, `NotPredicate`, and
+/// `Capture`, `Catch`, `AndPredicate`, `NotPredicate`, and
 /// stops at `NonTerminal` and the atom leaves (`Literal`, `CharClass`,
 /// `AnyChar`). Crossing a `NonTerminal` would pull ignore into the
 /// callee's body — which the callee handles by its own auto-insertion
@@ -1952,8 +1911,7 @@ fn inject_ignore_in(pat: &mut Pattern) {
         Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
-        | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => inject_ignore_in(inner),
+        | Pattern::Capture { inner, .. } => inject_ignore_in(inner),
         Pattern::Catch {
             inner, recovery, ..
         } => {
@@ -2089,8 +2047,7 @@ fn contains_capture(pat: &Pattern) -> bool {
         | Pattern::RepeatOne { inner, .. }
         | Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
-        | Pattern::AndPredicate { inner, .. }
-        | Pattern::Lenient { inner, .. } => contains_capture(inner),
+        | Pattern::AndPredicate { inner, .. } => contains_capture(inner),
         Pattern::Catch {
             inner, recovery, ..
         } => contains_capture(inner) || contains_capture(recovery),
@@ -2269,9 +2226,7 @@ fn keyword_entries(
             Some(vec![s.chars().map(CharSet::singleton).collect()])
         }
         Pattern::CharClass { set, .. } => Some(vec![vec![set.clone()]]),
-        Pattern::Capture { inner, .. } | Pattern::Lenient { inner, .. } => {
-            keyword_entries(inner, rules, visiting)
-        }
+        Pattern::Capture { inner, .. } => keyword_entries(inner, rules, visiting),
         Pattern::OrderedChoice { alts, .. } => {
             let mut out = Vec::new();
             for a in alts {
@@ -2438,8 +2393,7 @@ mod tests {
             | Pattern::Optional { inner, .. }
             | Pattern::NotPredicate { inner, .. }
             | Pattern::AndPredicate { inner, .. }
-            | Pattern::Capture { inner, .. }
-            | Pattern::Lenient { inner, .. } => count_boundary(inner),
+            | Pattern::Capture { inner, .. } => count_boundary(inner),
             Pattern::Catch {
                 inner, recovery, ..
             } => count_boundary(inner) + count_boundary(recovery),

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -814,8 +814,8 @@ fn trailing_first(pat: &Pattern, nullable: &HashSet<String>) -> FollowSet {
         }
         Pattern::Sequence { items, .. } => {
             for item in items.iter().rev() {
-                // A trailing `&B` anchor (from `^&lbl`, or written by hand)
-                // pins the rule to its FOLLOW boundary: `B` is guaranteed
+                // A trailing `&B` anchor (from postfix `$`, or written by
+                // hand) pins the rule to its FOLLOW boundary: `B` is guaranteed
                 // to follow the match, so nothing the body leaves can
                 // silently leak past it. When the reverse walk reaches the
                 // anchor with nothing trailing accumulated yet, the rule is
@@ -1644,8 +1644,8 @@ fn lower_inferred_boundary_catch(
     }
 }
 
-/// Lower an anchor-only inferred boundary (`^&lbl`) to `Sequence([inner,
-/// &B])`. Unlike [`lower_inferred_boundary_catch`], no recovery `Catch`
+/// Lower an anchor-only inferred boundary (postfix `$`) to
+/// `Sequence([inner, &B])`. Unlike [`lower_inferred_boundary_catch`], no recovery `Catch`
 /// is synthesized: the trailing `AndPredicate(B)` makes a prefix-only
 /// match fail and backtrack to the caller's next ordered-choice
 /// alternative, which is backtrack-cheap in the speculative positions

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -1301,6 +1301,41 @@ fn element_subsumed_by(elem: &FollowElement, set: &FollowSet) -> bool {
     set.contains(elem)
 }
 
+/// Replace every `Rule(name)` element of a FOLLOW set with the terminal
+/// elements of its FIRST set, transitively (cycle-guarded). Literal,
+/// `CharClass`, `Capture` and `Eof` elements pass through unchanged. Used
+/// to lower an inferred `^^lbl` boundary to a pure token set — see the
+/// `InferBoundaryCatch` arm of `resolve_in_pattern`.
+fn expand_follow_to_terminals(fs: &FollowSet, first: &HashMap<String, FollowSet>) -> FollowSet {
+    fn go(
+        elem: &FollowElement,
+        first: &HashMap<String, FollowSet>,
+        visited: &mut HashSet<String>,
+        out: &mut FollowSet,
+    ) {
+        match elem {
+            FollowElement::Rule(name) => {
+                if visited.insert(name.clone()) {
+                    if let Some(rf) = first.get(name) {
+                        for e in rf {
+                            go(e, first, visited, out);
+                        }
+                    }
+                }
+            }
+            other => {
+                out.insert(other.clone());
+            }
+        }
+    }
+    let mut out = FollowSet::new();
+    let mut visited = HashSet::new();
+    for elem in fs {
+        go(elem, first, &mut visited, &mut out);
+    }
+    out
+}
+
 // -- FOLLOW-inferred boundary catch resolver -----------------------------
 
 /// Synthesize a boundary pattern from a FOLLOW set. Used by the
@@ -1378,11 +1413,12 @@ fn follow_element_inner_to_pattern(elem: &FollowElement) -> Pattern {
 /// pass, no `InferBoundaryCatch` remains in the rule bodies.
 pub fn resolve_inferred_boundaries(grammar: &mut Grammar) -> Result<(), CompileError> {
     let nullable = compute_nullable(&grammar.rules);
+    let first = compute_first(grammar);
     let follow = compute_follow(grammar);
     let mut new_rules: HashMap<String, Pattern> = HashMap::with_capacity(grammar.rules.len());
     for (name, body) in &grammar.rules {
         let rule_follow = follow.get(name).cloned().unwrap_or_default();
-        let resolved = resolve_in_pattern(body, &rule_follow, &nullable, name)?;
+        let resolved = resolve_in_pattern(body, &rule_follow, &nullable, &first, name)?;
         new_rules.insert(name.clone(), resolved);
     }
     grammar.rules = new_rules;
@@ -1393,6 +1429,7 @@ fn resolve_in_pattern(
     pat: &Pattern,
     trailing: &FollowSet,
     nullable: &HashSet<String>,
+    first: &HashMap<String, FollowSet>,
     rule_name: &str,
 ) -> Result<Pattern, CompileError> {
     match pat {
@@ -1412,6 +1449,7 @@ fn resolve_in_pattern(
                     &items[i],
                     &sub_trailing,
                     nullable,
+                    first,
                     rule_name,
                 )?);
             }
@@ -1423,7 +1461,9 @@ fn resolve_in_pattern(
         Pattern::OrderedChoice { alts, span } => {
             let mut out = Vec::with_capacity(alts.len());
             for alt in alts {
-                out.push(resolve_in_pattern(alt, trailing, nullable, rule_name)?);
+                out.push(resolve_in_pattern(
+                    alt, trailing, nullable, first, rule_name,
+                )?);
             }
             Ok(Pattern::OrderedChoice {
                 alts: out,
@@ -1440,6 +1480,7 @@ fn resolve_in_pattern(
                     inner,
                     &sub_trailing,
                     nullable,
+                    first,
                     rule_name,
                 )?),
                 span: *span,
@@ -1453,13 +1494,16 @@ fn resolve_in_pattern(
                     inner,
                     &sub_trailing,
                     nullable,
+                    first,
                     rule_name,
                 )?),
                 span: *span,
             })
         }
         Pattern::Optional { inner, span } => Ok(Pattern::Optional {
-            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            inner: Box::new(resolve_in_pattern(
+                inner, trailing, nullable, first, rule_name,
+            )?),
             span: *span,
         }),
         Pattern::NotPredicate { inner, span } => Ok(Pattern::NotPredicate {
@@ -1467,6 +1511,7 @@ fn resolve_in_pattern(
                 inner,
                 &FollowSet::new(),
                 nullable,
+                first,
                 rule_name,
             )?),
             span: *span,
@@ -1476,17 +1521,22 @@ fn resolve_in_pattern(
                 inner,
                 &FollowSet::new(),
                 nullable,
+                first,
                 rule_name,
             )?),
             span: *span,
         }),
         Pattern::Capture { kind, inner, span } => Ok(Pattern::Capture {
             kind: kind.clone(),
-            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            inner: Box::new(resolve_in_pattern(
+                inner, trailing, nullable, first, rule_name,
+            )?),
             span: *span,
         }),
         Pattern::Lenient { inner, span } => Ok(Pattern::Lenient {
-            inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+            inner: Box::new(resolve_in_pattern(
+                inner, trailing, nullable, first, rule_name,
+            )?),
             span: *span,
         }),
         Pattern::Catch {
@@ -1498,9 +1548,13 @@ fn resolve_in_pattern(
             // Success branch: inner inherits the catch's trailing.
             // Recovery branch: trailing is also the catch's trailing.
             Ok(Pattern::Catch {
-                inner: Box::new(resolve_in_pattern(inner, trailing, nullable, rule_name)?),
+                inner: Box::new(resolve_in_pattern(
+                    inner, trailing, nullable, first, rule_name,
+                )?),
                 label: label.clone(),
-                recovery: Box::new(resolve_in_pattern(recovery, trailing, nullable, rule_name)?),
+                recovery: Box::new(resolve_in_pattern(
+                    recovery, trailing, nullable, first, rule_name,
+                )?),
                 span: *span,
             })
         }
@@ -1512,9 +1566,18 @@ fn resolve_in_pattern(
                     span: *span,
                 });
             }
-            let boundary = follow_set_to_boundary_pattern(trailing);
+            // Expand rule references in the FOLLOW set to their terminal
+            // FIRST before synthesizing the boundary. A bare `^^lbl`'s
+            // boundary is "the next legitimate follower token", so it must
+            // be a token set: leaving a `Rule(R)` reference in the `&B`
+            // lookahead would (a) re-introduce R's own leniency into the
+            // lookahead — a fresh unanchored call site the lint then flags
+            // — and (b) be opaque. Expanding to terminals is complete by
+            // construction (it is the rule's real FOLLOW) and cascade-free.
+            let boundary =
+                follow_set_to_boundary_pattern(&expand_follow_to_terminals(trailing, first));
             // Resolve nested catches inside the inner first.
-            let resolved_inner = resolve_in_pattern(inner, trailing, nullable, rule_name)?;
+            let resolved_inner = resolve_in_pattern(inner, trailing, nullable, first, rule_name)?;
             Ok(lower_inferred_boundary_catch(
                 resolved_inner,
                 label.clone(),

--- a/crates/compiler/src/pegc/analysis.rs
+++ b/crates/compiler/src/pegc/analysis.rs
@@ -1558,7 +1558,12 @@ fn resolve_in_pattern(
                 span: *span,
             })
         }
-        Pattern::InferBoundaryCatch { inner, label, span } => {
+        Pattern::InferBoundaryCatch {
+            inner,
+            label,
+            anchor_only,
+            span,
+        } => {
             if trailing.is_empty() {
                 return Err(CompileError::CannotInferBoundary {
                     rule: rule_name.into(),
@@ -1578,12 +1583,21 @@ fn resolve_in_pattern(
                 follow_set_to_boundary_pattern(&expand_follow_to_terminals(trailing, first));
             // Resolve nested catches inside the inner first.
             let resolved_inner = resolve_in_pattern(inner, trailing, nullable, first, rule_name)?;
-            Ok(lower_inferred_boundary_catch(
-                resolved_inner,
-                label.clone(),
-                boundary,
-                *span,
-            ))
+            if *anchor_only {
+                // Anchor-only: `Seq([inner, &B])`, no recovery catch.
+                Ok(lower_inferred_boundary_anchor(
+                    resolved_inner,
+                    boundary,
+                    *span,
+                ))
+            } else {
+                Ok(lower_inferred_boundary_catch(
+                    resolved_inner,
+                    label.clone(),
+                    boundary,
+                    *span,
+                ))
+            }
         }
     }
 }
@@ -1652,6 +1666,26 @@ fn lower_inferred_boundary_catch(
         }),
         label,
         recovery: Box::new(recovery),
+        span,
+    }
+}
+
+/// Lower an anchor-only inferred boundary (`^&lbl`) to `Sequence([inner,
+/// &B])`. Unlike [`lower_inferred_boundary_catch`], no recovery `Catch`
+/// is synthesized: the trailing `AndPredicate(B)` makes a prefix-only
+/// match fail and backtrack to the caller's next ordered-choice
+/// alternative, which is backtrack-cheap in the speculative positions
+/// where a recovery-on-backtrack scan would be ruinous. The `&B`
+/// lookahead is non-consuming, so well-formed input — which always has a
+/// legal follower — is unaffected. `boundary` is the terminal-expanded
+/// FOLLOW set (see the `InferBoundaryCatch` arm of `resolve_in_pattern`).
+fn lower_inferred_boundary_anchor(inner: Pattern, boundary: Pattern, span: Span) -> Pattern {
+    let lookahead = Pattern::AndPredicate {
+        inner: Box::new(boundary),
+        span,
+    };
+    Pattern::Sequence {
+        items: vec![inner, lookahead],
         span,
     }
 }

--- a/crates/compiler/src/pegc/compiler.rs
+++ b/crates/compiler/src/pegc/compiler.rs
@@ -26,11 +26,11 @@ pub enum CompileError {
     },
     /// `lint_partial_match` returned a non-empty result. Each finding
     /// names a `(rule, caller)` pair where a trailing-nullable rule's
-    /// partial-match leniency reaches an unguarded scope. Anchor with
-    /// `^^lbl B` (or `^^lbl`) when the leniency is a bug, or mark the
-    /// rule `name: partial` when the leniency is intentional. Each
-    /// [`LintFinding`] carries the call-site's span so the rendered
-    /// message points directly at the unanchored call.
+    /// partial-match leniency reaches an unguarded scope. Anchor the rule
+    /// to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl` when recovery is also
+    /// wanted) or restructure it so the trailing optional can't win on a
+    /// prefix. Each [`LintFinding`] carries the call-site's span so the
+    /// rendered message points directly at the unanchored call.
     PartialMatchLeniency(Vec<LintFinding>),
     /// One or more literals are reachable from both a `reserved` rule and
     /// a `preferred` rule, so the synthesized `reserved` and `preferred`
@@ -476,9 +476,6 @@ impl Compiler {
                 self.patch_jump(success_commit, done);
                 self.emit(Instruction::RecoverScopeEnd);
             }
-            // Transparent at runtime — the `~` marker affects only
-            // the lint walker. See `Pattern::Lenient` documentation.
-            Pattern::Lenient { inner, .. } => self.compile_pat(inner),
             // The FOLLOW-inferred resolver must run before bytecode
             // emission; reaching this arm is a bug.
             Pattern::InferBoundaryCatch { .. } => {
@@ -688,8 +685,7 @@ fn check_refs(
         | Pattern::Optional { inner, .. }
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
-        | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. } => check_refs(_rule, inner, rules, rule_params),
+        | Pattern::Capture { inner, .. } => check_refs(_rule, inner, rules, rule_params),
         Pattern::Catch {
             inner, recovery, ..
         } => {

--- a/crates/compiler/src/pegc/compiler.rs
+++ b/crates/compiler/src/pegc/compiler.rs
@@ -15,10 +15,11 @@ pub enum CompileError {
     /// `Grammar::new`, which bypass the parser) whose map lacks a
     /// `"root"` entry.
     MissingRootRule,
-    /// One or more `^^lbl` catches have no following context to infer
-    /// their boundary from. Emitted by `resolve_inferred_boundaries`.
-    /// `span` is the source position of the `^^lbl` placeholder in the
-    /// grammar; rendered as `{line}:{col}:` in [`Display`].
+    /// An inferred-boundary anchor (`^^lbl` catch or postfix `$`) has no
+    /// following context to infer its boundary from. Emitted by
+    /// `resolve_inferred_boundaries`. `span` is the source position of the
+    /// placeholder; rendered as `{line}:{col}:` in [`Display`]. An empty
+    /// `label` marks the `$` form (which carries none).
     CannotInferBoundary {
         rule: String,
         label: String,
@@ -27,7 +28,7 @@ pub enum CompileError {
     /// `lint_partial_match` returned a non-empty result. Each finding
     /// names a `(rule, caller)` pair where a trailing-nullable rule's
     /// partial-match leniency reaches an unguarded scope. Anchor the rule
-    /// to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl` when recovery is also
+    /// to its FOLLOW (`$`, or `^^lbl B` / `^^lbl` when recovery is also
     /// wanted) or restructure it so the trailing optional can't win on a
     /// prefix. Each [`LintFinding`] carries the call-site's span so the
     /// rendered message points directly at the unanchored call.
@@ -75,6 +76,11 @@ impl std::fmt::Display for CompileError {
             CompileError::MissingRootRule => write!(
                 f,
                 "grammar must define an entry rule (the single top-level declaration)"
+            ),
+            CompileError::CannotInferBoundary { rule, label, span } if label.is_empty() => write!(
+                f,
+                "{span}: cannot infer a FOLLOW boundary for the `$` anchor in rule `{rule}`: \
+                 no following context. Either remove the anchor or restructure the rule."
             ),
             CompileError::CannotInferBoundary { rule, label, span } => write!(
                 f,

--- a/crates/compiler/src/pegc/desugar_indent.rs
+++ b/crates/compiler/src/pegc/desugar_indent.rs
@@ -151,7 +151,6 @@ fn top_level_demands_anchor(pat: &Pattern, needs: &HashSet<String>) -> bool {
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
         | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. }
         | Pattern::InferBoundaryCatch { inner, .. } => top_level_demands_anchor(inner, needs),
         Pattern::Catch {
             inner, recovery, ..
@@ -196,7 +195,6 @@ fn describe_top_level_demand(pat: &Pattern, needs: &HashSet<String>) -> Option<S
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
         | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. }
         | Pattern::InferBoundaryCatch { inner, .. } => describe_top_level_demand(inner, needs),
         Pattern::Catch {
             inner, recovery, ..
@@ -273,7 +271,6 @@ fn rewrite(
         | Pattern::NotPredicate { inner, .. }
         | Pattern::AndPredicate { inner, .. }
         | Pattern::Capture { inner, .. }
-        | Pattern::Lenient { inner, .. }
         | Pattern::InferBoundaryCatch { inner, .. } => rewrite(inner, anchor, needs, rule, fresh),
         Pattern::Catch {
             inner, recovery, ..
@@ -562,7 +559,6 @@ mod tests {
             | Pattern::NotPredicate { inner, .. }
             | Pattern::AndPredicate { inner, .. }
             | Pattern::Capture { inner, .. }
-            | Pattern::Lenient { inner, .. }
             | Pattern::InferBoundaryCatch { inner, .. } => contains_indent_op(inner),
             Pattern::Catch {
                 inner, recovery, ..

--- a/crates/compiler/src/pegc/parser.rs
+++ b/crates/compiler/src/pegc/parser.rs
@@ -148,9 +148,8 @@ struct ParsedRule {
     name_byte: usize,
     body_byte_start: usize,
     body_byte_end: usize,
-    /// The rule body, with `Pattern::Lenient` already wrapped when the
-    /// rule was ascribed `partial`. `NonTerminal` names are still the
-    /// authored short names; resolution rewrites them to flat keys.
+    /// The rule body. `NonTerminal` names are still the authored short
+    /// names; resolution rewrites them to flat keys.
     body: Pattern,
     atomic: bool,
     percent: bool,
@@ -212,9 +211,9 @@ impl Grammar {
     ///    via [`resolve_inferred_boundaries`] — synthesizes each
     ///    boundary from FOLLOW.
     /// 2. Run [`lint_partial_match`]; any finding is a fatal
-    ///    `CompileError::PartialMatchLeniency`. Anchor real bugs with
-    ///    `^^lbl B` (or `^^lbl`); mark intentional leniency with the
-    ///    `name: partial` ascription at the rule definition.
+    ///    `CompileError::PartialMatchLeniency`. Resolve a flagged call by
+    ///    anchoring the rule to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl`
+    ///    when recovery is also wanted) or restructuring the rule.
     /// 3. Inject auto-ignore calls into every non-atomic rule's body
     ///    (no-op when the grammar has no `ignore` rule).
     /// 4. Wrap `root`'s body with `ignore? body ignore? !.` (the
@@ -378,9 +377,6 @@ impl<'a> Parser<'a> {
         // contextual — recognized only in this slot, usable as ordinary
         // rule names / references everywhere else.
         //
-        // - `partial` declares every call to the rule intentionally
-        //   lenient, suppressing `lint_partial_match` findings at its
-        //   call sites; the body is wrapped in `Pattern::Lenient`.
         // - `atomic` opts the rule out of `ignore` auto-insertion.
         // - `reserved` implies `atomic` and appends a `boundary` call
         //   inside the rule's terminal captures; its literals seed the
@@ -388,13 +384,11 @@ impl<'a> Parser<'a> {
         // - `preferred` is the sibling of `reserved` whose literals feed
         //   `preferred` instead and stay identifier-eligible.
         //
-        // `atomic` / `reserved` / `preferred` are mutually exclusive;
-        // `partial` composes with any and, when present, must be first.
+        // `atomic` / `reserved` / `preferred` are mutually exclusive.
         let name_span = self.span();
         let name_byte = self.pos;
         let name = self.parse_ident()?;
         self.skip_ws();
-        let mut lenient_span: Option<Span> = None;
         let mut definition_atomic = false;
         let mut definition_percent = false;
         let mut definition_preferred = false;
@@ -406,21 +400,8 @@ impl<'a> Parser<'a> {
                 if !matches!(self.peek(), Some(c) if is_ident_start(c)) {
                     break;
                 }
-                let kw_span = self.span();
                 let kw = self.parse_ident()?;
                 match kw.as_str() {
-                    "partial" => {
-                        if lenient_span.is_some() {
-                            return Err(self.err("duplicate `partial` ascription".into()));
-                        }
-                        if definition_atomic || definition_percent {
-                            return Err(self.err(
-                                "`partial` must come before `atomic` / `reserved` / `preferred`"
-                                    .into(),
-                            ));
-                        }
-                        lenient_span = Some(kw_span);
-                    }
                     "atomic" | "reserved" | "preferred" => {
                         if definition_atomic || definition_percent {
                             return Err(self.err(
@@ -434,7 +415,7 @@ impl<'a> Parser<'a> {
                     }
                     other => {
                         return Err(self.err(format!(
-                            "unknown ascription `{other}`; expected `partial`, `atomic`, \
+                            "unknown ascription `{other}`; expected `atomic`, \
                              `reserved`, or `preferred`"
                         )));
                     }
@@ -443,25 +424,18 @@ impl<'a> Parser<'a> {
             }
             if count == 0 {
                 return Err(self.err(
-                    "`:` must be followed by at least one ascription (`partial`, \
-                     `atomic`, `reserved`, `preferred`)"
+                    "`:` must be followed by at least one ascription (`atomic`, \
+                     `reserved`, `preferred`)"
                         .into(),
                 ));
             }
         }
-        let definition_lenient = lenient_span.is_some();
         self.skip_ws();
         self.expect_str("=")?;
         self.skip_ws();
         let body_byte_start = self.pos;
-        let mut body = self.parse_choice()?;
+        let body = self.parse_choice()?;
         let body_byte_end = self.pos;
-        if let Some(span) = lenient_span {
-            body = Pattern::Lenient {
-                inner: Box::new(body),
-                span,
-            };
-        }
         // `reserved` and `preferred` are compiler-generated (see
         // `synthesize_reserved_preferred`); an author definition would be
         // silently overwritten, so reject it outright. Grammars may still
@@ -478,7 +452,7 @@ impl<'a> Parser<'a> {
         // compiler, so every ascription is meaningless on them and
         // rejected. Disabling whitespace auto-insertion is done by
         // omitting `ignore`, not by ascribing it.
-        if (definition_atomic || definition_percent || definition_preferred || definition_lenient)
+        if (definition_atomic || definition_percent || definition_preferred)
             && (name == IGNORE_RULE || name == BOUNDARY_RULE)
         {
             let disable_hint = if name == IGNORE_RULE {
@@ -488,7 +462,7 @@ impl<'a> Parser<'a> {
                 ""
             };
             return Err(self.err(format!(
-                "the `{name}` rule cannot carry an ascription (`partial`, `atomic`, \
+                "the `{name}` rule cannot carry an ascription (`atomic`, \
                  `reserved`, `preferred`){disable_hint}"
             )));
         }
@@ -543,10 +517,7 @@ impl<'a> Parser<'a> {
             atomic: definition_atomic,
             percent: definition_percent,
             preferred: definition_preferred,
-            has_ascription: definition_atomic
-                || definition_percent
-                || definition_preferred
-                || definition_lenient,
+            has_ascription: definition_atomic || definition_percent || definition_preferred,
             children,
         })
     }
@@ -720,7 +691,6 @@ impl<'a> Parser<'a> {
             | Pattern::NotPredicate { inner, .. }
             | Pattern::AndPredicate { inner, .. }
             | Pattern::Capture { inner, .. }
-            | Pattern::Lenient { inner, .. }
             | Pattern::InferBoundaryCatch { inner, .. } => Self::rewrite_refs(inner, stack),
             Pattern::Catch {
                 inner, recovery, ..

--- a/crates/compiler/src/pegc/parser.rs
+++ b/crates/compiler/src/pegc/parser.rs
@@ -783,6 +783,11 @@ impl<'a> Parser<'a> {
     ///   emits `Pattern::InferBoundaryCatch { inner, label }` and the
     ///   compile-time resolver synthesizes `B` from the call site's
     ///   FOLLOW set.
+    /// - `inner ^&label` — **anchor-only inferred boundary.** Like the
+    ///   bare `^^label` inferred form (boundary synthesized from FOLLOW),
+    ///   but lowers to `Seq([inner, &B])` with no recovery `Catch`. The
+    ///   anchor makes a prefix-only match fail and backtrack without the
+    ///   recovery-scan cost a `Catch` carries in speculative positions.
     ///
     /// The label identifier must touch the discriminator `^` (bare)
     /// or the second `^` of `^^` (anchored). `^_` / `^^_` are
@@ -832,6 +837,7 @@ impl<'a> Parser<'a> {
                     Pattern::InferBoundaryCatch {
                         inner: Box::new(lhs),
                         label,
+                        anchor_only: false,
                         span: catch_span,
                     }
                 };
@@ -841,6 +847,35 @@ impl<'a> Parser<'a> {
                 // returned when it hit the first `^`, so absorb the
                 // continuation here and rejoin under a Sequence.
                 let mut items = vec![catch_pat];
+                loop {
+                    self.skip_ws();
+                    if !self.at_prefix_start() {
+                        break;
+                    }
+                    items.push(self.parse_prefix()?);
+                }
+                lhs = Pattern::seq(items);
+            } else if self.peek() == Some(b'&') {
+                // `INNER ^&lbl` — anchor-only inferred boundary. Like the
+                // bare `^^lbl` inferred form, but lowers to `Seq([inner,
+                // &B])` with no recovery `Catch`: a prefix-only match
+                // fails the `&B` lookahead and backtracks (cheap), with
+                // none of the recovery-on-backtrack scan cost a `Catch`
+                // incurs. Used to discharge the leniency lint on
+                // speculative rules. The boundary `B` is always
+                // FOLLOW-inferred (no atom is parsed); the label is
+                // retained for diagnostic symmetry with `^^`.
+                self.pos += 1;
+                let label = self.parse_catch_label("^&")?;
+                let anchor = Pattern::InferBoundaryCatch {
+                    inner: Box::new(lhs),
+                    label,
+                    anchor_only: true,
+                    span: catch_span,
+                };
+                // Trailing sequence atoms after `^&lbl` belong to the
+                // enclosing sequence, mirroring the `^^lbl` path.
+                let mut items = vec![anchor];
                 loop {
                     self.skip_ws();
                     if !self.at_prefix_start() {

--- a/crates/compiler/src/pegc/parser.rs
+++ b/crates/compiler/src/pegc/parser.rs
@@ -212,7 +212,7 @@ impl Grammar {
     ///    boundary from FOLLOW.
     /// 2. Run [`lint_partial_match`]; any finding is a fatal
     ///    `CompileError::PartialMatchLeniency`. Resolve a flagged call by
-    ///    anchoring the rule to its FOLLOW (`^&lbl`, or `^^lbl B` / `^^lbl`
+    ///    anchoring the rule to its FOLLOW (`$`, or `^^lbl B` / `^^lbl`
     ///    when recovery is also wanted) or restructuring the rule.
     /// 3. Inject auto-ignore calls into every non-atomic rule's body
     ///    (no-op when the grammar has no `ignore` rule).
@@ -753,11 +753,13 @@ impl<'a> Parser<'a> {
     ///   emits `Pattern::InferBoundaryCatch { inner, label }` and the
     ///   compile-time resolver synthesizes `B` from the call site's
     ///   FOLLOW set.
-    /// - `inner ^&label` — **anchor-only inferred boundary.** Like the
-    ///   bare `^^label` inferred form (boundary synthesized from FOLLOW),
-    ///   but lowers to `Seq([inner, &B])` with no recovery `Catch`. The
-    ///   anchor makes a prefix-only match fail and backtrack without the
-    ///   recovery-scan cost a `Catch` carries in speculative positions.
+    /// - `inner $` — **anchor-only inferred boundary** (postfix, no
+    ///   label). Like the bare `^^label` inferred form (boundary
+    ///   synthesized from FOLLOW), but lowers to `Seq([inner, &B])` with
+    ///   no recovery `Catch`. The anchor makes a prefix-only match fail
+    ///   and backtrack without the recovery-scan cost a `Catch` carries in
+    ///   speculative positions. Parsed here, at the catch level, so it
+    ///   binds the whole preceding sequence rather than a single atom.
     ///
     /// The label identifier must touch the discriminator `^` (bare)
     /// or the second `^` of `^^` (anchored). `^_` / `^^_` are
@@ -772,6 +774,23 @@ impl<'a> Parser<'a> {
         let mut lhs = self.parse_sequence()?;
         loop {
             self.skip_ws();
+            // Postfix `$` — anchor-only inferred boundary. Binds the whole
+            // preceding sequence to its FOLLOW via `&B` (lowered to
+            // `Seq([inner, &B])` with no recovery `Catch`): a prefix-only
+            // match fails the `&B` lookahead and backtracks (cheap), with
+            // none of the recovery-on-backtrack scan cost a `Catch` incurs.
+            // The boundary is always FOLLOW-inferred; `$` takes no label.
+            if self.peek() == Some(b'$') {
+                let span = self.span();
+                self.pos += 1;
+                lhs = Pattern::InferBoundaryCatch {
+                    inner: Box::new(lhs),
+                    label: String::new(),
+                    anchor_only: true,
+                    span,
+                };
+                continue;
+            }
             if self.peek() != Some(b'^') {
                 break;
             }
@@ -817,35 +836,6 @@ impl<'a> Parser<'a> {
                 // returned when it hit the first `^`, so absorb the
                 // continuation here and rejoin under a Sequence.
                 let mut items = vec![catch_pat];
-                loop {
-                    self.skip_ws();
-                    if !self.at_prefix_start() {
-                        break;
-                    }
-                    items.push(self.parse_prefix()?);
-                }
-                lhs = Pattern::seq(items);
-            } else if self.peek() == Some(b'&') {
-                // `INNER ^&lbl` — anchor-only inferred boundary. Like the
-                // bare `^^lbl` inferred form, but lowers to `Seq([inner,
-                // &B])` with no recovery `Catch`: a prefix-only match
-                // fails the `&B` lookahead and backtracks (cheap), with
-                // none of the recovery-on-backtrack scan cost a `Catch`
-                // incurs. Used to discharge the leniency lint on
-                // speculative rules. The boundary `B` is always
-                // FOLLOW-inferred (no atom is parsed); the label is
-                // retained for diagnostic symmetry with `^^`.
-                self.pos += 1;
-                let label = self.parse_catch_label("^&")?;
-                let anchor = Pattern::InferBoundaryCatch {
-                    inner: Box::new(lhs),
-                    label,
-                    anchor_only: true,
-                    span: catch_span,
-                };
-                // Trailing sequence atoms after `^&lbl` belong to the
-                // enclosing sequence, mirroring the `^^lbl` path.
-                let mut items = vec![anchor];
                 loop {
                     self.skip_ws();
                     if !self.at_prefix_start() {

--- a/crates/compiler/src/pegc/pattern.rs
+++ b/crates/compiler/src/pegc/pattern.rs
@@ -174,13 +174,15 @@ pub enum Pattern {
     /// An `InferBoundaryCatch` should never reach the compiler or any
     /// downstream analysis — the resolver runs first and replaces it.
     ///
-    /// When `anchor_only` is set (surface `^&lbl`), the resolver lowers
-    /// it to a bare `Sequence([inner, AndPredicate(B)])` with **no**
-    /// recovery `Catch`: the rule is anchored to its FOLLOW boundary so
-    /// a prefix-only match fails and backtracks, but no skip-to-boundary
-    /// recovery scan is synthesized. This is the cheap, speculative-safe
-    /// anchor used to discharge the leniency lint without the
-    /// recovery-on-backtrack cost a `Catch` incurs.
+    /// When `anchor_only` is set (surface postfix `$`), the resolver
+    /// lowers it to a bare `Sequence([inner, AndPredicate(B)])` with
+    /// **no** recovery `Catch`: the rule is anchored to its FOLLOW
+    /// boundary so a prefix-only match fails and backtracks, but no
+    /// skip-to-boundary recovery scan is synthesized. This is the cheap,
+    /// speculative-safe anchor used to discharge the leniency lint without
+    /// the recovery-on-backtrack cost a `Catch` incurs. The `$` form
+    /// carries no label (the field is empty); only the recovery-bearing
+    /// `^^lbl` inferred form uses it.
     InferBoundaryCatch {
         inner: Box<Pattern>,
         label: String,

--- a/crates/compiler/src/pegc/pattern.rs
+++ b/crates/compiler/src/pegc/pattern.rs
@@ -182,9 +182,18 @@ pub enum Pattern {
     ///
     /// An `InferBoundaryCatch` should never reach the compiler or any
     /// downstream analysis — the resolver runs first and replaces it.
+    ///
+    /// When `anchor_only` is set (surface `^&lbl`), the resolver lowers
+    /// it to a bare `Sequence([inner, AndPredicate(B)])` with **no**
+    /// recovery `Catch`: the rule is anchored to its FOLLOW boundary so
+    /// a prefix-only match fails and backtracks, but no skip-to-boundary
+    /// recovery scan is synthesized. This is the cheap, speculative-safe
+    /// anchor used to discharge the leniency lint without the
+    /// recovery-on-backtrack cost a `Catch` incurs.
     InferBoundaryCatch {
         inner: Box<Pattern>,
         label: String,
+        anchor_only: bool,
         span: Span,
     },
     /// A declarative indentation combinator — `deeper(outer) as i`,
@@ -442,9 +451,15 @@ impl Pattern {
                 inner: Box::new(inner.strip_spans()),
                 span: Span::SYNTHETIC,
             },
-            Pattern::InferBoundaryCatch { inner, label, .. } => Pattern::InferBoundaryCatch {
+            Pattern::InferBoundaryCatch {
+                inner,
+                label,
+                anchor_only,
+                ..
+            } => Pattern::InferBoundaryCatch {
                 inner: Box::new(inner.strip_spans()),
                 label: label.clone(),
+                anchor_only: *anchor_only,
                 span: Span::SYNTHETIC,
             },
             Pattern::IndentCombinator { op, arg, bind, .. } => Pattern::IndentCombinator {

--- a/crates/compiler/src/pegc/pattern.rs
+++ b/crates/compiler/src/pegc/pattern.rs
@@ -163,15 +163,6 @@ pub enum Pattern {
         recovery: Box<Pattern>,
         span: Span,
     },
-    /// Author-local marker that a pattern is intentionally lenient — the
-    /// `lint_partial_match` walker treats this as an opaque barrier and
-    /// does not descend into it for call-site detection. At runtime the
-    /// wrapper is transparent: the compiler emits exactly the inner
-    /// pattern's bytecode. Surface syntax: the `name: partial` ascription.
-    Lenient {
-        inner: Box<Pattern>,
-        span: Span,
-    },
     /// Boundary-anchored catch with the boundary inferred from the
     /// call site's FOLLOW set. Placeholder produced at parse time by
     /// the `^^lbl` surface form; resolved before bytecode emission by
@@ -247,7 +238,6 @@ impl Pattern {
             | Pattern::NonTerminal { span, .. }
             | Pattern::Capture { span, .. }
             | Pattern::Catch { span, .. }
-            | Pattern::Lenient { span, .. }
             | Pattern::InferBoundaryCatch { span, .. }
             | Pattern::IndentCombinator { span, .. }
             | Pattern::IndentOp { span, .. } => *span,
@@ -361,13 +351,6 @@ impl Pattern {
         }
     }
 
-    pub fn lenient(inner: Pattern) -> Pattern {
-        Pattern::Lenient {
-            inner: Box::new(inner),
-            span: Span::SYNTHETIC,
-        }
-    }
-
     /// Labeled catch — equivalent to `inner ^label recovery` in source.
     /// The label is a diagnostic tag flowed into `RecoveryDiagnostic` so
     /// `pegdb recoveries explain` can cluster firings by it.
@@ -445,10 +428,6 @@ impl Pattern {
                 inner: Box::new(inner.strip_spans()),
                 label: label.clone(),
                 recovery: Box::new(recovery.strip_spans()),
-                span: Span::SYNTHETIC,
-            },
-            Pattern::Lenient { inner, .. } => Pattern::Lenient {
-                inner: Box::new(inner.strip_spans()),
                 span: Span::SYNTHETIC,
             },
             Pattern::InferBoundaryCatch {

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -1772,6 +1772,66 @@ fn lint_partial_match_clean_resync_nested_constituent_flagged() {
 }
 
 #[test]
+fn anchor_only_inferred_lowers_to_bare_and_predicate_not_catch() {
+    // `^&lbl` lowers to `Seq([inner, &B])` — a bare FOLLOW anchor with no
+    // recovery catch — distinct from `^^lbl`, which wraps the body in a
+    // `Catch`. The cheap backtrack-on-failure of the bare `&B` is what
+    // makes the anchor safe in speculative positions a recovery scan would
+    // blow up.
+    let mut g = parse("root = 'a' ('b')? ^&tail\n").expect("anchored parses");
+    resolve_inferred_boundaries(&mut g).expect("boundaries resolve");
+    match &g.rules["root"] {
+        Pattern::Sequence { items, .. } => {
+            assert!(
+                matches!(items.last(), Some(Pattern::AndPredicate { .. })),
+                "anchored body ends in `&B`: {:?}",
+                g.rules["root"]
+            );
+            assert!(
+                !matches!(items.first(), Some(Pattern::Catch { .. })),
+                "anchor-only must not synthesize a Catch: {:?}",
+                g.rules["root"]
+            );
+        }
+        other => panic!("expected `Seq([inner, &B])`, got {other:?}"),
+    }
+}
+
+#[test]
+fn lint_partial_match_real_sqlite_grammar_function_call_anchored() {
+    // The shipped grammar anchors `function_call` with `^&fn_tail`: its
+    // trailing `(filter_clause)? (kw_over window_ref)?` optionals are
+    // pinned to the expression FOLLOW, so the speculative call from
+    // `primary` is discharged. Stripping the anchor re-exposes the
+    // prefix-leniency footgun, so the lint must flag it.
+    let source = std::fs::read_to_string(workspace_root().join("grammars/sqlite.peg"))
+        .expect("sqlite.peg fixture present");
+
+    let mut anchored = parse(&source).expect("sqlite.peg parses");
+    resolve_inferred_boundaries(&mut anchored).expect("boundaries resolve");
+    assert!(
+        !lint_partial_match(&anchored)
+            .iter()
+            .any(|f| f.rule == "function_call"),
+        "function_call is anchored; should not be flagged"
+    );
+
+    let stripped_src = source.replace(" ^&fn_tail", "");
+    assert!(
+        stripped_src != source,
+        "expected to strip the `^&fn_tail` anchor from the fixture"
+    );
+    let mut stripped = parse(&stripped_src).expect("stripped grammar parses");
+    resolve_inferred_boundaries(&mut stripped).expect("boundaries resolve");
+    assert!(
+        lint_partial_match(&stripped)
+            .iter()
+            .any(|f| f.rule == "function_call"),
+        "function_call must flag once the anchor is stripped"
+    );
+}
+
+#[test]
 fn lint_partial_match_real_sqlite_grammar_aliased_expr_anchored() {
     // The shipped grammar has the PR #101 fix: aliased_expr is anchored
     // via `&(ws result_column_boundary)` inside result_column. The lint

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -5,7 +5,8 @@ use syntax_highlighter::pegvm::{
     Capture, CaptureKind, CharSet, Instruction, Label, LabelId, MatchResult, MemoId, RuleKind, VM,
 };
 use syntax_highlighter_compiler::pegc::analysis::{
-    compute_follow, lint_partial_match, FollowElement, LintFinding, LintKind,
+    compute_follow, lint_partial_match, resolve_inferred_boundaries, FollowElement, LintFinding,
+    LintKind,
 };
 use syntax_highlighter_compiler::pegc::{compile_pattern, parse, Grammar, Pattern, Span};
 
@@ -1777,7 +1778,10 @@ fn lint_partial_match_real_sqlite_grammar_aliased_expr_anchored() {
     // must not flag aliased_expr → result_column.
     let source = std::fs::read_to_string(workspace_root().join("grammars/sqlite.peg"))
         .expect("sqlite.peg fixture present");
-    let g = parse(&source).expect("sqlite.peg parses");
+    let mut g = parse(&source).expect("sqlite.peg parses");
+    // The lint runs after boundary resolution (the `^^lbl` catches the
+    // grammar now carries must be lowered first).
+    resolve_inferred_boundaries(&mut g).expect("boundaries resolve");
     let findings = lint_partial_match(&g);
     let bad = findings
         .iter()
@@ -1796,10 +1800,12 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
     let source = std::fs::read_to_string(workspace_root().join("grammars/sqlite.peg"))
         .expect("sqlite.peg fixture present");
     let mut g = parse(&source).expect("sqlite.peg parses");
-    // Replace result_column's body with an unanchored version. Under
-    // lexical scoping `table_star` / `aliased_expr` nest inside
-    // `result_column`, so their flat keys are the mangled
+    // Resolve the grammar's `^^lbl` catches first (the lint's
+    // precondition), then replace result_column's body with an unanchored
+    // version. Under lexical scoping `table_star` / `aliased_expr` nest
+    // inside `result_column`, so their flat keys are the mangled
     // `result_column::…` names — reference those so the choice resolves.
+    resolve_inferred_boundaries(&mut g).expect("boundaries resolve");
     g.rules.insert(
         "result_column".into(),
         Pattern::choice(vec![

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -1773,12 +1773,12 @@ fn lint_partial_match_clean_resync_nested_constituent_flagged() {
 
 #[test]
 fn anchor_only_inferred_lowers_to_bare_and_predicate_not_catch() {
-    // `^&lbl` lowers to `Seq([inner, &B])` — a bare FOLLOW anchor with no
-    // recovery catch — distinct from `^^lbl`, which wraps the body in a
+    // Postfix `$` lowers to `Seq([inner, &B])` — a bare FOLLOW anchor with
+    // no recovery catch — distinct from `^^lbl`, which wraps the body in a
     // `Catch`. The cheap backtrack-on-failure of the bare `&B` is what
     // makes the anchor safe in speculative positions a recovery scan would
     // blow up.
-    let mut g = parse("root = 'a' ('b')? ^&tail\n").expect("anchored parses");
+    let mut g = parse("root = 'a' ('b')? $\n").expect("anchored parses");
     resolve_inferred_boundaries(&mut g).expect("boundaries resolve");
     match &g.rules["root"] {
         Pattern::Sequence { items, .. } => {
@@ -1799,7 +1799,7 @@ fn anchor_only_inferred_lowers_to_bare_and_predicate_not_catch() {
 
 #[test]
 fn lint_partial_match_real_sqlite_grammar_function_call_anchored() {
-    // The shipped grammar anchors `function_call` with `^&fn_tail`: its
+    // The shipped grammar anchors `function_call` with a postfix `$`: its
     // trailing `(filter_clause)? (kw_over window_ref)?` optionals are
     // pinned to the expression FOLLOW, so the speculative call from
     // `primary` is discharged. Stripping the anchor re-exposes the
@@ -1816,10 +1816,12 @@ fn lint_partial_match_real_sqlite_grammar_function_call_anchored() {
         "function_call is anchored; should not be flagged"
     );
 
-    let stripped_src = source.replace(" ^&fn_tail", "");
+    // `(kw_over window_ref)? $` is unique to function_call — strip just
+    // that anchor, leaving the other rules' `$` in place.
+    let stripped_src = source.replace("(kw_over window_ref)? $", "(kw_over window_ref)?");
     assert!(
         stripped_src != source,
-        "expected to strip the `^&fn_tail` anchor from the fixture"
+        "expected to strip function_call's `$` anchor from the fixture"
     );
     let mut stripped = parse(&stripped_src).expect("stripped grammar parses");
     resolve_inferred_boundaries(&mut stripped).expect("boundaries resolve");
@@ -1833,11 +1835,11 @@ fn lint_partial_match_real_sqlite_grammar_function_call_anchored() {
 
 #[test]
 fn lint_partial_match_real_go_grammar_opt_semi_anchored() {
-    // `opt_semi = ';'? ^&semi_tail` is a *nullable* body: without the
-    // trailing-`&B` precision in `trailing_first`, the reverse tail-walk
-    // would still see the `';'?` and flag it. The anchor pins it to the
-    // statement-follower FOLLOW (the ASI boundary), discharging it; strip
-    // the anchor and the leniency lint flags it again.
+    // `opt_semi = ';'? $` is a *nullable* body: without the trailing-`&B`
+    // precision in `trailing_first`, the reverse tail-walk would still see
+    // the `';'?` and flag it. The anchor pins it to the statement-follower
+    // FOLLOW (the ASI boundary), discharging it; strip the anchor and the
+    // leniency lint flags it again.
     let source = std::fs::read_to_string(workspace_root().join("grammars/go.peg"))
         .expect("go.peg fixture present");
 
@@ -1850,10 +1852,13 @@ fn lint_partial_match_real_go_grammar_opt_semi_anchored() {
         "opt_semi is anchored; should not be flagged"
     );
 
-    let stripped_src = source.replace(" ^&semi_tail", "");
+    let stripped_src = source.replace(
+        "opt_semi = @punctuation ';'? $",
+        "opt_semi = @punctuation ';'?",
+    );
     assert!(
         stripped_src != source,
-        "expected to strip the `^&semi_tail` anchor from the fixture"
+        "expected to strip opt_semi's `$` anchor from the fixture"
     );
     let mut stripped = parse(&stripped_src).expect("stripped grammar parses");
     resolve_inferred_boundaries(&mut stripped).expect("boundaries resolve");

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -1661,11 +1661,14 @@ fn lint_partial_match_validated_by_disjoint_consumer() {
 }
 
 #[test]
-fn lint_partial_match_absorbed_by_outer_catch_flagged() {
+fn lint_partial_match_clean_resync_catch_discharged() {
     // root = (a)*^[;]
     // a = 'x' 'y'?
-    // a's leniency at the call site is absorbed by the *^ recovery
-    // wrapper — exactly the PR #101 shape.
+    // a's leniency is absorbed by a *clean-resync* catch: the recovery
+    // skips to the `;` sync token, so a leak surfaces as a visible
+    // recovery span at the statement boundary rather than silent loss.
+    // Leg 2 (clean-resync dominator) discharges it — `a` is the whole
+    // iteration body, nothing meaningful sits between it and `;`.
     let mut rules = HashMap::new();
     let recovery_body = Pattern::repeat(Pattern::seq(vec![
         Pattern::not_predicate(Pattern::literal(";")),
@@ -1686,8 +1689,85 @@ fn lint_partial_match_absorbed_by_outer_catch_flagged() {
         ]),
     );
     let g = Grammar::new(rules);
+    assert!(
+        lint_partial_match(&g).is_empty(),
+        "clean-resync sync-set catch should discharge the leniency"
+    );
+}
+
+#[test]
+fn lint_partial_match_bare_skip_catch_flagged() {
+    // root = (a)*^
+    // a = 'x' 'y'?
+    // Same shape but the recovery is the bare byte-by-byte skip (`.`) of a
+    // plain `*^`: a leak is absorbed one byte at a time — exactly the PR
+    // #101 footgun (the partial match silently "succeeds"). Not a clean
+    // resync, so the call still flags.
+    let mut rules = HashMap::new();
+    let call_inside_catch = Pattern::repeat(Pattern::Catch {
+        inner: Box::new(Pattern::nt("a")),
+        label: "recovery".into(),
+        recovery: Box::new(Pattern::capture("recovery", Pattern::any_char())),
+        span: Span::SYNTHETIC,
+    });
+    rules.insert("root".into(), call_inside_catch);
+    rules.insert(
+        "a".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::optional(Pattern::literal("y")),
+        ]),
+    );
+    let g = Grammar::new(rules);
     let findings = lint_partial_match(&g);
     assert_eq!(findings, vec![finding("a", "root")]);
+}
+
+#[test]
+fn lint_partial_match_clean_resync_nested_constituent_flagged() {
+    // root = (item)*^[;]
+    // item = c (',' c)*
+    // c    = 'x' 'y'?
+    // `c` sits *inside* `item`, with a meaningful `(',' c)*` tail before
+    // the `;` boundary — the minimized `aliased_expr` shape. A leak in `c`
+    // would let the sync-set swallow the remaining `, c` constituents, so
+    // the clean catch is too coarse here: leg 2 must keep `c` flagged
+    // (the fix is a constituent-level boundary, like sqlite's
+    // `^^bad_column`), even though the statement-level `item` discharges.
+    let mut rules = HashMap::new();
+    let catch = Pattern::repeat(Pattern::Catch {
+        inner: Box::new(Pattern::nt("item")),
+        label: "recovery".into(),
+        recovery: Box::new(Pattern::seq(vec![
+            Pattern::repeat(Pattern::seq(vec![
+                Pattern::not_predicate(Pattern::literal(";")),
+                Pattern::any_char(),
+            ])),
+            Pattern::literal(";"),
+        ])),
+        span: Span::SYNTHETIC,
+    });
+    rules.insert("root".into(), catch);
+    rules.insert(
+        "item".into(),
+        Pattern::seq(vec![
+            Pattern::nt("c"),
+            Pattern::repeat(Pattern::seq(vec![Pattern::literal(","), Pattern::nt("c")])),
+        ]),
+    );
+    rules.insert(
+        "c".into(),
+        Pattern::seq(vec![
+            Pattern::literal("x"),
+            Pattern::optional(Pattern::literal("y")),
+        ]),
+    );
+    let g = Grammar::new(rules);
+    let findings = lint_partial_match(&g);
+    assert!(
+        findings.iter().any(|f| f.rule == "c" && f.caller == "item"),
+        "nested constituent with a meaningful tail must stay flagged: {findings:?}"
+    );
 }
 
 #[test]
@@ -1771,9 +1851,10 @@ fn partial_must_precede_main_ascription() {
 
 #[test]
 fn definition_lenient_suppresses_lint_at_every_call_site() {
-    // Use the Catch-absorbed shape the lint reliably flags: a
-    // top-level `*^[;]` recovery loop calling a trailing-Optional rule.
-    let unmarked = parse("root = (r)*^[;] {\nr = 'x' 'y'?\n}").expect("parse unmarked");
+    // Use the shape the lint reliably flags: a top-level bare `*^`
+    // (byte-by-byte recovery) loop calling a trailing-Optional rule. The
+    // bare skip is not a clean resync, so leg 2 leaves it flagged.
+    let unmarked = parse("root = (r)*^ {\nr = 'x' 'y'?\n}").expect("parse unmarked");
     assert!(
         lint_partial_match(&unmarked)
             .iter()
@@ -1781,7 +1862,7 @@ fn definition_lenient_suppresses_lint_at_every_call_site() {
         "baseline: unmarked grammar should flag r"
     );
 
-    let marked = parse("root = (r)*^[;] {\nr: partial = 'x' 'y'?\n}").expect("parse marked");
+    let marked = parse("root = (r)*^ {\nr: partial = 'x' 'y'?\n}").expect("parse marked");
     let findings = lint_partial_match(&marked);
     assert!(
         !findings.iter().any(|f| f.rule == "r"),
@@ -1809,8 +1890,9 @@ fn definition_lenient_marker_is_runtime_transparent() {
 
 #[test]
 fn compile_errors_on_partial_match_leniency() {
-    // `*^[;]` Catch-absorbed shape — the lint reliably flags this.
-    let g = parse("root = (r)*^[;] {\nr = 'x' 'y'?\n}").expect("parse");
+    // Bare `*^` byte-by-byte recovery shape — the lint reliably flags
+    // this (no clean resync, so leg 2 does not discharge it).
+    let g = parse("root = (r)*^ {\nr = 'x' 'y'?\n}").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     match err {
         syntax_highlighter_compiler::pegc::CompileError::PartialMatchLeniency(findings) => {
@@ -1825,7 +1907,7 @@ fn compile_errors_on_partial_match_leniency() {
 
 #[test]
 fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
-    let g = parse("root = (r)*^[;] {\nr: partial = 'x' 'y'?\n}").expect("parse");
+    let g = parse("root = (r)*^ {\nr: partial = 'x' 'y'?\n}").expect("parse");
     g.compile()
         .expect("compile should succeed with definition-level `r: partial`");
 }
@@ -1880,7 +1962,7 @@ fn bracketed_close_catch_runs_recovery_path() {
 
 #[test]
 fn compile_error_display_lists_findings() {
-    let g = parse("root = (r)*^[;] {\nr = 'x' 'y'?\n}").expect("parse");
+    let g = parse("root = (r)*^ {\nr = 'x' 'y'?\n}").expect("parse");
     let err = g.compile().expect_err("compile should fail");
     let msg = format!("{err}");
     assert!(msg.contains("partial-match leniency"));
@@ -2008,11 +2090,11 @@ fn all_shipped_grammars_compile_clean() {
 
 #[test]
 fn partial_match_leniency_carries_call_site_span_in_display() {
-    // `(r)*^[;]` is the catch-absorbed shape that reliably flags — the
-    // `r` reference at line 1, col 9 is the call site the lint
-    // surfaces. The rendered Display must include `{line}:{col}` so
+    // Bare `(r)*^` is the byte-by-byte recovery shape that reliably
+    // flags — the `r` reference at line 1, col 9 is the call site the
+    // lint surfaces. The rendered Display must include `{line}:{col}` so
     // grammar authors can jump to the unanchored call directly.
-    let src = "root = (r)*^[;] {\nr = 'x' 'y'?\n}";
+    let src = "root = (r)*^ {\nr = 'x' 'y'?\n}";
     let g = parse(src).expect("parses");
     let err = g.compile().expect_err("partial-match leniency expected");
     let rendered = format!("{err}");
@@ -2028,7 +2110,7 @@ fn partial_match_leniency_finding_carries_call_site_span() {
     // the Display impl is a thin formatting layer over it. Pin the
     // structured field directly so callers (e.g. editor diagnostics)
     // get the same position the rendered text reports.
-    let src = "root = (r)*^[;] {\nr = 'x' 'y'?\n}";
+    let src = "root = (r)*^ {\nr = 'x' 'y'?\n}";
     let g = parse(src).expect("parses");
     let findings = lint_partial_match(&g);
     let f = findings

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -1918,74 +1918,6 @@ fn lint_partial_match_real_sqlite_grammar_unanchored_aliased_expr_flagged() {
     );
 }
 
-// ---- Partial ascription (name: partial = body) ---------------
-
-#[test]
-fn partial_ascription_wraps_rule_body() {
-    // `name: partial = body` parses the body with a top-level
-    // `Pattern::Lenient` wrap, exposing the intent to the lint. The
-    // ascription rides a non-root child (the top-level root rejects
-    // every ascription), so `r` nests under `root`.
-    let g = parse("root = r {\nr: partial = 'a'?\n}").expect("parse");
-    assert_eq!(
-        g.rules["r"].strip_spans(),
-        Pattern::lenient(Pattern::optional(Pattern::literal("a"))),
-    );
-}
-
-#[test]
-fn partial_must_precede_main_ascription() {
-    // `partial` composes with `atomic` / `reserved` / `preferred` but
-    // must be written first; the reversed order is a parse error. The
-    // ascription rides a non-root child (the top-level root rejects
-    // every ascription).
-    parse("root = r {\nr: partial atomic = 'a'\n}").expect("partial-first order parses");
-    let err =
-        parse("root = r {\nr: atomic partial = 'a'\n}").expect_err("partial after main must error");
-    assert!(
-        err.message.contains("`partial` must come before"),
-        "unexpected error: {}",
-        err.message
-    );
-}
-
-#[test]
-fn definition_lenient_suppresses_lint_at_every_call_site() {
-    // Use the shape the lint reliably flags: a top-level bare `*^`
-    // (byte-by-byte recovery) loop calling a trailing-Optional rule. The
-    // bare skip is not a clean resync, so leg 2 leaves it flagged.
-    let unmarked = parse("root = (r)*^ {\nr = 'x' 'y'?\n}").expect("parse unmarked");
-    assert!(
-        lint_partial_match(&unmarked)
-            .iter()
-            .any(|f| f.rule == "r" && f.caller == "root"),
-        "baseline: unmarked grammar should flag r"
-    );
-
-    let marked = parse("root = (r)*^ {\nr: partial = 'x' 'y'?\n}").expect("parse marked");
-    let findings = lint_partial_match(&marked);
-    assert!(
-        !findings.iter().any(|f| f.rule == "r"),
-        "definition-level `r: partial` should suppress all r-related findings, got: {findings:?}"
-    );
-}
-
-#[test]
-fn definition_lenient_marker_is_runtime_transparent() {
-    // The `name: partial =` wrap compiles to the same bytecode as the
-    // bare form. The marker rides a non-special helper rule — `root`
-    // (like `ignore` / `boundary`) rejects every ascription.
-    let plain = parse("root = r {\nr = 'x'+\n}")
-        .expect("parse plain")
-        .compile()
-        .expect("compile plain");
-    let marked = parse("root = r {\nr: partial = 'x'+\n}")
-        .expect("parse marked")
-        .compile()
-        .expect("compile marked");
-    assert_eq!(plain.code, marked.code);
-}
-
 // ---- Compile-fatal lint integration ---------------------------
 
 #[test]
@@ -2003,13 +1935,6 @@ fn compile_errors_on_partial_match_leniency() {
         }
         other => panic!("expected PartialMatchLeniency, got: {other:?}"),
     }
-}
-
-#[test]
-fn compile_succeeds_with_definition_lenient_on_flagged_rule() {
-    let g = parse("root = (r)*^ {\nr: partial = 'x' 'y'?\n}").expect("parse");
-    g.compile()
-        .expect("compile should succeed with definition-level `r: partial`");
 }
 
 #[test]
@@ -2341,11 +2266,11 @@ fn ascription_on_special_rule_is_rejected() {
     // The three special rules — the start rule `root` and the two
     // auto-insertion targets `ignore` (whitespace) and `boundary` (word
     // boundary) — are structural slots, not lexable tokens: every
-    // ascription (`partial`, `atomic`, `reserved`, `preferred`) is
-    // rejected on all of them. Disabling whitespace auto-insertion is
-    // done by omitting `ignore`, not by ascribing it.
+    // ascription (`atomic`, `reserved`, `preferred`) is rejected on all
+    // of them. Disabling whitespace auto-insertion is done by omitting
+    // `ignore`, not by ascribing it.
     for name in ["root", "ignore", "boundary"] {
-        for asc in ["partial", "atomic", "reserved", "preferred"] {
+        for asc in ["atomic", "reserved", "preferred"] {
             let src = format!("{name}: {asc} = 'a'");
             let err = parse(&src).expect_err("an ascription on a special rule must error");
             assert!(
@@ -2361,23 +2286,6 @@ fn ascription_on_special_rule_is_rejected() {
             );
         }
     }
-}
-
-#[test]
-fn partial_composes_with_reserved() {
-    // `partial reserved` combines the leniency marker with the
-    // reserved-word ascription (partial written first).
-    let src =
-        "root = r {\nignore = (\\s)*\nboundary = !'x'\nr: partial reserved = @keyword 'if'\n}";
-    let g = parse(src).unwrap_or_else(|e| panic!("parse {src:?}: {}", e.message));
-    assert!(
-        g.percent_rules.contains("r"),
-        "{src:?} should mark r percent"
-    );
-    assert!(
-        matches!(g.rules["r"], Pattern::Lenient { .. }),
-        "{src:?} should wrap r in Lenient"
-    );
 }
 
 #[test]

--- a/crates/compiler/tests/compiler_tests.rs
+++ b/crates/compiler/tests/compiler_tests.rs
@@ -1832,6 +1832,40 @@ fn lint_partial_match_real_sqlite_grammar_function_call_anchored() {
 }
 
 #[test]
+fn lint_partial_match_real_go_grammar_opt_semi_anchored() {
+    // `opt_semi = ';'? ^&semi_tail` is a *nullable* body: without the
+    // trailing-`&B` precision in `trailing_first`, the reverse tail-walk
+    // would still see the `';'?` and flag it. The anchor pins it to the
+    // statement-follower FOLLOW (the ASI boundary), discharging it; strip
+    // the anchor and the leniency lint flags it again.
+    let source = std::fs::read_to_string(workspace_root().join("grammars/go.peg"))
+        .expect("go.peg fixture present");
+
+    let mut anchored = parse(&source).expect("go.peg parses");
+    resolve_inferred_boundaries(&mut anchored).expect("boundaries resolve");
+    assert!(
+        !lint_partial_match(&anchored)
+            .iter()
+            .any(|f| f.rule == "opt_semi"),
+        "opt_semi is anchored; should not be flagged"
+    );
+
+    let stripped_src = source.replace(" ^&semi_tail", "");
+    assert!(
+        stripped_src != source,
+        "expected to strip the `^&semi_tail` anchor from the fixture"
+    );
+    let mut stripped = parse(&stripped_src).expect("stripped grammar parses");
+    resolve_inferred_boundaries(&mut stripped).expect("boundaries resolve");
+    assert!(
+        lint_partial_match(&stripped)
+            .iter()
+            .any(|f| f.rule == "opt_semi"),
+        "nullable opt_semi must flag once the anchor is stripped"
+    );
+}
+
+#[test]
 fn lint_partial_match_real_sqlite_grammar_aliased_expr_anchored() {
     // The shipped grammar has the PR #101 fix: aliased_expr is anchored
     // via `&(ws result_column_boundary)` inside result_column. The lint

--- a/crates/compiler/tests/grammar_go_tests.rs
+++ b/crates/compiler/tests/grammar_go_tests.rs
@@ -431,6 +431,26 @@ fn non_ascii_identifier_in_short_var_decl() {
 }
 
 #[test]
+fn non_ascii_identifier_in_expression_position() {
+    // A non-ASCII identifier used as a bare operand (not just a binding
+    // LHS) must parse to completion and colour as a variable. The ASCII
+    // operand path uses `[a-z_]` / `[A-Z]`, so this exercises the general
+    // `@variable ident` fallback in `expr_primary`; without it the operand
+    // falls through to the `@type` path and only "completes" via recovery.
+    let input = "package main\n\nfunc f() { g(世界); _ = 値 + 1 }\n";
+    let (caps, kinds) = assert_complete_full(input);
+    let var_spans: Vec<&str> = caps
+        .iter()
+        .filter(|c| kinds[c.kind.0 as usize] == "variable")
+        .map(|c| &input[c.start..c.end])
+        .collect();
+    assert!(
+        var_spans.contains(&"世界") && var_spans.contains(&"値"),
+        "expected non-ASCII operands `世界` and `値` as variables; got {var_spans:?}"
+    );
+}
+
+#[test]
 fn bound_predeclared_name_is_always_a_variable() {
     // Predeclared names are `%?` (preferred), not reserved, so `int`
     // shadows as an identifier wherever a binding identifier is expected

--- a/crates/compiler/tests/grammar_javascript_tests.rs
+++ b/crates/compiler/tests/grammar_javascript_tests.rs
@@ -291,6 +291,17 @@ fn try_catch_finally_parses() {
 }
 
 #[test]
+fn try_requires_catch_or_finally() {
+    // A `try` block alone is a syntax error in JS — `try_stmt` requires at
+    // least a catch or a finally. Both single-clause forms parse; the bare
+    // form does not complete.
+    assert_complete_full("try { f(); } catch (e) { log(e); }\n");
+    assert_complete_full("try { f(); } finally { cleanup(); }\n");
+    let (_, _, _, complete) = run("try { f(); }\n");
+    assert!(!complete, "bare `try {{}}` must not be a complete parse");
+}
+
+#[test]
 fn switch_case_parses() {
     let input = "switch (x) { case 1: a(); break; case 2: b(); break; default: c(); }\n";
     let (_, _) = assert_complete_full(input);

--- a/crates/compiler/tests/grammar_tests.rs
+++ b/crates/compiler/tests/grammar_tests.rs
@@ -820,14 +820,6 @@ fn inferred_vs_explicit_no_ambiguity() {
     );
 }
 
-// ---- Partial ascription (definition-level only) ---------------
-//
-// Definition-level `name: partial = body` parsing is verified
-// end-to-end by the `partial_ascription_*` tests in
-// `tests/compiler_tests.rs`. A call-site leniency form was considered
-// during design and dropped before landing: empirically zero shipped
-// grammars used it after the pivot to definition-level marking.
-
 #[test]
 fn catch_accepts_underscore_prefixed_labels() {
     // `_foo` (underscore prefix, not bare `_`) stays a valid label.
@@ -1179,19 +1171,6 @@ fn end_to_end_inferred_catch_clean_input_no_recovery() {
         .filter(|c| prog.capture_kinds[c.kind.0 as usize] == "recovery")
         .count();
     assert_eq!(recovery_captures, 0, "clean input should emit no recovery");
-}
-
-#[test]
-fn end_to_end_lenient_marker_is_runtime_transparent() {
-    use syntax_highlighter::pegvm::VM;
-    // The marker rides a non-special helper rule — `root` (like
-    // `ignore` / `boundary`) rejects every ascription.
-    let plain = parse("root = r {\nr = 'x'+\n}").compile().unwrap();
-    let lenient = parse("root = r {\nr: partial = 'x'+\n}").compile().unwrap();
-    assert_eq!(plain.code, lenient.code, "`partial` is runtime-transparent");
-    let r = VM::new(&lenient.code, b"xxx").run();
-    assert!(r.complete);
-    assert_eq!(r.matched, 3);
 }
 
 #[test]

--- a/crates/compiler/tests/grammar_tests.rs
+++ b/crates/compiler/tests/grammar_tests.rs
@@ -759,6 +759,26 @@ fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
 }
 
 #[test]
+fn postfix_dollar_parses_to_anchor_only_placeholder() {
+    // `$` is the anchor-only inferred boundary: an `InferBoundaryCatch`
+    // with `anchor_only: true` and no label, binding the whole preceding
+    // sequence. The resolver lowers it to `Seq([inner, &B])`.
+    let g = parse("r = 'a' 'b'? $");
+    assert_eq!(
+        g.rules["r"],
+        Pattern::InferBoundaryCatch {
+            inner: Box::new(Pattern::seq(vec![
+                Pattern::literal("a"),
+                Pattern::optional(Pattern::literal("b")),
+            ])),
+            label: String::new(),
+            anchor_only: true,
+            span: Span::SYNTHETIC,
+        },
+    );
+}
+
+#[test]
 fn inferred_catch_before_choice_separator() {
     let g = parse("r = 'a' ^^lbl / 'b'");
     assert_eq!(

--- a/crates/compiler/tests/grammar_tests.rs
+++ b/crates/compiler/tests/grammar_tests.rs
@@ -752,6 +752,7 @@ fn inferred_catch_at_end_of_rule_parses_to_placeholder() {
         Pattern::InferBoundaryCatch {
             inner: Box::new(Pattern::literal("a")),
             label: "lbl".into(),
+            anchor_only: false,
             span: Span::SYNTHETIC,
         },
     );
@@ -766,6 +767,7 @@ fn inferred_catch_before_choice_separator() {
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                anchor_only: false,
                 span: Span::SYNTHETIC,
             },
             Pattern::literal("b"),
@@ -782,6 +784,7 @@ fn inferred_catch_before_paren_close() {
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                anchor_only: false,
                 span: Span::SYNTHETIC,
             },
             Pattern::literal("c"),
@@ -809,6 +812,7 @@ fn inferred_vs_explicit_no_ambiguity() {
             Pattern::InferBoundaryCatch {
                 inner: Box::new(Pattern::literal("a")),
                 label: "lbl".into(),
+                anchor_only: false,
                 span: Span::SYNTHETIC,
             },
             Pattern::literal("b"),

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -174,7 +174,7 @@ c = (external_decl)*^ {
                   / @operator '=' !'='
     }
 
-    expr_cond: partial = expr_lor (@operator '?' expr @punctuation ':' expr_assign)?
+    expr_cond = expr_lor (@operator '?' expr @punctuation ':' expr_assign)?
 
     expr_lor = expr_lor @operator '||' expr_land / expr_land
     expr_land = expr_land @operator '&&' expr_bor / expr_bor

--- a/grammars/c.peg
+++ b/grammars/c.peg
@@ -149,8 +149,8 @@ c = (external_decl)*^ {
     labeled_stmt = @variable ident @punctuation ':' stmt
                  / kw_case expr_cond @punctuation ':' stmt
                  / kw_default @punctuation ':' stmt
-    if_stmt: partial = kw_if @punctuation '(' expr @punctuation ')' stmt
-                       (kw_else stmt)?
+    if_stmt = kw_if @punctuation '(' expr @punctuation ')' stmt
+              (kw_else stmt)?
     for_stmt = kw_for @punctuation '(' for_init expr? @punctuation ';' expr? @punctuation ')' stmt
     for_init = decl
              / expr? @punctuation ';'

--- a/grammars/css.peg
+++ b/grammars/css.peg
@@ -62,8 +62,8 @@ css = (statement)*^ {
                     / rule
                     / @punctuation ';'
         {
-            declaration: partial = @property prop_ident @punctuation ':' value_list
-                                   @keyword '!important'? (@punctuation ';' / &'}')
+            declaration = @property prop_ident @punctuation ':' value_list
+                          @keyword '!important'? (@punctuation ';' / &'}')
             {
                 prop_ident: atomic = '--' ident_body+
                                     / '-'? ident
@@ -96,7 +96,7 @@ css = (statement)*^ {
     hex_color: atomic = @constant ('#' [\da-fA-F]+)
 
     number_with_unit = @number num_body {
-        num_body: partial atomic = [+\-]? (num_float / \d+) num_unit? {
+        num_body: atomic = [+\-]? (num_float / \d+) num_unit? {
             num_float: atomic = \d* '.' \d+
                                / \d+ '.' \d*
             num_unit = '%'

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -35,9 +35,9 @@ go = package_clause import_decl* (top_decl)*^ {
     top_decl = decl
                / func_decl
                / method_decl {
-        func_decl = kw_func @function ident type_params? fn_signature block? ^&fd_tail
+        func_decl = kw_func @function ident type_params? fn_signature block? $
 
-        method_decl = kw_func method_receiver @function ident fn_signature block? ^&md_tail {
+        method_decl = kw_func method_receiver @function ident fn_signature block? $ {
             method_receiver = @punctuation '(' (@variable ident)? type_expr @punctuation ')'
         }
     }
@@ -59,7 +59,7 @@ go = package_clause import_decl* (top_decl)*^ {
              / ident_list type_expr
              / ident_list @operator '=' expr_list
 
-    const_spec = const_ident_list type_expr? (@operator '=' expr_list)? ^&cs_tail {
+    const_spec = const_ident_list type_expr? (@operator '=' expr_list)? $ {
         const_ident_list = @constant ident (@punctuation ',' @constant ident)*
     }
 
@@ -78,7 +78,7 @@ go = package_clause import_decl* (top_decl)*^ {
     type_term = @operator '~' type_expr
               / type_expr
 
-    fn_signature = fn_params fn_result? ^&fs_tail {
+    fn_signature = fn_params fn_result? $ {
         fn_result = fn_params
                   / type_expr
     }
@@ -129,13 +129,13 @@ go = package_clause import_decl* (top_decl)*^ {
                      / @operator '*'? type_name string_lit?
     }
 
-    type_name = @type qualified_ident type_args? ^&tn_tail {
+    type_name = @type qualified_ident type_args? $ {
         type_args = @punctuation '[' type_arg_list @punctuation ']' {
             type_arg_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
         }
     }
 
-    qualified_ident = ident (@punctuation '.' ident)? ^&qi_tail
+    qualified_ident = ident (@punctuation '.' ident)? $
 
     block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
 
@@ -429,5 +429,5 @@ go = package_clause import_decl* (top_decl)*^ {
                              / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
                              / 'print' / 'println' / 'real' / 'recover'
 
-    opt_semi = @punctuation ';'? ^&semi_tail
+    opt_semi = @punctuation ';'? $
 }

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -158,8 +158,8 @@ go = package_clause import_decl* (top_decl)*^ {
         empty_stmt = @punctuation ';'
         labeled_stmt = @variable ident @punctuation ':' stmt
 
-        if_stmt: partial = kw_if (simple_stmt @punctuation ';')? expr_no_compound block
-                           (kw_else (if_stmt / block))? {
+        if_stmt = kw_if (simple_stmt @punctuation ';')? expr_no_compound block
+                  (kw_else (if_stmt / block))? {
             kw_if: reserved = @keyword 'if'
             kw_else: reserved = @keyword 'else'
         }
@@ -218,15 +218,15 @@ go = package_clause import_decl* (top_decl)*^ {
             kw_defer: reserved = @keyword 'defer'
         }
 
-        return_stmt: partial = kw_return expr_list? {
+        return_stmt = kw_return expr_list? {
             kw_return: reserved = @keyword 'return'
         }
 
-        break_stmt: partial = kw_break (@variable ident)? {
+        break_stmt = kw_break (@variable ident)? {
             kw_break: reserved = @keyword 'break'
         }
 
-        continue_stmt: partial = kw_continue (@variable ident)? {
+        continue_stmt = kw_continue (@variable ident)? {
             kw_continue: reserved = @keyword 'continue'
         }
 

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -135,11 +135,7 @@ go = package_clause import_decl* (top_decl)*^ {
         }
     }
 
-    # holdout: a bare `^&` FOLLOW anchor here turns a valid parse of a
-    # non-ASCII identifier in trailing expression position (e.g. `x := 世界`)
-    # from complete into a partial match — ASCII identifiers are unaffected.
-    # Root cause not yet isolated; kept lenient until it is.
-    qualified_ident: partial = ident (@punctuation '.' ident)?
+    qualified_ident = ident (@punctuation '.' ident)? ^&qi_tail
 
     block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
 
@@ -290,6 +286,7 @@ go = package_clause import_decl* (top_decl)*^ {
                                                  / @type predeclared_type
                                                  / @function predeclared_fn &(@punctuation '(')
                                                  / @variable lower_ident
+                                                 / @variable ident
                                                  / paren_expr {
                                         composite_lit = @type qualified_ident composite_body
                                                       / kw_map @punctuation '[' type_expr @punctuation ']' type_expr composite_body
@@ -328,6 +325,7 @@ go = package_clause import_decl* (top_decl)*^ {
                                                     / @type predeclared_type
                                                     / @function predeclared_fn &(@punctuation '(')
                                                     / @variable lower_ident
+                                                    / @variable ident
                                                     / paren_expr
                                 }
                             }

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -42,12 +42,12 @@ go = package_clause import_decl* (top_decl)*^ {
         }
     }
 
-    decl: partial = kw_var var_spec_group
-                  / kw_var var_spec opt_semi
-                  / kw_const const_spec_group
-                  / kw_const const_spec opt_semi
-                  / kw_type type_spec_group
-                  / kw_type type_spec opt_semi {
+    decl = kw_var var_spec_group
+         / kw_var var_spec opt_semi
+         / kw_const const_spec_group
+         / kw_const const_spec opt_semi
+         / kw_type type_spec_group
+         / kw_type type_spec opt_semi {
         kw_var: reserved = @keyword 'var'
         kw_const: reserved = @keyword 'const'
         var_spec_group = @punctuation '(' (var_spec opt_semi)* @punctuation ')'

--- a/grammars/go.peg
+++ b/grammars/go.peg
@@ -35,9 +35,9 @@ go = package_clause import_decl* (top_decl)*^ {
     top_decl = decl
                / func_decl
                / method_decl {
-        func_decl: partial = kw_func @function ident type_params? fn_signature block?
+        func_decl = kw_func @function ident type_params? fn_signature block? ^&fd_tail
 
-        method_decl: partial = kw_func method_receiver @function ident fn_signature block? {
+        method_decl = kw_func method_receiver @function ident fn_signature block? ^&md_tail {
             method_receiver = @punctuation '(' (@variable ident)? type_expr @punctuation ')'
         }
     }
@@ -59,7 +59,7 @@ go = package_clause import_decl* (top_decl)*^ {
              / ident_list type_expr
              / ident_list @operator '=' expr_list
 
-    const_spec: partial = const_ident_list type_expr? (@operator '=' expr_list)? {
+    const_spec = const_ident_list type_expr? (@operator '=' expr_list)? ^&cs_tail {
         const_ident_list = @constant ident (@punctuation ',' @constant ident)*
     }
 
@@ -78,7 +78,7 @@ go = package_clause import_decl* (top_decl)*^ {
     type_term = @operator '~' type_expr
               / type_expr
 
-    fn_signature: partial = fn_params fn_result? {
+    fn_signature = fn_params fn_result? ^&fs_tail {
         fn_result = fn_params
                   / type_expr
     }
@@ -129,12 +129,16 @@ go = package_clause import_decl* (top_decl)*^ {
                      / @operator '*'? type_name string_lit?
     }
 
-    type_name: partial = @type qualified_ident type_args? {
+    type_name = @type qualified_ident type_args? ^&tn_tail {
         type_args = @punctuation '[' type_arg_list @punctuation ']' {
             type_arg_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
         }
     }
 
+    # holdout: a bare `^&` FOLLOW anchor here turns a valid parse of a
+    # non-ASCII identifier in trailing expression position (e.g. `x := 世界`)
+    # from complete into a partial match — ASCII identifiers are unaffected.
+    # Root cause not yet isolated; kept lenient until it is.
     qualified_ident: partial = ident (@punctuation '.' ident)?
 
     block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
@@ -427,5 +431,5 @@ go = package_clause import_decl* (top_decl)*^ {
                              / 'delete' / 'imag' / 'len' / 'make' / 'new' / 'panic'
                              / 'print' / 'println' / 'real' / 'recover'
 
-    opt_semi: partial = @punctuation ';'?
+    opt_semi = @punctuation ';'? ^&semi_tail
 }

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -77,7 +77,7 @@ javascript = (stmt)*^ {
          / expr opt_semi
 
     # ASI: `;` accepted but never required at statement boundaries.
-    opt_semi: partial = @punctuation ';'?
+    opt_semi = @punctuation ';'? ^&semi_tail
     empty_stmt = @punctuation ';'
 
     import_decl = kw_import import_body opt_semi {
@@ -105,7 +105,7 @@ javascript = (stmt)*^ {
         export_default_body = fn_decl
                             / class_decl
                             / expr opt_semi
-        export_named: partial = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi {
+        export_named = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi ^&en_tail {
             export_specifier_list = export_specifier (@punctuation ',' export_specifier)* (@punctuation ',')?
             export_specifier = @variable ident_name kw_as @variable ident_name
                              / @variable ident
@@ -135,11 +135,11 @@ javascript = (stmt)*^ {
 
     var_decl = (kw_var / kw_let / kw_const) var_declarator_list {
         var_declarator_list = var_declarator (@punctuation ',' var_declarator)*
-        var_declarator: partial = pattern (@operator '=' expr_no_comma)?
+        var_declarator = pattern (@operator '=' expr_no_comma)? ^&vd_tail
     }
 
-    if_stmt: partial = kw_if @punctuation '(' expr @punctuation ')' stmt
-                       (kw_else stmt)?
+    if_stmt = kw_if @punctuation '(' expr @punctuation ')' stmt
+                       (kw_else stmt)? ^&if_tail
     for_stmt = kw_for kw_await? @punctuation '(' for_head @punctuation ')' stmt {
         for_head = for_c_style
                  / for_in_of
@@ -159,14 +159,14 @@ javascript = (stmt)*^ {
                     / kw_default @punctuation ':' (!switch_case_term stmt)*
         switch_case_term = kw_case / kw_default / @punctuation '}'
     }
-    try_stmt: partial = kw_try block catch_clause? finally_clause? {
+    try_stmt = kw_try block (catch_clause finally_clause? / finally_clause) ^&try_tail {
         catch_clause = kw_catch (@punctuation '(' pattern @punctuation ')')? block
         finally_clause = kw_finally block
     }
     throw_stmt = kw_throw expr opt_semi
-    return_stmt: partial = kw_return expr? opt_semi
-    break_stmt: partial = kw_break (@variable ident)? opt_semi
-    continue_stmt: partial = kw_continue (@variable ident)? opt_semi
+    return_stmt = kw_return expr? opt_semi ^&ret_tail
+    break_stmt = kw_break (@variable ident)? opt_semi ^&brk_tail
+    continue_stmt = kw_continue (@variable ident)? opt_semi ^&cont_tail
     debugger_stmt = kw_debugger opt_semi
     labeled_stmt = @variable ident @punctuation ':' stmt
     block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
@@ -218,10 +218,10 @@ javascript = (stmt)*^ {
                        / expr_no_comma
         }
 
-        expr_yield: partial = kw_yield @operator '*'? expr_assign?
+        expr_yield = kw_yield @operator '*'? expr_assign? ^&yield_tail
     }
 
-    expr_conditional: partial = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)?
+    expr_conditional = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)? ^&cond_tail
 
     expr_nullish = expr_nullish @operator '??' !'=' expr_lor / expr_lor
     expr_lor = expr_lor @operator '||' !'=' expr_land / expr_land

--- a/grammars/javascript.peg
+++ b/grammars/javascript.peg
@@ -77,7 +77,7 @@ javascript = (stmt)*^ {
          / expr opt_semi
 
     # ASI: `;` accepted but never required at statement boundaries.
-    opt_semi = @punctuation ';'? ^&semi_tail
+    opt_semi = @punctuation ';'? $
     empty_stmt = @punctuation ';'
 
     import_decl = kw_import import_body opt_semi {
@@ -105,7 +105,7 @@ javascript = (stmt)*^ {
         export_default_body = fn_decl
                             / class_decl
                             / expr opt_semi
-        export_named = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi ^&en_tail {
+        export_named = @punctuation '{' export_specifier_list? @punctuation '}' (kw_from string_lit)? opt_semi $ {
             export_specifier_list = export_specifier (@punctuation ',' export_specifier)* (@punctuation ',')?
             export_specifier = @variable ident_name kw_as @variable ident_name
                              / @variable ident
@@ -135,11 +135,11 @@ javascript = (stmt)*^ {
 
     var_decl = (kw_var / kw_let / kw_const) var_declarator_list {
         var_declarator_list = var_declarator (@punctuation ',' var_declarator)*
-        var_declarator = pattern (@operator '=' expr_no_comma)? ^&vd_tail
+        var_declarator = pattern (@operator '=' expr_no_comma)? $
     }
 
     if_stmt = kw_if @punctuation '(' expr @punctuation ')' stmt
-                       (kw_else stmt)? ^&if_tail
+                       (kw_else stmt)? $
     for_stmt = kw_for kw_await? @punctuation '(' for_head @punctuation ')' stmt {
         for_head = for_c_style
                  / for_in_of
@@ -159,14 +159,14 @@ javascript = (stmt)*^ {
                     / kw_default @punctuation ':' (!switch_case_term stmt)*
         switch_case_term = kw_case / kw_default / @punctuation '}'
     }
-    try_stmt = kw_try block (catch_clause finally_clause? / finally_clause) ^&try_tail {
+    try_stmt = kw_try block (catch_clause finally_clause? / finally_clause) $ {
         catch_clause = kw_catch (@punctuation '(' pattern @punctuation ')')? block
         finally_clause = kw_finally block
     }
     throw_stmt = kw_throw expr opt_semi
-    return_stmt = kw_return expr? opt_semi ^&ret_tail
-    break_stmt = kw_break (@variable ident)? opt_semi ^&brk_tail
-    continue_stmt = kw_continue (@variable ident)? opt_semi ^&cont_tail
+    return_stmt = kw_return expr? opt_semi $
+    break_stmt = kw_break (@variable ident)? opt_semi $
+    continue_stmt = kw_continue (@variable ident)? opt_semi $
     debugger_stmt = kw_debugger opt_semi
     labeled_stmt = @variable ident @punctuation ':' stmt
     block = @punctuation '{' (stmt* @punctuation '}' ^^block_close ..= @punctuation '}')
@@ -218,10 +218,10 @@ javascript = (stmt)*^ {
                        / expr_no_comma
         }
 
-        expr_yield = kw_yield @operator '*'? expr_assign? ^&yield_tail
+        expr_yield = kw_yield @operator '*'? expr_assign? $
     }
 
-    expr_conditional = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)? ^&cond_tail
+    expr_conditional = expr_nullish (@operator '?' expr_no_comma @punctuation ':' expr_no_comma)? $
 
     expr_nullish = expr_nullish @operator '??' !'=' expr_lor / expr_lor
     expr_lor = expr_lor @operator '||' !'=' expr_land / expr_land

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -140,7 +140,7 @@ rust = (item)*^ {
 
     macro_rules_item = @function 'macro_rules' @punctuation '!' @function ident brace_block
 
-    macro_invocation_stmt: partial = @function ident @punctuation '!' macro_args (@punctuation ';')?
+    macro_invocation_stmt = @function ident @punctuation '!' macro_args (@punctuation ';')? ^&mi_tail
     macro_args = paren_group
                / brace_block
                / bracket_group
@@ -177,8 +177,8 @@ rust = (item)*^ {
               / type_never
               / type_path
 
-    type_fn: partial = type_fn_qualifier* kw_fn @punctuation '(' type_list? @punctuation ')'
-                       (@punctuation '->' type_expr)?
+    type_fn = type_fn_qualifier* kw_fn @punctuation '(' type_list? @punctuation ')'
+                       (@punctuation '->' type_expr)? ^&fn_tail
     type_fn_qualifier = kw_unsafe
                       / kw_extern string_lit?
     type_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
@@ -209,7 +209,7 @@ rust = (item)*^ {
 
     generic_args = @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>'
                  / @punctuation '<' generic_arg_list? @punctuation '>'
-    paren_generic_args: partial = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)?
+    paren_generic_args = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)? ^&pga_tail
     generic_arg_list = generic_arg (@punctuation ',' generic_arg)* (@punctuation ',')?
     generic_arg = lifetime
                 / type_expr
@@ -295,7 +295,7 @@ rust = (item)*^ {
     postfix_member = turbofish_method
                    / @function ident (@punctuation '(' expr_list? @punctuation ')')?
                    / @number digit_seq
-    turbofish_method: partial = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')?
+    turbofish_method = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')? ^&tm_tail
 
     expr_primary = literal
                  / expr_if
@@ -315,17 +315,17 @@ rust = (item)*^ {
                  / expr_macro_or_path
                  / expr_keyword
 
-    expr_if: partial = kw_if (kw_let pattern @operator '=')? expr block
-                       (kw_else (expr_if / block))?
+    expr_if = kw_if (kw_let pattern @operator '=')? expr block
+                       (kw_else (expr_if / block))? ^&if_tail
     expr_match = kw_match expr @punctuation '{' match_arms? @punctuation '}'
     match_arms = match_arm (@punctuation ',' match_arm)* (@punctuation ',')?
     match_arm = attr_outer* pattern (kw_if expr)? @punctuation '=>' expr
     expr_while = kw_while (kw_let pattern @operator '=')? expr block
     expr_loop = loop_label? kw_loop block
     expr_for = kw_for pattern kw_in expr block
-    expr_return: partial = kw_return expr?
-    expr_break: partial = kw_break loop_label? expr?
-    expr_continue: partial = kw_continue loop_label?
+    expr_return = kw_return expr? ^&ret_tail
+    expr_break = kw_break loop_label? expr? ^&brk_tail
+    expr_continue = kw_continue loop_label? ^&cont_tail
     expr_unsafe = kw_unsafe block
     expr_closure = kw_move? @punctuation '|' closure_params? @punctuation '|'
                    (@punctuation '->' type_expr)? expr
@@ -342,7 +342,7 @@ rust = (item)*^ {
 
     loop_label: atomic = @punctuation '\'' @variable ident @punctuation ':'
 
-    expr_macro_or_path: partial = path_expr (struct_init / @punctuation '!' macro_args)?
+    expr_macro_or_path = path_expr (struct_init / @punctuation '!' macro_args)? ^&mop_tail
     path_expr = path_seg (@punctuation '::' path_seg)*
     path_seg = @type upper_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?
              / @function lower_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -140,7 +140,7 @@ rust = (item)*^ {
 
     macro_rules_item = @function 'macro_rules' @punctuation '!' @function ident brace_block
 
-    macro_invocation_stmt = @function ident @punctuation '!' macro_args (@punctuation ';')? ^&mi_tail
+    macro_invocation_stmt = @function ident @punctuation '!' macro_args (@punctuation ';')? $
     macro_args = paren_group
                / brace_block
                / bracket_group
@@ -178,7 +178,7 @@ rust = (item)*^ {
               / type_path
 
     type_fn = type_fn_qualifier* kw_fn @punctuation '(' type_list? @punctuation ')'
-                       (@punctuation '->' type_expr)? ^&fn_tail
+                       (@punctuation '->' type_expr)? $
     type_fn_qualifier = kw_unsafe
                       / kw_extern string_lit?
     type_list = type_expr (@punctuation ',' type_expr)* (@punctuation ',')?
@@ -209,7 +209,7 @@ rust = (item)*^ {
 
     generic_args = @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>'
                  / @punctuation '<' generic_arg_list? @punctuation '>'
-    paren_generic_args = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)? ^&pga_tail
+    paren_generic_args = @punctuation '(' type_list? @punctuation ')' (@punctuation '->' type_expr)? $
     generic_arg_list = generic_arg (@punctuation ',' generic_arg)* (@punctuation ',')?
     generic_arg = lifetime
                 / type_expr
@@ -295,7 +295,7 @@ rust = (item)*^ {
     postfix_member = turbofish_method
                    / @function ident (@punctuation '(' expr_list? @punctuation ')')?
                    / @number digit_seq
-    turbofish_method = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')? ^&tm_tail
+    turbofish_method = @function ident @punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>' (@punctuation '(' expr_list? @punctuation ')')? $
 
     expr_primary = literal
                  / expr_if
@@ -316,16 +316,16 @@ rust = (item)*^ {
                  / expr_keyword
 
     expr_if = kw_if (kw_let pattern @operator '=')? expr block
-                       (kw_else (expr_if / block))? ^&if_tail
+                       (kw_else (expr_if / block))? $
     expr_match = kw_match expr @punctuation '{' match_arms? @punctuation '}'
     match_arms = match_arm (@punctuation ',' match_arm)* (@punctuation ',')?
     match_arm = attr_outer* pattern (kw_if expr)? @punctuation '=>' expr
     expr_while = kw_while (kw_let pattern @operator '=')? expr block
     expr_loop = loop_label? kw_loop block
     expr_for = kw_for pattern kw_in expr block
-    expr_return = kw_return expr? ^&ret_tail
-    expr_break = kw_break loop_label? expr? ^&brk_tail
-    expr_continue = kw_continue loop_label? ^&cont_tail
+    expr_return = kw_return expr? $
+    expr_break = kw_break loop_label? expr? $
+    expr_continue = kw_continue loop_label? $
     expr_unsafe = kw_unsafe block
     expr_closure = kw_move? @punctuation '|' closure_params? @punctuation '|'
                    (@punctuation '->' type_expr)? expr
@@ -342,7 +342,7 @@ rust = (item)*^ {
 
     loop_label: atomic = @punctuation '\'' @variable ident @punctuation ':'
 
-    expr_macro_or_path = path_expr (struct_init / @punctuation '!' macro_args)? ^&mop_tail
+    expr_macro_or_path = path_expr (struct_init / @punctuation '!' macro_args)? $
     path_expr = path_seg (@punctuation '::' path_seg)*
     path_seg = @type upper_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?
              / @function lower_ident (@punctuation '::' @punctuation '<' generic_arg_list? @punctuation '>')?

--- a/grammars/rust.peg
+++ b/grammars/rust.peg
@@ -237,8 +237,8 @@ rust = (item)*^ {
     pattern_box = kw_box pattern_atom
     pattern_tuple = @punctuation '(' pattern_list? @punctuation ')'
     pattern_list = pattern (@punctuation ',' pattern)* (@punctuation ',')?
-    pattern_struct_or_enum: partial = @type upper_ident (@punctuation '::' @type upper_ident)*
-                                     (pattern_struct_body / pattern_tuple)?
+    pattern_struct_or_enum = @type upper_ident (@punctuation '::' @type upper_ident)*
+                             (pattern_struct_body / pattern_tuple)?
     pattern_struct_body = @punctuation '{' pattern_struct_fields? @punctuation '}'
     pattern_struct_fields = pattern_struct_field (@punctuation ',' pattern_struct_field)* (@punctuation ',')?
     pattern_struct_field = @property ident @punctuation ':' pattern
@@ -249,8 +249,8 @@ rust = (item)*^ {
     pattern_literal = string_lit / char_lit / number_lit / lit_const
     pattern_wild = @punctuation '_'
     pattern_rest = @punctuation '..'
-    pattern_binding: partial = kw_ref? kw_mut? @variable ident
-                              (@punctuation '@' pattern_atom)?
+    pattern_binding = kw_ref? kw_mut? @variable ident
+                      (@punctuation '@' pattern_atom)?
 
     expr = expr_assign
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -369,9 +369,9 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     paren_primary = @punctuation '(' (select_stmt / expr) @punctuation ')'
 
-    function_call: partial = @function bare_ident_nonkw @punctuation '(' func_args? @punctuation ')'
+    function_call = @function bare_ident_nonkw @punctuation '(' func_args? @punctuation ')'
                             (filter_clause)?
-                            (kw_over window_ref)? {
+                            (kw_over window_ref)? ^&fn_tail {
         func_args = @operator '*'
                   / (kw_distinct)? expr (@punctuation ',' expr)*
     }

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -30,7 +30,7 @@ sqlite = (statement stmt_sep?)*^[;] {
                    / reindex_stmt
                    / analyze_stmt
 
-    select_stmt = with_clause? select_core compound_tail* order_clause? limit_clause? ^&select_tail
+    select_stmt = with_clause? select_core compound_tail* order_clause? limit_clause? $
 
     with_clause = kw_with (kw_recursive)? cte_defn (@punctuation ',' cte_defn)*
     cte_defn = @type bare_ident
@@ -39,7 +39,7 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     select_core = kw_select ((kw_distinct / kw_all))? result_list
                            (from_clause)? (where_clause)? (group_clause)? (having_clause)?
-                           (window_clause)? ^&core_tail
+                           (window_clause)? $
 
     result_list = result_column (@punctuation ',' result_column)*
     result_column = (table_star / @operator '*' / aliased_expr)
@@ -59,11 +59,11 @@ sqlite = (statement stmt_sep?)*^[;] {
     from_clause = kw_from table_or_subquery (join_clause)*
     table_or_subquery = @punctuation '(' select_stmt @punctuation ')' (table_alias)?
                       / qualified_table_name (table_alias)?
-    qualified_table_name = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)? ^&qtn_tail
+    qualified_table_name = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)? $
     table_alias = kw_as @variable bare_ident_nonkw
                 / @variable bare_ident_nonkw
 
-    join_clause = join_op table_or_subquery (join_constraint)? ^&join_tail {
+    join_clause = join_op table_or_subquery (join_constraint)? $ {
         join_op = @punctuation ','
                 / kw_natural (join_type)? kw_join
                 / join_type kw_join
@@ -92,7 +92,7 @@ sqlite = (statement stmt_sep?)*^[;] {
     order_item = (expr ((kw_asc / kw_desc))?) ^^bad_order_item
 
     limit_clause = kw_limit expr (kw_offset expr
-                                                / @punctuation ',' expr)? ^&limit_tail
+                                                / @punctuation ',' expr)? $
 
     window_clause = kw_window named_window (@punctuation ',' named_window)* {
         named_window = @variable bare_ident_nonkw kw_as window_defn
@@ -195,7 +195,7 @@ sqlite = (statement stmt_sep?)*^[;] {
     # `UNSIGNED BIG INT`.
     type_name = @type bare_ident_nonkw (@type bare_ident_nonkw)*
                          (@punctuation '(' signed_number
-                              (@punctuation ',' signed_number)? @punctuation ')')? ^&type_tail
+                              (@punctuation ',' signed_number)? @punctuation ')')? $
 
     signed_number = (@operator '-' / @operator '+')? @number number_body
 
@@ -371,7 +371,7 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     function_call = @function bare_ident_nonkw @punctuation '(' func_args? @punctuation ')'
                             (filter_clause)?
-                            (kw_over window_ref)? ^&fn_tail {
+                            (kw_over window_ref)? $ {
         func_args = @operator '*'
                   / (kw_distinct)? expr (@punctuation ',' expr)*
     }

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -89,7 +89,7 @@ sqlite = (statement stmt_sep?)*^[;] {
     having_clause = kw_having expr
 
     order_clause = kw_order kw_by order_item (@punctuation ',' order_item)*
-    order_item: partial = expr ((kw_asc / kw_desc))?
+    order_item = (expr ((kw_asc / kw_desc))?) ^^bad_order_item
 
     limit_clause: partial = kw_limit expr (kw_offset expr
                                                 / @punctuation ',' expr)?

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -30,16 +30,16 @@ sqlite = (statement stmt_sep?)*^[;] {
                    / reindex_stmt
                    / analyze_stmt
 
-    select_stmt: partial = with_clause? select_core compound_tail* order_clause? limit_clause?
+    select_stmt = with_clause? select_core compound_tail* order_clause? limit_clause? ^&select_tail
 
     with_clause = kw_with (kw_recursive)? cte_defn (@punctuation ',' cte_defn)*
     cte_defn = @type bare_ident
                (@punctuation '(' ident_list @punctuation ')')?
                kw_as @punctuation '(' select_stmt @punctuation ')'
 
-    select_core: partial = kw_select ((kw_distinct / kw_all))? result_list
+    select_core = kw_select ((kw_distinct / kw_all))? result_list
                            (from_clause)? (where_clause)? (group_clause)? (having_clause)?
-                           (window_clause)?
+                           (window_clause)? ^&core_tail
 
     result_list = result_column (@punctuation ',' result_column)*
     result_column = (table_star / @operator '*' / aliased_expr)
@@ -59,11 +59,11 @@ sqlite = (statement stmt_sep?)*^[;] {
     from_clause = kw_from table_or_subquery (join_clause)*
     table_or_subquery = @punctuation '(' select_stmt @punctuation ')' (table_alias)?
                       / qualified_table_name (table_alias)?
-    qualified_table_name: partial = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)?
+    qualified_table_name = @type bare_ident_nonkw (@punctuation '.' @type bare_ident_nonkw)? ^&qtn_tail
     table_alias = kw_as @variable bare_ident_nonkw
                 / @variable bare_ident_nonkw
 
-    join_clause: partial = join_op table_or_subquery (join_constraint)? {
+    join_clause = join_op table_or_subquery (join_constraint)? ^&join_tail {
         join_op = @punctuation ','
                 / kw_natural (join_type)? kw_join
                 / join_type kw_join
@@ -91,8 +91,8 @@ sqlite = (statement stmt_sep?)*^[;] {
     order_clause = kw_order kw_by order_item (@punctuation ',' order_item)*
     order_item = (expr ((kw_asc / kw_desc))?) ^^bad_order_item
 
-    limit_clause: partial = kw_limit expr (kw_offset expr
-                                                / @punctuation ',' expr)?
+    limit_clause = kw_limit expr (kw_offset expr
+                                                / @punctuation ',' expr)? ^&limit_tail
 
     window_clause = kw_window named_window (@punctuation ',' named_window)* {
         named_window = @variable bare_ident_nonkw kw_as window_defn
@@ -193,9 +193,9 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
     # `UNSIGNED BIG INT`.
-    type_name: partial = @type bare_ident_nonkw (@type bare_ident_nonkw)*
+    type_name = @type bare_ident_nonkw (@type bare_ident_nonkw)*
                          (@punctuation '(' signed_number
-                              (@punctuation ',' signed_number)? @punctuation ')')?
+                              (@punctuation ',' signed_number)? @punctuation ')')? ^&type_tail
 
     signed_number = (@operator '-' / @operator '+')? @number number_body
 

--- a/grammars/sqlite.peg
+++ b/grammars/sqlite.peg
@@ -123,12 +123,12 @@ sqlite = (statement stmt_sep?)*^[;] {
                       / kw_ties
     }
 
-    insert_stmt: partial = with_clause? insert_prefix kw_into qualified_table_name
-                           (kw_as @variable bare_ident_nonkw)?
-                           (@punctuation '(' ident_list @punctuation ')')?
-                           insert_source
-                           (upsert_clause)*
-                           (returning_clause)? {
+    insert_stmt = with_clause? insert_prefix kw_into qualified_table_name
+                  (kw_as @variable bare_ident_nonkw)?
+                  (@punctuation '(' ident_list @punctuation ')')?
+                  insert_source
+                  (upsert_clause)*
+                  (returning_clause)? {
         insert_prefix = kw_insert (kw_or conflict_action)?
                       / kw_replace
 
@@ -160,20 +160,20 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     returning_clause = kw_returning result_list
 
-    update_stmt: partial = with_clause? kw_update (kw_or conflict_action)?
-                          qualified_table_name (table_alias)?
-                          kw_set update_set_list
-                          (from_clause)?
-                          (where_clause)?
-                          order_clause?
-                          limit_clause?
-                          (returning_clause)?
+    update_stmt = with_clause? kw_update (kw_or conflict_action)?
+                  qualified_table_name (table_alias)?
+                  kw_set update_set_list
+                  (from_clause)?
+                  (where_clause)?
+                  order_clause?
+                  limit_clause?
+                  (returning_clause)?
 
-    delete_stmt: partial = with_clause? kw_delete kw_from qualified_table_name (table_alias)?
-                          (where_clause)?
-                          order_clause?
-                          limit_clause?
-                          (returning_clause)?
+    delete_stmt = with_clause? kw_delete kw_from qualified_table_name (table_alias)?
+                  (where_clause)?
+                  order_clause?
+                  limit_clause?
+                  (returning_clause)?
 
     create_table_stmt = kw_create ((kw_temporary / kw_temp))? kw_table
                         (kw_if kw_not kw_exists)?
@@ -187,9 +187,9 @@ sqlite = (statement stmt_sep?)*^[;] {
         table_option = kw_without kw_rowid / kw_strict
     }
 
-    column_def: partial = @variable bare_ident_nonkw
-                          (type_name)?
-                          (column_constraint)*
+    column_def = @variable bare_ident_nonkw
+                 (type_name)?
+                 (column_constraint)*
 
     # SQLite accepts multi-word type names like `DOUBLE PRECISION` and
     # `UNSIGNED BIG INT`.
@@ -220,10 +220,10 @@ sqlite = (statement stmt_sep?)*^[;] {
         / kw_foreign kw_key @punctuation '(' ident_list @punctuation ')'
               foreign_key_clause
 
-    foreign_key_clause: partial = kw_references @type bare_ident_nonkw
-                                 (@punctuation '(' ident_list @punctuation ')')?
-                                 (fk_action)*
-                                 (fk_deferrable)? {
+    foreign_key_clause = kw_references @type bare_ident_nonkw
+                         (@punctuation '(' ident_list @punctuation ')')?
+                         (fk_action)*
+                         (fk_deferrable)? {
         fk_action = kw_on (kw_delete / kw_update) fk_action_body
                   / kw_match @variable bare_ident_nonkw {
             fk_action_body = kw_set (kw_null / kw_default)
@@ -231,7 +231,7 @@ sqlite = (statement stmt_sep?)*^[;] {
                            / kw_restrict
                            / kw_no kw_action
         }
-        fk_deferrable: partial = (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
+        fk_deferrable = (kw_not)? kw_deferrable (kw_initially (kw_immediate / kw_deferred))?
     }
 
     conflict_clause = kw_on kw_conflict conflict_action
@@ -246,12 +246,12 @@ sqlite = (statement stmt_sep?)*^[;] {
        / kw_drop (kw_column)? @variable bare_ident_nonkw
      )
 
-    create_index_stmt: partial = kw_create (kw_unique)? kw_index
-                                (kw_if kw_not kw_exists)?
-                                qualified_table_name
-                                kw_on @type bare_ident_nonkw
-                                @punctuation '(' indexed_col_list @punctuation ')'
-                                (where_clause)?
+    create_index_stmt = kw_create (kw_unique)? kw_index
+                        (kw_if kw_not kw_exists)?
+                        qualified_table_name
+                        kw_on @type bare_ident_nonkw
+                        @punctuation '(' indexed_col_list @punctuation ')'
+                        (where_clause)?
 
     drop_index_stmt = kw_drop kw_index (kw_if kw_exists)? qualified_table_name
 
@@ -282,32 +282,32 @@ sqlite = (statement stmt_sep?)*^[;] {
 
     drop_trigger_stmt = kw_drop kw_trigger (kw_if kw_exists)? qualified_table_name
 
-    begin_stmt: partial = kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
+    begin_stmt = kw_begin ((kw_deferred / kw_immediate / kw_exclusive))?
                           (kw_transaction)?
-    commit_stmt: partial = (kw_commit / kw_end) (kw_transaction)?
-    rollback_stmt: partial = kw_rollback (kw_transaction)?
+    commit_stmt = (kw_commit / kw_end) (kw_transaction)?
+    rollback_stmt = kw_rollback (kw_transaction)?
                              (kw_to (kw_savepoint)? @variable bare_ident_nonkw)?
     savepoint_stmt = kw_savepoint @variable bare_ident_nonkw
     release_stmt = kw_release (kw_savepoint)? @variable bare_ident_nonkw
 
-    pragma_stmt: partial = kw_pragma qualified_table_name
+    pragma_stmt = kw_pragma qualified_table_name
                            (@operator '=' pragma_value
                             / @punctuation '(' pragma_value @punctuation ')')? {
         pragma_value = signed_number / string_lit / @variable bare_ident
     }
 
-    vacuum_stmt: partial = kw_vacuum (@type bare_ident_nonkw)? (kw_into string_lit)?
+    vacuum_stmt = kw_vacuum (@type bare_ident_nonkw)? (kw_into string_lit)?
 
     attach_stmt = kw_attach (kw_database)? expr kw_as
                   @type bare_ident_nonkw
     detach_stmt = kw_detach (kw_database)? @type bare_ident_nonkw
 
-    reindex_stmt: partial = kw_reindex (qualified_table_name)?
-    analyze_stmt: partial = kw_analyze (qualified_table_name)?
+    reindex_stmt = kw_reindex (qualified_table_name)?
+    analyze_stmt = kw_analyze (qualified_table_name)?
 
     explain_stmt = kw_explain (kw_query kw_plan)? statement_body
 
-    create_virtual_table_stmt: partial =
+    create_virtual_table_stmt =
         kw_create kw_virtual kw_table
         (kw_if kw_not kw_exists)?
         qualified_table_name


### PR DESCRIPTION
The `partial` leniency marker (issue #113) was an unenforced trust token: it suppressed the partial-match-leniency lint without stating — or checking — the recovery scope it depended on. This retires it. Every rule that was lenient is now anchored to its FOLLOW, so the lint is the sole enforcement and there is no opt-out.

The enabling mechanism is a new postfix `$` **anchor-only boundary** — it lowers to `Seq([inner, &B])` (B = the rule's terminal-expanded FOLLOW) with no recovery `Catch`. A prefix-only match fails the `&B` lookahead and backtracks, which is cheap in the speculative expression positions where a recovery catch would turn every backtrack into a skip-to-boundary scan (that approach hung). A small `trailing_first` precision change discharges nullable bodies too, so the ASI separator (`opt_semi = ';'? $`) anchors to its follower set. See `crates/compiler/src/pegc/README.md` (Anchor-only inferred boundary).

All 60 markers across sqlite/rust/go/js are gone, and so is the machinery: the `partial` ascription, `Pattern::Lenient`, and its transparent-traversal arms. The lint (`lint_partial_match`, the original prefix-leniency guard) stays; its remediation is now "anchor to FOLLOW or restructure".

Two grammar bugs surfaced and were fixed in passing:

- **go:** a non-ASCII identifier in expression position (e.g. `x := 世界`) had no clean operand production — it routed through the `@type` path and only "completed" via recovery. It now has a first-class `@variable ident` operand.
- **js:** `try_stmt` accepted a bare `try {}` with no catch/finally (a syntax error); it now requires at least one clause.

Closes #113.

<details>
<summary>Cost and the approaches that didn't work</summary>

Parse time is flat across grammars except ~13% on javascript, from the `&B` lookahead on the hot `expr_conditional`; no hangs, and the recovery baselines stay at zero (`&B` succeeds on well-formed input). Two earlier ideas were ruled out by measurement: a FOLLOW genuine-optionality check is unsound (`order_item` and the load-bearing `aliased_expr` are FOLLOW-indistinguishable), and anchoring with a recovery `Catch` in speculative positions hangs (wrapping `select_core`'s whole body went from ~6ms to >25s). The bare `&B` anchor avoids both.
</details>
