### PR TITLE
Exclude trailing trivia from rule body ranges

### DIFF
--- a/crates/bin/tests/pegc_tests.rs
+++ b/crates/bin/tests/pegc_tests.rs
@@ -169,6 +169,31 @@ fn stats_emits_correct_counts_for_canary_grammar() {
     assert!(lines.next().is_none(), "canary should emit one rule record");
 }
 
+// `stats_trailing_trivia_canary.peg` places comment trivia after each
+// kind of rule body — a section divider between nested rules, a
+// same-line trailing comment, a comment before the closing `}`, and a
+// trailing file comment. `body_chars` must count only the body itself
+// (#137: the parser used to end body ranges past the trailing trivia,
+// and `.trim()` cannot strip comments).
+#[test]
+fn stats_body_chars_excludes_trailing_comment_blocks() {
+    let path = "crates/compiler/tests/fixtures/stats_trailing_trivia_canary.peg";
+    assert_exists(path);
+    let (code, stdout, stderr) = run(&["stats", path]);
+    assert_eq!(code, 0, "stderr was: {stderr}");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 4, "expected 1 header + 3 per-rule: {lines:?}");
+    let mut by_rule: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for line in &lines[1..] {
+        let rule = json_field_str(line, "rule").expect("rule present");
+        by_rule.insert(rule, line);
+    }
+    // root = `a b` (3), a = `[fF]` (4), b = `'y'` (3).
+    assert_eq!(json_field_str(by_rule["\"root\""], "body_chars"), Some("3"));
+    assert_eq!(json_field_str(by_rule["\"a\""], "body_chars"), Some("4"));
+    assert_eq!(json_field_str(by_rule["\"b\""], "body_chars"), Some("3"));
+}
+
 // Multi-rule fixture pinning per-rule reference counting: `a` is
 // referenced three times (twice from `root`, once from `b`), `b` once
 // (from `root`), and `root` zero times.

--- a/crates/compiler/src/pegc/parser.rs
+++ b/crates/compiler/src/pegc/parser.rs
@@ -130,11 +130,12 @@ pub struct Grammar {
 #[derive(Debug, Clone)]
 pub struct RuleHeader {
     pub name: String,
-    /// Byte offset of the rule's identifier (after any leading `~` / `*`).
+    /// Byte offset of the rule's identifier.
     pub name_byte: usize,
     /// Byte offset of the first non-whitespace byte after `=`.
     pub body_byte_start: usize,
-    /// Byte offset just past the last byte consumed for the body.
+    /// Byte offset just past the body's last non-trivia byte — trailing
+    /// whitespace and comments are excluded.
     pub body_byte_end: usize,
 }
 
@@ -294,6 +295,14 @@ struct Parser<'a> {
     /// rather than O(offset). Every Pattern node carries a [`Span`];
     /// the per-node lookup dominates parser cost without this.
     line_starts: Vec<usize>,
+    /// Byte offset just past the last non-trivia byte consumed so far.
+    /// `skip_ws` maintains it (see there); `parse_rule_def` reads it to
+    /// end a rule's body range before trailing whitespace and comments.
+    last_solid_end: usize,
+    /// Where the previous `skip_ws` stopped. Distinguishes "solid bytes
+    /// consumed since the last skip" from a second back-to-back
+    /// `skip_ws` call, which must not move the watermark.
+    ws_end: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -310,6 +319,8 @@ impl<'a> Parser<'a> {
             src,
             pos: 0,
             line_starts,
+            last_solid_end: 0,
+            ws_end: 0,
         }
     }
 
@@ -435,7 +446,15 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let body_byte_start = self.pos;
         let body = self.parse_choice()?;
-        let body_byte_end = self.pos;
+        // `parse_choice` returns through a trailing `skip_ws`, so
+        // `self.pos` sits past any whitespace and comments that follow
+        // the body; the watermark ends the range at the body's last
+        // solid byte instead.
+        let body_byte_end = self.last_solid_end.max(body_byte_start);
+        debug_assert!(
+            body_byte_end > body_byte_start,
+            "rule body consumed no solid bytes"
+        );
         // `reserved` and `preferred` are compiler-generated (see
         // `synthesize_reserved_preferred`); an author definition would be
         // silently overwritten, so reject it outright. Grammars may still
@@ -1677,6 +1696,15 @@ impl<'a> Parser<'a> {
     }
 
     fn skip_ws(&mut self) {
+        // `skip_ws` is the only trivia consumer, so `pos > ws_end` here
+        // means solid bytes were consumed since the previous skip; that
+        // guard keeps a back-to-back `skip_ws` (e.g. a sequence's
+        // trailing skip followed by a caller's loop-top skip) from
+        // dragging the watermark past the trivia the first one ate.
+        debug_assert!(self.pos >= self.ws_end, "parser position moved backwards");
+        if self.pos > self.ws_end {
+            self.last_solid_end = self.pos;
+        }
         loop {
             match self.peek() {
                 Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') => self.pos += 1,
@@ -1691,6 +1719,7 @@ impl<'a> Parser<'a> {
                 _ => break,
             }
         }
+        self.ws_end = self.pos;
     }
 
     fn peek(&self) -> Option<u8> {

--- a/crates/compiler/tests/fixtures/stats_trailing_trivia_canary.peg
+++ b/crates/compiler/tests/fixtures/stats_trailing_trivia_canary.peg
@@ -1,0 +1,6 @@
+root = a b {
+    a = [fF]
+    # --- section ---
+    b = 'y' # trailing note
+}
+# trailing file comment

--- a/crates/compiler/tests/grammar_tests.rs
+++ b/crates/compiler/tests/grammar_tests.rs
@@ -1626,3 +1626,74 @@ fn case_insensitive_literal_unterminated_errors() {
         err.message
     );
 }
+
+// ---------------------------------------------------------------------
+// RuleHeader body ranges: `body_byte_end` must sit just past the body's
+// last non-trivia byte, whatever token the body happens to end on —
+// trailing whitespace and comments belong to the gap, not the body.
+// Positional assertions, so these use `parse_src` directly.
+
+/// Slice `src` by the named rule's header body range.
+fn body_slice<'a>(src: &'a str, rule: &str) -> &'a str {
+    let g = parse_src(src).expect("parse failed");
+    let h = g
+        .rule_headers
+        .iter()
+        .find(|h| h.name == rule)
+        .expect("rule header present");
+    &src[h.body_byte_start..h.body_byte_end]
+}
+
+#[test]
+fn body_range_excludes_trailing_comment() {
+    assert_eq!(body_slice("r = 'x' # note\n", "r"), "'x'");
+}
+
+#[test]
+fn body_range_excludes_trailing_comment_block_before_next_rule() {
+    let src = "r = a {\n    a = 'x'\n    # divider\n    # more\n    b = a 'y'\n}\n";
+    assert_eq!(body_slice(src, "a"), "'x'");
+    assert_eq!(body_slice(src, "b"), "a 'y'");
+}
+
+#[test]
+fn body_range_ends_at_postfix_repeat() {
+    assert_eq!(body_slice("r = 'x'*\n", "r"), "'x'*");
+}
+
+#[test]
+fn body_range_ends_at_exact_count() {
+    assert_eq!(body_slice("r = 'x'{3}\n", "r"), "'x'{3}");
+}
+
+#[test]
+fn body_range_ends_at_boundary_anchor() {
+    assert_eq!(body_slice("r = a $ {\n    a = 'x'\n}\n", "a"), "'x'");
+    assert_eq!(body_slice("r = a $ {\n    a = 'x'\n}\n", "r"), "a $");
+}
+
+#[test]
+fn body_range_ends_at_sync_set() {
+    assert_eq!(body_slice("r = 'x'*^[;]\n", "r"), "'x'*^[;]");
+}
+
+#[test]
+fn body_range_of_parent_stops_before_scope_block() {
+    assert_eq!(
+        body_slice("r = a b {\n    a = 'x'\n    b = 'y'\n}\n", "r"),
+        "a b"
+    );
+}
+
+#[test]
+fn body_range_of_last_nested_rule_stops_before_closing_brace() {
+    assert_eq!(
+        body_slice("r = a {\n    a = 'x'\n    # last words\n}\n", "a"),
+        "'x'"
+    );
+}
+
+#[test]
+fn body_range_at_eof_without_newline() {
+    assert_eq!(body_slice("r = 'x'", "r"), "'x'");
+}


### PR DESCRIPTION
`parse_rule_def` snapshotted `body_byte_end` at the parser position after `parse_choice` returned, which sits past the trailing `skip_ws` — so a rule's body range swallowed any whitespace and comments between the body's last token and whatever comes next, and `pegc stats` `body_chars` counted comment text that `.trim()` cannot strip.

The parser now keeps a solid-content watermark (`Parser::last_solid_end`): `skip_ws` bumps it at entry when solid bytes were consumed since the previous skip (the `ws_end` guard keeps back-to-back skips from dragging it past consumed trivia), and `parse_rule_def` ends the body range there instead of at the current position.

Tests pin the fix at both levels: `stats_body_chars_excludes_trailing_comment_blocks` over a new fixture with comment trivia after every body shape, and `body_range_*` tests in `grammar_tests.rs` slicing the source by header ranges for each body-final token shape (trailing comment, postfix repeat, exact count, boundary anchor `$`, sync set, nested rule before `}`, EOF without newline).

Closes #137
